### PR TITLE
uix.camera.Camera.play property is broken

### DIFF
--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -107,7 +107,7 @@ class Camera(Image):
         if not self._camera:
             return
         if value:
-            self._camera.play()
+            self._camera.start()
         else:
             self._camera.stop()
 


### PR DESCRIPTION
The play property in uix.camera.Camera class is broken. It calls a play() method on the underlying raw camera device. I believe it is supposed to call the start() method because I can't find anything related to play in either camera modules (gstreamer, opencv, videocapture). I've tested this patch on gstreamer and it seems to be working now, before the patch the program would throw
AttributeError: 'CameraGStreamer' object has no attribute 'play'
