### PR TITLE
Fix:animation order for zip. Sort the filenamelist

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -189,8 +189,11 @@ class ImageLoader(object):
         # Read all images inside
         z = zipfile.ZipFile(_filename, 'r')
         image_data = []
+        #sort filename list
+        znamelist = z.namelist()
+        znamelist.sort()
         #for each file in zip
-        for zfilename in z.namelist():
+        for zfilename in znamelist:
             try:
                 #read file and store it in mem with fileIO struct around it
                 tmpfile = SIO.StringIO(z.read(zfilename))


### PR DESCRIPTION
animation was not by file name
but in order of files put in zip.
