### PR TITLE
Allow dynamic changes to url in loader

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -118,7 +118,11 @@ class LoaderBase(object):
         or _load_urllib() if the file is on Internet'''
 
         filename, load_callback, post_callback = parameters
-        proto = filename.split(':', 1)[0]
+        try:
+            proto = filename.split(':', 1)[0]
+        except:
+            #if blank filename then return
+            return
         if load_callback is not None:
             data = load_callback(filename)
         elif proto in ('http', 'https', 'ftp'):
@@ -145,6 +149,7 @@ class LoaderBase(object):
         import tempfile
         data = None
         try:
+            _out_filename = ''
             suffix = '.%s' % (filename.split('.')[-1])
             _out_osfd, _out_filename = tempfile.mkstemp(
                     prefix='kivyloader', suffix=suffix)
@@ -164,7 +169,8 @@ class LoaderBase(object):
             Logger.exception('Failed to load image <%s>' % filename)
             return self.error_image
         finally:
-            unlink(_out_filename)
+            if _out_filename != '':
+                unlink(_out_filename)
 
         return data
 


### PR DESCRIPTION
As I commented on issue #316, there was another/related issue with AsyncImage/loader.py, 
it seems to get stuck randomly if someone is trying to edit the url in live mode due to invalid url's.

To reproduce the issue:

```
1) Load the Async Image example with the inspector module
2) Let the image load and start the inspector
3) Edit the source to a new url
```

Try setting a few different urls if it doesn't get stuck displaying the first url,
it more often than not gets stuck while setting the first url in my case.

Although this can be worked around by forcing only complete url's to be used in the loader.
I think it would be better if loader was resistant to incomplete/invalid url's.

I kept this separate from the AsyncImage branch as this is more an issue with loader than AsyncImage and I'm not quite sure this is the right way to fix this issue.
