### PR TITLE
dirty patch to allow omnicompletion in vim

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -175,8 +175,11 @@ def kivy_usage():
 
 
 # Start !
-Logger.setLevel(level=LOG_LEVELS.get('info'))
-Logger.info('Kivy v%s' % (__version__))
+if 'vim' in globals():
+    Logger.setLevel(level=LOG_LEVELS.get('critical'))
+else:
+    Logger.setLevel(level=LOG_LEVELS.get('info'))
+    Logger.info('Kivy v%s' % (__version__))
 
 #: Global settings options for kivy
 kivy_options = {


### PR DESCRIPTION
 -> shut logger off if "vim" in globals

now ctrl-x ctrl-o works nicely in kivy projects.

I tried to fix it in python-omnicomplete, but i failed, after hours of fiddlings, so i went on fixing it here, i don't like much the idea of detecting one editor in the framework, but it doesn't hurt anybody i guess, if you see better solutions...
