### PR TITLE
Fix auto scroll to top when selection is deleted

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -322,7 +322,9 @@ class TextInput(Widget):
         l = self._lines
         dy = self.line_height + self._line_spacing
         cx = x - self.x
-        cy = (self.top - self.padding_y + self.scroll_y * dy) - y
+        scrl_y = self.scroll_y
+        scrl_y = scrl_y/ dy if scrl_y > 0 else 0
+        cy = (self.top - self.padding_y + scrl_y * dy) - y
         cy = int(boundary(round(cy / dy), 0, len(l) - 1))
         dcx = 0
         for i in xrange(1, len(l[cy])+1):
@@ -346,6 +348,8 @@ class TextInput(Widget):
     def delete_selection(self):
         '''Delete the current text selection (if any)
         '''
+        scrl_x = self.scroll_x
+        scrl_y = self.scroll_y
         if not self._selection:
             return
         v = self.text
@@ -355,6 +359,8 @@ class TextInput(Widget):
         text = v[:a] + v[b:]
         self.text = text
         self.cursor = self.get_cursor_from_index(a)
+        self.scroll_x = scrl_x
+        self.scroll_y = scrl_y
         self.cancel_selection()
 
     def _update_selection(self, finished=False):


### PR DESCRIPTION
Fix auto scroll to top when selection is deleted
in multiline TextInput and fix calculation of
cursur pos after scrolling text. Should fix #318

To see the issues this fixes; follow these steps:

```
a) In kivy.uix directry run python textinput.py
b) Scroll the text in multi-line TextInput down, doesn't matter how much.
c) Now touch the multi-line TextInput. The position of the cursor isn't correct.
```

To see the other issue:

```
a) Make a selection in the multi-line TextInput at any position greater than the first Line.
b) Now delete/cut the selection
c) The selection is deleted but the text scrolls to top.
```
