### PR TITLE
Fix window resizing on Windows 7

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -474,6 +474,9 @@ class WindowBase(EventDispatcher):
         self.canvas = Canvas()
         self.render_context.add(self.canvas)
 
+        # set up the OpenGL viewport here instead of by resize event.
+        self.update_viewport()
+
     def on_flip(self):
         '''Flip between buffers (event)'''
         self.flip()

--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -39,11 +39,14 @@ class WindowPygame(WindowBase):
         self.flags = pygame.HWSURFACE | pygame.OPENGL | \
                      pygame.DOUBLEBUF
 
-        # right now, activate resizable window only on linux.
-        # on window / macosx, the opengl context is lost, and we need to
-        # reconstruct everything. Check #168 for a state of the work.
-        if sys.platform == 'linux2':
-            self.flags |= pygame.RESIZABLE
+        ### right now, activate resizable window only on linux.
+        ### on window / macosx, the opengl context is lost, and we need to
+        ### reconstruct everything. Check #168 for a state of the work.
+        #
+        # Not necessary to call display.set_mode each time the window is resized.
+        # This is what destroys the opengl context.
+
+        self.flags |= pygame.RESIZABLE
 
         pygame.display.init()
 
@@ -260,14 +263,9 @@ class WindowPygame(WindowBase):
 
     def _do_resize(self, dt):
         Logger.debug('Window: Resize window to %s' % str(self._size))
-        self._pygame_set_mode(self._size)
         self.dispatch('on_resize', *self._size)
 
     def mainloop(self):
-        # don't known why, but pygame required a resize event
-        # for opengl, before mainloop... window reinit ?
-        self.dispatch('on_resize', *self.size)
-
         while not EventLoop.quit and EventLoop.status == 'started':
             try:
                 self._mainloop()
@@ -287,7 +285,6 @@ class WindowPygame(WindowBase):
 
     def _set_size(self, size):
         if super(WindowPygame, self)._set_size(size):
-            self._pygame_set_mode()
             return True
     size = property(WindowBase._get_size, _set_size)
 


### PR DESCRIPTION
Remove calls to `display.set_mode` from resize events, which would reset the GL context each time. It's not necessary to call set_mode after the window is already resized, and I couldn't find any clue about why that code was added. (I used git blame and everything!)

Remove the on_resize call from mainloop(), instead calling update_viewport in `WindowBase.__init__` to initially configure the GL. update_viewport is otherwise never called except in response to a resize event.

Please give this patch a try and let me know if there's something I overlooked. I've been using a resizable pygame window with one of my own projects for over a year and I've never had to reinit the GL context in response to a resize.
