### PR TITLE
Fix textinput backspace when TextInput.readonly is True

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = python2
+PYTHON = python
 CHECKSCRIPT = kivy/tools/pep8checker/pep8kivy.py
 KIVY_DIR = kivy/
 


### PR DESCRIPTION
Sorry for two commits, I need python2 in Makefile because I'm on ArchLinux. I restored the Makefile in the second one.
