### PR TITLE
Added disable_multitouch as a mouse config option

### DIFF
--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -205,8 +205,8 @@ class MouseMotionEventProvider(MotionEventProvider):
         rx = x / float(width)
         ry = 1. - y / float(height)
         cur = self.find_touch(rx, ry)
-        if button in ('left', 'scrollup', 'scrolldown') and cur and not (
-                'ctrl' in modifiers) or self.disable_multitouch:
+        if (button in ('left', 'scrollup', 'scrolldown') or
+                self.disable_multitouch) and cur and not ('ctrl' in modifiers):
             self.remove_touch(cur)
             self.current_drag = None
         if self.alt_touch:


### PR DESCRIPTION
By default middle and right mouse buttons ared used for multitouch emulation.
If you want to use them for other purpose you can disable this behavior by
activating the "disable_multitouch" token.

   [input]
   mouse = mouse,disable_multitouch
