### PR TITLE
Fix setting arguments on Translate instance when args passed in on creation

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -450,7 +450,7 @@ cdef class Translate(Transform):
         Transform.__init__(self)
         if len(args) == 3:
             x, y, z = args
-            self.matrix = Matrix().translate(x, y, z)
+            self.set_translate(x, y, z)
 
     cdef set_translate(self, double x, double y, double z):
         self.matrix = Matrix().translate(x, y, z)


### PR DESCRIPTION
The _x, _y and _z attributes aren't being set if Translate is created with the initial translation arguments. This simple change addresses that.
