### PR TITLE
replace all "from . import" stuff, with absolute imports

### DIFF
--- a/kivy/core/audio/audio_gstreamer.py
+++ b/kivy/core/audio/audio_gstreamer.py
@@ -11,7 +11,7 @@ try:
 except:
     raise
 
-from . import Sound, SoundLoader
+from kivy.core.audio import Sound, SoundLoader
 import os
 import sys
 from kivy.logger import Logger

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -6,7 +6,7 @@ __all__ = ('SoundPygame', )
 
 from kivy.clock import Clock
 from kivy.utils import platform
-from . import Sound, SoundLoader
+from kivy.core.audio import Sound, SoundLoader
 
 try:
     if platform() == 'android':

--- a/kivy/core/camera/camera_gstreamer.py
+++ b/kivy/core/camera/camera_gstreamer.py
@@ -6,7 +6,7 @@ __all__ = ('CameraGStreamer', )
 
 from kivy.clock import Clock
 from kivy.graphics.texture import Texture
-from . import CameraBase
+from kivy.core.camera import CameraBase
 
 try:
     import pygst

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -11,7 +11,7 @@ __all__ = ('CameraOpenCV')
 from kivy.logger import Logger
 from kivy.clock import Clock
 from kivy.graphics.texture import Texture
-from . import CameraBase
+from kivy.core.camera import CameraBase
 
 try:
     cv = __import__('opencv', fromlist='.')

--- a/kivy/core/camera/camera_videocapture.py
+++ b/kivy/core/camera/camera_videocapture.py
@@ -8,7 +8,7 @@ VideoCapture Camera: Implement CameraBase with VideoCapture
 
 __all__ = ('CameraVideoCapture', )
 
-from . import CameraBase
+from kivy.core.camera import CameraBase
 from kivy.clock import Clock
 
 try:

--- a/kivy/core/clipboard/clipboard_dummy.py
+++ b/kivy/core/clipboard/clipboard_dummy.py
@@ -4,7 +4,7 @@ Clipboard Dummy: internal implementation without using system
 
 __all__ = ('ClipboardDummy', )
 
-from . import ClipboardBase
+from kivy.core.clipboard import ClipboardBase
 
 
 class ClipboardDummy(ClipboardBase):

--- a/kivy/core/clipboard/clipboard_pygame.py
+++ b/kivy/core/clipboard/clipboard_pygame.py
@@ -5,7 +5,7 @@ Clipboard Pygame: implementation of clipboard using pygame.scrap.
 __all__ = ('ClipboardPygame', )
 
 from kivy.utils import platform
-from . import ClipboardBase
+from kivy.core.clipboard import ClipboardBase
 
 if platform() not in ('win', 'linux'):
     raise SystemError('unsupported platform for pygame clipboard')

--- a/kivy/core/image/img_dds.py
+++ b/kivy/core/image/img_dds.py
@@ -6,7 +6,7 @@ __all__ = ('ImageLoaderDDS', )
 
 from kivy.lib.ddsfile import DDSFile
 from kivy.logger import Logger
-from . import ImageLoaderBase, ImageData, ImageLoader
+from kivy.core.image import ImageLoaderBase, ImageData, ImageLoader
 
 
 class ImageLoaderDDS(ImageLoaderBase):

--- a/kivy/core/image/img_gif.py
+++ b/kivy/core/image/img_gif.py
@@ -35,7 +35,7 @@ from array import array
 KNOWN_FORMATS = ('GIF87a', 'GIF89a')
 
 from kivy.logger import Logger
-from . import ImageLoaderBase, ImageData, ImageLoader
+from kivy.core.image import ImageLoaderBase, ImageData, ImageLoader
 
 Debug = False
 

--- a/kivy/core/image/img_pil.py
+++ b/kivy/core/image/img_pil.py
@@ -10,7 +10,7 @@ except:
     raise
 
 from kivy.logger import Logger
-from . import ImageLoaderBase, ImageData, ImageLoader
+from kivy.core.image import ImageLoaderBase, ImageData, ImageLoader
 
 
 class ImageLoaderPIL(ImageLoaderBase):

--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -5,7 +5,7 @@ Pygame: Pygame image loader
 __all__ = ('ImageLoaderPygame', )
 
 from kivy.logger import Logger
-from . import ImageLoaderBase, ImageData, ImageLoader
+from kivy.core.image import ImageLoaderBase, ImageData, ImageLoader
 
 try:
     import pygame

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -42,7 +42,7 @@ from kivy.utils import platform
 from kivy.parser import parse_color
 from kivy.logger import Logger
 import re
-from . import Label, LabelBase
+from kivy.core.text import Label, LabelBase
 from copy import copy
 
 # We need to do this trick when documentation is generated

--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -9,7 +9,7 @@ try:
 except:
     raise
 
-from . import LabelBase
+from kivy.core.text import LabelBase
 from kivy.core.image import ImageData
 
 # used for fetching extends before creature image surface

--- a/kivy/core/text/text_pygame.py
+++ b/kivy/core/text/text_pygame.py
@@ -4,7 +4,7 @@ Text Pygame: Draw text with pygame
 
 __all__ = ('LabelPygame', )
 
-from . import LabelBase
+from kivy.core.text import LabelBase
 from kivy.core.image import ImageData
 
 try:

--- a/kivy/core/video/video_ffmpeg.py
+++ b/kivy/core/video/video_ffmpeg.py
@@ -20,7 +20,7 @@ try:
 except:
     raise
 
-from . import VideoBase
+from kivy.core.video import VideoBase
 from kivy.graphics.texture import Texture
 
 

--- a/kivy/core/video/video_gstreamer.py
+++ b/kivy/core/video/video_gstreamer.py
@@ -25,7 +25,7 @@ from kivy.graphics.texture import Texture
 from kivy.logger import Logger
 from functools import partial
 from weakref import ref
-from . import VideoBase
+from kivy.core.video import VideoBase
 
 # install the gobject iteration
 from kivy.support import install_gobject_iteration

--- a/kivy/core/video/video_pyglet.py
+++ b/kivy/core/video/video_pyglet.py
@@ -8,7 +8,7 @@ try:
 except:
     raise
 
-from . import VideoBase
+from kivy.core.video import VideoBase
 
 
 #have to set these before importing pyglet.gl

--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -7,7 +7,7 @@ __all__ = ('WindowPygame', )
 # fail early if possible
 import pygame
 
-from . import WindowBase
+from kivy.core.window import WindowBase
 from kivy.core import CoreCriticalException
 from os import environ
 from os.path import exists, join


### PR DESCRIPTION
usage of "from . import" imports is a bad practice that break tools like pylint/pyreverse, others modules in the same places are imported by absolute path, so that makes for a better coherence too.
