### PR TITLE
updated make-kivy-ext script

### DIFF
--- a/kivy/tools/extensions/make-kivyext.py
+++ b/kivy/tools/extensions/make-kivyext.py
@@ -71,7 +71,7 @@ class PackageBuild(Command):
     def run(self):
         # Call this file and make a distributable .zip file that has our desired
         # folder structure
-        call(['python', 'setup.py', 'install', '--root', 'output/',
+        call([sys.executable, 'setup.py', 'install', '--root', 'output/',
             '--install-lib', '/', '--install-platlib', '/', '--install-data',
             '/%(extname)s/data', 'bdist', '--formats=zip'])
         files = os.listdir('dist')


### PR DESCRIPTION
- i **didn't** change the shebang line
- examples in use:
  
  python setup.py create_package
  python2 setup.py create_package
  python2.6 setup.py create_package
  python2.7 setup.py create_package

Without this patch, whatever the version of python is revered to `$PATH/python` is run irrespective of what the **user** chooses at the command line.
