### PR TITLE
- made it so that option values are automatically converted to a string

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -206,6 +206,9 @@ class ConfigParser(PythonConfigParser):
         PythonConfigParser.read(self, filename)
 
     def set(self, section, option, value):
+        '''Functions similarly to PythonConfigParser's set method, except that
+        the value is implicitly converted to a string.
+        '''
         return PythonConfigParser.set(self, section, option, str(value))
 
     def setdefaults(self, section, keyvalues):


### PR DESCRIPTION
Commit messages is self-explanatory, but essentially, ConfigParser expects strings when using set() [1]. If not, a Type error is passed. I've opted for implicit conversion to string to avoid this. Also addresses issue #555
