### PR TITLE
Callable filters support for kivy.uix.filechooser

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -153,6 +153,11 @@ class FileChooserController(FloatLayout):
       [!seq]     matches any character not in seq
       ========== =================================
 
+    Also possible is for an entry in this list to be a callable (function or
+    method) that will be called with the path and a name as arguments.  This
+    function returns True to indicate a match or False to indicate that there
+    is no match.
+    .. versionadded:: 1.4.0
     '''
 
     filter_dirs = BooleanProperty(False)


### PR DESCRIPTION
Callable filters are useful for things like content-aware filtering (eg: a filter that shows all loadable images regardless of extensions) but could also provide other matching mechanisms such as regexes, predicates (eg: file size > some number), etc.  You might also use as the filter the method of a class whose properties control what the filter does.
