### PR TITLE
UIX: Widget: ensure widget is removed from any parent before adding it.

### DIFF
--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -157,6 +157,7 @@ class Bubble(GridLayout):
             color=self.background_color)
         self.content = content = BubbleContent(parent=self)
         super(Bubble, self).__init__(**kwargs)
+        content.parent = None
         self.add_widget(content)
         self.on_arrow_pos()
 
@@ -226,6 +227,10 @@ class Bubble(GridLayout):
         self_arrow_img.height = self_arrow_img.texture_size[1]
         widget_list = []
         arrow_list = []
+        parent = self_arrow_img.parent
+        if parent:
+            parent.remove_widget(self_arrow_img)
+
         if self_arrow_pos[0] == 'b' or self_arrow_pos[0] == 't':
             self.cols = 1
             self.rows = 2

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -393,6 +393,9 @@ class TabbedPanel(GridLayout):
         content = self.content
         if content is None:
             return
+        parent = widget.parent
+        if widget.parent:
+            parent.remove_widget(widget)
         if widget == content or widget == self._tab_layout:
             super(TabbedPanel, self).add_widget(widget, index)
         elif isinstance(widget, TabbedPanelHeader):
@@ -491,6 +494,8 @@ class TabbedPanel(GridLayout):
         tab_layout.clear_widgets()
         scrl_v = ScrollView(size_hint=(None, 1))
         tabs = self._tab_strip
+        if tabs.parent:
+            tabs.parent.remove_widget(tabs)
         scrl_v.add_widget(tabs)
         scrl_v.pos = (0, 0)
         self_update_scrollview = self._update_scrollview

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -65,6 +65,7 @@ from kivy.properties import NumericProperty, StringProperty, \
 from kivy.graphics import Canvas
 from kivy.base import EventLoop
 from kivy.lang import Builder
+from kivy.logger import Logger
 
 
 class WidgetException(Exception):
@@ -230,7 +231,10 @@ class Widget(EventDispatcher):
         parent = widget.parent
         # ensure widget isn't already added to another widget
         if parent:
-            parent.remove_widget(widget)
+            Logger.warning(''.join(('Cannot add Widget ', str(widget),\
+                ' It already has a parent ', str(parent),
+                ' Skipping addition')))
+            return
         widget.parent = self
         if index == 0 or len(self.children) == 0:
             self.children.insert(0, widget)


### PR DESCRIPTION
should fix:  #562

Took the approach of adding this in Widget itself instead just in popup as,
I've seen many situations when a Widget is accidentally made a child of
more than one Widgets and in all of them the result is a Clock->max iteration error.
