### PR TITLE
Propogated icon property to window

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -238,6 +238,8 @@ class WindowBase(EventDispatcher):
     You must take care of it if you are doing recursive check.
     '''
 
+    icon = StringProperty()
+
     def _get_modifiers(self):
         return self._modifiers
 
@@ -591,7 +593,7 @@ class WindowBase(EventDispatcher):
 
         .. versionadded:: 1.0.5
         '''
-        pass
+        self.icon = filename
 
     def to_widget(self, x, y, initial=True, relative=False):
         return (x, y)

--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -103,7 +103,8 @@ class WindowPygame(WindowBase):
 
         # set window icon before calling set_mode
         try:
-            filename_icon = Config.get('kivy', 'window_icon')
+            #filename_icon = Config.get('kivy', 'window_icon')
+            filename_icon = self.icon or Config.get('kivy', 'window_icon')
             if filename_icon == '':
                 logo_size = 512 if platform() == 'darwin' else 32
                 filename_icon = join(kivy_home_dir, 'icon', 'kivy-icon-%d.png' %
@@ -164,6 +165,7 @@ class WindowPygame(WindowBase):
             if im is None:
                 raise Exception('Unable to load window icon (not found)')
             pygame.display.set_icon(im)
+            super(WindowPygame, self).set_icon(filename)
         except:
             Logger.exception('WinPygame: unable to set icon')
 


### PR DESCRIPTION
Fixes issue #560. 

This is a second go at it. Seemed appropriate that the window should keep track of it's icon property. See the aforementioned issue for an explanation as to why this implementation is superior.
