### PR TITLE
- now possible to set a window's size at runtime (respects rotation)

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -250,17 +250,22 @@ class WindowBase(EventDispatcher):
     def _get_size(self):
         r = self._rotation
         w, h = self._size
-        if r == 0 or r == 180:
+        if r in (0, 180):
             return w, h
         return h, w
 
     def _set_size(self, size):
-        if super(WindowBase, self)._set_size(size):
-            Logger.debug('Window: Resize window to %s' % str(self.size))
+        if self._size != size:
+            r = self._rotation
+            if r in (0, 180):
+                self._size = size
+            else:
+                self._size = size[1], size[0]
+
             self.dispatch('on_resize', *size)
             return True
-        return False
-
+        else:
+            return False
     size = AliasProperty(_get_size, _set_size)
     '''Get the rotated size of the window. If :data:`rotation` is set, then the
     size will change to reflect the rotation.


### PR DESCRIPTION
Given the following code, kivy crashes with an attribute error, since EventDispatcher doesn't have a _size attribute:

``` python
from kivy.app import App
from kivy.factory import Factory

class Foo(App):
    def on_start(self):
        self._app_window.size = 10, 10

if __name__ == '__main__':
    Foo().run()
```

I've reworked the logic of the _set_size method to correct this. One thing to point out is that similarly to the _get_size method, I accommodate for rotation. If this shouldn't be so, let me know and I'll revert it. 

It might also be worth implementing a window property to give direct access to the app's window. If you agree, I'll implement that as well.
