### PR TITLE
No Warnings, Again

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,8 +3,8 @@
 
 # You can set these variables from the command line.
 PYTHON		  = python
-#SPHINXOPTS    = -W
-SPHINXOPTS    =
+SPHINXOPTS    = -W
+#SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -63,8 +63,7 @@ release = kivy.__version__
 today_fmt = '%B %d, %Y'
 
 # suppress exclusion warnings
-#exclude_patterns = ['gettingstarted/*', 'api-index.rst',
-#    'api-kivy.lib.osc.*', 'guide/layouts.rst']
+exclude_patterns = ['gettingstarted/*', 'guide/layouts.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/doc/sources/contents.rst.inc
+++ b/doc/sources/contents.rst.inc
@@ -6,6 +6,7 @@ and why you'd want to use it.
 It goes on with a discussion of the architecture and shows you how to create
 stunning applications in short time using the framework.
 
+
 .. toctree::
     :maxdepth: 2
 

--- a/doc/sources/gettingstarted/framework.rst
+++ b/doc/sources/gettingstarted/framework.rst
@@ -15,7 +15,7 @@ Non-widget stuff
 
 .. |atlas_text| replace:: :class:`Atlas <kivy.atlas.Atlas>` is a class for managing texture maps, i.e. packing multiple textures into one image. Using it allows you to reduce the number of images to load and speed up the application start.
 
-.. |clock_text| replace:: :class:`Clock <kivy.clock.Clock>` provides you with a convenient way to do jobs at set time intervals and is preferred over *sleep()*  which would block the kivy Event Loop. These intervals can be set relative to the OpenGL Drawing instructions, :ref:`before <schedule-before-frame>` or :ref:`after <schedule-after-frame>` frame.  Clock also provides you with a way to create :ref:`triggered events <triggered-events>` that are grouped together and only called once before the next frame.
+.. |clock_text| replace:: :class:`Clock <kivy.clock.Clock>` provides you with a convenient way to do jobs at set time intervals and is preferred over *sleep()*  which would block the kivy Event Loop. These intervals can be set relative to the OpenGL Drawing instructions, :ref:`before <schedule-before-frame>` or :ref:`after <schedule-before-frame>` frame.  Clock also provides you with a way to create :ref:`triggered events <triggered-events>` that are grouped together and only called once before the next frame.
 
 .. |sched_once| replace:: :meth:`~kivy.clock.ClockBase.schedule_once`
 .. |sched_intrvl| replace:: :meth:`~kivy.clock.ClockBase.schedule_interval`

--- a/doc/sources/index.rst
+++ b/doc/sources/index.rst
@@ -1,5 +1,6 @@
 :orphan:
 
+
 Welcome to Kivy
 ===============
 
@@ -18,6 +19,28 @@ If you want to contribute to Kivy, make sure to read :ref:`contributing`. If you
 concern isn't addressed in the documentation, feel free to :ref:`contact`.
 
 .. include:: contents.rst.inc
+
+.. Suppress warnings about documents not being included in toc, but don't
+   actually show them. 
+.. toctree::
+    :hidden:
+
+    api-index
+    api-kivy.lib.osc.OSC
+    api-kivy.lib.osc.oscAPI
+..  gettingstarted/diving
+    gettingstarted/drawing
+    gettingstarted/events
+    gettingstarted/examples
+    gettingstarted/first_app
+    gettingstarted/framework
+    gettingstarted/installation
+    gettingstarted/intro
+    gettingstarted/layouts
+    gettingstarted/packaging
+    gettingstarted/properties
+    gettingstarted/rules
+    guide/layouts
 
 
 Appendix

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -59,6 +59,8 @@ module::
 
         # and keep the instance of foo, until you don't need it anymore!
 
+.. _schedule-before-frame:
+
 Schedule before frame
 ---------------------
 
@@ -84,6 +86,8 @@ If you need to increase the limit, set the :data:`max_iteration` property::
 
     from kivy.clock import Clock
     Clock.max_iteration = 20
+
+.. _triggered-events:
 
 Triggered Events
 ----------------


### PR DESCRIPTION
This time, I decided to use a hidden TOC. From what I understood of tito's comments, he was concerned about docs being skipped all together when processing them. There are now two ways to handle the issue:
- keep exclude_patterns enabled: The way I see it, the docs should in fact be excluded since they aren't yet being used. Once they are used, simply remove them from exclude patterns. I'm not sure that these files not getting regenerated is relevant, as they aren't in use in the first place.
- disable exclude_patterns and enable hiddne toctree: sources/index has a hidden toctree which serves the same purpose (in this use case) as exclude_patterns does in conf.py. In case my previous points aren't sufficient, I thought it might be worth trying this out instead. 

The reason I am so adamant about having warnings treated as errors by default is that its much easier to uncover documentation errors (such as the fact that certain labels didn't exist when I implemented these changes). While I could enable such strictness on my end alone, I'm not sure its fair that I (or anyone else) have to fix documentation errors after the fact if they could have been fixed sooner. 

Your thoughts?
