### PR TITLE
force dirname output to "." when blank

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -370,6 +370,8 @@ class App(EventDispatcher):
         '''
         try:
             default_kv_directory = dirname(getfile(self.__class__))
+            if default_kv_directory == '':
+                default_kv_directory = '.'
         except TypeError:
             # if it's a builtin module.. use the current dir.
             default_kv_directory = '.'
@@ -491,6 +493,8 @@ class App(EventDispatcher):
         if self._app_directory is None:
             try:
                 self._app_directory = dirname(getfile(self.__class__))
+                if self._app_directory == '':
+                    self._app_directory = '.'
             except TypeError:
                 # if it's a builtin module.. use the current dir.
                 self._app_directory = '.'


### PR DESCRIPTION
Issue #595, using `%`-substitution isn't as clever as `os.path.join` is, so convert `dirname` output instead.  (This is as portable as the existing code, which forces `'.'` when `inspect.getfile` throws a `TypeError`.)
