### PR TITLE
Simplified select method signature

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 '''
 Drop-Down List
 ==============
@@ -193,7 +194,7 @@ class DropDown(ScrollView):
             self.attach_to.unbind(pos=self._reposition, size=self._reposition)
             self.attach_to = None
 
-    def select(self, data, *ignored):
+    def select(self, data):
         '''Call this method to trigger the `on_select` event, with the `data`
         selection. The `data` can be anything you want.
         '''
@@ -291,7 +292,7 @@ if __name__ == '__main__':
         dp.bind(on_select=lambda instance, x: setattr(button, 'text', x))
         for i in xrange(10):
             item = Button(text='hello %d' % i, size_hint_y=None, height=44)
-            item.bind(on_release=partial(dp.select, item.text))
+            item.bind(on_release=lambda button: dp.select(button.text))
             dp.add_widget(item)
         dp.open(button)
 


### PR DESCRIPTION
In client code, you can use lambda instead of partial which prevents you from needing the cryptic *ignored attribute. As an added bonus, the argument passed to lambda _is_ used, so there isn't any 'useless' code. 
