### PR TITLE
fix url loader bug with querysrtings #547

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -316,6 +316,10 @@ class ImageLoader(object):
         # extract extensions
         ext = filename.split('.')[-1].lower()
 
+        # prevent url querystrings
+        if filename.startswith((('http://', 'https://'))):
+            ext = ext.split('?')[0]
+
         # special case. When we are trying to load a "zip" file with image, we
         # will use the special zip_loader in ImageLoader. This might return a
         # sequence of images contained in the zip.


### PR DESCRIPTION
check if image is http(s) based then removed the eventual querystring before checking file extension
