### PR TITLE
Core: markup and text allow for blanks lines when using \n for empty

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -287,6 +287,8 @@ class LabelBase(object):
 
                 # calculate the word width
                 ww, wh = 0, 0
+                if word == '':
+                    ww, wh = get_extents(' ')
                 for glyph in word:
                     gw, gh = cache[glyph]
                     ww += gw

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -198,6 +198,7 @@ class MarkupLabel(MarkupLabelBase):
 
         # verify that each glyph have size
         glyphs = list(set(word))
+        glyphs.append(' ')
         get_extents = self.get_extents
         for glyph in glyphs:
             if not glyph in cache:
@@ -219,7 +220,7 @@ class MarkupLabel(MarkupLabelBase):
         for part in re.split(r'( |\n)', word):
 
             if part == '':
-                continue
+                part = ' '
 
             if part == '\n':
                 # put a new line!
@@ -266,7 +267,7 @@ class MarkupLabel(MarkupLabelBase):
         y = 0
         w, h = self._size
         refs = self._refs
-        no_of_lines = len(self._lines)
+        txt_height = sum(line[1] for line in self._lines)
 
         for line in self._lines:
             lh = line[1]
@@ -283,9 +284,9 @@ class MarkupLabel(MarkupLabelBase):
             # vertical alignement
             if y == 0:
                 if av == 1:
-                    y = int((h - (lh*no_of_lines))/2)
+                    y = int((h - txt_height)/2)
                 elif av == 2:
-                    y = h - (lh*(no_of_lines))
+                    y = h - (txt_height)
 
 
             for pw, ph, part, options in line[2]:


### PR DESCRIPTION
lines
should fix issue #619

Using label to display blank lines around lines using `\n` didn't use to work.
This facilitates also that, so now you you can use `My First line\n\nfollowed by blank second line` to 
display a empty line at a desired place using `\n`.

I was wondering about the policy for unit tests for issues. If I adapt the following code http://paste.kde.org/531194/ to write a test for the fore mentioned issue. Should I be creating a separate test_issue_619.py or should I move the tests meant for markup/label in one file `test_markup.py` and move these tests to `def test_619(...)` functions?
