### PR TITLE
Alternative Unicode Label Fix

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -401,6 +401,8 @@ class LabelBase(object):
         except AttributeError:
             # python 3 support
             return str(self._text)
+        except UnicodeEncodeError:
+            return self._text
 
     def _set_text(self, text):
         if text != self._text:


### PR DESCRIPTION
- fixes issue #649, simpler alternative to pull request # 651
- doesn't touch `kivy.uix.label` and remains compatible with python 3 (for future porting efforts)

Seemed to me that the issue was in accessing text, not writing it, so I tried a different approach. Another benefit of this version is more specific exception handling, which should make it easier to debug further issues as other exceptions won't fall through unnoticed.
