### PR TITLE
Fixed bug with adding a Camera widget in .kv file

### DIFF
--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -96,6 +96,8 @@ class Camera(Image):
         self._camera = None
         if self.index < 0:
             return
+        if self.resolution[0] < 0 or self.resolution[1] < 0:
+            return
         self._camera = CoreCamera(index=self.index,
             resolution=self.resolution, stopped=True)
         self._camera.bind(on_load=self._camera_loaded)


### PR DESCRIPTION
The resolution property is not initialized before _on_index() is called.
So the app crashes because [-1, -1] is not a supported resolution.

...
Camera:
    resolution: (640, 480)
    index: 0
