### PR TITLE
Faster text input insertion and deletion

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -240,12 +240,12 @@ class TextInput(Widget):
         self.bind(font_size=self._trigger_refresh_line_options,
                   font_name=self._trigger_refresh_line_options)
 
-        self.bind(padding_x=self._trigger_refresh_text,
-                  padding_y=self._trigger_refresh_text,
-                  tab_width=self._trigger_refresh_text,
-                  font_size=self._trigger_refresh_text,
-                  font_name=self._trigger_refresh_text,
-                  size=self._trigger_refresh_text)
+        self.bind(padding_x=self._update_text_options,
+                  padding_y=self._update_text_options,
+                  tab_width=self._update_text_options,
+                  font_size=self._update_text_options,
+                  font_name=self._update_text_options,
+                  size=self._update_text_options)
 
         self.bind(pos=self._trigger_update_graphics)
 
@@ -902,6 +902,10 @@ class TextInput(Widget):
         Clock.schedule_once(
             lambda *args: self._refresh_text_from_property(*largs))
 
+    def _update_text_options(self, *largs):
+        Cache_remove('textinput.width')
+        self._trigger_refresh_text()
+
     def _refresh_text_from_property(self, *largs):
         self._refresh_text(self.text, *largs)
 
@@ -1096,7 +1100,6 @@ class TextInput(Widget):
         miny = self.y + _padding_y
         maxy = _top - _padding_y
         draw_selection = self._draw_selection
-        #scroll_y = self.scroll_y
         a, b = self._selection_from, self._selection_to
         if a > b:
             a, b = b, a


### PR DESCRIPTION
Using the perf test from here https://github.com/kivy/kivy/pull/661. This is the difference I get.
## With master branch

```
=====================
Test: load_large_text
=====================
loading uix/textinput.py....
putting text in textinput
mem usage after test
44 MB
------------------------------------------
Loaded 1602 lines 1.22284793854 secs
------------------------------------------
=====================
Test: stress_insert
=====================
[INFO   ] [Clipboard   ] using <pygame> as clipboard provider
Done!
pasted 1602 lines 9.0 times
mem usage after test
120 MB
total lines in text input: 17612
--------------------------------------
total time elapsed: 27.5229020119
--------------------------------------
=====================
Test: stress_del
=====================
Done!
deleted 210 characters 9 times
mem usage after test
159 MB
total lines in text input: 17553
--------------------------------------
total time elapsed: 75.9813170433
--------------------------------------
=====================
Test: stress_selection
=====================
Done!
mem usage after test
159 MB
--------------------------------------
total time elapsed: 0
--------------------------------------
===================
All Tests Completed
===================
```
## with this branch

```
=====================
Test: load_large_text
=====================
loading uix/textinput.py....
putting text in textinput
mem usage after test
45 MB
------------------------------------------
Loaded 1699 lines 0.942888975143 secs
------------------------------------------
=====================
Test: stress_insert
=====================
[INFO   ] [Clipboard   ] using <pygame> as clipboard provider
Done!
pasted 1699 lines 8.0 times
mem usage after test
89 MB
total lines in text input: 16981
--------------------------------------
total time elapsed: 3.90121006966
--------------------------------------
=====================
Test: stress_del
=====================
Done!
deleted 210 characters 9 times
mem usage after test
91 MB
total lines in text input: 16922
--------------------------------------
total time elapsed: 2.36115598679
--------------------------------------
=====================
Test: stress_selection
=====================
Done!
mem usage after test
91 MB
--------------------------------------
total time elapsed: 0
--------------------------------------
===================
All Tests Completed
===================
```
