### PR TITLE
UIX: Slider: fix value when min and step > 0 ( #694 )

### DIFF
--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -112,7 +112,7 @@ class Slider(Widget):
         if step == 0:
             self.value = val
         else:
-            self.value = min(round((val - vmin) / step) * step, self.max)
+            self.value = min(round((val - vmin) / step) * step, self.max) + vmin
     value_normalized = AliasProperty(get_norm_value, set_norm_value,
                                      bind=('value', 'min', 'max', 'step'))
     '''Normalized value inside the :data:`range` (min/max) to 0-1 range::
@@ -173,6 +173,10 @@ class Slider(Widget):
 
     :data:`value_pos` is an :class:`~kivy.properties.AliasProperty`.
     '''
+
+    def __init__(self, **kwargs):
+        super(Slider, self).__init__(**kwargs)
+        self.value_normalized = 0.1
 
     def on_touch_down(self, touch):
         if self.collide_point(*touch.pos):


### PR DESCRIPTION
Slider position calculation was a bit off when `min` and `set` were > 0.
This should fix issue #694
