### PR TITLE
fix for slider bug when min<0, max>0 and step>0

### DIFF
--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -112,7 +112,7 @@ class Slider(Widget):
         if step == 0:
             self.value = val
         else:
-            self.value = min(round((val - vmin) / step) * step, self.max) + vmin
+            self.value = min(round((val - vmin) / step) * step + vmin, self.max)
     value_normalized = AliasProperty(get_norm_value, set_norm_value,
                                      bind=('value', 'min', 'max', 'step'))
     '''Normalized value inside the :data:`range` (min/max) to 0-1 range::


### PR DESCRIPTION
Bug #694 was recently closed, but it was not totally fixed. The case where slider min is negative and step is not zero still had problems. This changeset fixes this last issue.
