### PR TITLE
NumericProperty: return `value` when called before dpi is set

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -443,6 +443,11 @@ cdef class NumericProperty(Property):
         global EventLoop
         if EventLoop is None:
             from kivy.base import EventLoop
+            try:
+                EventLoop.dpi
+            except AttributeError:
+                return float(value)
+
         cdef float rv = float(value)
         cdef float dpi = EventLoop.dpi
         obj.__storage[self.name]['format'] = ext


### PR DESCRIPTION
I'm not sure if this the correct solution, or why exactly is the dpi not accessible at such a early stage.
(some issue with reify?). 
