### PR TITLE
Lexer got moved to kivy.extras package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -326,7 +326,7 @@ setup(
         'kivy.tools.packaging',
         'kivy.tools.packaging.pyinstaller_hooks',
         'kivy.tools.highlight',
-        'kivy.tools.highlight.pygments',
+        'kivy.extras',
         'kivy.tools.extensions',
         'kivy.uix', ],
     package_dir={'kivy': 'kivy'},


### PR DESCRIPTION
setup.py was broken by a recent commit for the code highlighter. This fixes it.
