### PR TITLE
UIX:Label honour `color` property when using makup

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -3,7 +3,7 @@
 <Label>:
     canvas:
         Color:
-            rgba: self.color
+            rgba: self.color if not self.markup else (1, 1, 1, 1)
         Rectangle:
             texture: self.texture
             size: self.texture_size

--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -43,6 +43,7 @@ from kivy.uix.textinput import TextInput
 from kivy.core.text.markup import MarkupLabel as Label
 from kivy.cache import Cache
 from kivy.properties import ObjectProperty
+from kivy.utils import get_hex_from_color
 
 Cache_get = Cache.get
 Cache_append = Cache.append
@@ -75,24 +76,13 @@ class CodeInput(TextInput):
         # use text_color as foreground color
         text_color = kwargs.get('foreground_color')
         if text_color:
-            get_hex_clr = self.get_hex_clr
-            self.text_color = ''.join(('#',
-                get_hex_clr(text_color[0]),
-                get_hex_clr(text_color[1]),
-                get_hex_clr(text_color[2]),
-                get_hex_clr(text_color[3])))
+            self.text_color = get_hex_from_color(text_color)
         # set foreground to white to allow text colors to show
         # use text_color as the default color in bbcodes
         self.use_text_color = False
         self.foreground_color = [1, 1, 1, .999]
         if not kwargs.get('background_color'):
             self.background_color = [.9, .92, .92, 1]
-
-    def get_hex_clr(self, color):
-        clr = hex(int(color * 255))[2:]
-        if len(str(clr)) < 2:
-            clr = ''.join(('0', str(clr)))
-        return clr
 
     def _create_line_label(self, text):
         # Create a label from a text, using line options
@@ -171,12 +161,7 @@ class CodeInput(TextInput):
         if not self.use_text_color:
             self.use_text_color = True
             return
-        get_hex_clr = self.get_hex_clr
-        self.text_color = ''.join((
-                get_hex_clr(text_color[0]),
-                get_hex_clr(text_color[1]),
-                get_hex_clr(text_color[2]),
-                get_hex_clr(text_color[3])))
+        self.text_color = get_hex_from_color(text_color)
         self.use_text_color = False
         self.foreground_color = (1, 1, 1, .999)
         self._trigger_refresh_text()

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -103,6 +103,7 @@ from kivy.core.text.markup import MarkupLabel as CoreMarkupLabel
 from kivy.properties import StringProperty, OptionProperty, \
         NumericProperty, BooleanProperty, ReferenceListProperty, \
         ListProperty, ObjectProperty, DictProperty
+from kivy.utils import get_hex_from_color
 
 
 class Label(Widget):
@@ -178,10 +179,18 @@ class Label(Widget):
         if self._label.text.strip() == '':
             self.texture_size = (0, 0)
         else:
-            self._label.refresh()
-            if self._label.__class__ is CoreMarkupLabel:
+            mrkup = self._label.__class__ is CoreMarkupLabel
+            if mrkup:
+                text = self._label.text
+                self._label.text = ''.join(('[color=',
+                                            get_hex_from_color(self.color), ']',
+                                            text, '[/color]'))
+                self._label.refresh()
+                self._label.text = text
                 self.refs = self._label.refs
                 self.anchors = self._label.anchors
+            else:
+                self._label.refresh()
             texture = self._label.texture
             if texture is not None:
                 self.texture = self._label.texture

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -6,7 +6,7 @@ Utils
 '''
 
 __all__ = ('intersection', 'difference', 'strtotuple',
-           'get_color_from_hex', 'get_random_color',
+           'get_color_from_hex', 'get_hex_from_color', 'get_random_color',
            'is_color_transparent', 'boundary',
            'deprecated', 'SafeList',
            'interpolate', 'OrderedDict', 'QueryDict',
@@ -92,6 +92,17 @@ def get_color_from_hex(s):
     if len(value) == 3:
         value.append(1)
     return value
+
+
+def get_hex_from_color(color):
+    '''Transform from kivy color to hex'''
+    hex_clr = '#'
+    for clr in color:
+        clr = hex(int(clr * 255))[2:]
+        if len(str(clr)) < 2:
+            clr = ''.join(('0', str(clr)))
+        hex_clr += clr
+    return hex_clr
 
 
 def get_random_color(alpha=1.0):


### PR DESCRIPTION
The `color` property for label was conflicting markup colours as setting `color` to anything other than 1, 1, 1, 1 meant that markup colours were affected. 

This fix works around the issue by wrapping around a tag [color=#self.color_in_hex] text [/color], and forcing the `color` to 1, 1, 1, 1  if markup is True.

This also introduces a new function in kivy.utils  `get_hex_from_color` for getting a hex from kivy color.

To reproduce the issue or test this patch::

1) Run demo/exampleskivycatalog (love this thing :D)
2) Choose `Labels` from the Buttons on the left
3) In the editor on the right add a color property to the label with the text "label with markup" 
