### PR TITLE
Amending docstring: precision on non-fullscreen ModalViews/Popups

### DIFF
--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -8,8 +8,9 @@ The :class:`ModalView` widget is used to create modal views. By default, the
 view will cover the whole "parent" window.
 
 Remember that the default size of a Widget is size_hint=(1, 1). If you don't
-want your view to be fullscreen, deactivate the size_hint and use a specific
-size attribute.
+want your view to be fullscreen, either use lower than 1 size hints (for
+instance size_hint=(.8, .8)) or deactivate the size_hint and use fixed size
+attributes.
 
 Examples
 --------

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -12,8 +12,9 @@ will cover the whole "parent" window. When you are creating a popup, you must at
 a minimum set a :data:`Popup.title` and a :data:`Popup.content` widget.
 
 Remember that the default size of a Widget is size_hint=(1, 1). If you don't
-want your popup to be fullscreen, deactivate the size_hint and use a specific
-size attribute.
+want your popup to be fullscreen, either use lower than 1 size hints (for
+instance size_hint=(.8, .8)) or deactivate the size_hint and use fixed size
+attributes.
 
 
 .. versionchanged:: 1.4.0


### PR DESCRIPTION
It seems to me that one can create a non-fullscreen ModalView/Popup by using size_hints lower than 1. I tested this on Popup, and since the docstring is the same in ModalView, I fixed both.
