### PR TITLE
A script to allow for a portable version of Kivy under Wine

### DIFF
--- a/kivy/tools/packaging/win32/kivyenvwine.sh
+++ b/kivy/tools/packaging/win32/kivyenvwine.sh
@@ -66,7 +66,7 @@ echo 'Convert to windows path:' $KIVY_PORTABLE_ROOT
 KIVY_PORTABLE_ROOT_PY="$(python -c 'import os, sys; print os.path.realpath(sys.argv[1])' $KIVY_PORTABLE_ROOT/kivy)"
 # Weird bug happens if this check is not done.
 if [ -z $PYTHONPATH ]; then
-    export PYTHONPATH="$KIVY_PORTABLE_ROOT_PY"
+    export PYTHONPATH="$KIVY_PORTABLE_ROOT_PY\\"
 else
     export PYTHONPATH="$KIVY_PORTABLE_ROOT_PY\;$PYTHONPATH"
 fi


### PR DESCRIPTION
I modified the kivyenv.sh into a new file, kivyenvwine.sh, so that the portable version can be run from Wine (which, of course, would be used with PyInstaller.)
