### PR TITLE
DropDown._reposition() mis-calculating the width of widget.

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -246,7 +246,7 @@ class DropDown(ScrollView):
         if not widget or not win:
             return
         wx, wy = widget.to_window(*widget.pos)
-        wtop, wright = widget.to_window(widget.top, widget.right)
+        wright, wtop = widget.to_window(widget.right, widget.top)
 
         # set width and x
         if self.auto_width:


### PR DESCRIPTION
to_window() coordinate mis-conversion
x, y axis parameter must be set to argument [0], [1] order.
