### PR TITLE
python2.6 compatible format strings

### DIFF
--- a/kivy/core/__init__.py
+++ b/kivy/core/__init__.py
@@ -38,7 +38,7 @@ def core_select_lib(category, llist, create_instance=False):
             # module activated in config ?
             if option not in kivy.kivy_options[category]:
                 libs_ignored.append(modulename)
-                Logger.debug('{}: Provider <{}> ignored by config'.format(
+                Logger.debug('{0}: Provider <{1}> ignored by config'.format(
                     category.capitalize(), option))
                 continue
 
@@ -50,35 +50,35 @@ def core_select_lib(category, llist, create_instance=False):
             cls = mod.__getattribute__(classname)
 
             # ok !
-            Logger.info('{}: Provider: {}{}'.format(
+            Logger.info('{0}: Provider: {1}{2}'.format(
                 category.capitalize(), option,
-                '({} ignored)'.format(libs_ignored) if libs_ignored else ''))
+                '({0} ignored)'.format(libs_ignored) if libs_ignored else ''))
             if create_instance:
                 cls = cls()
             return cls
 
         except ImportError as e:
             libs_ignored.append(modulename)
-            Logger.debug('{}: Ignored <{}> (import error)'.format(
+            Logger.debug('{0}: Ignored <{1}> (import error)'.format(
                 category.capitalize(), option))
             Logger.trace('', exc_info=e)
 
         except CoreCriticalException as e:
-            Logger.error('{}: Unable to use {}'.format(
+            Logger.error('{0}: Unable to use {1}'.format(
                     category.capitalize(), option))
             Logger.error(
-                    '{}: The module raised an important error: {!r}'.format(
+                    '{0}: The module raised an important error: {1!r}'.format(
                     category.capitalize(), e.message))
             raise
 
         except Exception as e:
             libs_ignored.append(modulename)
-            Logger.trace('{}: Unable to use {}'.format(
+            Logger.trace('{0}: Unable to use {1}'.format(
                 category.capitalize(), option, category))
             Logger.trace('', exc_info=e)
 
     Logger.critical(
-        '{}: Unable to find any valuable {} provider at all!'.format(
+        '{0}: Unable to find any valuable {1} provider at all!'.format(
         category.capitalize(), category.capitalize()))
 
 
@@ -92,7 +92,7 @@ def core_register_libs(category, libs):
         try:
             # module activated in config ?
             if option not in kivy.kivy_options[category]:
-                Logger.debug('{}: option <{}> ignored by config'.format(
+                Logger.debug('{0}: option <{1}> ignored by config'.format(
                     category.capitalize(), option))
                 libs_ignored.append(lib)
                 continue
@@ -107,13 +107,13 @@ def core_register_libs(category, libs):
             libs_loaded.append(lib)
 
         except Exception as e:
-            Logger.trace('{}: Unable to use <{}> as loader!'.format(
+            Logger.trace('{0}: Unable to use <{1}> as loader!'.format(
                 category.capitalize(), option))
             Logger.trace('', exc_info=e)
             libs_ignored.append(lib)
 
-    Logger.info('{}: Providers: {} {}'.format(
+    Logger.info('{0}: Providers: {1} {2}'.format(
         category.capitalize(),
         ', '.join(libs_loaded),
-        '({} ignored)'.format(', '.join(libs_ignored)) if libs_ignored else ''))
+        '({0} ignored)'.format(', '.join(libs_ignored)) if libs_ignored else ''))
 


### PR DESCRIPTION
G'day!

Very small patch -- the recent changes to logging in kivy/core/**init**.py are using the new string format() with empty field specifiers, which are supported by Python 2.7 onwards. This patch supplies the field indices, so it will work with Python 2.6.

Really enjoying this project, thankyou for your efforts. The API is so well thought-through, an absolute joy to work with.
