### PR TITLE
Added on_load dispatch to gstreamer video class

### DIFF
--- a/kivy/core/video/video_gstreamer.py
+++ b/kivy/core/video/video_gstreamer.py
@@ -104,6 +104,7 @@ class VideoGStreamer(VideoBase):
             # texture is not allocated yet, so create it first
             self._texture = Texture.create(size=size, colorfmt='rgb')
             self._texture.flip_vertical()
+            self.dispatch('on_load')
         # upload texture data to GPU
         self._texture.blit_buffer(buf.data, size=size, colorfmt='rgb')
 


### PR DESCRIPTION
The gstreamer videos weren't firing an on_load if the texture didn't exist.
Simple one liner added.
