### PR TITLE
Update kivy/modules/__init__.py

### DIFF
--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -117,8 +117,12 @@ class ModuleBase:
             module = __import__(name=modname)
             module = sys.modules[modname]
         except ImportError:
-            Logger.exception('Modules: unable to import <%s>' % name)
-            raise
+            try:
+                module = __import__(name=name)
+                module = sys.modules[name]
+            except ImportError:
+                Logger.exception('Modules: unable to import <%s>' % name)
+                raise
         # basic check on module
         if not hasattr(module, 'start'):
             Logger.warning('Modules: Module <%s> missing start() function' %


### PR DESCRIPTION
handle ImportError: try to import just by module name (in case it is user module, not kivy.modules.\* one)
