### PR TITLE
uix:GridLayout honour width/height for the col/row only if all the

### DIFF
--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -320,13 +320,17 @@ class GridLayout(Layout):
 
                 # compute minimum size / maximum stretch needed
                 if shw is None:
-                    cols[col] = max(cols[col], w)
+                    if not cols_sh[col]:
+                        cols[col] = max(cols[col], w)
                 else:
                     cols_sh[col] = max(cols_sh[col], shw)
+                    cols[col] = 0
                 if shh is None:
-                    rows[row] = max(rows[row], h)
+                    if not rows_sh[row]:
+                        rows[row] = max(rows[row], h)
                 else:
                     rows_sh[row] = max(rows_sh[row], shh)
+                    rows[row] = 0
 
                 # next child
                 i = i - 1


### PR DESCRIPTION
widgets are setting size_hint_x/y to None. closes #954

To reproduce the issue this solves::

1) Run Kivy catalog, Choose the Button labeled 'GridLayout' from the left.

Notice that GridLayout takes up less area than is available to it if all the widget's in a row/column don't have size_hint_x/y set either None or between 0/1.

I feel the expected behaviour should be to honour width/height for the col/row only if all the widgets in that perticular row/col are setting size_hint_x/y to None and to ignore the width/height otherwise.
