### PR TITLE
Expose on load from Video class

### DIFF
--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -200,6 +200,7 @@ class Video(Image):
         self.eos = True
 
     def _on_load(self, *largs):
+        self.loaded = True
         self._on_video_frame(largs)
 
     def on_volume(self, instance, value):


### PR DESCRIPTION
Needed a way to switch from a loading screen to the video screen using a ScreenManager.
the kivy.uix.video.Video class didn't provide a clean way of checking if the video was loaded or not. Exposed it through a BooleanProperty.
