### PR TITLE
uix: BoxLayout and GridLayout honour size_hint for a single child

### DIFF
--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -126,11 +126,11 @@ class BoxLayout(Layout):
             if shw is None:
                 minimum_size_x += w.width
             else:
-                stretch_weight_x += shw
+                stretch_weight_x += shw if len_children > 1 else 1
             if shh is None:
                 minimum_size_y += w.height
             else:
-                stretch_weight_y += shh
+                stretch_weight_y += shh if len_children > 1 else 1
 
         if orientation == 'horizontal':
             x = y = padding

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -376,7 +376,8 @@ class GridLayout(Layout):
         else:
             cols = self._cols[:]
             cols_sh = self._cols_sh
-            cols_weigth = sum([x for x in cols_sh if x])
+            cols_weigth = sum([x for x in cols_sh if x])\
+                        if len_children > 1 else 1
             strech_w = max(0, selfw - self.minimum_width)
             for index in xrange(len(cols)):
                 # if the col don't have strech information, nothing to do
@@ -397,7 +398,8 @@ class GridLayout(Layout):
         else:
             rows = self._rows[:]
             rows_sh = self._rows_sh
-            rows_weigth = sum([x for x in rows_sh if x])
+            rows_weigth = sum([x for x in rows_sh if x])\
+                        if len_children > 1 else 1
             strech_h = max(0, selfh - self.minimum_height)
             for index in xrange(len(rows)):
                 # if the row don't have strech information, nothing to do


### PR DESCRIPTION
Handling of size_hint when there is only a single child is not consistent between layouts.
BoxLayout and GridLayout don't seem to honour size_hint when dealing with only a single child.

To reproduce run the following code

```
# -*- coding: utf-8 -*-
import kivy
from kivy.app import App
from kivy.uix.boxlayout import BoxLayout
from kivy.lang import Builder

root=Builder.load_string(
'''
TabbedPanel:
    do_default_tab: False
    TabbedPanelItem:
        text: 'BoxLayout'
        BoxLayout:
            Button:
                size_hint: .5, .5
    TabbedPanelItem:
        text: 'FloatLayout'
        FloatLayout:
            Button:
                size_hint: .5, .5
    TabbedPanelItem:
        text: 'RelativeLayout'
        RelativeLayout:
            Button:
                size_hint: .5, .5
    TabbedPanelItem:
        text: 'GridLayout'
        GridLayout:
            cols: 1
            Button:
                size_hint: .5, .5
    TabbedPanelItem:
        text: 'StackLayout'
        StackLayout:
            Button:
                size_hint: .5, .5
''')

class MyApp(App):

    def build(self):
        return root


if __name__ == '__main__':
    MyApp().run()
```
