### PR TITLE
Sublime Text 2 Kivy Language Syntax Highlighting

### DIFF
--- a/kivy/tools/highlight/kivy.json-tmlanguage
+++ b/kivy/tools/highlight/kivy.json-tmlanguage
@@ -1,0 +1,20 @@
+{ "name": "Kivy Language",
+  "scopeName": "source.python.kivy",
+  "fileTypes": ["kv"],
+  "patterns": [
+    { "match": "#:.*?$",
+      "name": "support.type.kivy" },
+    { "match": "#.*?$",
+      "name": "comment.kivy" },
+    { "match": "\\<.+\\>",
+      "name": "support.class.kivy" },
+    { "match": "[A-Za-z][A-Za-z0-9]+$",
+      "name": "support.function.kivy" },
+    { "match": ".*?:$",
+      "name": "support.function.kivy" },
+    { "name": "entity.name.section.kivy",
+      "match": "(.*?):" },
+    { "include": "source.python" }
+  ],
+  "uuid": "49cecc44-5094-48ec-a876-91f597e8bf81"
+}

--- a/kivy/tools/highlight/kivy.tmLanguage
+++ b/kivy/tools/highlight/kivy.tmLanguage
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>kv</string>
+	</array>
+	<key>name</key>
+	<string>Kivy Language</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>match</key>
+			<string>#:.*?$</string>
+			<key>name</key>
+			<string>support.type.kivy</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>#.*?$</string>
+			<key>name</key>
+			<string>comment.kivy</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\&lt;.+\&gt;</string>
+			<key>name</key>
+			<string>support.class.kivy</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>[A-Za-z][A-Za-z0-9]+$</string>
+			<key>name</key>
+			<string>support.function.kivy</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>.*?:$</string>
+			<key>name</key>
+			<string>support.function.kivy</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(.*?):</string>
+			<key>name</key>
+			<string>entity.name.section.kivy</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>source.python</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>source.python.kivy</string>
+	<key>uuid</key>
+	<string>49cecc44-5094-48ec-a876-91f597e8bf81</string>
+</dict>
+</plist>


### PR DESCRIPTION
Added preliminary basic syntax highlighting for the Kivy Language to be used in the Sublime Text 2 text editor. Should also work in TextMate due to the way in which Sublime Text 2 mirrors the structure of TextMate, though this aspect is untested. Tested and functioning for personal use.
