### PR TITLE
Made ImageLoader.zip_loader skip loaders that raised an error or returned None.

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -250,6 +250,7 @@ class ImageLoader(object):
         # sort filename list
         znamelist = z.namelist()
         znamelist.sort()
+        image = None
         for zfilename in znamelist:
             try:
                 #read file and store it in mem with fileIO struct around it
@@ -261,11 +262,16 @@ class ImageLoader(object):
                         continue
                     Logger.debug('Image%s: Load <%s> from <%s>' %
                             (loader.__name__[11:], zfilename, filename))
-                    im = loader(tmpfile, **kwargs)
+                    try:
+                        im = loader(tmpfile, **kwargs)
+                    except:
+                        # Loader failed, continue trying.
+                        continue
                     break
                 if im is not None:
                     # append ImageData to local variable before it's overwritten
                     image_data.append(im._data[0])
+                    image = im 
                 #else: if not image file skip to next
             except:
                 Logger.warning('Image: Unable to load image' +
@@ -275,9 +281,9 @@ class ImageLoader(object):
         if len(image_data) == 0:
             raise Exception('no images in zip <%s>' % filename)
         # replace Image.Data with the array of all the images in the zip
-        im._data = image_data
-        im.filename = filename
-        return im
+        image._data = image_data
+        image.filename = filename
+        return image
 
     @staticmethod
     def register(defcls):


### PR DESCRIPTION
For some reason one of the image loaders was failing on Mac OS X. Running the widgets/sequence_images example:

```
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_001.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_001.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_002.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_002.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_003.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_003.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_004.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_004.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_005.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_005.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_006.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_006.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_007.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_007.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_008.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_008.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_009.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_009.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_010.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_010.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_011.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_011.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_012.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_012.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_013.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_013.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_014.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_014.png> in zip <data/images/button_white_animated.zip> trying to continue...
[DEBUG  ] [ImageImageIO] Load <buttonoverlay_dn_015.png> from <data/images/button_white_animated.zip>
[WARNING] [Image       ] Unable to load image<buttonoverlay_dn_015.png> in zip <data/images/button_white_animated.zip> trying to continue...
 Traceback (most recent call last):
   File "main.py", line 147, in <module>
     mainApp().run()
   File "/Library/Python/2.7/site-packages/kivy/app.py", line 527, in run
     root = self.build()
   File "main.py", line 140, in build
     upl = mainclass()
   File "main.py", line 76, in __init__
     background_normal = 'data/images/button_white_animated.zip')
   File "/Users/Eric/Projects/kivy/examples/widgets/sequenced_images/uix/custom_button.py", line 42, in __init__
     keep_ratio = self.keep_ratio, mipmap = True)
   File "/Library/Python/2.7/site-packages/kivy/uix/image.py", line 219, in __init__
     self.texture_update()
   File "/Library/Python/2.7/site-packages/kivy/uix/image.py", line 234, in texture_update
     nocache=self.nocache)
   File "/Library/Python/2.7/site-packages/kivy/core/image/__init__.py", line 418, in __init__
     self.filename = arg
   File "/Library/Python/2.7/site-packages/kivy/core/image/__init__.py", line 606, in _set_filename
     mipmap=self._mipmap, nocache=self._nocache)
   File "/Library/Python/2.7/site-packages/kivy/core/image/__init__.py", line 339, in load
     return ImageLoader.zip_loader(filename)
   File "/Library/Python/2.7/site-packages/kivy/core/image/__init__.py", line 276, in zip_loader
     raise Exception('no images in zip <%s>' % filename)
 Exception: no images in zip <data/images/button_white_animated.zip>
```

However, wrapping the: 

```
im = loader(tmpfile, **kwargs)
```

in `try...except` was not enough.

Sometimes there was an image not recognized by any loader. (e.g. an artefact from the zip program while performing the zipping), and if that artefact turns out to be the last file attempted to be loaded, `im` in:

```
im._data = image_data
```

would be `None`, causing an AttributeError.

So I've had to change it to use another variable `image` to keep track of the last image successfully loaded. It is only assigned when `im` returned from the loader is not `None`.
