### PR TITLE
uix: TextInput improve visual polish and mninor performance improvements

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -154,8 +154,10 @@
     but_cut: cut
     but_copy: copy
     but_paste: paste
+    but_selectall: selectall
+
     size_hint: None, None
-    size: 150, 50
+    size: '150sp', '50sp'
     BubbleButton:
         id: cut
         text: 'Cut'
@@ -168,6 +170,10 @@
         id: paste
         text: 'Paste'
         on_release: root.do('paste')
+    BubbleButton:
+        id: selectall
+        text: 'Select All'
+        on_release: root.do('selectall')
 
 
 <TreeViewNode>:


### PR DESCRIPTION
- Use `sp` conversion to set size for bubble closes #1065
- Add animation to cut copy paste Bubble
- position `cut copy paste` Bubble so that it appears above/below the
  finger not obscured by it.
- add `select all` option to paste bubble.
- minor speed improvements for cursor movements.
- use unique cid for text_width cache. (no body noticed a issue with this?)
