### PR TITLE
Lazy texture uploading

### DIFF
--- a/kivy/graphics/context.pyx
+++ b/kivy/graphics/context.pyx
@@ -70,8 +70,9 @@ cdef class Context:
     cdef void dealloc_texture(self, Texture texture):
         if texture._nofree or texture.__class__ is TextureRegion:
             return
-        self.lr_texture.append(texture.id)
-        self.trigger_gl_dealloc()
+        if texture.id > 0:
+            self.lr_texture.append(texture.id)
+            self.trigger_gl_dealloc()
 
     cdef void dealloc_vbo(self, VBO vbo):
         if vbo.have_id():

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -181,6 +181,9 @@ cdef class Fbo(RenderContext):
             self._texture = Texture.create(size=(self._width, self._height))
             do_clear = 1
 
+        # apply any changes if needed
+        self._texture.bind()
+
         # create framebuffer
         glGenFramebuffers(1, &f_id)
         self.buffer_id = f_id

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -762,7 +762,7 @@ cdef class RenderContext(Canvas):
         if _active_texture != index:
             _active_texture = index
             glActiveTexture(GL_TEXTURE0 + index)
-        glBindTexture(texture._target, texture._id)
+        texture.bind()
         self.flag_update()
 
     cdef void enter(self):

--- a/kivy/graphics/texture.pxd
+++ b/kivy/graphics/texture.pxd
@@ -2,6 +2,7 @@ from c_opengl cimport GLuint
 
 cdef class Texture:
     cdef object __weakref__
+    cdef unsigned int flags
 
     cdef object _source
     cdef float _tex_coords[8]
@@ -24,6 +25,7 @@ cdef class Texture:
     cdef int _nofree
     cdef list observers
     cdef object _proxyimage
+    cdef object _callback
 
     cdef void update_tex_coords(self)
     cdef void set_min_filter(self, str x)
@@ -31,6 +33,7 @@ cdef class Texture:
     cdef void set_wrap(self, str x)
     cdef void reload(self)
     cdef void _reload_propagate(self, Texture texture)
+    cdef void allocate(self)
 
     cpdef flip_vertical(self)
     cpdef get_region(self, x, y, width, height)
@@ -41,3 +44,4 @@ cdef class TextureRegion(Texture):
     cdef int y
     cdef Texture owner
     cdef void reload(self)
+    cpdef bind(self)

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -196,6 +196,15 @@ IF USE_OPENGL_DEBUG == 1:
     from kivy.graphics.c_opengl_debug cimport *
 from kivy.graphics.opengl_utils cimport *
 
+# update flags
+cdef int TI_MIN_FILTER      = 1 << 0
+cdef int TI_MAG_FILTER      = 1 << 1
+cdef int TI_WRAP            = 1 << 2
+cdef int TI_NEED_GEN        = 1 << 3
+cdef int TI_NEED_ALLOCATE   = 1 << 4
+cdef int TI_NEED_PIXELS     = 1 << 5
+
+
 # compatibility layer
 cdef GLuint GL_BGR = 0x80E0
 cdef GLuint GL_BGRA = 0x80E1
@@ -302,7 +311,7 @@ cdef inline int _is_compressed_fmt(str x):
     return x.startswith('s3tc_dxt')
 
 
-cdef inline int _buffer_fmt_to_gl(str x):
+cdef inline int _buffer_fmt_to_gl(bytes x):
     '''Return the GL numeric value from a buffer string format
     '''
     x = x.lower()
@@ -312,7 +321,7 @@ cdef inline int _buffer_fmt_to_gl(str x):
         raise Exception('Unknown <%s> buffer format' % x)
 
 
-cdef inline int _buffer_type_to_gl_size(str x):
+cdef inline int _buffer_type_to_gl_size(bytes x):
     '''Return the size of a buffer string format in bytes
     '''
     x = x.lower()
@@ -442,22 +451,19 @@ cdef inline void _gl_prepare_pixels_upload(int width) nogil:
 
 
 cdef Texture _texture_create(int width, int height, str colorfmt, str bufferfmt,
-                     int mipmap, int allocate):
+                     int mipmap, int allocate, object callback):
     '''Create the OpenGL texture.
     '''
     cdef GLuint target = GL_TEXTURE_2D
     cdef GLuint texid = 0
     cdef Texture texture
     cdef int texture_width, texture_height
-    cdef int glbufferfmt = _buffer_fmt_to_gl(bufferfmt)
+    cdef int glbufferfmt = _buffer_fmt_to_gl(<bytes>bufferfmt)
     cdef int make_npot = 0
-    cdef int is_npot = 0
-    cdef int glfmt, iglbufferfmt, datasize, dataerr = 0
-    cdef void *data = NULL
 
     # check if it's a pot or not
     if not _is_pow2(width) or not _is_pow2(height):
-        make_npot = is_npot = 1
+        make_npot = 1
 
     IF not USE_OPENGL_ES2:
         if gl_get_version_major() < 3:
@@ -476,16 +482,15 @@ cdef Texture _texture_create(int width, int height, str colorfmt, str bufferfmt,
         texture_width = _nearest_pow2(width)
         texture_height = _nearest_pow2(height)
 
-    # generate the texture
-    glGenTextures(1, &texid)
-
     # create the texture with the future color format.
     colorfmt = _convert_gl_format(colorfmt)
-    texture = Texture(texture_width, texture_height, target, texid,
-                      colorfmt=colorfmt, bufferfmt=bufferfmt, mipmap=mipmap)
+    texture = Texture(texture_width, texture_height, target,
+                      colorfmt=colorfmt, bufferfmt=bufferfmt, mipmap=mipmap,
+                      callback=callback)
+    if allocate:
+        texture.flags |= TI_NEED_ALLOCATE
 
     # set default parameter for this texture
-    texture.bind()
     texture.set_wrap('clamp_to_edge')
     if mipmap:
         texture.set_min_filter('linear_mipmap_nearest')
@@ -493,43 +498,6 @@ cdef Texture _texture_create(int width, int height, str colorfmt, str bufferfmt,
     else:
         texture.set_min_filter('linear')
         texture.set_mag_filter('linear')
-
-    # if allocation if wanted, do it now
-    if allocate:
-
-        # prepare information needed for nogil
-        glfmt = _color_fmt_to_gl(<bytes>colorfmt)
-        iglbufferfmt = glbufferfmt
-        datasize = texture_width * texture_height * \
-                _gl_format_size(glfmt) * _buffer_type_to_gl_size(bufferfmt)
-
-        # act as we have been able to allocate the texture
-        texture._is_allocated = 1
-
-        # do the rest outside the Python GIL
-        with nogil:
-            data = calloc(1, datasize)
-            if data != NULL:
-                # ensure pixel upload is correct
-                _gl_prepare_pixels_upload(texture_width)
-
-                # do the initial upload with fake data
-                glTexImage2D(target, 0, glfmt, texture_width, texture_height, 0,
-                             glfmt, iglbufferfmt, data)
-
-                # free the data !
-                free(data)
-
-                # create mipmap if needed
-                if mipmap and is_npot == 0:
-                    glGenerateMipmap(target)
-            else:
-                dataerr = 1
-
-        if dataerr:
-            texture._is_allocated = 0
-            raise Exception('Unable to allocate memory for texture (size is %s)' %
-                            datasize)
 
     # if the texture size is the same as initial size, return the texture
     # unmodified
@@ -540,7 +508,8 @@ cdef Texture _texture_create(int width, int height, str colorfmt, str bufferfmt,
     return texture.get_region(0, 0, width, height)
 
 
-def texture_create(size=None, colorfmt=None, bufferfmt=None, mipmap=False):
+def texture_create(size=None, colorfmt=None, bufferfmt=None, mipmap=False,
+    callback=None):
     '''Create a texture based on size.
 
     :Parameters:
@@ -554,16 +523,24 @@ def texture_create(size=None, colorfmt=None, bufferfmt=None, mipmap=False):
             'uint', 'bute', 'short', 'int', 'float'
         `mipmap`: bool, default to False
             If True, it will automatically generate mipmap texture.
+        `callback`: callable(), default to False
+            If a function is provided, it will be called when data will be
+            needed in the texture.
 
+    .. versionchanged:: 1.6.1
+        :data:`callback` has been added
     '''
-    cdef int width = 128, height = 128
+    cdef int width = 128, height = 128, allocate = 1
     if size is not None:
         width, height = size
     if colorfmt is None:
         colorfmt = 'rgba'
     if bufferfmt is None:
         bufferfmt = 'ubyte'
-    return _texture_create(width, height, colorfmt, bufferfmt, mipmap, 1)
+    if callback is not None:
+        allocate = 0
+    return _texture_create(width, height, colorfmt, bufferfmt, mipmap,
+            allocate, callback)
 
 
 def texture_create_from_data(im, mipmap=False):
@@ -594,7 +571,8 @@ def texture_create_from_data(im, mipmap=False):
         height = width = 1
         allocate = 1
         no_blit = 1
-    texture = _texture_create(width, height, im.fmt, 'ubyte', mipmap, allocate)
+    texture = _texture_create(width, height, im.fmt, 'ubyte', mipmap, allocate,
+                             None)
     if texture is None:
         return None
 
@@ -612,8 +590,8 @@ cdef class Texture:
     create = staticmethod(texture_create)
     create_from_data = staticmethod(texture_create_from_data)
 
-    def __init__(self, width, height, target, texid, colorfmt='rgb',
-            bufferfmt='ubyte', mipmap=False, source=None):
+    def __init__(self, width, height, target, texid=0, colorfmt='rgb',
+            bufferfmt='ubyte', mipmap=False, source=None, callback=None):
         self.observers = []
         self._width         = width
         self._height        = height
@@ -632,6 +610,13 @@ cdef class Texture:
         self._bufferfmt     = bufferfmt
         self._source        = source
         self._nofree        = 0
+        self._callback      = callback
+
+        if texid == 0:
+            self.flags |= TI_NEED_GEN
+        if callback is not None:
+            self.flags |= TI_NEED_PIXELS
+
         self.update_tex_coords()
         get_context().register_texture(self)
 
@@ -672,6 +657,49 @@ cdef class Texture:
                 self.observers.remove(cb)
                 continue
 
+    cdef void allocate(self):
+        cdef int glfmt, iglbufferfmt, datasize, dataerr = 0
+        cdef void *data = NULL
+        cdef int is_npot = 0
+
+        # check if it's a pot or not
+        if not _is_pow2(self._width) or not _is_pow2(self._height):
+            make_npot = is_npot = 1
+
+        # prepare information needed for nogil
+        glfmt = _color_fmt_to_gl(self._colorfmt)
+        iglbufferfmt = _buffer_fmt_to_gl(self._bufferfmt)
+        datasize = self._width * self._height * \
+                _gl_format_size(glfmt) * _buffer_type_to_gl_size(self._bufferfmt)
+
+        # act as we have been able to allocate the texture
+        self._is_allocated = 1
+
+        # do the rest outside the Python GIL
+        with nogil:
+            data = calloc(1, datasize)
+            if data != NULL:
+                # ensure pixel upload is correct
+                _gl_prepare_pixels_upload(self._width)
+
+                # do the initial upload with fake data
+                glTexImage2D(self._target, 0, glfmt, self._width, self._height,
+                        0, glfmt, iglbufferfmt, data)
+
+                # free the data !
+                free(data)
+
+                # create mipmap if needed
+                if self._mipmap and is_npot == 0:
+                    glGenerateMipmap(self._target)
+            else:
+                dataerr = 1
+
+        if dataerr:
+            self._is_allocated = 0
+            raise Exception('Unable to allocate memory for texture (size is %s)' %
+                            datasize)
+
     cpdef flip_vertical(self):
         '''Flip tex_coords for vertical displaying'''
         self._uvy += self._uvh
@@ -683,26 +711,69 @@ cdef class Texture:
         (x, y, width, height). Returns a :class:`TextureRegion` instance.'''
         return TextureRegion(x, y, width, height, self)
 
+    def ask_update(self, callback):
+        '''Indicate that the content of the texture should be updated, and the
+        callback function need to be called when the texture will be really
+        used.
+        '''
+        self.flags |= TI_NEED_PIXELS
+        self._callback = callback
+
     cpdef bind(self):
         '''Bind the texture to current opengl state'''
+        cdef GLuint value
+
+        # if we have no change to apply, just bind and exit
+        if not self.flags:
+            glBindTexture(self._target, self._id)
+            return
+
+        if self.flags & TI_NEED_GEN:
+            self.flags &= ~TI_NEED_GEN
+            glGenTextures(1, &self._id)
+
         glBindTexture(self._target, self._id)
 
+        if self.flags & TI_NEED_ALLOCATE:
+            self.flags &= ~TI_NEED_ALLOCATE
+            self.allocate()
+
+        if self.flags & TI_NEED_PIXELS:
+            self.flags &= ~TI_NEED_PIXELS
+            if self._callback:
+                self._callback(self)
+                self._callback = None
+
+        if self.flags & TI_MIN_FILTER:
+            self.flags &= ~TI_MIN_FILTER
+            value = _str_to_gl_texture_min_filter(self._min_filter)
+            glTexParameteri(self._target, GL_TEXTURE_MIN_FILTER, value)
+
+        if self.flags & TI_MAG_FILTER:
+            self.flags &= ~TI_MAG_FILTER
+            value = _str_to_gl_texture_mag_filter(self._mag_filter)
+            glTexParameteri(self._target, GL_TEXTURE_MAG_FILTER, value)
+
+        if self.flags & TI_WRAP:
+            self.flags &= ~TI_WRAP
+            value = _str_to_gl_texture_wrap(self._wrap)
+            glTexParameteri(self._target, GL_TEXTURE_WRAP_S, value)
+            glTexParameteri(self._target, GL_TEXTURE_WRAP_T, value)
+
     cdef void set_min_filter(self, str x):
-        cdef GLuint _value = _str_to_gl_texture_min_filter(x)
-        glTexParameteri(self._target, GL_TEXTURE_MIN_FILTER, _value)
-        self._min_filter = x
+        if self._min_filter != x:
+            self._min_filter = x
+            self.flags |= TI_MIN_FILTER
 
     cdef void set_mag_filter(self, str x):
-        cdef GLuint _value = _str_to_gl_texture_mag_filter(x)
-        glTexParameteri(self._target, GL_TEXTURE_MAG_FILTER, _value)
-        self._mag_filter = x
+        if self._mag_filter != x:
+            self._mag_filter = x
+            self.flags |= TI_MAG_FILTER
 
     cdef void set_wrap(self, str x):
-        cdef GLuint _value = _str_to_gl_texture_wrap(x)
-        glTexParameteri(self._target, GL_TEXTURE_WRAP_S, _value)
-        glTexParameteri(self._target, GL_TEXTURE_WRAP_T, _value)
-        self._wrap = x
-
+        if self._wrap != x:
+            self._wrap = x
+            self.flags |= TI_WRAP
 
     def blit_data(self, im, pos=None):
         '''Replace a whole texture with a image data
@@ -753,7 +824,11 @@ cdef class Texture:
             pos = (0, 0)
         if size is None:
             size = self.size
-        bufferfmt = _buffer_fmt_to_gl(bufferfmt)
+        bufferfmt = _buffer_fmt_to_gl(<bytes>bufferfmt)
+
+        # bind the texture, and create anything that should be created at this
+        # time.
+        self.bind()
 
         # need conversion ?
         cdef bytes data
@@ -776,7 +851,6 @@ cdef class Texture:
         cdef int _mipmap_level = mipmap_level
 
         with nogil:
-            glBindTexture(target, self._id)
             if is_compressed:
                 glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
                 glCompressedTexImage2D(target, _mipmap_level, glfmt, w, h, 0, datasize, cdata)
@@ -963,10 +1037,6 @@ cdef class Texture:
         def __get__(self):
             return self._min_filter
         def __set__(self, str x):
-            cdef GLuint value
-            if x == self._min_filter:
-                return
-            self.bind()
             self.set_min_filter(x)
 
     property mag_filter:
@@ -981,9 +1051,6 @@ cdef class Texture:
         def __get__(self):
             return self._mag_filter
         def __set__(self, str x):
-            if x == self._mag_filter:
-                return
-            self.bind()
             self.set_mag_filter(x)
 
     property wrap:
@@ -999,9 +1066,6 @@ cdef class Texture:
         def __get__(self):
             return self._wrap
         def __set__(self, str wrap):
-            if wrap == self._wrap:
-                return
-            self.bind()
             self.set_wrap(wrap)
 
     property pixels:
@@ -1052,6 +1116,9 @@ cdef class TextureRegion(Texture):
         # then update content again
         for cb in self.observers:
             cb(self)
+
+    cpdef bind(self):
+        self.owner.bind()
 
     property pixels:
         def __get__(self):


### PR DESCRIPTION
This approach will create and upload the texture data only when the texture is really used (bind()) by the graphics pipeline. All the previous method of creation are still working as usual.

I've changed the text provider to use this new feature, and now the label texture is internally allocated during layouts operations = faster.

Is anybody could test this branch too? (anybody that doesn't have a nvidia card and/or with something else that the kivy demo)
