### PR TITLE
* fix `make clean` to remove cythoned .c files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ clean:
 	-find kivy -iname '*.so' -exec rm {} \;
 	-find kivy -iname '*.pyc' -exec rm {} \;
 	-find kivy -iname '*.pyo' -exec rm {} \;
+	-find . -iname '*.pyx' -exec sh -c 'echo `dirname {}`/`basename {} .pyx`.c' \; | xargs rm
 
 distclean: clean
 	-git clean -dxf


### PR DESCRIPTION
We've been having problems lately with Cython not deleting and re-cythoning `_event.pyx` and `properties.pyx`. This pull request adds one line to `make clean` which finds all `.pyx` and deletes any corresponding `.c` file.
