### PR TITLE
Int-ify texture size in MarkupLabel

### DIFF
--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -44,6 +44,7 @@ from kivy.logger import Logger
 import re
 from kivy.core.text import Label, LabelBase
 from copy import copy
+from math import ceil
 
 # We need to do this trick when documentation is generated
 MarkupLabelBase = Label
@@ -215,7 +216,7 @@ class MarkupLabel(MarkupLabelBase):
             if not lines:
                 h = 1
             else:
-                h = sum([line[1] for line in lines])
+                h = int(ceil(sum([line[1] for line in lines])))
         return w, h
 
     def _pre_render_label(self, word, options, lines):


### PR DESCRIPTION
Fixes a crash in PIL when using MarkupLabels. (But introduces a new problem that I'm not sure how to debug.)
# Explanation

`kivy.core.text.LabelBase` has a default `line_height` parameter of 1.0. Consequently, `kivy.core.text.MarkupLabel._pre_render_label` gets a float value for `default_line_height`, which down the line gets passed to `Image.new` in `kivy.core.text.text_pil._render_begin`. PIL doesn't like the float, and asserts out.
# Summary

This patch makes the default returned height from `_pre_render` an int so that the assertion in PIL no longer fails. However, it doesn't fix the entire problem - I now get a nonexistent texture down the line. Documenting this in a new issue #1083.
