### PR TITLE
add mp3 to audio_pygame.py

### DIFF
--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -32,7 +32,9 @@ class SoundPygame(Sound):
     # __slots__ = ('_data', '_channel')
     @staticmethod
     def extensions():
-        return ('wav', 'ogg', 'mp3')
+        if platform() == 'android':
+            return ('wav', 'ogg', 'mp3')
+        return ('wav', 'ogg')
 
     def __init__(self, **kwargs):
         self._data = None


### PR DESCRIPTION
mp3 is supported on android (tested) 
http://developer.android.com/guide/appendix/media-formats.html

iOS should be supported too (haven't tested) 
http://developer.apple.com/library/ios/#documentation/AudioVideo/Conceptual/MultimediaPG/UsingAudio/UsingAudio.html

I don't know how to "a,b,c on android; x,y,z on iOS" so I can't add the rest of the formats.
