### PR TITLE
core: audio_pygame support for seek and get_length from android mediaplayer

### DIFF
--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -8,8 +8,9 @@ from kivy.clock import Clock
 from kivy.utils import platform
 from kivy.core.audio import Sound, SoundLoader
 
+_platform = platform()
 try:
-    if platform() == 'android':
+    if _platform == 'android':
         import android_mixer as mixer
     else:
         from pygame import mixer
@@ -32,7 +33,7 @@ class SoundPygame(Sound):
     # __slots__ = ('_data', '_channel')
     @staticmethod
     def extensions():
-        if platform() == 'android':
+        if _platform == 'android':
             return ('wav', 'ogg', 'mp3')
         return ('wav', 'ogg')
 
@@ -77,11 +78,15 @@ class SoundPygame(Sound):
         self._data = None
 
     def seek(self, position):
-        # Unable to seek in pygame...
-        pass
+        if not self._data:
+            return
+        if _platform == 'android' and self._channel:
+            self._channel.seek(position)
 
     def get_pos(self):
         if self._data is not None:
+            if _platform == 'android' and self._channel:
+                return self._channel.get_pos()
             return mixer.music.get_pos()
         return 0
 
@@ -96,6 +101,8 @@ class SoundPygame(Sound):
         return super(SoundPygame, self)._set_volume(volume)
 
     def _get_length(self):
+        if _platform == 'android' and self._channel:
+            return self._channel.get_length()
         if self._data is not None:
             return self._data.get_length()
         return super(SoundPygame, self)._get_length()


### PR DESCRIPTION
This is a part of https://github.com/kivy/python-for-android/pull/106

Testing with the following code::

```
from kivy.app import App
from kivy.core.audio import SoundLoader
from kivy.clock import Clock
from kivy.logger import Logger
from kivy.lang import Builder

root = Builder.load_string('''
BoxLayout:
    audio_pos: 0
    orientation: 'vertical'
    Label:
        text: str(slider.value)
    Slider:
        id: slider
        min: 0.0
        value: root.audio_pos
    BoxLayout
        Button:
            text: "play"
            on_press:
                root.sound.play()
                root.upd_pos()
        Button:
            text: 'stop'
            on_release:
                root.sound.stop()
                slider.value = 0.0
                root.upd_pos(stop=True)
        Button:
            text: 'seek to 20.0'
            on_release: root.sound.seek(20.0)
''')

class TestApp(App):
    def build(self):
        root.sound = SoundLoader.load('audio02.ogg')
        root.upd_pos = self.upd_pos
        return root

    def upd_pos(self, stop=False):
        if stop:
            Clock.unschedule(self.get_pos)
        else:
            Clock.unschedule(self.get_pos)
            Clock.schedule_interval(self.get_pos, 1./9.)

    def get_pos(self, dt):
        root.ids.slider.max = root.sound._get_length()
        root.audio_pos = root.sound.get_pos()

if __name__ == '__main__':
    TestApp().run()
```
