### PR TITLE
Allow other projects to use the kivy pep8 checker.

### DIFF
--- a/kivy/tools/pep8checker/pre-commit.githook
+++ b/kivy/tools/pep8checker/pre-commit.githook
@@ -18,7 +18,7 @@
         chmod +x .git/hooks/pre-commit
 '''
 
-import sys
+import sys, os
 from os.path import dirname, abspath, sep, join
 from subprocess import call, Popen, PIPE
 


### PR DESCRIPTION
This edits the pre commit git hook to allow other projects to copy the hook file into their git directory and use it (provided they have kivy in their path).
