### PR TITLE
Fix DeprecationWarnings in Widget

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -123,7 +123,9 @@ cdef class EventDispatcher(object):
     def __init__(self, **kwargs):
         cdef str func, name, key
         cdef dict properties
-        super(EventDispatcher, self).__init__(**kwargs)
+        # object.__init__ takes no parameters as of 2.6; passing kwargs
+        # triggers a DeprecationWarning or worse
+        super(EventDispatcher, self).__init__()
 
         # Auto bind on own handler if exist
         properties = self.properties()


### PR DESCRIPTION
As of 2.6, object.**init** takes no arguments. Passing it arguments triggers a
DeprecationWarning or worse. Kivy startup was producing a flood of DeprecationWarnings that gave me a headache :smile:

`__init__` in `EventDispatcher` was passing kwargs to `object.__init__`; this patch removes that.
## Before:

```
...
[DEBUG  ] [ImageImageIO] Load </usr/local/lib/python2.7/site-packages/kivy/data/../data/images/defaulttheme-0.png>
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
 /usr/local/lib/python2.7/site-packages/kivy/uix/widget.py:136: DeprecationWarning: object.__init__() takes no parameters
   super(Widget, self).__init__(**kwargs)
[DEBUG  ] [Cache       ] register <kv.loader> with limit=500, timeout=60s
...
```
## After:

```
...
[DEBUG  ] [ImageImageIO] Load </usr/local/lib/python2.7/site-packages/kivy/data/../data/images/defaulttheme-0.png>
[DEBUG  ] [Cache       ] register <kv.loader> with limit=500, timeout=60s
...
```
