### PR TITLE
Fix App.user_data_dir on windows.

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -532,7 +532,7 @@ class App(EventDispatcher):
 
         On Android `/sdcard/<app_name>` is returned.
 
-        On Windows `~/Application Settings/<app_name>` is returned.
+        On Windows `%APPDATA%/<app_name>` is returned.
 
         On Mac OS X `~/Library/Application Support <app_name>` is returned.
 
@@ -544,7 +544,7 @@ class App(EventDispatcher):
         elif platform == 'android':
             data_dir = join('/sdcard', self.name)
         elif platform == 'win':
-            data_dir = '~/Application Settings/{}'.format(self.name)
+            data_dir = os.path.join(os.environ['APPDATA'], self.name)
         elif platform == 'macosx':
             data_dir = '~/Library/Application Support/{}'.format(self.name)
         else:  # _platform == 'linux' or anything else...:


### PR DESCRIPTION
App.user_data_dir on Windows was returning "~/Application Settings/appname" which is invalid because ~ has no meaning on Windows and because Application Settings folder does not exist (verified not to exist on Windows 7, and I couldn't find mention of it on other versions when googling) I think "Application Data" might have been what was intended, but that is only correct for certain versions.

I changed user_data_dir to return "%APPDATA%/appname" instead (using os.environ['APPDATA']).

The APPDATA environment variable is valid and correct for this purpose on Windows XP, Vista, 7, and 8 (But NOT on Windows 98, which i figure we don't care about because kivy doesn't support it for other reasons)

This fix is pretty simple, and I think it is correct, but be warned I have not actually tested it yet, because I have not yet successfully built kivy on Windows (make complains "make (e=2): the system cannot find the file specified")
