### PR TITLE
Audio on ios

### DIFF
--- a/kivy/core/audio/audio_sdl.pyx
+++ b/kivy/core/audio/audio_sdl.pyx
@@ -35,6 +35,7 @@ cdef extern from "SDL_mixer.h":
     int Mix_PlayChannel(int, Mix_Chunk *, int)
     int Mix_HaltChannel(int)
     Mix_Chunk *Mix_GetChunk(int)
+    int Mix_Playing(int)
 
     int MIX_DEFAULT_FORMAT
     int MIX_DEFAULT_FREQUENCY
@@ -97,7 +98,7 @@ class SoundSDL(Sound):
         cdef MixContainer mc = self.mc
         if mc.channel == -1 or mc.chunk == NULL:
             return False
-        if Mix_GetChunk(mc.channel) == mc.chunk:
+        if Mix_Playing(mc.channel):
             return
         self.stop()
         return False


### PR DESCRIPTION
This tiny fix does the trick! SoundLoader.load() now works on iOS
