### PR TITLE
graphics/opengl: implemented/fixed a few Python bindings.

### DIFF
--- a/kivy/graphics/opengl.pyx
+++ b/kivy/graphics/opengl.pyx
@@ -714,7 +714,7 @@ def glDrawElements(GLenum mode, GLsizei count, GLenum type, bytes indices):
     '''See: `glDrawElements() on Kronos website
     <http://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawElements.xml>`_
     '''
-    c_opengl.glDrawElements(mode, count, type, <void *>indices)
+    c_opengl.glDrawElements(mode, count, type, <GLvoid *>(<char *>indices))
 
 def glEnable(GLenum cap):
     '''See: `glEnable() on Kronos website
@@ -1470,14 +1470,11 @@ def glUniformMatrix3fv(GLint location, GLsizei count):#, GLboolean transpose,  b
     # c_opengl.glUniformMatrix3fv(location, count, transpose, <GLfloat*>ptr_value)
     raise NotImplemented()
 
-def glUniformMatrix4fv(GLint location, GLsizei count):#, GLboolean transpose,  bytes values):
+def glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose,  bytes value):
     '''See: `glUniformMatrix4fv() on Kronos website
     <http://www.khronos.org/opengles/sdk/docs/man/xhtml/glUniformMatrix4fv.xml>`_
-
-    .. warning:: Not implemented yet.
     '''
-    # c_opengl.glUniformMatrix4fv(location, count, transpose, <GLfloat*>ptr_value)
-    raise NotImplemented()
+    c_opengl.glUniformMatrix4fv(location, count, transpose, <GLfloat*>(<char *>value))
 
 def glUseProgram(GLuint program):
     '''See: `glUseProgram() on Kronos website
@@ -1551,14 +1548,12 @@ def glVertexAttrib4fv(GLuint indx, list values):
     #c_opengl.glVertexAttrib4fv(indx, values)
     raise NotImplemented()
 
-def glVertexAttribPointer(GLuint indx, GLint size):#, GLenum type, GLboolean normalized, GLsizei stride,  GLvoid* ptr):
+def glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, bytes data):
     '''See: `glVertexAttribPointer() on Kronos website
     <http://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttribPointer.xml>`_
 
-    .. warning:: Not implemented yet.
     '''
-    # c_opengl.glVertexAttribPointer(indx, size, type, normalized, stride, <GLvoid*>ptr)
-    raise NotImplemented()
+    c_opengl.glVertexAttribPointer(index, size, type, normalized, stride, <GLvoid *>(<char *>data))
 
 def glViewport(GLint x, GLint y, GLsizei width, GLsizei height):
     '''See: `glViewport() on Kronos website


### PR DESCRIPTION
Implemented glVertexAttribPointer and glUniformMatrix4fv.

Fixed glDrawElements: bytes must be cast to "char *" before being cast to "void *" so that Cython's implicit bytes -> c string rule kicks in. Without that you get a pointer to the Python object rather than the string of data.
