### PR TITLE
Button.trigger_action()

### DIFF
--- a/kivy/uix/button.py
+++ b/kivy/uix/button.py
@@ -147,8 +147,11 @@ class Button(Label):
         pass
 
     def trigger_action(self, duration=0.1):
-        '''Trigger whatever action(s) have been bound to the button.
+        '''Trigger whatever action(s) have been bound to the button by calling
+        both the on_press and on_release callbacks.
+
         This simulates a quick button press without using any touch events.
+
         Duration is the length of the press in seconds. Pass 0 if you want
         the action to happen instantly.
 


### PR DESCRIPTION
This function simulates a button press without an actual touch event.

I think this is needed for the Button class because manually calling button.on_press() button.on_release() appears at first glance to be the correct way to do this, but in reality it fails for callbacks bound by .kv or button.bind()

This also comes in pretty handy if you want to make a button react to a keyboard event, like maybe ENTER clicking a confirm button, or F1 clicking a Help button.
