### PR TITLE
uix:TextInput convert to unicode only if string isn't already unicode

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1071,7 +1071,12 @@ class TextInput(Widget):
     def _get_text_width(self, text, tab_width, _label_cached):
         # Return the width of a text, according to the current line options
         kw = self._get_line_options()
-        cid = u'{}\0{}'.format(text, kw)
+
+        try:
+            cid = u'{}\0{}'.format(text, kw)
+        except UnicodeDecodeError:
+            cid = '{}\0{}'.format(text, kw)
+
         width = Cache_get('textinput.width', cid)
         if width:
             return width


### PR DESCRIPTION
closes http://github.com/kivy/python-for-android/issues/114

Testing with the following code.

```
#-*- coding: utf-8 -*-
from kivy.app import App
from kivy.lang import Builder

root = Builder.load_string('''
TextInput:
    text: 'привіт світ'
''')

class TestApp(App):

    def build(self):
        #root.text = u'привіт світ'
        return root

if __name__ == '__main__':
    TestApp().run()
```
