### PR TITLE
Add a Factory.unregister method

### DIFF
--- a/kivy/factory.py
+++ b/kivy/factory.py
@@ -86,15 +86,16 @@ class FactoryBase(object):
             'baseclasses': baseclasses,
             'filename': filename}
 
-    def unregister(self, classname):
-        '''Unregisters the classname previously registered via the
-        register method. This allows the same classname to be re-used
-        in different contexts.
+    def unregister(self, *classnames):
+        '''Unregisters the classnames previously registered via the
+        register method. This allows the same classnames to be re-used in
+        different contexts.
         
         .. versionadded:: 1.7.1
         '''
-        if classname in self.classes:
-            self.classes.pop(classname)
+        for classname in classnames:
+            if classname in self.classes:
+                self.classes.pop(classname)
 
     def unregister_from_filename(self, filename):
         '''Unregister all the factory object related to the filename passed in


### PR DESCRIPTION
When using multiple screens, we have found the inability to re-use class names in the factory very restrictive. Initially I favored having 'Factory.register' override previous registrations, but realized this might break compatibility.

In order to achieve flexibility and compatibility, I thought adding a "Factory.unregister" would be best. This allows class names to be re-used at will, whilst maintaining the current behavior. This pull request (hopefully) will achieve that.
