### PR TITLE
Fix for allowing unicode string / path in Settings

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -427,7 +427,7 @@ class WindowBase(EventDispatcher):
         if 'rotation' not in kwargs:
             kwargs['rotation'] = Config.getint('graphics', 'rotation')
         if 'position' not in kwargs:
-            kwargs['position'] = Config.get('graphics', 'position', 'auto')
+            kwargs['position'] = Config.getdefault('graphics', 'position', 'auto')
         if 'top' in kwargs:
             kwargs['position'] = 'custom'
             kwargs['top'] = kwargs['top']

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -562,7 +562,7 @@
             size_hint_x: .66
             id: labellayout
             markup: True
-            text: '{0}\n[size=13sp][color=999999]{1}[/color][/size]'.format(root.title or '', root.desc or '')
+            text: u'{0}\n[size=13sp][color=999999]{1}[/color][/size]'.format(root.title or '', root.desc or '')
             font_size: '15sp'
             text_size: self.width - 32, None
 
@@ -580,19 +580,19 @@
 
 <SettingString>:
     Label:
-        text: str(root.value)
+        text: root.value or ''
         pos: root.pos
         font_size: '15sp'
 
 <SettingPath>:
     Label:
-        text: str(root.value)
+        text: root.value or ''
         pos: root.pos
         font_size: '15sp'
 
 <SettingOptions>:
     Label:
-        text: str(root.value)
+        text: root.value or ''
         pos: root.pos
         font_size: '15sp'
 

--- a/kivy/tests/test_issue_1084.py
+++ b/kivy/tests/test_issue_1084.py
@@ -1,0 +1,43 @@
+#
+# Bug fixed: 
+# - put utf-8 in string, and validate -> no more crash due to str() encoding
+# - put utf-8 in string, validate, close, open the app and edit the value -> no
+# more weird space due to ascii->utf8 encoding.
+# - create an unicode directory, and select it with Path. -> no more crash at
+# validation.
+# - create an unicode directory, and select it with Path and restart -> the path
+# is still correct.
+
+from kivy.app import App
+from kivy.uix.settings import Settings
+
+data = '''
+[
+    {
+        "type": "string",
+        "title": "String",
+        "desc": "-",
+        "section": "test",
+        "key": "string"
+    },
+    {
+        "type": "path",
+        "title": "Path",
+        "desc": "-",
+        "section": "test",
+        "key": "path"
+    }
+]
+'''
+
+class UnicodeIssueSetting(App):
+    def build_config(self, config):
+        config.add_section('test')
+        config.setdefault('test', 'string', 'Hello world')
+        config.setdefault('test', 'path', '/')
+    def build(self):
+        s = Settings()
+        s.add_json_panel('Test Panel', self.config, data=data)
+        return s
+
+UnicodeIssueSetting().run()

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -272,7 +272,9 @@ class SettingItem(FloatLayout):
             return
         # get current value in config
         panel = self.panel
-        panel.set_value(self.section, self.key, str(value))
+        if not isinstance(value, basestring):
+            value = str(value)
+        panel.set_value(self.section, self.key, value)
 
 
 class SettingBoolean(SettingItem):
@@ -344,7 +346,7 @@ class SettingString(SettingItem):
             content=content, size_hint=(None, None), size=('400dp', '250dp'))
 
         # create the textinput used for numeric input
-        self.textinput = textinput = TextInput(text=str(self.value),
+        self.textinput = textinput = TextInput(text=self.value,
             font_size=24, multiline=False, size_hint_y=None, height='50dp')
         textinput.bind(on_text_validate=self._validate)
         self.textinput = textinput
@@ -422,9 +424,8 @@ class SettingPath(SettingItem):
             content=content, size_hint=(None, None), size=(400, 400))
 
         # create the filechooser
-        self.textinput = textinput = FileChooserListView(path=str(self.value),
-                                                         size_hint=(1, 1),
-                                                         dirselect=True)
+        self.textinput = textinput = FileChooserListView(
+                path=self.value, size_hint=(1, 1), dirselect=True)
         textinput.bind(on_path=self._validate)
         self.textinput = textinput
 


### PR DESCRIPTION
Bug fixed:
- put utf-8 in string, and validate -> no more crash due to str()
  encoding
- put utf-8 in string, validate, close, open the app and edit the value
  -> no more weird space due to ascii->utf8 encoding.
- create an unicode directory, and select it with Path. -> no more
  crash at validation.
- create an unicode directory, and select it with Path and restart ->
  the path is still correct.

Tested on OSX only.

closes #1084
