### PR TITLE
Update scatterlayout.py

### DIFF
--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -5,15 +5,15 @@ Scatter Layout
 .. versionadded:: 1.6.0
 
 
-This layout allows you to set relative coordinate for children. If you want
+This layout allows you to set relative coordinates for children. If you want
 absolute positioning, check :class:`~kivy.uix.floatlayout.FloatLayout`.
 
 The :class:`ScatterLayout` class behaves just like the regular Float
 Layout, except that its child widgets are positioned relative to the layout.
 
-For example, if you create a :class:`ScatterLayout`, add a widgets with
+For example, if you create a :class:`ScatterLayout`, add a widget with
 position = (0,0), the child widget will also move, when you change the
-position of the :class:`ScatterLayout`.  The child widgets coordiantes remain
+position of the :class:`ScatterLayout`.  The child widget's coordinates remain
 (0,0), i.e. they are relative to the containing layout. Since
 :class:`ScatterLayout` is implemented using a :class:`Scatter` widget, you can
 also translate and scale the layout like a normal :class:`Scatter` widget,
@@ -29,16 +29,16 @@ and the child widgets will behave as expected.
     Since the actual :class:`ScatterLayout` is a :class:`Scatter`, its
     add_widget and remove_widget functions are overwritten to add children
     to the embedded :class:`FloatLayout` (accessible as `content` property of
-    :class:`RelativeLayout`) automatically. So if you want to access the added
+    :class:`Scatter`) automatically. So if you want to access the added
     child elements, you need self.content.children, instead of self.children.
 
 .. warning::
 
-    The :class:'ScatterLayout' was introduced in 1.7.0 and was called
-    :class:'~kivy.uix.relativelayout.RelativeLayout' in prior versions.
-    :class:'~kivy.uix.relativelayout.RelativeLayout' is now an optimized
+    The :class:`ScatterLayout` was introduced in 1.7.0 and was called
+    :class:`~kivy.uix.relativelayout.RelativeLayout` in prior versions.
+    :class:`~kivy.uix.relativelayout.RelativeLayout` is now an optimized
     implementation that uses only a positional transform, to avoid some of the
-    heavier calculation involved form  :class:`Scatter`.
+    heavier calculation involved for :class:`Scatter`.
 
 '''
 


### PR DESCRIPTION
Fixed some typos and backtick marks en lieu of apostrophes. Please note particularly the suggested change at line 32 ('Scatter' instead of 'FloatLayout') of which I'm not sure.
