### PR TITLE
doc: revisions to guide/packagaing-ios.rst

### DIFF
--- a/doc/sources/guide/packaging-ios.rst
+++ b/doc/sources/guide/packaging-ios.rst
@@ -28,6 +28,7 @@ use `Homebrew <http://mxcl.github.com/homebrew/>`_ to install thoses dependencie
     brew install autoconf automake libtool pkg-config mercurial
     brew link libtool
     brew link mercurial
+    sudo easy_install pip
     sudo pip install cython
 
 Ensure that everything is ok before starting the second step!


### PR DESCRIPTION
Using MacOSX 10.8.3, XCode 4.6.2, I found that before running

```
sudo pip install cython
```

I had to had to do

```
sudo easy_install pip
```

first. Thought it might be good to add that, in case it's a common thing...
