### PR TITLE
Edit `BoundedNumericProperty.check` to use %f rather than %d for float ...

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -880,11 +880,11 @@ cdef class BoundedNumericProperty(Property):
                     obj.__class__.__name__,
                     self.name, _min))
         elif ps.bnum_use_min == 2:
-            _min = ps.bnum_f_min
-            if value < _min:
-                raise ValueError('%s.%s is below the minimum bound (%d)' % (
+            _f_min = ps.bnum_f_min
+            if value < _f_min:
+                raise ValueError('%s.%s is below the minimum bound (%f)' % (
                     obj.__class__.__name__,
-                    self.name, _min))
+                    self.name, _f_min))
         if ps.bnum_use_max == 1:
             _max = ps.bnum_max
             if value > _max:
@@ -892,11 +892,11 @@ cdef class BoundedNumericProperty(Property):
                     obj.__class__.__name__,
                     self.name, _max))
         elif ps.bnum_use_max == 2:
-            _max = ps.bnum_f_max
-            if value > _max:
-                raise ValueError('%s.%s is above the maximum bound (%d)' % (
+            _f_max = ps.bnum_f_max
+            if value > _f_max:
+                raise ValueError('%s.%s is above the maximum bound (%f)' % (
                     obj.__class__.__name__,
-                    self.name, _max))
+                    self.name, _f_max))
         return True
 
     property bounds:


### PR DESCRIPTION
... max/min in ValueError error message.

If the supplied value is outside the bounds of BoundedNumericProperty, a ValueError is raised by `BoundedNumericProperty.check`.  However, the error message inside the ValueError is incorrect if the max or min are floats, since the error message uses "%d" rather than "%f".

This means for example that if the min is 0.6 and you supply a value of 0.4, the error message will tell you that your value was below the minimum bound of "0", which is incorrect for 2 reasons.
