### PR TITLE
Clear version change documentation

### DIFF
--- a/kivy/uix/relativelayout.py
+++ b/kivy/uix/relativelayout.py
@@ -23,10 +23,10 @@ relative to the containing layout.
     Prior to version 1.7.0 The :class:`RelativeLayout` was implemented as a
     :class`FloatLayout` inside a :class:`Scatter`.  This behaviour/widget has
     been renamed to `ScatterLayout`.  The :class:`RelativeLayout` now only
-    supports relative position (and cant be roatated or scaled), so that the
-    implemetation can be optimized and avoid the heavier calculations from
-    :class:`Scatter` (e.g. inverse matrix, recaculating multiple properties,
-    etc)
+    supports relative position (and can't be rotated, scaled or translated on 
+    a multitouch system using two or more fingers), so that the implementation 
+    can be optimized and avoid the heavier calculations from :class:`Scatter` 
+    (e.g. inverse matrix, recaculating multiple properties,etc)
 
 '''
 


### PR DESCRIPTION
The documentation of [RelativeLayout.py](https://github.com/kivy/kivy/blob/master/kivy/uix/relativelayout.py#L21) says:

```
.. versionchanged:: 1.7.0

    Prior to version 1.7.0 The :class:`RelativeLayout` was implemented as a
    :class`FloatLayout` inside a :class:`Scatter`.  This behaviour/widget has
    been renamed to `ScatterLayout`.  The :class:`RelativeLayout` now only
    supports relative position (and cant be roatated or scaled), so that the
    implemetation can be optimized and avoid the heavier calculations from
    :class:`Scatter` (e.g. inverse matrix, recaculating multiple properties,
    etc)
```

I was struggling why is it that it says it cannot be rotated or scaled?. I had a `Widget` that inherits from `RelativeLayout` in which I was able to `Rotate` and `Scale` without any problem. It took me quite a while to find out that the documentation only refers to multi-touch behaviour.
