### PR TITLE
core:Image fix for zip image loader, now tested to be working on py2 and py3

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -258,8 +258,10 @@ class ImageLoader(object):
         Returns an Image with a list/array of type ImageData stored in
         Image._data
         '''
+        # read zip in menory for faster access
+        _file = SIO.BytesIO(open(filename, 'rb').read())
         # read all images inside the zip
-        z = zipfile.ZipFile(filename, 'r')
+        z = zipfile.ZipFile(_file)
         image_data = []
         # sort filename list
         znamelist = z.namelist()
@@ -268,7 +270,7 @@ class ImageLoader(object):
         for zfilename in znamelist:
             try:
                 #read file and store it in mem with fileIO struct around it
-                tmpfile = SIO.StringIO(z.read(zfilename))
+                tmpfile = SIO.BytesIO(z.read(zfilename))
                 ext = zfilename.split('.')[-1].lower()
                 im = None
                 for loader in ImageLoader.loaders:


### PR DESCRIPTION
Recent merge of py3 branch into master broke a few things like the zip loader. This fixes that making sure that the zip is loaded using BytesIO instead of StringIO.

Tested on Py3 and py2 using examples/widgets/sequenced_images example.
