### PR TITLE
A few typo fixes to website docs

### DIFF
--- a/doc/sources/gettingstarted/diving.rst
+++ b/doc/sources/gettingstarted/diving.rst
@@ -6,7 +6,7 @@ To get straight into kivy, take a look at :doc:`/index`.
 Kivy comes with a set of :doc:`examples` in the ``kivy_installation/examples`` directory.
 You should try modifying/improving/adapting them to your needs.
 
-Browse the `snippet wiki <http://wiki.kivy.org>`_ . You can even add your own snippet in
+Browse the `snippet wiki <http://wiki.kivy.org>`_. You can even add your own snippet in
 the user snippets section.
 
 Understand the basics about :mod:`kivy graphics <kivy.graphics>`.
@@ -16,7 +16,7 @@ Take a look at the built-in :mod:`widgets <kivy.uix>`.
 Follow the :doc:`/guide-index` to get even more familiar with kivy.
 
 See how to use different :mod:`Modules <kivy.modules>` in the modules section,
-like the :mod:`Inspector <kivy.modules.inspector>` for live inspection.
+such as the :mod:`Inspector <kivy.modules.inspector>` for live inspection.
 
 Learn how to handle custom :mod:`Input <kivy.input>`.
 

--- a/doc/sources/gettingstarted/events.rst
+++ b/doc/sources/gettingstarted/events.rst
@@ -1,7 +1,7 @@
 Events
 ------
 
-Kivy is mostly event-based, meaning the flow of the program is determined
+Kivy is mostly `event-based <http://en.wikipedia.org/wiki/Event-driven_programming>`_, meaning the flow of the program is determined
 by events.
 
 **Clock events**
@@ -47,7 +47,7 @@ changes its position or size, the corresponding event is automatically fired.
 In addition, you have the ability to create your own events using
 :meth:`~kivy.event.EventDispatcher.register_event_type`, as the
 `on_press` and `on_release` events in the :class:`~kivy.uix.button.Button`
-widgit demonstrate.
+widget demonstrate.
 
 Another thing to note is that if you override an event, you become responsible
 for implementing all its behaviour previously handled by the base class. The

--- a/doc/sources/gettingstarted/examples.rst
+++ b/doc/sources/gettingstarted/examples.rst
@@ -7,7 +7,7 @@ Examples
 
 .. |ani_dir| replace:: ./examples/animation
 .. |ani_file| replace:: animate.py
-.. |ani_desc| replace:: Widget animation using :class:`Animation <kivy.animation.Animation>` .
+.. |ani_desc| replace:: Widget animation using :class:`Animation <kivy.animation.Animation>`
 
 
 .. |app_dir| replace:: ./examples/application
@@ -48,12 +48,12 @@ Examples
 
 .. |sho_dir| replace:: ../examples/demo/showcase
 .. |sho_file| replace:: main.py
-.. |sho_desc| replace:: Showcase of **widgets and layouts** used in kivy.
+.. |sho_desc| replace:: Showcase of **widgets and layouts** used in kivy
 
 .. |tch_dir| replace:: ./examples/demo/touchtracer
 .. |tch_file| replace:: main.py
-.. |tch_desc| replace:: Draw lines under every detected touch.
-.. |tch_desc2| replace:: A good place to understand **how touch events work in kivy**.
+.. |tch_desc| replace:: Draw lines under every detected touch
+.. |tch_desc2| replace:: A good place to understand **how touch events work in kivy**
 
 .. |tws_dir| replace:: ./examples/frameworks/twisted
 .. |tws_file| replace:: echo_client_app.py
@@ -62,11 +62,11 @@ Examples
 
 .. |gst_dir| replace:: ./examples/gestures
 .. |gst_file| replace:: gesture_board.py
-.. |gst_desc| replace:: A clean board to try out **gestures**.
+.. |gst_desc| replace:: A clean board to try out **gestures**
 
 .. |kv_dir| replace:: ./examples/guide/designwithkv
 .. |kv_file| replace:: main.py
-.. |kv_desc| replace:: Programming Guide examples on how to :doc:`design with kv lang </guide/lang>`
+.. |kv_desc| replace:: Programming Guide examples about how to :doc:`design with kv lang </guide/lang>`
 
 .. |fwd_dir| replace:: ./examples/tutorials/firstwidget
 .. |fwd_file| replace:: 1_skeleton.py
@@ -75,81 +75,81 @@ Examples
 .. |fwd_file4| replace:: 4_draw_line.py
 .. |fwd_file5| replace:: 5_random_colors.py
 .. |fwd_file6| replace:: 6_button.py
-.. |fwd_desc| replace:: Programming Guide examples :doc:`Your first widget </tutorials/firstwidget>`
+.. |fwd_desc| replace:: Programming Guide example: :doc:`Your first widget </tutorials/firstwidget>`
 
 .. |qst_dir| replace:: ./examples/guide/quickstart
 .. |qst_file| replace:: main.py
-.. |qst_desc| replace:: Programming Guide example.
+.. |qst_desc| replace:: Programming Guide example
 
 .. |kin_dir| replace::  ./examples/kinect
 .. |kin_file| replace:: main.py
-.. |kin_desc| replace:: Howto use **kinect** for input.
+.. |kin_desc| replace:: How to use **kinect** for input
 
 .. |kvd_dir| replace::  ./examples/kv
 .. |kvd_file| replace:: kvrun.py
-.. |kvd_desc| replace:: Load kv files, use **kv lang to load different widgets**.
+.. |kvd_desc| replace:: Load kv files, use **kv lang to load different widgets**
 
 .. |rst_dir| replace::  ./examples/RST_Editor
 .. |rst_file| replace:: main.py
-.. |rst_desc| replace:: An  RST editor for the :class:`RstDocument <kivy.uix.rst.RstDocument>` Widget.
+.. |rst_desc| replace:: An RST editor for the :class:`RstDocument <kivy.uix.rst.RstDocument>` Widget
 
 .. |sdr_dir| replace::  ./examples/shader
 .. |sdr_file| replace:: plasma.py
 .. |sdr_file1| replace:: shadertree.py
-.. |sdr_desc| replace:: How to use different **Shaders**.
+.. |sdr_desc| replace:: How to use different **Shaders**
 
 .. |png_dir| replace::  ./examples/tutorials/pong
 .. |png_file| replace:: main.py
-.. |png_desc| replace:: :doc:`/tutorials/pong`. Your first step in kivy programming.
+.. |png_desc| replace:: :doc:`/tutorials/pong`. Your first step in kivy programming
 
 .. |wdg_dir| replace::  ./examples/widgets
 .. |wdg_file1| replace:: accordion_1.py
-.. |wdg_desc1| replace:: Usage and Showcase of :class:`Accordion <kivy.uix.accordion>`  Widget.
+.. |wdg_desc1| replace:: Usage and showcase of :class:`Accordion <kivy.uix.accordion>`  Widget
 .. |wdg_file2| replace:: asyncimage.py
-.. |wdg_desc2| replace:: Usage and Showcase of :class:`AsyncImage <kivy.uix.image.AsyncImage>` Widget.
+.. |wdg_desc2| replace:: Usage and showcase of :class:`AsyncImage <kivy.uix.image.AsyncImage>` Widget
 .. |wdg_file25| replace:: boxlayout_pos_hint.py
-.. |wdg_desc25| replace:: Showcase of pos_hint under BoxLayout :class:`BoxLayout <kivy.uix.boxlayout>`
+.. |wdg_desc25| replace:: Showcase of pos_hint under :class:`BoxLayout <kivy.uix.boxlayout>`
 .. |wdg_file3| replace:: bubble_test.py
-.. |wdg_desc3| replace:: Usage and Showcase of :class:`Bubble <kivy.uix.bubble>`  Widget.
+.. |wdg_desc3| replace:: Usage and Showcase of :class:`Bubble <kivy.uix.bubble>`  Widget
 .. |wdg_file4| replace:: customcollide.py
 .. |wdg_desc4| replace:: Test for **collision** with custom shaped widget
 .. |wdg_file5| replace:: fbowidget.py
-.. |wdg_desc5| replace:: Usage of :class:`FBO <kivy.graphics.fbo>` to speed up graphics.
+.. |wdg_desc5| replace:: Usage of :class:`FBO <kivy.graphics.fbo>` to speed up graphics
 .. |wdg_file6| replace:: image_mipmap.py
-.. |wdg_desc6| replace:: How to use :class:`Image <kivy.uix.image>` widget with mipmap.
+.. |wdg_desc6| replace:: How to use :class:`Image <kivy.uix.image>` widget with mipmap
 .. |wdg_file7| replace:: keyboardlistener.py
-.. |wdg_desc7| replace:: Listen to the keyboard input and spew result to console.
+.. |wdg_desc7| replace:: Listen to the keyboard input and spew result to console
 .. |wdg_file8| replace:: label_mipmap.py
 .. |wdg_desc8| replace:: How to use :class:`Label <kivy.uix.label>` widget with
 .. |wdg_file81| replace:: label_with_markup.py
-.. |wdg_desc81| replace:: Useage of :class:`Label <kivy.uix.label>` widget with markup.
+.. |wdg_desc81| replace:: Usage of :class:`Label <kivy.uix.label>` widget with markup
 .. |wdg_file82| replace:: popup_with_kv.py
-.. |wdg_desc82| replace:: Useage of :class:`Popup <kivy.uix.popup>` widget with ``kv`` language
+.. |wdg_desc82| replace:: Usage of :class:`Popup <kivy.uix.popup>` widget with ``kv`` language
 .. |wdg_file9| replace:: rstexample.py
-.. |wdg_desc9| replace:: Usage and Showcase of :class:`RstDocument <kivy.uix.rst.RstDocument>` Widget.
+.. |wdg_desc9| replace:: Usage and showcase of :class:`RstDocument <kivy.uix.rst.RstDocument>` Widget
 .. |wdg_file10| replace:: scatter.py
-.. |wdg_desc10| replace:: Usage and Showcase of :class:`Scatter <kivy.uix.scatter>` Widget.
+.. |wdg_desc10| replace:: Usage and showcase of :class:`Scatter <kivy.uix.scatter>` Widget
 .. |wdg_file11| replace:: screenmanager.py
-.. |wdg_desc11| replace:: Usage and showase of :mod:`ScreenManager <kivy.uix.screenmanager>` Module.
+.. |wdg_desc11| replace:: Usage and showcase of :mod:`ScreenManager <kivy.uix.screenmanager>` Module
 .. |wdg_file12| replace:: scrollview.py
-.. |wdg_desc12| replace:: Usage and Showcase of :class:`ScrollView <kivy.uix.scrollview>` Widget.
+.. |wdg_desc12| replace:: Usage and showcase of :class:`ScrollView <kivy.uix.scrollview>` Widget
 .. |wdg_file14| replace:: spinner.py
-.. |wdg_desc14| replace:: Usage and Showcase of :class:`Spinner <kivy.uix.spinner>` Widget.
+.. |wdg_desc14| replace:: Usage and showcase of :class:`Spinner <kivy.uix.spinner>` Widget
 .. |wdg_file15| replace:: tabbedpanel.py
 .. |wdg_desc15| replace:: Usage of a simple :class:`TabbedPanel <kivy.uix.tabbedpanel.TabbedPanel>`
 .. |wdg_file16| replace:: tabbed_panel_showcase.py
-.. |wdg_desc16| replace:: Advanced Showcase of :class:`TabbedPanel <kivy.uix.tabbedpanel.TabbedPanel>`
+.. |wdg_desc16| replace:: Advanced showcase of :class:`TabbedPanel <kivy.uix.tabbedpanel.TabbedPanel>`
 .. |wdg_file17| replace:: textalign.py
-.. |wdg_desc17| replace:: Usage of text alignment in :class:`Label <kivy.uix.label>` widget.
+.. |wdg_desc17| replace:: Usage of text alignment in :class:`Label <kivy.uix.label>` widget
 .. |wdg_file18| replace:: textinput.py
-.. |wdg_desc18| replace:: Usage and Showcase of :class:`TextInput <kivy.uix.textinput>` Widget.
+.. |wdg_desc18| replace:: Usage and Showcase of :class:`TextInput <kivy.uix.textinput>` Widget
 .. |wdg_file19| replace:: unicode_textinput.py
-.. |wdg_desc19| replace:: Showcase of unicode text in :class:`TextInput <kivy.uix.textinput>` Widget.
+.. |wdg_desc19| replace:: Showcase of unicode text in :class:`TextInput <kivy.uix.textinput>` Widget
 .. |wdg_file20| replace:: videoplayer.py
-.. |wdg_desc20| replace:: Usage and options of :class:`VideoPlayer <kivy.uix.videoplayer>` Widget.
+.. |wdg_desc20| replace:: Usage and options of :class:`VideoPlayer <kivy.uix.videoplayer>` Widget
 .. |seq_dir| replace::  ./examples/widgets/sequenced_images:
 .. |seq_file| replace:: main.py
-.. |seq_desc| replace:: Showcase usage of **sequenced images**: gif, images in .zip.
+.. |seq_desc| replace:: Showcase usage of **sequenced images**: gif, images in .zip
 
 +------------+---------------+------------------------+
 |  Directory |   Filename/s  |  Example Description   |

--- a/doc/sources/gettingstarted/framework.rst
+++ b/doc/sources/gettingstarted/framework.rst
@@ -13,13 +13,13 @@ Non-widget stuff
 .. |atlas_img| image:: ../images/gs-atlas.png
 
 .. |atlas_text| replace:: :class:`Atlas <kivy.atlas.Atlas>` is a class for
-    managing texture maps i.e. packing multiple textures into one image.
+    managing texture maps, i.e. packing multiple textures into one image.
     This allows you to reduce the number of images loaded and thus speed up the
     application start.
 
 .. |clock_text| replace:: :class:`Clock <kivy.clock.Clock>` provides you with a
-    convenient way to schecdule jobs at set time intervals and is preferred
-    over *sleep()*,  which would block the kivy event loop. These intervals can
+    convenient way to schedule jobs at set time intervals and is preferred
+    over `sleep()`,  which would block the kivy event loop. These intervals can
     be set relative to the OpenGL drawing instructions,
     :ref:`before <schedule-before-frame>` or
     :ref:`after <schedule-before-frame>`. The Clock also provides you with a way

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -29,8 +29,13 @@ Development Version
 ~~~~~~~~~~~~~~~~~~~
 
 If you want the development version of Kivy in order to benefit from the latest
-additions to the framework, you can get the source code from github::
+additions to the framework, you can get the
+`source code <https://github.com/kivy/kivy>`_ from github_::
+
 
     git clone http://github.com/kivy/kivy
 
-Take a look at our instructions for installing the :ref:`installation_devel`
+Take a look at our instructions for installing the :ref:`installation_devel`.
+
+
+.. _github: https://github.com/

--- a/doc/sources/gettingstarted/intro.rst
+++ b/doc/sources/gettingstarted/intro.rst
@@ -28,7 +28,7 @@ Using Kivy on your computer, you can create apps that run on:
 - Any other touch-enabled professional/homebrew devices supporting TUIO
   (Tangible User Interface Objects).
 
-Kivy empowers you with the freedom of writing your code once and having it run
+Kivy empowers you with the freedom to write your code once and have it run
 as-is on different platforms.
 
 Follow this guide to get the tools you need, understand the major concepts and

--- a/doc/sources/gettingstarted/layouts.rst
+++ b/doc/sources/gettingstarted/layouts.rst
@@ -15,16 +15,16 @@ Layouts are containers used to arrange widgets in a particular manner::
                     bottom) or `tb-lr` order.
 
 When you add a widget to a layout, the following properties are used to
-determine the widgets size and position, depending on the type of layout:
+determine the widget's size and position, depending on the type of layout:
 
     **size_hint**: defines the size of a widget in its parent space as a percentage.
     Values are restricted to the range 0.0 - 1.0 i.e. 0.01 = 1% and 1. = 100%.
 
     **pos_hint**: is used to place the widget relative to the parent.
 
-The **size_hint** and **pos_hint** are used to calculate widget's size and
-position only if the value/s are not set to None. If you set these values to
-None, the layout will not position/size the widget and you can specify the
+The **size_hint** and **pos_hint** are used to calculate a widget's size and
+position only if the value(s) are not set to ``None``. If you set these values to
+``None``, the layout will not position/size the widget and you can specify the
 values (x, y, width, height) directly in screen coordinates.
 
 For a detailed look at how you can arrange widgets using layouts, please refer

--- a/doc/sources/gettingstarted/properties.rst
+++ b/doc/sources/gettingstarted/properties.rst
@@ -27,7 +27,7 @@ To use them, **you have to declare them at class level**. That is, directly in
 the class, not in any method of the class. A property is a class attribute
 that will automatically create instance attributes. Each property by default
 provides an ``on_<propertyname>`` event that is called whenever the property's
-state/value changes .
+state/value changes.
 
 Kivy provides the following properties:
     :mod:`~kivy.properties.NumericProperty`,
@@ -41,4 +41,4 @@ Kivy provides the following properties:
     :mod:`~kivy.properties.AliasProperty`,
     :mod:`~kivy.properties.DictProperty`,
 
-For an in-depth explaination, look at :doc:`/api-kivy.properties`
+For an in-depth explaination, take a look at :doc:`/api-kivy.properties`.

--- a/doc/sources/gettingstarted/rules.rst
+++ b/doc/sources/gettingstarted/rules.rst
@@ -21,6 +21,6 @@ In the above code :
                     # (note the indentation).
             rows: 2 # this how you set each property of your widget/layout
 
-That's it, that's how simple it is to design your GUI in the kv language. To get
+That's it, that's how simple it is to design your GUI in the Kv language. For
 a more in-depth understanding, please refer to the :doc:`/guide/lang`
 documentation.

--- a/doc/sources/index.rst
+++ b/doc/sources/index.rst
@@ -9,7 +9,7 @@ rapid development of applications equipped with novel user interfaces, such as
 multi-touch apps.
 
 We recommend that you get started with :doc:`/gettingstarted/index`. Then head
-over to the :ref:`guide-index`. We also have a :ref:`quickstart` if you are
+over to the :ref:`guide-index`. We also have :ref:`quickstart` if you are
 impatient.
 
 You are probably wondering why you should be interested in using Kivy. There is
@@ -34,7 +34,7 @@ Kivy is released under the terms of the GNU LGPL Version 3.
 You should have received a copy of the LGPL alongside your Kivy
 distribution. See the file COPYING in the Kivy root folder.
 An online version of the license can be found at
-http://www.gnu.org/licenses/lgpl-3.0.txt
+http://www.gnu.org/licenses/lgpl-3.0.txt.
 
 In a nutshell, the license allows you to use Kivy in your own projects
 regardless of whether they are open source, closed source, commercial or free.


### PR DESCRIPTION
I found some typos while learning how to use Kivy from the excellent online docs. This patch fixes minor typos in 10 documentation files, and adds one or two links. All changes have been compiled and tested by inspection of the rendered pages in a browser. Thanks for all your hard work - as a Python programmer developing on Android, this project is gratefully appreciated.
