### PR TITLE
[PY3] Replacing "," with "()" to make code compatible with py27 py33

### DIFF
--- a/examples/3Drendering/objloader.py
+++ b/examples/3Drendering/objloader.py
@@ -137,6 +137,6 @@ def MTL(filename):
         if values[0] == 'newmtl':
             mtl = contents[values[1]] = {}
         elif mtl is None:
-            raise ValueError, "mtl file doesn't start with newmtl stmt"
+            raise ValueError("mtl file doesn't start with newmtl stmt")
         mtl[values[0]] = values[1:]
     return contents


### PR DESCRIPTION
As you can see below our code uses the old syntax to raise an error with a custom text.
