### PR TITLE
core: Widget use actual widget reference instead of proxy ref when

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -316,12 +316,13 @@ class Widget(WidgetBase):
         >>> slider = Slider()
         >>> root.add_widget(slider)
         '''
-        widget = widget.__self__
-        if widget is self:
-            raise WidgetException('You cannot add yourself in a Widget')
         if not isinstance(widget, Widget):
             raise WidgetException(
                 'add_widget() can be used only with Widget classes.')
+
+        widget = widget.__self__
+        if widget is self:
+            raise WidgetException('You cannot add yourself in a Widget')
         parent = widget.parent
         # check if widget is already a child of another widget
         if parent:


### PR DESCRIPTION
adding to another widget.
 closes #1322.
