### PR TITLE
Updating ScatterLayout documentation (ScatterLayout vs Scatter and ScatterLayout vs FloatLayout)

### DIFF
--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -4,20 +4,19 @@ Scatter Layout
 
 .. versionadded:: 1.6.0
 
-
-This layout allows you to set relative coordinates for children. If you want
-absolute positioning, check :class:`~kivy.uix.floatlayout.FloatLayout`.
-
-The :class:`ScatterLayout` class behaves just like the regular Float
-Layout, except that its child widgets are positioned relative to the layout.
-
+This layout behaves just as :class:`~kivy.uix.floatlayout.RelativeLayout`.
 For example, if you create a :class:`ScatterLayout`, add a widget with
 position = (0,0), the child widget will also move, when you change the
 position of the :class:`ScatterLayout`.  The child widget's coordinates remain
-(0,0), i.e. they are relative to the containing layout. Since
-:class:`ScatterLayout` is implemented using a :class:`Scatter` widget, you can
-also translate and scale the layout like a normal :class:`Scatter` widget,
-and the child widgets will behave as expected.
+(0,0), i.e. they are relative to the containing layout.
+
+However, since :class:`ScatterLayout` is implemented using a :class:`Scatter` 
+widget, you can also translate, rotate and scale the layout using touches 
+(mouse or fingers) just like a normal :class:`Scatter` widget, and the child 
+widgets will behave as expected.
+
+In contrast with a Scatter, the Layout favours 'hint' properties, such as
+size_hint, size_hint_x, size_hint_y and pos_hint. 
 
 ..note::
 


### PR DESCRIPTION
The previous documentation was based in the old RelativeLayout (based in a Scatter). The documentation didn't indicate the difference between Scatter and ScatterLayout. It is also more clear if we compare the ScatterLayout against the RelativeLayout since they behaviour is the same (except for the scatter functionality). Scatter is already relative so the only difference that I can see is the possibility of using the hint properties.
