### PR TITLE
MotionEvent.is_triple_tap docs: syntax fix

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -257,6 +257,7 @@ class MotionEvent(MotionEventBase):
         self.is_double_tap = False
 
         #: Indicate if the touch is a triple tap or not
+        #:
         #: .. versionadded:: 1.7.0
         self.is_triple_tap = False
 


### PR DESCRIPTION
A directive needs an empty line before it. Add empty line.
