### PR TITLE
Fix #1396 : Allow objects inheriting from list or tuple

### DIFF
--- a/kivy/adapters/simplelistadapter.py
+++ b/kivy/adapters/simplelistadapter.py
@@ -44,7 +44,8 @@ class SimpleListAdapter(Adapter):
     def __init__(self, **kwargs):
         if 'data' not in kwargs:
             raise Exception('list adapter: input must include data argument')
-        if type(kwargs['data']) not in (tuple, list):
+        if not isinstance(kwargs['data'], list) and \
+                not isinstance(kwargs['data'], tuple):
             raise Exception('list adapter: data must be a tuple or list')
         super(SimpleListAdapter, self).__init__(**kwargs)
 

--- a/kivy/tests/test_adapters.py
+++ b/kivy/tests/test_adapters.py
@@ -441,6 +441,18 @@ class AdaptersTestCase(unittest.TestCase):
         msg = 'list adapter: data must be a tuple or list'
         self.assertEqual(str(cm.exception), msg)
 
+    def test_simple_list_adapter_for_inherited_list(self):
+        # Test for issue 1396 : list, tuple and inheritance
+        class ExtendedList(list):
+            pass
+        class ExtendedTuple(tuple):
+            pass
+        # Equivalent to assertNotRaise
+        simple_list_adapter = SimpleListAdapter(data=ExtendedList(),
+                                  template='CustomSimpleListItem')
+        simple_list_adapter = SimpleListAdapter(data=ExtendedTuple(),
+                                  template='CustomSimpleListItem')
+
     def test_simple_list_adapter_with_template(self):
         list_item_args_converter = \
                 lambda row_index, obj: {'text': str(obj),


### PR DESCRIPTION
A SimpleListAdapter doesn't accept objects inheriting form list or
tuple, because it checks directly the type.

Here, in place of testing the type of the object, we use isinstance.

Also provide a testcase
