### PR TITLE
uix:Settings fix handeling of numeric input

### DIFF
--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -462,9 +462,9 @@ class SettingNumeric(SettingString):
         self._dismiss()
         try:
             if is_float:
-                self.value = float(self.textinput.text)
+                self.value = unicode(float(self.textinput.text))
             else:
-                self.value = int(self.textinput.text)
+                self.value = unicode(int(self.textinput.text))
         except ValueError:
             return
 


### PR DESCRIPTION
Weird how it went unnoticed.

To reproduce the Issue this Fixes..
1. Open settings, edit a numeric setting like fps.

The value isn't updated and the next time you try setting the value, it crashes.

Need to test further::
-  are there situations that rely on the self.value being numeric?
- should the conversion be moved to where the Textinput's text is being set?
