### PR TITLE
uix:ActionBar make items added to ActionOverflow persistant in the overflow dropdown. Minor bug fixes.

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -499,6 +499,7 @@
         Color:
             rgba: self.background_color
         BorderImage:
+            border: root.border
             pos: self.pos
             size: self.size
             source: self.background_image
@@ -524,7 +525,7 @@
             source: self.background_image
 
 <ActionButton>:
-    background_normal: 'atlas://data/images/defaulttheme/action_bar' if self.inside_group else 'atlas://data/images/defaulttheme/action_item'
+    background_normal: 'atlas://data/images/defaulttheme/' + ('action_bar' if self.inside_group else 'action_item')
 	background_down: 'atlas://data/images/defaulttheme/action_item_down'
 	size_hint_x: None if not root.inside_group else 1
 	width: [dp(48) if (root.icon and not root.inside_group) else max(dp(48), (self.texture_size[0] + dp(32))), self.size_hint_x][0]
@@ -533,6 +534,7 @@
 	Image:
 		opacity: 1 if (root.icon and not root.inside_group) else 0
 		source: root.icon
+        mipmap: root.mipmap
 		pos: root.x + dp(4), root.y + dp(4)
 		size: root.width - dp(8), root.height - sp(8)
 
@@ -560,18 +562,20 @@
             allow_stretch: True
             size_hint_x: None
             width: self.texture_size[0] if root.with_previous else dp(8)
+            mipmap: root.mipmap
         Image:
             source: root.app_icon
             allow_stretch: True
             size_hint_x: None
             width: self.height
-			mipmap: True
+			mipmap: root.mipmap
 		Widget:
 			size_hint_x: None
 			width: '5sp'
         Label:
             text: root.title
             text_size: self.size
+            color: root.color
             shorten: True
             halign: 'left'
             valign: 'middle'

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -100,6 +100,14 @@ class ActionItem(object):
        default to 'atlas://data/images/defaulttheme/action_item_down'.
     '''
 
+    mipmap = BooleanProperty(True)
+    '''Defines whether the Image/icon dispayed on top of the button uses
+    mipamap or not.
+
+    :data:`mipmap` is a :class:`~kivy.properties.BooleanProperty` defaults
+    to `True`
+    '''
+
 
 class ActionButton(Button, ActionItem):
     '''ActionButton class, see module documentation for more information.
@@ -578,6 +586,10 @@ class ActionBar(BoxLayout):
 
       :data:`background_image` is an :class:`~kivy.properties.StringProperty`,
       default to 'action_bar'
+    '''
+
+    border = ListProperty([2, 2, 2, 2])
+    ''':data:`border` to be applied to the :data:`background_image`
     '''
 
     __events__ = ('on_previous',)


### PR DESCRIPTION
- Support keeping items in overflow icon always if items are directly added to ActionOverFlow
- Fix positioning of items when they are re-added to the Actionbar using `group_index` to calculate the
  position to insert the items.
