### PR TITLE
core:keyboard, avoid multiple bindinngs

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -71,8 +71,9 @@ class Keyboard(EventDispatcher):
         # numpad
         'numpad0': 256, 'numpad1': 257, 'numpad2': 258, 'numpad3': 259,
         'numpad4': 260, 'numpad5': 261, 'numpad6': 262, 'numpad7': 263,
-        'numpad8': 264, 'numpad9': 265, 'numpaddecimal': 266, 'numpaddivide': 267,
-        'numpadmul': 268, 'numpadsubstract': 269, 'numpadadd': 270,
+        'numpad8': 264, 'numpad9': 265, 'numpaddecimal': 266,
+        'numpaddivide': 267, 'numpadmul': 268, 'numpadsubstract': 269,
+        'numpadadd': 270,
 
         # F1-15
         'f1': 282, 'f2': 283, 'f3': 282, 'f4': 285, 'f5': 286, 'f6': 287,
@@ -436,7 +437,8 @@ class WindowBase(EventDispatcher):
         if 'rotation' not in kwargs:
             kwargs['rotation'] = Config.getint('graphics', 'rotation')
         if 'position' not in kwargs:
-            kwargs['position'] = Config.getdefault('graphics', 'position', 'auto')
+            kwargs['position'] = Config.getdefault('graphics', 'position',
+                                     'auto')
         if 'top' in kwargs:
             kwargs['position'] = 'custom'
             kwargs['top'] = kwargs['top']
@@ -968,12 +970,11 @@ class WindowBase(EventDispatcher):
             keyboard.target = target
 
         # use system (hardware) keyboard according to flag
-        if self.use_syskeyboard:
-            self.bind(
+        if self.allow_vkeyboard and self.use_syskeyboard:
+            self.unbind(
                 on_key_down=keyboard._on_window_key_down,
                 on_key_up=keyboard._on_window_key_up)
-        else:
-            self.unbind(
+            self.bind(
                 on_key_down=keyboard._on_window_key_down,
                 on_key_up=keyboard._on_window_key_up)
 


### PR DESCRIPTION
With the recent pull for systemanddock and systemandmulti system keyboard was being bound in everytime TextInput was focused.

To reproduce the issue this fixes::
- start a kivy app with two or more textinputs with keyboard mode set to one of system/systemanddoc/systemandmulti .
- focus each Text Input one by one and type.

On a side note: what is the point of systemandmulti? multiple TextInputs can be focused at the same time. to have the system keyboard bound to more than one Textinputs doesn't make sense. This would probably lead to buggy behavior.
