### PR TITLE
Fix #1419. Use memoryview instead of deprecated buffer.

### DIFF
--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -404,7 +404,7 @@ cdef class Fbo(RenderContext):
         self.bind()
         data = py_glReadPixels(wx, wy, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)
         self.release()
-        raw_data = str(buffer(data))
+        raw_data = str(memoryview(data))
         
         return [ord(i) for i in raw_data]
 


### PR DESCRIPTION
Buffer is deprecated in python 3 in favour of memoryview, which was added in 2.7.
