### PR TITLE
Use widget's id as its __hash__.

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -199,6 +199,9 @@ class Widget(WidgetBase):
             return False
         return self.proxy_ref is other.proxy_ref
 
+    def __hash__(self):
+        return id(self)
+
     @property
     def __self__(self):
         return self


### PR DESCRIPTION
Using `id` for a widget's `__hash__` is safe because `__eq__` only returns `True` if it is the same object. Fixes a `TypeError` in `ButtonBehaviour` `on_touch` methods in python3.
