### PR TITLE
Add text_type to kivy.compat as alias for unicode/str.

### DIFF
--- a/kivy/compat.py
+++ b/kivy/compat.py
@@ -16,10 +16,12 @@ PY2 = sys.version_info[0] == 2
 
 #: String types that can be used for checking if a object is a string
 string_types = None
+text_type = None
 if PY2:
     string_types = basestring
+    text_type = unicode
 else:
-    string_types = str
+    string_types = text_type = str
 
 if PY2:
     iterkeys = lambda d: d.iterkeys()

--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -9,6 +9,7 @@ try:
 except:
     raise
 
+from kivy.compat import text_type
 from kivy.core.text import LabelBase
 from kivy.core.image import ImageData
 
@@ -23,7 +24,7 @@ class LabelPIL(LabelBase):
         fontsize = int(self.options['font_size'])
         fontname = self.options['font_name_r']
         try:
-            id = '%s.%s' % (unicode(fontname), unicode(fontsize))
+            id = '%s.%s' % (text_type(fontname), text_type(fontsize))
         except UnicodeDecodeError:
             id = '%s.%s' % (fontname, fontsize)
 

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -111,7 +111,7 @@ import os
 from kivy.metrics import dp
 from kivy.config import ConfigParser
 from kivy.animation import Animation
-from kivy.compat import string_types
+from kivy.compat import string_types, text_type
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
 from kivy.uix.filechooser import FileChooserListView
@@ -463,9 +463,9 @@ class SettingNumeric(SettingString):
         self._dismiss()
         try:
             if is_float:
-                self.value = unicode(float(self.textinput.text))
+                self.value = text_type(float(self.textinput.text))
             else:
-                self.value = unicode(int(self.textinput.text))
+                self.value = text_type(int(self.textinput.text))
         except ValueError:
             return
 


### PR DESCRIPTION
Fixes `NameError: global name 'unicode' is not defined` in python3.
