### PR TITLE
uix:DropDown introduce `on_dismiss` event and use it in Spinner. fixes

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -115,6 +115,11 @@ class DropDown(ScrollView):
             Fired when a selection is done, with the data of the selection as
             first argument. Data is what you pass in the :meth:`select` method
             as first argument.
+        `on_dismiss`:
+            .. versionadded:: 1.8.0
+
+            Fired when the DropDown is dismissed either on selection or on
+            touching outside the widget.
     '''
 
     auto_width = BooleanProperty(True)
@@ -152,7 +157,7 @@ class DropDown(ScrollView):
     list, which is a :class:`~kivy.uix.gridlayout.GridLayout` by default.
     '''
 
-    __events__ = ('on_select', )
+    __events__ = ('on_select', 'on_dismiss')
 
     def __init__(self, **kwargs):
         self._win = None
@@ -194,6 +199,10 @@ class DropDown(ScrollView):
         if self.attach_to:
             self.attach_to.unbind(pos=self._reposition, size=self._reposition)
             self.attach_to = None
+        self.dispatch('on_dismiss')
+
+    def on_dismiss(self):
+        pass
 
     def select(self, data):
         '''Call this method to trigger the `on_select` event, with the `data`

--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -104,10 +104,12 @@ class Spinner(Button):
     def _build_dropdown(self, *largs):
         if self._dropdown:
             self._dropdown.unbind(on_select=self._on_dropdown_select)
+            self._dropdown.unbind(on_dismiss=self._toggle_dropdown)
             self._dropdown.dismiss()
             self._dropdown = None
         self._dropdown = self.dropdown_cls()
         self._dropdown.bind(on_select=self._on_dropdown_select)
+        self._dropdown.bind(on_dismiss=self._toggle_dropdown)
         self._update_dropdown()
 
     def _update_dropdown(self, *largs):
@@ -130,5 +132,6 @@ class Spinner(Button):
         if value:
             self._dropdown.open(self)
         else:
-            self._dropdown.dismiss()
+            if self._dropdown.attach_to:
+                self._dropdown.dismiss()
 


### PR DESCRIPTION
the issue of having to press the spinner twice to show the dropdown if
dismissed by touching outside.
