### PR TITLE
remove_widgets method added to Widgets.py

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -74,6 +74,21 @@ widget moves, you can bind your own callback function like this::
 
 Read more about the :doc:`/api-kivy.properties`.
 
+
+
+remove_widgets method
+---------------------
+
+This method was added so multiple child widgets could be removed at once.
+Usage:
+
+    parent.remove_widgets(parent.children[index_number:])
+                           or
+    parent.remove_widgets(parent.children[:index_number])
+                           or
+    parent.remove_widgets([widget1,widget2,widget3])
+                           or
+    parent.remove_widgets(custom_widget_list_variable)
 '''
 
 __all__ = ('Widget', 'WidgetException')
@@ -375,6 +390,14 @@ class Widget(WidgetBase):
         self.canvas.remove(widget.canvas)
         widget.parent = None
 
+    '''remove_widget method added version 1.7.1'''
+    def remove_widgets(self,child_list):
+        '''Remove all widgets contained in child_list.
+        '''
+        remove_widget = self.remove_widget
+        for child in child_list:
+            remove_widget(child)
+    
     def clear_widgets(self):
         '''Remove all widgets added to this widget.
         '''


### PR DESCRIPTION
This new method was added so lists of child widgets can be removed from their parents at once. This alleviates the need for loops to be used for this task.
