### PR TITLE
fix: add storage module to docs

### DIFF
--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -45,6 +45,10 @@ import kivy.modules.touchring
 import kivy.modules.inspector
 import kivy.modules.recorder
 import kivy.modules.screen
+import kivy.storage
+import kivy.storage.dictstore
+import kivy.storage.jsonstore
+import kivy.storage.redisstore
 import kivy.network.urlrequest
 import kivy.support
 import kivy.input.recorder


### PR DESCRIPTION
Noticed that this module was not being included in the docs. Wanted to add it as it's a really useful feature....
