### PR TITLE
fix: add the webdebugger module to the docs

### DIFF
--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -45,8 +45,8 @@ import kivy.modules.touchring
 import kivy.modules.inspector
 import kivy.modules.recorder
 import kivy.modules.screen
-import kivy.modules.webdebugger
 import kivy.network.urlrequest
+import kivy.modules.webdebugger
 import kivy.support
 import kivy.input.recorder
 import kivy.interactive


### PR DESCRIPTION
Without this entry, the webdebugger module does not seem to get included in the doc builds
