### PR TITLE
Stop dictprop deleting key if value is None

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -631,12 +631,7 @@ class ObservableDict(dict):
         self.__setitem__(attr, value)
 
     def __setitem__(self, key, value):
-        if value is None:
-            # remove attribute if value is None
-            # is this really needed?
-            self.__delitem__(key)
-        else:
-            dict.__setitem__(self, key, value)
+        dict.__setitem__(self, key, value)
         observable_dict_dispatch(self)
 
     def __delitem__(self, key):


### PR DESCRIPTION
Currently, the DictProperty deletes a key if `__setitem__` is called with a value of 'None'. It isn't clear why it should do this, since normal python dictionaries would allow the assignation. The existing code even includes the comment '# is this really needed? '.

This pull request resolves the issue at https://github.com/kivy/kivy/issues/1461 by deleting the extra behaviour and letting the user set DictProperty values to None.
