### PR TITLE
fix: prevent loader.stop() from hanging

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -377,7 +377,7 @@ class LoaderBase(object):
     def image(self, filename, load_callback=None, post_callback=None, **kwargs):
         '''Load a image using the Loader. A ProxyImage is returned with a
         loading image. You can use it as follows::
-            
+
             from kivy.app import App
             from kivy.uix.image import Image
             from kivy.loader import Loader
@@ -477,8 +477,10 @@ else:
             self.tasks.put((func, args, kargs))
 
         def stop(self):
+            '''Flush the Queue of pending tasks
+            '''
             self.running = False
-            self.tasks.join() 
+            self.tasks = queue.Queue()
 
     class LoaderThreadPool(LoaderBase):
         def __init__(self):


### PR DESCRIPTION
This fix addresses issues found here: https://groups.google.com/forum/#!topic/kivy-users/wAPRCk9eHYg

Just a comment here. This change would alter the current "stop" behavior, but for the better in my opinion. The stop method currently does not "stop" any loading, but waits until all tasks have finished. That seem counter to what I would have guessed.

If there is an objection to the change though, I could re-submit the PR adding a "clear" or "reset" method?. It certainly seems to solve the locking issue found above in a simple, clean and robust way?

ps. Resubmitting so it can be auto-merged
