### PR TITLE
Fixed angle_end/start with new circle drawing algorithm

### DIFF
--- a/examples/canvas/circle.py
+++ b/examples/canvas/circle.py
@@ -4,9 +4,11 @@ from kivy.app import App
 from kivy.lang import Builder
 
 kv = '''
-FloatLayout:
-
+BoxLayout:
+    orientation: 'vertical'
     BoxLayout:
+        size_hint_y: None
+        height: sp(100)
         BoxLayout:
             orientation: 'vertical'
             Slider:
@@ -14,7 +16,7 @@ FloatLayout:
                 min: -360.
                 max: 360.
             Label:
-                text: '{}'.format(e1.value)
+                text: 'angle_start = {}'.format(e1.value)
         BoxLayout:
             orientation: 'vertical'
             Slider:
@@ -23,19 +25,41 @@ FloatLayout:
                 max: 360.
                 value: 360
             Label:
-                text: '{}'.format(e2.value)
+                text: 'angle_end = {}'.format(e2.value)
 
-        ToggleButton:
-            id: e3
-            text: 'Fast algo\\n(width == height)' if self.state == 'normal' else 'Normal algo\\n(width != height)'
-
-    FloatLayout
+    BoxLayout:
+        size_hint_y: None
+        height: sp(100)
+        BoxLayout:
+            orientation: 'vertical'
+            Slider:
+                id: wm
+                min: 0
+                max: 2
+                value: 1
+            Label:
+                text: 'Width mult. = {}'.format(wm.value)
+        BoxLayout:
+            orientation: 'vertical'
+            Slider:
+                id: hm
+                min: 0
+                max: 2
+                value: 1
+            Label:
+                text: 'Height mult. = {}'.format(hm.value)
+        Button:
+            text: 'Reset ratios'
+            on_press: wm.value = 1; hm.value = 1
+        
+    FloatLayout:
+        
         canvas:
             Color:
                 rgb: 1, 1, 1
             Ellipse:
                 pos: 100, 100
-                size: 200, 201 if e3.state == 'down' else 200
+                size: 200 * wm.value, 201 * hm.value
                 source: 'data/logo/kivy-icon-512.png'
                 angle_start: e1.value
                 angle_end: e2.value

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -866,7 +866,7 @@ cdef class Ellipse(Rectangle):
         angle_end = self._angle_end * 0.017453292519943295
         angle_range = -1 * (angle_end - angle_start) / self._segments
 
-        # add start vertice in the middle
+        # add start vertex in the middle
         x = self.x + rx
         y = self.y + ry
         ttx = ((x - self.x) / self.w) * tw + tx
@@ -877,49 +877,36 @@ cdef class Ellipse(Rectangle):
         vertices[0].t0 = tty
         indices[0] = 0
 
-        if rx == ry:
-            # super fast version
-            # credits goes to: http://slabode.exofire.net/circle_draw.shtml
-            # there is few issues with angle, so until fixed, allow this to work
-            # only on "default" ellipse
-            tangetial_factor = tan(angle_range)
-            radial_factor = cos(angle_range)
-            cx = self.x + rx
-            cy = self.y + ry
-            x = rx * sin(angle_start)
-            y = rx * cos(angle_start)
+        # super fast ellipse drawing
+        # credit goes to: http://slabode.exofire.net/circle_draw.shtml
+        tangetial_factor = tan(angle_range)
+        radial_factor = cos(angle_range)
 
-            for i in xrange(1, count + 2):
-                ttx = ((rx + x) / self.w) * tw + tx
-                tty = ((ry + y) / self.h) * th + ty
-                vertices[i].x = cx + x
-                vertices[i].y = cy + y
-                vertices[i].s0 = ttx
-                vertices[i].t0 = tty
-                indices[i] = i
+        # Calculate the coordinates for a circle with radius 0.5 about
+        # the point (0.5, 0.5). Only stretch to an ellipse later.
+        cx = 0.5
+        cy = 0.5
+        r = 0.5
+        x = r * sin(angle_start)
+        y = r * cos(angle_start)
 
-                fx = -y
-                fy = x
-                x += fx * tangetial_factor
-                y += fy * tangetial_factor
-                x *= radial_factor
-                y *= radial_factor
+        for i in xrange(1, count + 2):
+            ttx = (cx + x) * tw + tx
+            tty = (cy + y) * th + ty
+            real_x = self.x + (cx + x) * self.w
+            real_y = self.y + (cy + y) * self.h
+            vertices[i].x = real_x
+            vertices[i].y = real_y
+            vertices[i].s0 = ttx
+            vertices[i].t0 = tty
+            indices[i] = i
 
-        else:
-
-            angle_range = abs(angle_range)
-
-            for i in xrange(1, count + 2):
-                angle = angle_start + (angle_dir * (i - 1) * angle_range)
-                x = (self.x + rx) + (rx * sin(angle))
-                y = (self.y + ry) + (ry * cos(angle))
-                ttx = ((x - self.x) / self.w) * tw + tx
-                tty = ((y - self.y) / self.h) * th + ty
-                vertices[i].x = x
-                vertices[i].y = y
-                vertices[i].s0 = ttx
-                vertices[i].t0 = tty
-                indices[i] = i
+            fx = -y
+            fy = x
+            x += fx * tangetial_factor
+            y += fy * tangetial_factor
+            x *= radial_factor
+            y *= radial_factor
 
         self.batch.set_data(vertices, count + 2, indices, count + 2)
 
@@ -952,4 +939,6 @@ cdef class Ellipse(Rectangle):
         def __set__(self, value):
             self._angle_end = value
             self.flag_update()
+
+    
 


### PR DESCRIPTION
The problem related to the old (slower) algorithm using the absolute value of the angle change, whereas the new one depends on the sign.

~~This still doesn't fix a separate bug where if the width/height ratio isn't 1, the texture can be cropped (taking a circle out of the image rather than showing the full ellipse), so the old algorithm is still used if width != height.~~

Edit: I've now also fixed the texture crop bug, so the new algorithm gives (as far as I can tell) exactly the same results as the old one. I haven't benchmarked it though...not sure the best way.

This PR also updates the circle example to allow control of stretching.
