### PR TITLE
Made SettingsString textinput scale independent

### DIFF
--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -348,7 +348,7 @@ class SettingString(SettingItem):
 
         # create the textinput used for numeric input
         self.textinput = textinput = TextInput(text=self.value,
-            font_size=24, multiline=False, size_hint_y=None, height='50dp')
+            font_size='24sp', multiline=False, size_hint_y=None, height='42sp')
         textinput.bind(on_text_validate=self._validate)
         self.textinput = textinput
 


### PR DESCRIPTION
As per the kivy-users discussion at https://groups.google.com/forum/#!topic/kivy-users/PYzkWSHOZzU , it seems the textinput used by the settings panel to enter text has a fixed font size (24px). This doesn't work well on new super high resolution screens, where the text is thus extremely small.

This commit defines both the font size and textinput height in terms of scale independent pixels, which should give a good textinput behaviour across different screen dpis.
