### PR TITLE
Add warnings to width/height properties

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -477,6 +477,11 @@ class Widget(WidgetBase):
 
     :data:`width` is a :class:`~kivy.properties.NumericProperty`, default
     to 100.
+    
+    .. warning::
+        Keep in mind that the `width` property is subject to layout logic, and
+        that this has not happened yet at the time of the widget's `__init__`
+        method.
     '''
 
     height = NumericProperty(100)
@@ -484,6 +489,11 @@ class Widget(WidgetBase):
 
     :data:`height` is a :class:`~kivy.properties.NumericProperty`, default
     to 100.
+
+    .. warning::
+        Keep in mind that the `height` property is subject to layout logic, and
+        that this has not happened yet at the time of the widget's `__init__`
+        method.
     '''
 
     pos = ReferenceListProperty(x, y)


### PR DESCRIPTION
Especially new users might stumble when trying to reference width and
height properties before the layout is done. It's not immediately
obvious why a widget that should span the whole screen, for example, has
a width of 100 (default) at the time of initialization.

This fix adds a warning to the documentation to help lessen the
confusion.
