### PR TITLE
Fix format of returning value of get_pixel_color fbo function

### DIFF
--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -404,7 +404,7 @@ cdef class Fbo(RenderContext):
         self.bind()
         data = py_glReadPixels(wx, wy, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)
         self.release()
-        raw_data = str(memoryview(data))
+        raw_data = str(data)
         
         return [ord(i) for i in raw_data]
 


### PR DESCRIPTION
Next code

raw_data = str(memoryview(data))

returned 12 elements tuple with some incorrect data. After fixing it returns right 4 elements tuple which contains integer values(from 0 to 255) of red, green, blue, alpha of chosen pixel.
