### PR TITLE
Add to documents requirement of installing zlib1g-dev for installing kivy development version

### DIFF
--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -86,7 +86,7 @@ For other versions of Ubuntu, this one should work::
 
     $ sudo apt-get install python-setuptools python-pygame python-opengl \
       python-gst0.10 python-enchant gstreamer0.10-plugins-good python-dev \
-      build-essential libgl1-mesa-dev libgles2-mesa-dev python-pip
+      build-essential libgl1-mesa-dev libgles2-mesa-dev zlib1g-dev python-pip
 
 Kivy requires a recent version of Cython, so it's better to use the last
 version published on pypi::


### PR DESCRIPTION
For some version of Ubuntu(e.g. for 13.04) it necessary to install zlib1g-dev, as without it error while compilation may occur(can't find zlib.h). I found that while googling but I think it would be good to have it in instruction to not disappoint developers.
