### PR TITLE
ListItemButton and ListItemLabel require CompositeListItem only

### DIFF
--- a/kivy/uix/listview.py
+++ b/kivy/uix/listview.py
@@ -655,12 +655,12 @@ class ListItemButton(SelectableView, Button):
 
     def select(self, *args):
         self.background_color = self.selected_color
-        if type(self.parent) is CompositeListItem:
+        if isinstance(self.parent, CompositeListItem):
             self.parent.select_from_child(self, *args)
 
     def deselect(self, *args):
         self.background_color = self.deselected_color
-        if type(self.parent) is CompositeListItem:
+        if isinstance(self.parent, CompositeListItem):
             self.parent.deselect_from_child(self, *args)
 
     def select_from_composite(self, *args):
@@ -688,12 +688,12 @@ class ListItemLabel(SelectableView, Label):
 
     def select(self, *args):
         self.bold = True
-        if type(self.parent) is CompositeListItem:
+        if isinstance(self.parent, CompositeListItem):
             self.parent.select_from_child(self, *args)
 
     def deselect(self, *args):
         self.bold = False
-        if type(self.parent) is CompositeListItem:
+        if isinstance(self.parent, CompositeListItem):
             self.parent.deselect_from_child(self, *args)
 
     def select_from_composite(self, *args):


### PR DESCRIPTION
To work inside a composite item, kivy.uix.listview.ListItemButton and kivy.uix.listview.ListItemLabel currently require their parent widget to be an exact instance of the CompositeListItem class. That's restrictive as users may want to subclass CompositeListItem and still use the supplied list item widgets.

The patch provided allows ListItemButton and ListItemLabel to work within any parent widget whose class inherits from CompositeListItem.
