### PR TITLE
doc: proposal to revise property docs

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1216,7 +1216,6 @@ cdef class VariableListProperty(Property):
         `\*\*kwargs`: a list of keyword arguments
             Not currently used.
     
-    
     Keeping in mind that the `default` list is expanded to a list of length 4,
     here are some examples of how VariabelListProperty's are handled.
 


### PR DESCRIPTION
When looking up the OptionProperty recently, I found it quite confusing. It assumes you've read the intro "each property has a default value as the first argument...". Seems to me you should be able to go straight to the property and see exactly how to call it without assuming you've read the prologue. 

This PR add's explicit parameter descriptions to each property. One exception being the VariableListProperty, which I don't quite grasp. But if this PR is accepted, I will work on that ;-)

Comment's appreciated. But the goal here is to make each property doc string self contained. You should be able to see exactly how to call it just from it's own docstring....
