### PR TITLE
Removed SD card requirement from doc

### DIFF
--- a/doc/sources/guide/android.rst
+++ b/doc/sources/guide/android.rst
@@ -4,10 +4,7 @@
 Kivy on Android
 ===============
 
-Kivy runs on Android, but you need a phone with:
-
-* SD Card
-* OpenGL ES 2.0 (Android 2.2 minimum)
+Kivy runs on Android, but you need a phone with OpenGL ES 2.0 (Android 2.2 minimum). This is standard on modern devices.
 
 Requirements for an Android application
 ---------------------------------------


### PR DESCRIPTION
I just saw a discussion on reddit where a user was confused by the android docs, which imply kivy only works on phones with external sd cards. This pr removes the offending tetext. Maybe there should be something about how kivy handles an emulated /sdcard directory, but the old wording was just confusing and wrong.
