### PR TITLE
When no Text provider is found, provide message instead of Error.

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -22,6 +22,7 @@ from kivy.graphics.texture import Texture
 from kivy.core import core_select_lib
 from kivy.resources import resource_find
 from kivy.compat import PY2
+from kivy.logger import Logger
 
 DEFAULT_FONT = 'DroidSans'
 
@@ -550,9 +551,13 @@ Label = core_select_lib('text', (
 
 # For the first initalization, register the default font
 if 'KIVY_DOC' not in os.environ:
-    Label.register('DroidSans',
-        'data/fonts/DroidSans.ttf',
-        'data/fonts/DroidSans-Italic.ttf',
-        'data/fonts/DroidSans-Bold.ttf',
-        'data/fonts/DroidSans-BoldItalic.ttf')
-
+    if Label is not None:
+        Label.register('DroidSans',
+            'data/fonts/DroidSans.ttf',
+            'data/fonts/DroidSans-Italic.ttf',
+            'data/fonts/DroidSans-Bold.ttf',
+            'data/fonts/DroidSans-BoldItalic.ttf')
+    else:
+        Logger.critical(
+            'Text: Unable to register the default font, probably due to the '
+            'absence of Text provider.')


### PR DESCRIPTION
When core_select_lib doesn't find a proper provider, it prints some log
messages, but does not return any object nor raises an Exception.
Therefore, we get an AttributeError when trying to do
Label.register(...).

The error is: AttributeError: 'NoneType' object has no attribute
'register'

Fixes bug #1622
