### PR TITLE
uix: ScrollView change usage of scroll_type to use a list make the

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -473,7 +473,7 @@ class ScrollView(StencilView):
 
             elif (self.effect_y and self.do_scroll_x and vp.width > self.width
                     and btn in ('scrollleft', 'scrollright')):
-                e = self.effect_y if ud['in_bar_y'] else self.effect_x
+                e = self.effect_x if ud['in_bar_y'] else self.effect_y
 
             if e:
                 if btn in ('scrolldown', 'scrollleft'):


### PR DESCRIPTION
change usage of scroll_type to use a list make the option more future
proof as per discussion on irc, considering there can be other options
for scrolling including eye tracking etc....

Update scroll position when mouse wheel is used to scroll closes #1230 

Make ScrollView scroll differently depending on which
bar mouse is on when mouse wheel is used.
