### PR TITLE
Use splitter double tap on border to alternate between max/min size.

### DIFF
--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -14,8 +14,8 @@ Splitter
 
 The :class:`Splitter` is a widget that helps you re-size it's child
 widget/layout by letting you re-size it via
-dragging the boundary. This widget is similar to the
-:class:`~kivy.uix.scrollview.ScrollView` in that it allows only one child
+dragging the boundary or double tapping the boundary. This widget is similar to
+the :class:`~kivy.uix.scrollview.ScrollView` in that it allows only one child
 widget.
 
 Usage::
@@ -247,6 +247,27 @@ class Splitter(BoxLayout):
     def strip_up(self, instance, touch):
         if touch.grab_current is not instance:
             return
+
+        if touch.is_double_tap:
+            max_size = self.max_size
+            min_size = self.min_size
+            sz_frm = self.sizable_from[0]
+            s = self.size
+
+            if sz_frm in ('t', 'b'):
+                if self.size_hint_y:
+                    self.size_hint_y = None
+                if s[1] - min_size <= max_size - s[1]:
+                    self.height = max_size
+                else:
+                    self.height = min_size
+            else:
+                if self.size_hint_x:
+                    self.size_hint_x = None
+                if s[0] - min_size <= max_size - s[0]:
+                    self.width = max_size
+                else:
+                    self.width = min_size
         touch.ungrab(instance)
         self.dispatch('on_release')
 


### PR DESCRIPTION
When double clicking splitter boundary add the ability to jump to the max/min. If it's closer to max, it jumps to min and vice-versa. This way you can maximize/minimize by double tapping.
