### PR TITLE
Propogate touches when only scrolling on on bars, but didn't touch bar.

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -510,6 +510,7 @@ class ScrollView(StencilView):
             return
         if scroll_type == ['bars']:
             self._change_touch_mode()
+            return False
         else:
             Clock.schedule_once(self._change_touch_mode,
                             self.scroll_timeout / 1000.)


### PR DESCRIPTION
Return false when content is touched but only scrolling on bars is enabled.
