### PR TITLE
Don't make the scrollbar larger than the widget.

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -838,7 +838,7 @@
         size_hint_x: None
         width: min(dp(200), 0.4*root.width)
         font_size: '15sp'
-    
+
 
 <MenuSidebar>:
     size_hint_x: None
@@ -902,12 +902,12 @@
             rgba: self.bar_color[:3] + [self.bar_color[3] * self.bar_alpha if (self.do_scroll_y and self.viewport_size[1]>self.height) else 0]
         Rectangle:
             pos: self.right - self.bar_width - self.bar_margin, self.y + self.height * self.vbar[0]
-            size: self.bar_width, self.height * self.vbar[1]
+            size: min(self.bar_width, self.width), self.height * self.vbar[1]
         Color:
             rgba: self.bar_color[:3] + [self.bar_color[3] * self.bar_alpha if (self.do_scroll_x and self.viewport_size[0] > self.width) else 0]
         Rectangle:
             pos: self.x + self.width * self.hbar[0], self.y + self.bar_margin
-            size: self.width * self.hbar[1], self.bar_width
+            size: self.width * self.hbar[1], min(self.bar_width, self.height)
 
 
 # =============================================================================


### PR DESCRIPTION
When sizing a scrollview widget with e.g. a splitter we don't want the scrollbar to be visible while the widget itself is hidden (due to size zero). . So make sure the scrollbar is at most as large as the widget.
