### PR TITLE
Add to docs how to install kvy into an existing python installation on Windows.

### DIFF
--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -70,7 +70,7 @@ to launch Kivy applications by just double-clicking them:
     #. Right click on the main Python file (.py file extention) of the application you want to launch
     #. From the context menu that appears, select *Open With*
     #. Browse your hard disk drive and find the file ``kivy.bat`` from the portable package. Select it.
-    #. Select "Always open the file with..." if you don't want to repeat this procedure every time you 
+    #. Select "Always open the file with..." if you don't want to repeat this procedure every time you
        double click a .py file.
     #. You are done. Open the file.
 
@@ -155,7 +155,7 @@ pick a specific Python version. (On my Linux workstation, ``/usr/bin/kivy`` is s
 NOTE: In order to work correctly on Linux, your Python file must be saved with Unix-style (LF-only) line endings.
 
 Full documentation can be found at:
-`Python3.3 docs <http://docs.python.org/3.3/using/windows.html#launcher>`_ and 
+`Python3.3 docs <http://docs.python.org/3.3/using/windows.html#launcher>`_ and
 `PEP 397 <http://www.python.org/dev/peps/pep-0397/>`_.
 
 Use development Kivy
@@ -185,10 +185,67 @@ If you want to use the latest development version of Kivy, you can follow these 
 .. note::
 
     If you get errors you may need to upgrade Cython:
-    
+
     1.  Launch kivy.bat
     2. ``cd Python/Scripts``
     3. ``pip install --upgrade cython``
+
+Using an exisiting Python installation (64/32 bit)
+--------------------------------------------------
+
+As an alternative to downloading the kivy distribuation zip file, you can
+install the kivy requirments into an existing 32 or 64 bit Python installation.
+For this example we'll assume you have Python installed in ``C:\dev\python27``:
+
+#.  You need a MinGW installation. You can use the MinGW directory included
+    in the kivy distribution or download a fresh MinGW. If you're compiling for 64
+    bit you'll need to the download the 64 bit MinGW.
+#.  If you want to use gstreamer, copy it from the kivy distribution directory.
+#.  Get the kivy.bat file from the kivy distribution, or alternativly set the
+    path and other environmental variables as in the kivy.bat file in order to have
+    a permenant setup. You'll have to execute the fowllowing instructions from this environemt.
+
+    You'll need to edit the paths first to point to the correct python and MinGW
+    locations. If you started with a clean MinGW installation you'll also have to
+    add to the path the location of make.exe if you will be doing any kivy development.
+#.  Download and install distutils and pip. You can install both using the
+    ez_setup.py and get_pip.py files from http://www.pip-installer.org/en/latest/installing.html.
+#.  In ``C:\dev\python27\Lib\distutils`` create a empty ``distutils.cfg`` file.
+    In the file type::
+
+        [build]
+        compiler=mingw32
+
+#.  Download and install cython by typing::
+
+        pip install https://github.com/cython/cython/zipball/master
+
+#.  Download Glew 1.5.7 from http://sourceforge.net/projects/glew/files/glew/.
+    Install the Glew files into the following locations::
+
+        glew32.dll -> ``C:\dev\python27``
+        glew32.dll -> MinGW\lib
+        glew32.lib -> MinGW\lib
+        glew32s.lib -> MinGW\lib
+        glew.h -> MinGW\include\GL
+        glxew.h -> MinGW\include\GL
+
+#.  Download and install the precompiled Pygame 1.9.2 binaries from
+    http://www.lfd.uci.edu/~gohlke/pythonlibs/#pygame.
+#.  Finally, to install the latest kivy, type::
+
+        pip install https://github.com/kivy/kivy/zipball/master
+
+    Alternativly instead of the githup zipball you can point to a specific
+    kivy zip file. Also, if you have a development version of kivy and want
+    to continue working on it while still installing it you can use the pip
+    --editable switch e.g.::
+
+        pip install --editable C:\dev\kivy
+
+    This will put a link in the site-packages directory pointing to your kivy
+    source, so any changes in the source will be reflected in the install.
+    See here for more details: http://pythonhosted.org/setuptools/setuptools.html#development-mode.
 
 .. _winpackagecontents:
 


### PR DESCRIPTION
Show how you can install kivy into an existing python 32 or 64 bit installation.

I wasn't sure about what the restrictions were regarding the Glew and Pygame versions numbers.
