### PR TITLE
Remove settings rectangle.

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -796,12 +796,6 @@
 
 <Settings>:
     orientation: 'horizontal'
-    canvas:
-        Color:
-            rgb: 0, 0, 0
-        Rectangle:
-            pos: self.pos
-            size: self.size
 
 <InterfaceWithSidebar>:
     orientation: 'horizontal'


### PR DESCRIPTION
I'm not sure why this rectangle is needed. If I leave it there, it basically blacks out the whole settings screen in my app. But it doesn't seem to happen with a standalone settings app. Removing this rectangle fixes it

An alternative is to move the rectangle to canvas.before.
