### PR TITLE
core:Gracefully exit if one of the essential providers Window/text/image

### DIFF
--- a/kivy/core/__init__.py
+++ b/kivy/core/__init__.py
@@ -121,4 +121,5 @@ def core_register_libs(category, libs, base='kivy.core'):
         ', '.join(libs_loaded),
         '({0} ignored)'.format(
             ', '.join(libs_ignored)) if libs_ignored else ''))
+    return libs_loaded
 

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -791,7 +791,13 @@ image_libs += [
     ('pygame', 'img_pygame'),
     ('pil', 'img_pil'),
     ('gif', 'img_gif')]
-core_register_libs('image', image_libs)
+libs_loaded = core_register_libs('image', image_libs)
+
+if not libs_loaded:
+    import sys
+
+    Logger.critical('App: Unable to get any Image provider, abort.')
+    sys.exit(1)
 
 # resolve binding.
 from kivy.graphics.texture import Texture, TextureRegion

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -548,6 +548,13 @@ Label = core_select_lib('text', (
     ('pil', 'text_pil', 'LabelPIL'),
 ))
 
+if not Label:
+    from kivy.logger import Logger
+    import sys
+
+    Logger.critical('App: Unable to get a Text provider, abort.')
+    sys.exit(1)
+
 # For the first initalization, register the default font
 if 'KIVY_DOC' not in os.environ:
     Label.register('DroidSans',


### PR DESCRIPTION
Gracefully exit if one of the essential providers Window/text/image don't get any valuable providers. Alt solution for #1623
