### PR TITLE
Fixed active state for radio button

### DIFF
--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -91,14 +91,17 @@ class CheckBox(Widget):
         self._release_group(self)
         self.active = not self.active
 
+    def _release(self):
+        self.active = not self.active
+
     def on_touch_down(self, touch):
         if not self.collide_point(*touch.pos):
             return
-
+        if self.disabled:
+            return True
         if self.group is None or self.group == '':
-            self._toggle_active()
-
-        elif self.group is not None:
+            self._release()
+        elif self.group:
             if not self.active:
                 self._toggle_active()
         return True


### PR DESCRIPTION
If in the checkbox there is a group, the checkbox becomes radiobutton, but it was possibile to disable the active state and leaves the group without a value, with this fix if there are radiobuttons at least one is always checked and if there is checkboxes is possbile to checked or unchecked
