### PR TITLE
[WIP] Add multiselect to tree

### DIFF
--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -135,6 +135,18 @@ class TreeViewNode(object):
             raise TreeViewException('You cannot use directly TreeViewNode.')
         super(TreeViewNode, self).__init__(**kwargs)
 
+    def on_is_leaf(self, instance, val):
+        tree = self.parent_tree
+        if (not val) and tree and tree.select_leaves_only:
+            tree.deselect_node(self)
+        self.is_selected = False
+
+    def on_no_selection(self, instance, val):
+        tree = self.parent_tree
+        if val and tree:
+            tree.deselect_node(self)
+        self.is_selected = False
+
     is_leaf = BooleanProperty(True)
     '''Boolean to indicate whether this node is a leaf or not. Used to adjust
     the graphical representation.
@@ -207,12 +219,24 @@ class TreeViewNode(object):
     '''
 
     parent_node = ObjectProperty(None, allownone=True)
-    '''Parent node. This attribute is needed because the :data:`parent` can be
-    None when the node is not displayed.
+    '''The :class:`TreeViewNode` that is the parent node of this node. This
+    attribute is needed because the :data:`parent` can be None when the node
+    is not displayed.
 
     .. versionadded:: 1.0.7
 
-    :data:`parent_node` is an :class:`~kivy.properties.ObjectProperty` and
+    :data:`parent_node` is a :class:`~kivy.properties.ObjectProperty` and
+    defaults to None.
+    '''
+
+    parent_tree = ObjectProperty(None, allownone=True)
+    '''The :class:`TreeView` instance of which this is a node. If the node has
+    not been added to any tree or if it has been removed it'll be None. This
+    is preferd to :data:`parent`.
+
+    .. versionadded:: 1.8.1
+
+    :data:`parent_tree` is a :class:`~kivy.properties.ObjectProperty` and
     defaults to None.
     '''
 
@@ -306,6 +330,7 @@ class TreeView(Widget):
         if parent is None and self._root:
             parent = self._root
         if parent:
+            node.parent_tree = self
             parent.is_leaf = False
             parent.nodes.append(node)
             node.parent_node = parent
@@ -339,6 +364,7 @@ class TreeView(Widget):
             node.parent_node = None
             node.unbind(size=self._trigger_layout)
             self._trigger_layout()
+            node.parent_tree = None
 
     def on_node_expand(self, node):
         pass


### PR DESCRIPTION
Adds multi selection to trees. Also adds selecting with shift and ctrl as is typical on a desktop. Finally, it adds a option to only select leaf nodes. It should leave everything backward compatible.

The next step is to update filechooser to use these options instead of hacking multi selection. If this looks ok, I'll attempt it.

If it won't make it into 1.8, I'll have to bump the versionadded values.
