### PR TITLE
Update __init__.py

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -232,7 +232,11 @@ class LabelBase(object):
                                        text[-segment:].strip())
         else:
             segment = max_letters - 3  # length of '...'
-            return u'{0}...'.format(text[:segment].strip())
+            try:
+                return u'{0}...'.format(text[:segment].strip())
+            except:
+                text = unicode(text,errors='ignore')
+                return u'{0}...'.format(text[:segment].strip())
 
     def render(self, real=False):
         '''Return a tuple (width, height) to create the image


### PR DESCRIPTION
when shortening a text with invalid encoding, the shorten function will crash. (sorry for english)

UnicodeDecodeError: 'ascii' codec can't decode byte 0xb1 in position 0: ordinal not in range(128)
