### PR TITLE
Fixes setuptools problem on Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ from copy import deepcopy
 import os
 from os.path import join, dirname, sep, exists, basename
 from os import walk, environ
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from distutils.core import setup
 from distutils.extension import Extension
 
 if sys.version > '3':


### PR DESCRIPTION
The old way does not work in Python3.3. This way works in Python2.7 and 3.3
