### PR TITLE
fix: honor index insertion for TabbedPanelHeader objects

### DIFF
--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -521,7 +521,7 @@ class TabbedPanel(GridLayout):
             super(TabbedPanel, self).add_widget(widget, index)
         elif isinstance(widget, TabbedPanelHeader):
             self_tabs = self._tab_strip
-            self_tabs.add_widget(widget)
+            self_tabs.add_widget(widget, index)
             widget.group = '__tab%r__' % self_tabs.uid
             self.on_tab_width()
         else:


### PR DESCRIPTION
Addresses issue https://github.com/kivy/kivy/blob/master/kivy/uix/tabbedpanel.py#L524
