### PR TITLE
Fix CoreImage to use resource_find when loading files

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -354,6 +354,8 @@ class ImageLoader(object):
         if filename.startswith((('http://', 'https://'))):
             ext = ext.split('?')[0]
 
+        filename = resource_find(filename)
+
         # special case. When we are trying to load a "zip" file with image, we
         # will use the special zip_loader in ImageLoader. This might return a
         # sequence of images contained in the zip.


### PR DESCRIPTION
CoreImage should use resource_find when loading image files.

Example:

``` python
#!/usr/bin/env python
from kivy.app import App
from kivy.uix.widget import Widget
from kivy.graphics import Rectangle
from kivy.core.image import Image as CoreImage


class TestWidget(Widget):

    def __init__(self, **kwargs):
        super(TestWidget, self).__init__(**kwargs)

        img_texture = CoreImage('Logo.zip').texture
        img_texture2 = CoreImage('Logo2.png').texture

        with self.canvas:
            Rectangle(size=img_texture.size, texture=img_texture)
            Rectangle(pos=(200, 200), size=img_texture2.size, texture=img_texture2)

class TestApp(App):

    def build(self):
        return TestWidget()

if __name__ == '__main__':
    from kivy.resources import resource_add_path
    resource_add_path('./res_dir')
    TestApp().run()

```

Image files are located in `./res_dir`
