### PR TITLE
Fbo: with_stencilbuffer parameter.

### DIFF
--- a/kivy/graphics/fbo.pxd
+++ b/kivy/graphics/fbo.pxd
@@ -6,10 +6,12 @@ cdef class Fbo(RenderContext):
     cdef int _width
     cdef int _height
     cdef int _depthbuffer_attached
+    cdef int _stencilbuffer_attached
     cdef int _push_viewport
     cdef float _clear_color[4]
     cdef GLuint buffer_id
     cdef GLuint depthbuffer_id
+    cdef GLuint stencilbuffer_id
     cdef GLint _viewport[4]
     cdef Texture _texture
     cdef int _is_bound


### PR DESCRIPTION
Adds a stencil buffer to fbo if a new option is set to True.

Example of code that demonstrate stencil instructions on fbo:

``` python
from kivy.app import App
from kivy.uix.widget import Widget
from kivy.graphics import Color, Rectangle, Fbo, StencilPush, StencilPop, StencilUse, StencilUnUse


class TestWidget(Widget):

    def __init__(self, **kwargs):
        super(TestWidget, self).__init__(**kwargs)

        # Create Fbo with a stencil buffer
        with self.canvas:
            self.my_fbo = Fbo(size=self.size, with_stencilbuffer=True)

        # Add Fbo texture to canvas
        with self.canvas:
            Color()
            Rectangle(pos=self.pos, size=self.size, texture=self.my_fbo.texture)

        # Use Stencil instruction on Fbo
        with self.my_fbo:
            StencilPush()

            Rectangle(pos=(100, 100), size=(100, 100))

            StencilUse()

            Color(0, 1, 0)
            Rectangle(pos=self.pos, size=self.size)

            StencilPop()


class TestApp(App):
    def build(self):
        return TestWidget(pos=(0, 0), size=(400, 400))

if __name__ == '__main__':
    TestApp().run()
```

This PR was made as a first step to fix #1578. But after enabling stencil buffer on fbo, the shader transition shows only a black screen while it is in progress. My experience in openGL is not enough so far to understand why.

Thanks,
tohin
