### PR TITLE
Avoids the "Too many open files" error in case of a large number of inpu...

### DIFF
--- a/kivy/atlas.py
+++ b/kivy/atlas.py
@@ -254,7 +254,13 @@ class Atlas(EventDispatcher):
             size_w = size_h = int(size)
 
         # open all of the images
-        ims = [(f, Image.open(f)) for f in filenames]
+        ims = list()
+        for f in filenames:
+            fp = open(f)
+            im = Image.open(fp)
+            im.load()
+            fp.close()
+            ims.append((f, im))
 
         # sort by image area
         ims = sorted(ims, key=lambda im: im[1].size[0] * im[1].size[1],


### PR DESCRIPTION
...t files.

While trying to create an atlas file from 1200 images I reached the open file limit.

This patch allows to load them all closing the file descriptor after the file has been read.
