### PR TITLE
Added index method to InstructionGroup

### DIFF
--- a/kivy/graphics/instructions.pxd
+++ b/kivy/graphics/instructions.pxd
@@ -42,6 +42,7 @@ cdef class InstructionGroup(Instruction):
     cdef void reload(self)
     cpdef add(self, Instruction c)
     cpdef insert(self, int index, Instruction c)
+    cpdef index(self, Instruction c)
     cpdef remove(self, Instruction c)
     cpdef clear(self)
     cpdef remove_group(self, str groupname)

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -157,6 +157,13 @@ cdef class InstructionGroup(Instruction):
         c.rinsert(self, index)
         self.flag_update()
 
+    cpdef index(self, Instruction c):
+        '''Get the index of the given :class:`Instruction` in our list.
+
+        .. versionadded:: 1.8.1
+        '''
+        return self.children.index(c)
+
     cpdef remove(self, Instruction c):
         '''Remove an existing :class:`Instruction` from our list.
         '''


### PR DESCRIPTION
This is useful if you want to remove the instruction, but then later put it back in the same place.
