### PR TITLE
Fix scrolling on empty scrollview.

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -544,6 +544,8 @@ class ScrollView(StencilView):
         # handle mouse scrolling, only if the viewport size is bigger than the
         # scrollview size, and if the user allowed to do it
         vp = self._viewport
+        if not vp:
+            return True
         scroll_type = self.scroll_type
         ud = touch.ud
         scroll_bar = 'bars' in scroll_type


### PR DESCRIPTION
This fixes https://github.com/kivy/kivy/issues/1852.

The issue was with scrolling on a empty scrollview. This code reproduced the issue:

```
from kivy.app import runTouchApp
from kivy.lang import Builder
kv = """
ScrollView
"""
if __name__ == '__main__':
    runTouchApp(Builder.load_string(kv))
```

Which would crash before this pr.
