### PR TITLE
Rst fixes

### DIFF
--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -546,8 +546,6 @@ class RstDocument(ScrollView):
         '''
         if filename in self.toctrees:
             return
-        if not exists(filename):
-            return
 
         with open(filename, 'rb') as fd:
             text = fd.read().decode(encoding, errors)


### PR DESCRIPTION
Commit 1 fixes https://github.com/kivy/kivy/issues/1858.

Commit 2 makes rst raise an error when a files doesn't exist (through open) instead of ignoring it. Without it, when specifying a incorrect file path, you'd not know why nothing is showing. In places where non-existent external files are loaded through rst internal links, the preload function seems to be try/excepted anyway, so those errors would still be ignored.
