### PR TITLE
Shorten the string only if it's larger than texture size.

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -303,9 +303,7 @@ class LabelBase(object):
 
             # Shorten the text that we actually display
             text = self.text
-            last_word_width = get_extents(text[text.rstrip().rfind(' '):])[0]
-            if (options['shorten'] and
-                    get_extents(text)[0] > uw - last_word_width):
+            if (options['shorten'] and get_extents(text)[0] > uw):
                 text = self.shorten(text)
 
             # first, split lines


### PR DESCRIPTION
This fixes https://github.com/kivy/kivy/issues/1703.

Before, it'd shorten the string whenever the size of the texture was not larger than the size of the string plus the length of the last word. I don't see why, so this shortens whenever the size of the string is larger than the size of the texture.
