### PR TITLE
Add looping to VideoPlayer

### DIFF
--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -132,6 +132,8 @@ class Video(Image):
         super(Image, self).__init__(**kwargs)
         self.bind(source=self._trigger_video_load)
 
+        if "eos" in kwargs:
+            self.options["eos"] = kwargs["eos"]
         if self.source:
             self._trigger_video_load()
 

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -53,7 +53,7 @@ You can allow stretching by passing custom options to a
 :class:`VideoPlayer` instance::
 
     player = VideoPlayer(source='myvideo.avi', state='play',
-        options={'allow_stretch': True})
+        options={'allow_stretch': True, 'eos': 'loop'})
 
 '''
 


### PR DESCRIPTION
Although this works, I'm not sure this is the correct way to do it.

The VideoPlayer contains a  Video, both of which have an "eos" property as a boolean. The CoreVideo (in video/**init**.py) has "eos" as a string, which already works with a 'loop' value. All rather confusing. 

So this facilitates the setting of the CoreVideo "eos" for looping, but passed through two classes whose "eos" is a different type? Perhaps it would be better to add a "loop" boolean property to the CoreVideo so it's clearer? 
