### PR TITLE
doc: added warning for ordering of dynamic classes

### DIFF
--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -406,6 +406,12 @@ In Python, you can create an instance of the dynamic class as follows:
     from kivy.factory import Factory
     button_inst = Factory.ImageButton()
 
+.. note::
+
+    Using dynamic classes, a child class can be declared before it's parent.
+    This however, leads to the unintuitive situation where the parent
+    properties/methods override those of the child. Be careful if you choose
+    to do this.
 
 .. _template_usage:
 


### PR DESCRIPTION
This PR addresses this issue: https://github.com/kivy/kivy/issues/1791

I initially addressed this with a PR to prevent it. https://github.com/kivy/kivy/pull/1813

This broke the showcase and other examples. On further thought, the name "dynamic classes" seems to imply very flexible, on-the-fly class composition. This ability makes dynamic classes really flexible, so why not consider it a feature? Added documentation accordingly.
