### PR TITLE
Revert "Added index method to InstructionGroup"

### DIFF
--- a/kivy/graphics/instructions.pxd
+++ b/kivy/graphics/instructions.pxd
@@ -42,7 +42,6 @@ cdef class InstructionGroup(Instruction):
     cdef void reload(self)
     cpdef add(self, Instruction c)
     cpdef insert(self, int index, Instruction c)
-    cpdef index(self, Instruction c)
     cpdef remove(self, Instruction c)
     cpdef clear(self)
     cpdef remove_group(self, str groupname)

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -157,13 +157,6 @@ cdef class InstructionGroup(Instruction):
         c.rinsert(self, index)
         self.flag_update()
 
-    cpdef index(self, Instruction c):
-        '''Get the index of the given :class:`Instruction` in our list.
-
-        .. versionadded:: 1.8.1
-        '''
-        return self.children.index(c)
-
     cpdef remove(self, Instruction c):
         '''Remove an existing :class:`Instruction` from our list.
         '''


### PR DESCRIPTION
This reverts commit cc9af2bb191338f31225c192df9739a28e29f197.

This commit only duplicates the functionality of
the existing method InstructionGroup.indexof

I'm really sorry about submitting this originally...I have no idea how I missed the existing method...
