### PR TITLE
VideoPlayer not responding to source change

### DIFF
--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -480,6 +480,8 @@ class VideoPlayer(GridLayout):
         if self._video is not None:
             self._video.unload()
             self._video = None
+        if value:
+            self._trigger_video_load()
 
     def _load_thumbnail(self):
         if not self.container:


### PR DESCRIPTION
If the course is not set on **init**, the video object is never set and therefore does not play video when setting the .source and .state properties later. This can be confirmed via this snippet.

https://gist.github.com/Zen-CODE/9038217

The fix allows the source to be set after initialization,
