### PR TITLE
- properly unset the selected_node attribute, which addresses issue #1898

### DIFF
--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -319,6 +319,7 @@ class TreeView(Widget):
             nodes = parent.nodes
             if node in nodes:
                 nodes.remove(node)
+                self._selected_node = None
             parent.is_leaf = not bool(len(nodes))
             node.parent_node = None
             node.unbind(size=self._trigger_layout)
@@ -487,7 +488,7 @@ class TreeView(Widget):
     #
     _root = ObjectProperty(None)
 
-    _selected_node = ObjectProperty(None)
+    _selected_node = ObjectProperty(None, allownone=True)
 
     #
     # Properties


### PR DESCRIPTION
One thing I was unsure of is whether or not the node itself should be deleted, or if that should be left to the user (in case he wants to move the node elsewhere or enable it again). 

Actually, I don't really like line 322/323 which reads

``` python
parent.is_leaf = not bool(len(nodes))
```

Seems cleaner to bind the is_leaf property to the nodes property. Otherwise, both the `bool` and `len` calls are unnecessary:

``` python
parent.is_leaf = not nodes
```

Actually, as I look at the class, I suspect that a lot of the manual setting of attributes could be cleaned up by binding those attributes. If you agree, I'd be willing to tackle the idea as a separate request.
