### PR TITLE
Correct label padding to be positive, not negative.

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -436,8 +436,8 @@ class LabelBase(object):
         # first pass, calculating width/height
         sz = self.render()
         self._size_texture = sz
-        self._size = (sz[0] + self.options['padding_x'] * 2,
-                      sz[1] + self.options['padding_y'] * 2)
+        self._size = (sz[0] - self.options['padding_x'] * 2,
+                      sz[1] - self.options['padding_y'] * 2)
 
         # if no text are rendered, return nothing.
         width, height = self._size
@@ -505,14 +505,14 @@ class LabelBase(object):
         '''Return the content width'''
         if self.texture is None:
             return 0
-        return self.texture.width + 2 * self.options['padding_x']
+        return self.texture.width - 2 * self.options['padding_x']
 
     @property
     def content_height(self):
         '''Return the content height'''
         if self.texture is None:
             return 0
-        return self.texture.height + 2 * self.options['padding_y']
+        return self.texture.height - 2 * self.options['padding_y']
 
     @property
     def content_size(self):


### PR DESCRIPTION
Before, padding of label had to be set to a negative value in order to make the label move inward. This fixes it. I think this behavior was by mistake, not intentionally. To see the problem, run this example before and after the commit:

```
from kivy.app import runTouchApp
from kivy.lang import Builder


kv = """
Label:
    text: "Here is some text"
    text_size: self.size
    padding: [20, 5]
"""

if __name__ == '__main__':
    runTouchApp(Builder.load_string(kv))
```

Before the commit, part of the label moves outside the edges of the window.
