### PR TITLE
Don't remove debian subdirectory if it exists on git cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ clean:
 	-find . -iname '*.pyx' -exec sh -c 'echo `dirname {}`/`basename {} .pyx`.c' \; | xargs rm
 
 distclean: clean
-	-git clean -dxf
+	-git clean -dxf -e debian
 
 theming:
 	$(PYTHON) -m kivy.atlas kivy/data/images/defaulttheme 512 kivy/tools/theming/defaulttheme/*.png


### PR DESCRIPTION
This doesn't harm if you don't build a Debian package as `git cleanup` will work
just fine if the `debian` directory does not exist. Without this patch the
`distclean` rule will also remove the `debian` directory which make it
impossible to correctly build a debian package.
