### PR TITLE
Loader: guess extension from mime type

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -47,6 +47,7 @@ from time import sleep
 from os.path import join
 from os import write, close, unlink, environ
 import threading
+import mimetypes
 
 # Register a cache for loader
 Cache.register('kv.loader', limit=500, timeout=60)
@@ -296,9 +297,6 @@ class LoaderBase(object):
         data = fd = _out_osfd = None
         try:
             _out_filename = ''
-            suffix = '.%s' % (filename.split('.')[-1])
-            _out_osfd, _out_filename = tempfile.mkstemp(
-                prefix='kivyloader', suffix=suffix)
 
             if proto == 'smb':
                 # read from samba shares
@@ -306,6 +304,21 @@ class LoaderBase(object):
             else:
                 # read from internet
                 fd = urllib_request.urlopen(filename)
+
+            ctype = fd.info().gettype()
+            suffix = mimetypes.guess_extension(ctype)
+            if not suffix:
+                # strip query string and split on path
+                parts = filename.split('?')[0].split('/')[1:]
+                while len(parts) > 1 and not parts[0]:
+                    # strip out blanks from '//'
+                    parts = parts[1:]
+                if len(parts) > 1 and '.' in parts[-1]:
+                    # we don't want '.com', '.net', etc. as the extension
+                    suffix = '.' + parts[-1].split('.')[-1]
+            _out_osfd, _out_filename = tempfile.mkstemp(
+                prefix='kivyloader', suffix=suffix)
+
             idata = fd.read()
             fd.close()
             fd = None
@@ -322,7 +335,7 @@ class LoaderBase(object):
             for imdata in data._data:
                 imdata.source = filename
         except Exception:
-            Logger.exception('Failed to load image <%s>' % filename)
+            Logger.exception('Loader: Failed to load image <%s>' % filename)
             # close file when remote file not found or download error
             try:
                 close(_out_osfd)


### PR DESCRIPTION
Try to guess the file extension from the MIME type before checking the URL. If the extension cannot be guessed, then check the URL more accurately by removing the query string and ensuring the server name is skipped (to avoid a file extension of '.com').

This allows the Loader to be used with web services such as the Google Static Maps API.
