### PR TITLE
Resolve #1925 by handling URL's with parameters

### DIFF
--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -59,6 +59,8 @@ class SoundLoader:
         if rfn is not None:
             filename = rfn
         ext = filename.split('.')[-1].lower()
+        if '?' in ext:
+            ext = ext.split('?')[0]
         for classobj in SoundLoader._classes:
             if ext in classobj.extensions():
                 return classobj(source=filename)


### PR DESCRIPTION
Resolve issue #1925 by stripping URL parameters from a file name if the file contains them.

Before:

```
from kivy.core.audio import SoundLoader
s = SoundLoader.load(r"https://dl.dropboxusercontent.com/s/31iff182wy99cp1/test.wav?dl=1&token_hash=AAEjMqwEdOBUPNBVfTsDPPQW_CZPNRBgRvBNiXpRxx5btA")
s.play()
[WARNING           ] [Audio       ] Unable to find a loader for <https://dl.dropboxusercontent.com/s/31iff182wy99cp1/test.wav?dl=1&token_hash=AAEjMqwEdOBUPNBVfTsDPPQW_CZPNRBgRvBNiXpRxx5btA>
```

After:

```
from kivy.core.audio import SoundLoader
s = SoundLoader.load(r"https://dl.dropboxusercontent.com/s/31iff182wy99cp1/test.wav?dl=1&token_hash=AAEjMqwEdOBUPNBVfTsDPPQW_CZPNRBgRvBNiXpRxx5btA")
s.play()
#No error, sound plays as expected
```
