### PR TITLE
Fixes an exception raised when this script is run by python 3

### DIFF
--- a/kivy/tools/pep8checker/pep8.py
+++ b/kivy/tools/pep8checker/pep8.py
@@ -104,9 +104,9 @@ import keyword
 import tokenize
 from optparse import OptionParser
 from fnmatch import fnmatch
+from io import TextIOWrapper
 try:
     from ConfigParser import RawConfigParser
-    from io import TextIOWrapper
 except ImportError:
     from configparser import RawConfigParser
 


### PR DESCRIPTION
Fixes a bug in the pep8 checker which raises this exception on all commits when python defaults to python3:

```
Traceback (most recent call last):
  File "/home/matthew/GitHub/kivy/kivy/tools/pep8checker/pep8kivy.py", line 4, in <module>
    import pep8
  File "/home/matthew/GitHub/kivy/kivy/tools/pep8checker/pep8.py", line 1054, in <module>
    stdin_get_value = TextIOWrapper(sys.stdin.buffer, errors='ignore').read
NameError: name 'TextIOWrapper' is not defined
Error: 1 styleguide violation(s) encountered!
Your commit has been aborted. Please fix the violations and retry.

Command finished with error UnknownError.
Command exited with value 1.
```

This exception is due to two imports in a try block, but only one in the except block, leading to a unimported module.
