### PR TITLE
- fixed typo in kivy.storage example

### DIFF
--- a/kivy/storage/__init__.py
+++ b/kivy/storage/__init__.py
@@ -49,7 +49,7 @@ Because the data is persistant, you can check later to see if the key exists::
     from kivy.storage.jsonstore import JsonStore
 
     store = JsonStore('hello.json')
-    if store.exists('tite'):
+    if store.exists('tito'):
         print('tite exists:', store.get('tito'))
         store.delete('tito')
 


### PR DESCRIPTION
As per a discussion on the mailing list [1], I fixed a typo in the example given for kivy.storage. Thanks Benjamin
