### PR TITLE
Make state normal on 'inspect' toggle button when inspector is deactivated

### DIFF
--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -372,6 +372,7 @@ class Inspector(FloatLayout):
 
     def animation_close(self, instance, value):
         if self.activated is False:
+            self.inspect_enabled = False
             self.win.remove_widget(self)
             self.content.clear_widgets()
             treeview = self.treeview


### PR DESCRIPTION
Fix issue #1895 when inspector freezes up the GUI after being closed.
