### PR TITLE
- apply title_args to accordion title by using setattr

### DIFF
--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -312,7 +312,8 @@ class AccordionItem(FloatLayout):
                                     title=self.title,
                                     item=self)
         for k, v in self.title_args.items():
-            setattr(instance, k, v)
+            if hasattr(instance, k):
+                setattr(instance, k, v)
         c.add_widget(instance)
 
 


### PR DESCRIPTION
Presumably this could be implemented in kivy.lang, but I wasn't sure what the implications of doing so were. That said, it seems like all arguments passed to kivy.lang.Builder are swallowed, except for the first argument, which is assumed to be a name. 

Rather than passing an argument that will only be swallowed later, I pass the arguments to the instance after it's been built.
