### PR TITLE
[WIP] new feature: pausable animation

### DIFF
--- a/examples/widgets/pausable_animation.py
+++ b/examples/widgets/pausable_animation.py
@@ -1,0 +1,48 @@
+import kivy
+from kivy.animation import Animation
+from kivy.app import App
+from kivy.uix.button import Button
+from kivy.core.window import Window
+from kivy.uix.floatlayout import FloatLayout
+from functools import partial
+
+
+class TestPAuseAnimationApp(App):
+    def animate(self, instance):
+        def plop(*args):
+            print args
+        animation = Animation(x=Window.width / 2, y=Window.height / 2,
+                              duration=3)
+        animation += Animation(x=0, y=0, duration=3)
+        animation.repeat = True
+        animation.bind(on_pause=partial(plop, 'pause'))
+        animation.start(instance)
+        return animation
+
+    def pauseAnimation(self, animation, button):
+        #toggle the pause property
+        pause = not animation.paused
+        animation.pause(pause)
+
+    def pauseAll(self, *args):
+        self.paused = not self.paused
+        Animation.pause_all(self.paused)
+
+    def build(self):
+        f = FloatLayout()
+        self.paused = False
+        b1 = Button(size_hint=(None, None), text='Button1')
+        a = self.animate(b1)
+        b1.bind(on_press=partial(self.pauseAnimation, a))
+        b2 = Button(size_hint=(None, None), text='pause all')
+        b2.bind(on_press=self.pauseAll)
+        b3 = Button(size_hint=(None, None), text='Button3')
+        a = self.animate(b3)
+        b3.bind(on_press=partial(self.pauseAnimation, a))
+        f.add_widget(b1)
+        f.add_widget(b2)
+        f.add_widget(b3)
+        return f
+
+if __name__ == '__main__':
+    TestPAuseAnimationApp().run()

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -110,7 +110,7 @@ class Animation(EventDispatcher):
 
     _instances = set()
 
-    __events__ = ('on_start', 'on_progress', 'on_complete')
+    __events__ = ('on_start', 'on_progress', 'on_complete', 'on_pause')
 
     def __init__(self, **kw):
         super(Animation, self).__init__(**kw)
@@ -126,12 +126,19 @@ class Animation(EventDispatcher):
             kw.pop(key, None)
         self._animated_properties = kw
         self._widgets = {}
+        self._onpause = False
 
     @property
     def duration(self):
         '''Return the duration of the animation.
         '''
         return self._duration
+
+    @property
+    def paused(self):
+        '''Return the pause state of the animation.
+        '''
+        return self._onpause
 
     @property
     def transition(self):
@@ -189,6 +196,21 @@ class Animation(EventDispatcher):
             for animation in set(Animation._instances):
                 animation.cancel(widget)
 
+    @staticmethod
+    def pause_all(pause):
+        '''Pause all animations.
+
+        Example::
+
+            anim = Animation(x=50)
+            anim.start(widget)
+
+            # and later
+            Animation.pause_all(True)
+        '''
+        for animation in list(Animation._instances):
+            animation.pause(pause)
+
     def start(self, widget):
         '''Start the animation on a widget.
         '''
@@ -216,6 +238,14 @@ class Animation(EventDispatcher):
         self._clock_uninstall()
         if not self._widgets:
             self._unregister()
+
+    def pause(self, pause):
+        '''Pause the animation, triggering the `on_pause` event.
+        '''
+        self._onpause = pause
+        if pause:
+            for widget in self._widgets:
+                self.dispatch('on_pause', widget)
 
     def stop_property(self, widget, prop):
         '''Even if an animation is running, remove a property. It will not be
@@ -299,6 +329,8 @@ class Animation(EventDispatcher):
         for uid in list(widgets.keys())[:]:
             anim = widgets[uid]
             widget = anim['widget']
+            if self._onpause:
+                return
             if anim['time'] is None:
                 anim['time'] = 0.
             else:
@@ -348,6 +380,9 @@ class Animation(EventDispatcher):
     # Default handlers
     #
     def on_start(self, widget):
+        pass
+
+    def on_pause(self, widget):
         pass
 
     def on_progress(self, widget, progress):
@@ -406,6 +441,11 @@ class Sequence(Animation):
                 not self.anim2.have_properties_to_animate(widget)):
             self.stop(widget)
 
+    def pause(self, pause):
+        self.anim1.pause(pause)
+        self.anim2.pause(pause)
+        super(Sequence, self).pause(pause)
+
     def cancel(self, widget):
         self.anim1.cancel(widget)
         self.anim2.cancel(widget)
@@ -463,6 +503,11 @@ class Parallel(Animation):
         if props:
             self.dispatch('on_complete', widget)
         super(Parallel, self).cancel(widget)
+
+    def pause(self, pause):
+        self.anim1.pause(pause)
+        self.anim2.pause(pause)
+        super(Parallel, self).pause(pause)
 
     def stop_property(self, widget, prop):
         self.anim1.stop_property(widget, prop)


### PR DESCRIPTION
Hi,
Currently there is no way to pause an animation, although it could be useful (think for instance to the pause button of a game, which needs to pause every widget).

Trying to address that case using the provided stop() and start() functions defined on the Animation class is not a solution, as one does want to restart where it just as been paused, and not from the begining (specially when dealing with sequences of animation).

That's the goal of this pull request, the slight modifications I've made are:
- adds a pause property,
- fires a on_pause event,
- avoids to update the properties on the _update function.

That's it!

I'll appreciate for reviewers to peek in, and hoping this is useful enough to be merged.

Regards