### PR TITLE
cleaned up gitignore thanks to new git releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,15 +9,16 @@ python
 deps.zip
 python.exe
 Kivy.dmg
-doc/sources/api-*.rst
-kivy/graphics/config.h
-kivy/lib/vidcore_lite/bcm.h
-kivy/graphics/config.pxi
+api-*.rst
+config.h
+bcm.h
+config.pxi
 .last_known_portable_deps_hash
 iosbuild
 MANIFEST
 
 *.c
+*.h
 *.so
 *.pyc
 *.pyd


### PR DESCRIPTION
Not as shiny as some of the other cool projects, but I figured it was worth it. Thanks to newer versions of git, recursive glob patterns work, which allowed me to remove redundant lines from the gitignore file.

I tested this by creating a dummy git repo with similar ignore patterns and adding/removing files and directories. I also ran a `make` and `make pdf` to see if generated files were ignored properly.

If someone could do additional testing, I'd appreciate it, but I don't _think_ I broke anything.
