### PR TITLE
Allow reloading rst files and allow source to be ''

### DIFF
--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -56,7 +56,7 @@ document.
 __all__ = ('RstDocument', )
 
 import os
-from os.path import dirname, join, exists
+from os.path import dirname, join, exists, abspath
 from kivy.clock import Clock
 from kivy.compat import PY2
 from kivy.properties import ObjectProperty, NumericProperty, \
@@ -517,12 +517,11 @@ class RstDocument(ScrollView):
 
     def on_source(self, instance, value):
         if not value:
-            self.text = ''
             return
         if self.document_root is None:
             # set the documentation root to the directory name of the
             # first tile
-            self.document_root = dirname(value)
+            self.document_root = abspath(dirname(value))
         self._load_from_source()
 
     def on_text(self, instance, value):
@@ -621,11 +620,10 @@ class RstDocument(ScrollView):
         .. versionadded:: 1.3.0
         '''
         # check if it's a file ?
-        if self.document_root is not None and ref.endswith('.rst'):
-            filename = join(self.document_root, ref)
-            if exists(filename):
-                self.source = filename
-                return
+        if ref.endswith('.rst'):
+            # whether it's a valid or invalid file, let source deal with it
+            self.source = ref
+            return
 
         # get the association
         ref = self.refs_assoc.get(ref, ref)


### PR DESCRIPTION
- Before, if you set `source` to something if you tried later to set it to the empty string, `''` you'd get an error. This changes it to allow empty string, and if the empty string is given it'll set `self.text` to the empty string (clear it).
- Before, if a file already existed in the `self.toctrees` dict, when setting `source` to this filename again (after having changed `source` to a second filename in between), nothing would happen. This changes to reload the file when this happens, in case the file contents changed.
