### PR TITLE
created method flip_horizontal() for kivy.graphics.texture.Texture

### DIFF
--- a/kivy/graphics/texture.pxd
+++ b/kivy/graphics/texture.pxd
@@ -37,6 +37,7 @@ cdef class Texture:
     cdef void allocate(self)
 
     cpdef flip_vertical(self)
+    cpdef flip_horizontal(self)
     cpdef get_region(self, x, y, width, height)
     cpdef bind(self)
 

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -731,6 +731,12 @@ cdef class Texture:
         self._uvh = -self._uvh
         self.update_tex_coords()
 
+    cpdef flip_horizontal(self):
+        '''Flip tex_coords for horizontal display.'''
+        self._uvx += self._uvw
+        self._uvw = -self._uvw
+        self.update_tex_coords()
+
     cpdef get_region(self, x, y, width, height):
         '''Return a part of the texture defined by the rectangular arguments
         (x, y, width, height). Returns a :class:`TextureRegion` instance.'''


### PR DESCRIPTION
Backing issue https://github.com/kivy/kivy/issues/944

Tested with code:

``` python
#!/usr/bin/python
# -*- coding: utf-8 -*-

from kivy.app import App
from kivy.uix.gridlayout import GridLayout
from kivy.uix.widget import Widget
from kivy.graphics import Rectangle
from kivy.graphics.texture import Texture

class TestWidget(Widget):
    def __init__(self, **kwargs):
        super(TestWidget, self).__init__(**kwargs)

        # create a 64x64 texture, default to rgb / ubyte
        texture = Texture.create(size=(64, 64))

        # create 64x64 rgb tab, and fill with value from 0 to 255
        # we'll have a gradient from black to white
        size = 64 * 64 * 3
        buf = [x for y in xrange(64) for x in xrange(size/64) ]

        # then, convert the array to a ubyte string
        buf = ''.join(map(chr, buf))

        # then blit the buffer
        texture.blit_buffer(buf, colorfmt='rgb', bufferfmt='ubyte')  

        with self.canvas:
            Rectangle(texture=texture, pos=(0, 0), size=(64, 64))

        texture.flip_horizontal()

        with self.canvas:
            Rectangle(texture=texture, pos=(64, 0), size=(64, 64))

class MyApp(App):
    def build(self):
        root = GridLayout(cols=2, padding=50, spacing=50)
        root.add_widget(TestWidget())
        return root

if __name__ == '__main__':
    MyApp().run()
```
