### PR TITLE
use a more natural method to check if self._text is unicode.

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -526,7 +526,7 @@ class LabelBase(object):
     def _get_text(self):
         if PY2:
             try:
-                if type(self._text) is unicode:
+                if isinstance(self._text, unicode):
                     return self._text
                 return self._text.decode('utf8')
             except AttributeError:


### PR DESCRIPTION
uses isinstance instead of type which is encouraged typically in pep8
also ensures improved compatibility 

(we were basically getting hit with this bug and it was an easy fix so I figured I would push it over to you guys)

this is to handle the following case

```
class LabelText(unicode):
    def do_something():
        return repr(self)

Label(text=LabelText("some Message!"))
```

which would cause kivy to crash prior to this fix
