### PR TITLE
show_keyboard takes no arguments in api < 11 , should now catch exceptio...

### DIFF
--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -401,7 +401,11 @@ class WindowPygame(WindowBase):
         keyboard = super(WindowPygame, self).request_keyboard(
             callback, target, input_type)
         if android and not self.allow_vkeyboard:
-            android.show_keyboard(target, input_type)
+            try:
+                android.show_keyboard(target, input_type)
+            except TypeError:
+            # show keyboard took no args prior to API-11
+                android.show_keyboard()  # api < 11
         return keyboard
 
     def release_keyboard(self, *largs):


### PR DESCRIPTION
resolves an issue where using a textInput would crash the application when developing or using api < 11 (we were using 8 when we discovered the issue)
