### PR TITLE
Fix Syntax Highlighting for Sublime Text

### DIFF
--- a/kivy/tools/highlight/kivy.json-tmlanguage
+++ b/kivy/tools/highlight/kivy.json-tmlanguage
@@ -13,7 +13,7 @@
     { "match": ".*?:$",
       "name": "support.function.kivy" },
     { "name": "entity.name.section.kivy",
-      "match": "(.*?):" },
+      "match": "(.*?):$" },
     { "include": "source.python" }
   ],
   "uuid": "49cecc44-5094-48ec-a876-91f597e8bf81"

--- a/kivy/tools/highlight/kivy.tmLanguage
+++ b/kivy/tools/highlight/kivy.tmLanguage
@@ -42,7 +42,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(.*?):</string>
+			<string>(.*?):$</string>
 			<key>name</key>
 			<string>entity.name.section.kivy</string>
 		</dict>


### PR DESCRIPTION
fixed a highlighting error that would occur when a string contained a colon
