### PR TITLE
Only execute events that have not been removed.

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -268,9 +268,12 @@ class ClockEvent(object):
 
     def cancel(self):
         if self._is_triggered:
-            events = self.clock._events
+            clock = self.clock
+            events = clock._events
             cid = self.cid
             if cid in events and self in events[cid]:
+                if clock._current_event is self:
+                    clock._current_event = None
                 events[cid].remove(self)
         self._is_triggered = False
 


### PR DESCRIPTION
This moves up the check as to whether an event exists to before the event is ticked. In order to not have to recheck whether the event was removed during the tick, we cache the current event being ticked in a clock variable so that if it's removed during the tick, the variable is set to `None` and we don't remove it again. 

This way we save ourselves having to check whether the event has been removed, both before and after the tick. It also ensures that events removed are never called as long as the event is removed anytime before the event is ticked.

Fixes #2068.
