### PR TITLE
add .jpe to the supported extensions for providers that supports jpeg

### DIFF
--- a/kivy/core/image/img_imageio.pyx
+++ b/kivy/core/image/img_imageio.pyx
@@ -278,9 +278,10 @@ class ImageLoaderImageIO(ImageLoaderBase):
         # FIXME check which one are available on osx
         return ('bmp', 'bufr', 'cur', 'dcx', 'fits', 'fl', 'fpx', 'gbr',
                 'gd', 'gif', 'grib', 'hdf5', 'ico', 'im', 'imt', 'iptc',
-                'jpeg', 'jpg', 'mcidas', 'mic', 'mpeg', 'msp', 'pcd',
-                'pcx', 'pixar', 'png', 'ppm', 'psd', 'sgi', 'spider',
-                'tga', 'tiff', 'wal', 'wmf', 'xbm', 'xpm', 'xv')
+                'jpeg', 'jpg', 'jpe', 'mcidas', 'mic', 'mpeg', 'msp',
+                'pcd', 'pcx', 'pixar', 'png', 'ppm', 'psd', 'sgi',
+                'spider', 'tga', 'tiff', 'wal', 'wmf', 'xbm', 'xpm',
+                'xv')
 
     def load(self, filename):
         # FIXME: if the filename is unicode, the loader is failing.

--- a/kivy/core/image/img_pil.py
+++ b/kivy/core/image/img_pil.py
@@ -40,9 +40,10 @@ class ImageLoaderPIL(ImageLoaderBase):
         # See http://www.pythonware.com/library/pil/handbook/index.htm
         return ('bmp', 'bufr', 'cur', 'dcx', 'fits', 'fl', 'fpx', 'gbr',
                 'gd', 'gif', 'grib', 'hdf5', 'ico', 'im', 'imt', 'iptc',
-                'jpeg', 'jpg', 'mcidas', 'mic', 'mpeg', 'msp', 'pcd',
-                'pcx', 'pixar', 'png', 'ppm', 'psd', 'sgi', 'spider',
-                'tga', 'tiff', 'wal', 'wmf', 'xbm', 'xpm', 'xv')
+                'jpeg', 'jpg', 'jpe', 'mcidas', 'mic', 'mpeg', 'msp',
+                'pcd', 'pcx', 'pixar', 'png', 'ppm', 'psd', 'sgi',
+                'spider', 'tga', 'tiff', 'wal', 'wmf', 'xbm', 'xpm',
+                'xv')
 
     def _img_correct(self, _img_tmp):
         '''Convert image to the correct format and orientation.

--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -28,7 +28,7 @@ class ImageLoaderPygame(ImageLoaderBase):
             return ('bmp', )
         # Note to self:try to learn to use loader preferences instead-
         # of this- remove gif support from pygame
-        return ('jpg', 'jpeg', 'png', 'bmp', 'pcx', 'tga', 'tiff',
+        return ('jpg', 'jpeg', 'jpe', 'png', 'bmp', 'pcx', 'tga', 'tiff',
                 'tif', 'lbm', 'pbm', 'ppm', 'xpm')
 
     @staticmethod


### PR DESCRIPTION
As it seems to be an accepted extension for jpeg, guess_extension can
return it, and make AsyncImage save the image to .jpe, which was
breaking it.
