### PR TITLE
Allow VariableListProperty to accept any list derivative

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1280,7 +1280,7 @@ cdef class VariableListProperty(Property):
             return x
 
         tp = type(x)
-        if tp is list or tp is tuple:
+        if isinstance(x, (list, tuple)):
             l = len(x)
             if l == 1:
                 y = self._convert_numeric(obj, x[0])


### PR DESCRIPTION
Fixes #2079 to allow `VariableListProperty` to accept any list derivative, including other `VariableListProperty` for its value.
