### PR TITLE
Fixes to not include comments when binding kv properties.

### DIFF
--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -919,6 +919,9 @@ class ParserRuleProperty(object):
         # now, detect obj.prop
         # first, remove all the string from the value
         tmp = sub(lang_str, '', value)
+        idx = tmp.find('#')
+        if idx != -1:
+            tmp = tmp[:idx]
         # detect key.value inside value, and split them
         wk = list(set(findall(lang_keyvalue, tmp)))
         if len(wk):


### PR DESCRIPTION
Fixes #2093.

This removes the comments before finding the properties to which to bind in kv. 

Personally, I'd actually like for it to remain so we can use the comments to make the property bind to things, but that's not proper.
