### PR TITLE
fix problem with list(bool)

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -488,8 +488,7 @@ class FileChooserController(FloatLayout):
         filtered = []
         for filt in self.filters:
             if isinstance(filt, collections.Callable):
-                filtered.extend([fn for fn in files if filt(self.path,
-                                                                   fn)])
+                filtered.extend([fn for fn in files if filt(self.path, fn)])
             else:
                 filtered.extend([fn for fn in files if fnmatch(fn, filt)])
         if not self.filter_dirs:


### PR DESCRIPTION
"filter" was used as a varname, which caused 2->3 compatibility issues when filter was replaced with list(filter.
