### PR TITLE
Removed checking for PY2 for converting to string.

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -232,7 +232,7 @@ from kivy import kivy_config_fn
 from kivy.logger import Logger, logger_config_update
 from collections import OrderedDict
 from kivy.utils import platform
-from kivy.compat import PY2, string_types
+from kivy.compat import string_types
 
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
@@ -302,22 +302,20 @@ class ConfigParser(PythonConfigParser):
         the value is implicitly converted to a string.
         '''
         e_value = value
-        if PY2:
-            if not isinstance(value, string_types):
-                # might be boolean, int, etc.
-                e_value = str(value)
-            else:
-                if isinstance(value, unicode):
-                    e_value = value.encode('utf-8')
+        if not isinstance(value, string_types):
+            # might be boolean, int, etc.
+            e_value = str(value)
+        else:
+            if isinstance(value, unicode):
+                e_value = value.encode('utf-8')
         ret = PythonConfigParser.set(self, section, option, e_value)
         self._do_callbacks(section, option, value)
         return ret
 
     def get(self, section, option, **kwargs):
         value = PythonConfigParser.get(self, section, option, **kwargs)
-        if PY2:
-            if type(value) is str:
-                return value.decode('utf-8')
+        if type(value) is str:
+            return value.decode('utf-8')
         return value
 
     def setdefaults(self, section, keyvalues):


### PR DESCRIPTION
After examination the line and files of importance are:
kivy/config.py: [L541](https://github.com/kivy/kivy/blob/master/kivy/config.py#L541), [L300-L321](https://github.com/kivy/kivy/blob/master/kivy/config.py#L300-L321)
stdlib/ConfigParser (python3.3): [set and get](https://docs.python.org/3.3/library/configparser.html#legacy-api-examples)
stdlib/ConfigParser (python2.7): [set](https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser.set), [get](https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser.get)

After discussion beginning [in #kivy irc](https://botbot.me/freenode/kivy/msg/13953171/) (bot cuts out at about 4:07, but I try to reiterate as much as possible) it was found that the set method implemented in kivy/config.py L300-314 doesn't convert values to strings in python3 as is required by the set function in the ConfigParser from the standard library.

The original py2 check was implemented to guard against converting values to string incorrectly in python3 but from the article referenced in the [original commit](https://github.com/kivy/kivy/commit/76e4229ab652a803f1ac4e8f2d11429fd7dd25fc) in the "Drop 2.5, 3.1 and 3.2" section it actually suggests that 2.7 overlaps enough with 3.3+ that the syntax here is the same.

I've tested myself on python3.3 with success and since the code before the compatability commit was the same without the check then I'm fairly confident this will work on python2.x.

> tshirtman 04:20:35 PM
> ah, if it's that i guess we can drop it, we only support 2.7<x<3.0 and 3.3+

With this comment I expect that this change is acceptable.

I've also extended this logic to the `get` though I haven't actually had a problem with it.

Closes #2122.
