### PR TITLE
Placement of import config critical to opening window size.

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -11,6 +11,9 @@ order to change these settings, you can alter this file manually or use
 the Config object. Please see the :ref:`Configure Kivy` section for more
 information.
 
+Note: To avoid instances where a blank screen appears before resizing, kivy.config
+should be imported right after kivy.app ,or before any modules affecting the window.
+
 Usage of the Config object
 --------------------------
 


### PR DESCRIPTION
It should be important to add that config ought to be imported right after 

"from kivy.app import App"

if the user doesn't wish to observe a blank screen with the kivy icon before it resizes. 

This issue seems to be caused by placement of import config and Config.set statements after modules like kivy.core.window are imported. It is a difficult problem to spot for a new user, and should be noted in the documentation.
