### PR TITLE
Add on_request_close event to window to check before the window is closed

### DIFF
--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -269,6 +269,8 @@ class WindowPygame(WindowBase):
 
             # kill application (SIG_TERM)
             if event.type == pygame.QUIT:
+                if self.dispatch('on_request_close'):
+                    continue
                 EventLoop.quit = True
                 self.close()
 

--- a/kivy/core/window/window_sdl.py
+++ b/kivy/core/window/window_sdl.py
@@ -124,9 +124,10 @@ class WindowSDL(WindowBase):
 
             action, args = event[0], event[1:]
             if action == 'quit':
-                EventLoop.quit = True
-                self.close()
-                break
+                if not self.dispatch('on_request_close'):
+                    EventLoop.quit = True
+                    self.close()
+                    break
 
             elif action in ('fingermotion', 'fingerdown', 'fingerup'):
                 # for finger, pass the raw event to SDL motion event provider
@@ -247,9 +248,10 @@ class WindowSDL(WindowBase):
 
             action, args = event[0], event[1:]
             if action == 'quit':
-                EventLoop.quit = True
-                self.close()
-                break
+                if not self.dispatch('on_request_close'):
+                    EventLoop.quit = True
+                    self.close()
+                    break
             elif action == 'windowrestored':
                 break
 

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -164,7 +164,7 @@ class WindowX11(WindowBase):
 
         if 'KIVY_WINDOW_NO_BORDER' in environ:
             border = False
-            
+
         if 'KIVY_WINDOW_ABOVE' in environ:
             above = True
 
@@ -195,8 +195,8 @@ class WindowX11(WindowBase):
 
     def _mainloop(self):
         EventLoop.idle()
-        if x11_idle() == 0:
-            EventLoop.quit = True
+        if x11_idle() == 0 and not self.dispatch('on_request_close'):
+                EventLoop.quit = True
 
     def flip(self):
         x11_gl_swap()
@@ -210,9 +210,10 @@ class WindowX11(WindowBase):
         # TODO If just CMD+w is pressed, only the window should be closed.
         is_osx = platform == 'darwin'
         if key == 27 or (is_osx and key in (113, 119) and modifier == 1024):
-            stopTouchApp()
-            self.close()  # not sure what to do here
-            return True
+            if not self.dispatch('on_request_close', source='keyboard'):
+                stopTouchApp()
+                self.close()  # not sure what to do here
+                return True
         super(WindowX11, self).on_keyboard(key, scancode,
             codepoint=codepoint, modifier=modifier)
 


### PR DESCRIPTION
This replaces #1698.
- I added a `on_request_close` event which gets dispatched before we want to close the window. If it returns `True`, the window will not be closed.
- @tito suggested to use the `on_close` event. The problem with that is if someone uses that event to turn things off, what if they turn things off, but then the next callback returns `True` and the window is not closed after all and they are now in a unexpected state. So I think making a dedicated event for it is better. Plus it keeps backward compat.
- I also added the `on_request_close` event when the escape key is pressed. This does make kinda make the `exit_on_escape` config key somewhat redundant, but I left it there for backward compat. I don't think it'll hurt having both `on_request_close` and `exit_on_escape` options.
- When the `on_request_close` originates due to a keyboard escape key press, the `on_request_close` event also dispatches a keyword argument of `source='keyboard'`. This will allow the user to differentiate why the window wants to be closed; whether due to the escape key or due to the user pressing the red X and handle them accordingly.
