### PR TITLE
fix bug with sound state in audio_gstplayer.py

### DIFF
--- a/kivy/core/audio/audio_gstplayer.py
+++ b/kivy/core/audio/audio_gstplayer.py
@@ -52,7 +52,7 @@ class SoundGstplayer(Sound):
             self.player.stop()
             self.player.play()
         else:
-            self.player.stop()
+            self.stop()
 
     def load(self):
         self.unload()


### PR DESCRIPTION
Sound state is not appropriately updated on EOS - fixed by calling `self.stop()` instead of `self.player.stop()` on EOS.

http://stackoverflow.com/questions/23432116/on-stop-event-not-getting-called-in-kivy
