### PR TITLE
Add get_root_window method to App class

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -657,10 +657,11 @@ class App(EventDispatcher):
         return expanduser(defaultpath) % {
             'appname': self.name, 'appdir': self.directory}
 
-    def get_root_window(self):
+    @property
+    def root_window(self):
         '''.. versionadded:: 1.8.1
 
-        Returns the window instance used by the :meth:`run` method.
+        Returns the root window instance used by :meth:`run`.
         '''
         return self._app_window
 


### PR DESCRIPTION
This comes in handy when the user needs the window instance without importing Window manually or using a Widget instance to call Widget.get_root_window.
