### PR TITLE
Disable indent-tabs-mode in kivy-mode.el.

### DIFF
--- a/kivy/tools/highlight/kivy-mode.el
+++ b/kivy/tools/highlight/kivy-mode.el
@@ -235,6 +235,9 @@ immediately previous multiple of `kivy-indent-offset' spaces."
   (setq imenu-generic-expression kivy-imenu-generic-expression))
 
 (add-hook 'kivy-mode-hook 'kivy-set-imenu-generic-expression)
+(add-hook 'kivy-mode-hook
+          '(lambda ()
+             (setq indent-tabs-mode 'nil)))
 
 
 (defun kivy-mode-version ()


### PR DESCRIPTION
Summary: This fix sets indent-tabs-mode to nil so that indenting only uses spaces, instead of a combination of spaces and tabs.

I started with the following text in a buffer linked to a .kv file:

```
#:kivy 1.0.9
<MyRootWidget>:
    canvas:
Rectangle:
```

I put my cursor at the beginning of the Rectangle line, and pressed tab, expecting 8 spaces to be inserted. Instead a tab was inserted. Pressing it again resulted in cycling between 4 spaces, 0 spaces, and back to a tab. Thank God for whoever decided to highlight tabs in red, nevertheless it was still confusing. I can't imagine a reason for wanting the tab key to actually produce a tab in .kv files.

The behavior is caused by kivy-indent-line calling the indent-to function, which relies on indent-tabs-mode. The variable indent-tabs-mode is buffer-local when set, so it won't affect buffers other than .kv ones.
