### PR TITLE
Added handlers for non-multitouch touchscreen events

### DIFF
--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -115,6 +115,11 @@ else:
     MSC_MAX = 0x07
     MSC_CNT = (MSC_MAX + 1)
 
+    # Events for stmpe touchscreen
+    ABS_X = 0x00
+    ABS_Y = 0x01
+    ABS_PRESSURE = 0x18
+
     ABS_MT_TOUCH_MAJOR = 0x30  # Major axis of touching ellipse
     ABS_MT_TOUCH_MINOR = 0x31  # Minor axis (omit if circular)
     ABS_MT_WIDTH_MAJOR = 0x32  # Major axis of approaching ellipse
@@ -288,6 +293,23 @@ else:
                         point['y'] = \
                             min(1., max(0., point['y'] - ev_value / 1000.))
 
+                elif ev_type == EV_ABS:
+
+                    if ev_code == 0:
+                        val = 1. - normalize(ev_value,
+                                             range_min_position_x,
+                                             range_max_position_x)
+                        if invert_y:
+                            val = 1. - val
+                        point['y'] = val
+                    elif ev_code == 1:
+                        val = 1. - normalize(ev_value,
+                                             range_min_position_y,
+                                             range_max_position_y)
+                        if invert_x:
+                            val = 1. - val
+                        point['x'] = val
+
                 elif ev_type == EV_KEY:
                     buttons = {
                         272: 'left',
@@ -297,7 +319,8 @@ else:
                         276: 'extra',
                         277: 'forward',
                         278: 'back',
-                        279: 'task'}
+                        279: 'task',
+                        330: 'touch'}
 
                     if ev_code in buttons.keys():
                         if ev_value:
@@ -396,6 +419,24 @@ else:
                                     '<%s> range position Y is %d - %d' % (
                                         device_name, abs_min, abs_max))
                     elif y == ABS_MT_PRESSURE:
+                        range_min_pressure = drs('min_pressure', abs_min)
+                        range_max_pressure = drs('max_pressure', abs_max)
+                        Logger.info('HIDMotionEvent: ' +
+                                    '<%s> range pressure is %d - %d' % (
+                                        device_name, abs_min, abs_max))
+                    elif y == ABS_X:
+                        range_min_position_x = drs('min_position_x', abs_min)
+                        range_max_position_x = drs('max_position_x', abs_max)
+                        Logger.info('HIDMotionEvent: ' +
+                                    '<%s> range position X is %d - %d' % (
+                                        device_name, abs_min, abs_max))
+                    elif y == ABS_Y:
+                        range_min_position_y = drs('min_position_y', abs_min)
+                        range_max_position_y = drs('max_position_y', abs_max)
+                        Logger.info('HIDMotionEvent: ' +
+                                    '<%s> range position Y is %d - %d' % (
+                                        device_name, abs_min, abs_max))
+                    elif y == ABS_PRESSURE:
                         range_min_pressure = drs('min_pressure', abs_min)
                         range_max_pressure = drs('max_pressure', abs_max)
                         Logger.info('HIDMotionEvent: ' +


### PR DESCRIPTION
I found that the hidinput handlers did not handle the events that my touchscreen for Raspberry Pi was dispatching. These events are similar to the multitouch events already in place, but much simpler because they are for a simple resistive touchscreen. These changes allow these events to be handled where most appropriate.  Thanks!