### PR TITLE
include inner traceback in BuilderException

### DIFF
--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -734,6 +734,7 @@ __all__ = ('Builder', 'BuilderBase', 'BuilderException',
 import codecs
 import re
 import sys
+import traceback
 from re import sub, findall
 from os import environ
 from os.path import join
@@ -838,7 +839,7 @@ class ParserException(Exception):
     '''Exception raised when something wrong happened in a kv file.
     '''
 
-    def __init__(self, context, line, message):
+    def __init__(self, context, line, message, cause=None):
         self.filename = context.filename or '<inline>'
         self.line = line
         sourcecode = context.sourcecode
@@ -855,6 +856,9 @@ class ParserException(Exception):
 
         message = 'Parser: File "%s", line %d:\n%s\n%s' % (
             self.filename, self.line + 1, sc, message)
+        if cause:
+            message += '\n' + ''.join(traceback.format_tb(cause))
+        sys.exc_clear()
         super(ParserException, self).__init__(message)
 
 
@@ -1447,8 +1451,10 @@ def create_handler(iself, element, key, value, rule, idmap, delayed=False):
     try:
         return eval(value, idmap)
     except Exception as e:
+        tb = sys.exc_info()[2]
         raise BuilderException(rule.ctx, rule.line,
-                               '{}: {}'.format(e.__class__.__name__, e))
+                               '{}: {}'.format(e.__class__.__name__, e),
+                               cause=tb)
 
 
 class ParserSelector(object):
@@ -1752,9 +1758,10 @@ class BuilderBase(object):
                         value = eval(prule.value, idmap)
                         ctx[prule.name] = value
                 except Exception as e:
+                    tb = sys.exc_info()[2]
                     raise BuilderException(
                         prule.ctx, prule.line,
-                        '{}: {}'.format(e.__class__.__name__, e))
+                        '{}: {}'.format(e.__class__.__name__, e), cause=tb)
 
                 # create the template with an explicit ctx
                 child = cls(**ctx)
@@ -1801,9 +1808,10 @@ class BuilderBase(object):
                     setattr(widget_set, key, value)
         except Exception as e:
             if rule is not None:
+                tb = sys.exc_info()[2]
                 raise BuilderException(rule.ctx, rule.line,
                                        '{}: {}'.format(e.__class__.__name__,
-                                                       e))
+                                                       e), cause=tb)
             raise e
 
         # build handlers
@@ -1826,9 +1834,10 @@ class BuilderBase(object):
                         Factory.Widget.parent.dispatch(widget_set.__self__)
         except Exception as e:
             if crule is not None:
+                tb = sys.exc_info()[2]
                 raise BuilderException(
                     crule.ctx, crule.line,
-                    '{}: {}'.format(e.__class__.__name__, e))
+                    '{}: {}'.format(e.__class__.__name__, e), cause=tb)
             raise e
 
         # rule finished, forget it
@@ -1907,9 +1916,10 @@ class BuilderBase(object):
                             key, value, prule, idmap, True)
                     setattr(instr, key, value)
             except Exception as e:
+                tb = sys.exc_info()[2]
                 raise BuilderException(
                     prule.ctx, prule.line,
-                    '{}: {}'.format(e.__class__.__name__, e))
+                    '{}: {}'.format(e.__class__.__name__, e), cause=tb)
 
 #: Main instance of a :class:`BuilderBase`.
 Builder = register_context('Builder', BuilderBase)


### PR DESCRIPTION
`BuilderException` tends to hide the problem which caused the actual exception. Some problems require digging through the code and manually tracing it, especially when the exception is occurring in a property callback.

This fixes that by adding the inner traceback to the exception message, which turns this cryptic exception:

```
 Traceback (most recent call last):
   File "extest.py", line 15, in <module>
     ''')
   File "/home/ryan/git/aeris2/kivy/kivy/lang.py", line 1630, in load_string
     self._apply_rule(widget, parser.root, parser.root)
   File "/home/ryan/git/aeris2/kivy/kivy/lang.py", line 1814, in _apply_rule
     e), cause=tb)
 kivy.lang.BuilderException: Parser: File "<inline>", line 3:
 ...
       1:
       2:MyLabel:
 >>    3:   text: '12'
 ...
 NameError: global name 'hello' is not defined
```

...into this:

```
 Traceback (most recent call last):
   File "extest.py", line 15, in <module>
     ''')
   File "/home/ryan/git/aeris2/kivy/kivy/lang.py", line 1630, in load_string
     self._apply_rule(widget, parser.root, parser.root)
   File "/home/ryan/git/aeris2/kivy/kivy/lang.py", line 1814, in _apply_rule
     e), cause=tb)
 kivy.lang.BuilderException: Parser: File "<inline>", line 3:
 ...
       1:
       2:MyLabel:
 >>    3:   text: '12'
 ...
 NameError: global name 'hello' is not defined
   File "/home/ryan/git/aeris2/kivy/kivy/lang.py", line 1808, in _apply_rule
     setattr(widget_set, key, value)
   File "properties.pyx", line 345, in kivy.properties.Property.__set__ (kivy/properties.c:3597)
   File "properties.pyx", line 377, in kivy.properties.Property.set (kivy/properties.c:4072)
   File "properties.pyx", line 431, in kivy.properties.Property.dispatch (kivy/properties.c:4665)
   File "extest.py", line 10, in on_text
     print hello
```
