### PR TITLE
Remove strange chars.

### DIFF
--- a/kivy/input/providers/androidjoystick.py
+++ b/kivy/input/providers/androidjoystick.py
@@ -11,7 +11,7 @@ information, please refer to
 '''
 __all__ = ('AndroidMotionEventProvider', )
 
-import os
+import os
 
 try:
     import android  # NOQA


### PR DESCRIPTION
Removes invisible chars. Not sure why they are hiding there. They are not visible here, but here's what git diff showed:

```
C:\kivy-dev\kivy>git diff
diff --git a/kivy/input/providers/androidjoystick.py b/kivy/input/providers/androidjoystick.py
index d786cfc..1a52922 100644
--- a/kivy/input/providers/androidjoystick.py
+++ b/kivy/input/providers/androidjoystick.py
@@ -11,7 +11,7 @@ information, please refer to
 '''
 __all__ = ('AndroidMotionEventProvider', )

-<C2><86>import os
+import os

 try:
     import android  # NOQA
```
