### PR TITLE
Keep the markup color attribute after creation. Fixes #2210.

### DIFF
--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -202,7 +202,6 @@ class Label(Widget):
                 # force the rendering to get the references
                 if self._label.texture:
                     self._label.texture.bind()
-                self._label.text = text
                 self.refs = self._label.refs
                 self.anchors = self._label.anchors
             else:


### PR DESCRIPTION
Fixes #2210.

I'm not sure why text was reset after creation, in the first place.
