### PR TITLE
Fix py3 compat issue

### DIFF
--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -876,10 +876,7 @@ class ParserException(Exception):
             self.filename, self.line + 1, sc, message)
         if cause:
             message += '\n' + ''.join(traceback.format_tb(cause))
-        try:
-            sys.exc_clear()
-        except:
-            pass
+
         super(ParserException, self).__init__(message)
 
 


### PR DESCRIPTION
sys.exc_clear was removed in Python 3.
