### PR TITLE
force initial window size

### DIFF
--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -136,6 +136,9 @@ class WindowPygame(WindowBase):
             else:
                 raise CoreCriticalException(e.message)
 
+        if pygame.RESIZABLE & self.flags:
+            self._pygame_set_mode()
+
         info = pygame.display.Info()
         self._size = (info.current_w, info.current_h)
         #self.dispatch('on_resize', *self._size)


### PR DESCRIPTION
On Ubuntu (with some window managers), newly created windows are capped to the size of the primary display. However, Kivy and Pygame do not know that the created window is a different size, so everything is rendered at the requested size and the bottom of the app is clipped.

This only happens with resizable windows. So to fix this problem, I modified `WindowPygame` to call `_pygame_set_mode()` a second time if the window is resizable. This forces the requested window size, regardless of display size. It might be better to use the size the WM provided, but there doesn't seem to be any way to read that from Pygame until a resize event happens.