### PR TITLE
Prevent cache clash for textinput width between password = True/False.

### DIFF
--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -124,15 +124,14 @@ class CodeInput(TextInput):
 
     def _get_text_width(self, text, tab_width, _label_cached):
         # Return the width of a text, according to the current line options
-        width = Cache_get('textinput.width', text + u'_' +
-                          repr(self._get_line_options()))
-        if width:
+        cid = u'{}\0{}\0{}'.format(text, self.password,
+                                   self._get_line_options())
+        width = Cache_get('textinput.width', cid)
+        if width is not None:
             return width
         lbl = self._create_line_label(text)
-        width = lbl.width if lbl else 0
-        Cache_append(
-            'textinput.width',
-            text + u'_' + repr(self._get_line_options()), width)
+        width = lbl.width
+        Cache_append('textinput.width', cid, width)
         return width
 
     def _get_bbcode(self, ntext):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1421,9 +1421,9 @@ class TextInput(Widget):
         kw = self._get_line_options()
 
         try:
-            cid = u'{}\0{}'.format(text, kw)
+            cid = u'{}\0{}\0{}'.format(text, self.password, kw)
         except UnicodeDecodeError:
-            cid = '{}\0{}'.format(text, kw)
+            cid = '{}\0{}\0{}'.format(text, self.password, kw)
 
         width = Cache_get('textinput.width', cid)
         if width:


### PR DESCRIPTION
There's a clash in the cache if there ate two textinputs with identical text, one has password enabled, the other doesn't. You can see the issue with the following test code:

```
from kivy.app import App
from kivy.uix.boxlayout import BoxLayout

class TextInputApp(App):

    def build(self):
        root = BoxLayout(orientation='vertical')
        textinput = TextInput(password=True)
        root.add_widget(textinput)
        textinput2 = TextInput()
        root.add_widget(textinput2)
        def t(instance, value):
            textinput.text = value
        textinput2.bind(text=t)
        return root

TextInputApp().run()
```

Just type e.g. lots of w in the bottom textinput to see the issue.

Note, #2311 should be merged before this is merged.
