### PR TITLE
Fix typo in switch_to documentation

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -936,7 +936,7 @@ class ScreenManager(FloatLayout):
 
         If any animation is in progress, it will be stopped and replaced by
         this one: you should avoid this because the animation will just look
-        weird. Use either :meth:`switch` or :attr:`current` but not both.
+        weird. Use either :meth:`switch_to` or :attr:`current` but not both.
 
         The `screen` name will be changed if there is any conflict with the
         current screen.


### PR DESCRIPTION
`switch()` method doesn't exists. seems like it was a typo.
