### PR TITLE
Use class object for hash instead of the class method

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -264,6 +264,8 @@ except (OSError, ImportError):
 
 
 def _hash(cb):
+    if hasattr(cb, '__self__') and cb.__self__ is not None:
+        return (id(cb.__self__) & 0xFF00) >> 8
     return (id(cb) & 0xFF00) >> 8
 
 
@@ -583,11 +585,11 @@ class ClockBase(_ClockBase):
         else:
             if all:
                 for ev in self._events[_hash(callback)][:]:
-                    if ev.get_callback() is callback:
+                    if ev.get_callback() == callback:
                         ev.cancel()
             else:
                 for ev in self._events[_hash(callback)][:]:
-                    if ev.get_callback() is callback:
+                    if ev.get_callback() == callback:
                         ev.cancel()
                         break
 


### PR DESCRIPTION
The problem with doing `id(callback)` when callback is a class method, is that class methods get regenerated often, so two calls to id(self.callback) may give different results.

Instead we use `id(self.callback.__self__)` which is the class instance of the callback whose id does not change. This is documented here: https://docs.python.org/2/reference/datamodel.html.
