### PR TITLE
No builtin fonts

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -41,6 +41,7 @@ Available configuration tokens
 
 :kivy:
 
+    `default_font` : 'Droid Sans'
     `desktop`: int, 0 or 1
         This option controls desktop OS specific features, such as enabling
         drag-able scroll-bar in scroll views, disabling of bubbles in
@@ -242,7 +243,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 10
+KIVY_CONFIG_VERSION = 11
 
 Config = None
 '''Kivy configuration object. Its :attr:`~kivy.config.ConfigParser.name` is
@@ -688,6 +689,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 9:
             Config.setdefault('kivy', 'exit_on_escape', '1')
+
+        elif version == 10:
+            Config.setdefault('kivy', 'default_font', 'DroidSans')        
 
         #elif version == 1:
         #   # add here the command for upgrading from configuration 0 to 1

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -39,13 +39,20 @@ import os
 from functools import partial
 from copy import copy
 from kivy import kivy_data_dir
+from kivy.config import Config
 from kivy.graphics.texture import Texture
 from kivy.core import core_select_lib
 from kivy.core.text.text_layout import layout_text, LayoutWord
 from kivy.resources import resource_find
 from kivy.compat import PY2
 
-DEFAULT_FONT = 'DroidSans'
+
+
+# When we are generating documentation, Config doesn't exist
+_default_font = 'DroidSans'
+if Config:
+    _default_font = Config.get('kivy', 'default_font')
+
 
 FONT_REGULAR = 0
 FONT_ITALIC = 1
@@ -63,7 +70,7 @@ class LabelBase(object):
     :Parameters:
         `font_size`: int, defaults to 12
             Font size of the text
-        `font_name`: str, defaults to DEFAULT_FONT
+        `font_name`: str, defaults to 'DroidSans' through Config
             Font name of the text
         `bold`: bool, defaults to False
             Activate "bold" text style
@@ -135,7 +142,7 @@ class LabelBase(object):
 
     _texture_1px = None
 
-    def __init__(self, text='', font_size=12, font_name=DEFAULT_FONT,
+    def __init__(self, text='', font_size=12, font_name=_default_font,
                  bold=False, italic=False, halign='left', valign='bottom',
                  shorten=False, text_size=None, mipmap=False, color=None,
                  line_height=1.0, strip=False, shorten_from='center',
@@ -676,9 +683,10 @@ if 'KIVY_DOC' not in os.environ:
         Logger.critical('App: Unable to get a Text provider, abort.')
         sys.exit(1)
 
-# For the first initalization, register the default font
-    Label.register('DroidSans',
-                   'data/fonts/DroidSans.ttf',
-                   'data/fonts/DroidSans-Italic.ttf',
-                   'data/fonts/DroidSans-Bold.ttf',
-                   'data/fonts/DroidSans-BoldItalic.ttf')
+    # If the user has not changed config default, register the defualt font.
+    if _default_font == 'DroidSans':
+        Label.register('DroidSans',
+                       'data/fonts/DroidSans.ttf',
+                       'data/fonts/DroidSans-Italic.ttf',
+                       'data/fonts/DroidSans-Bold.ttf',
+                       'data/fonts/DroidSans-BoldItalic.ttf')

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -370,7 +370,7 @@ class Label(Widget):
         .. |unicodechar| image:: images/unicode-char.png
 
     :attr:`font_name` is a :class:`~kivy.properties.StringProperty` and
-    defaults to 'DroidSans'.
+    defaults to 'DroidSans' via `~kivy.config`.
     '''
 
     font_size = NumericProperty('15sp')

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -370,7 +370,8 @@ class Label(Widget):
         .. |unicodechar| image:: images/unicode-char.png
 
     :attr:`font_name` is a :class:`~kivy.properties.StringProperty` and
-    defaults to 'DroidSans' via `~kivy.config`.
+    defaults to 'DroidSans' and can be overridden in 
+    :class:`~kivy.config.Config`.
     '''
 
     font_size = NumericProperty('15sp')

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -155,6 +155,7 @@ The following example marks the anchors and references contained in a label::
 __all__ = ('Label', )
 
 from functools import partial
+from kivy.config import Config
 from kivy.clock import Clock
 from kivy.uix.widget import Widget
 from kivy.core.text import Label as CoreLabel
@@ -163,6 +164,12 @@ from kivy.properties import StringProperty, OptionProperty, \
     NumericProperty, BooleanProperty, ReferenceListProperty, \
     ListProperty, ObjectProperty, DictProperty
 from kivy.utils import get_hex_from_color
+
+# When we are generating documentation, Config doesn't exist
+_default_font = 'DroidSans'
+if Config:
+    _default_font = Config.get('kivy', 'default_font')
+
 
 
 class Label(Widget):
@@ -344,7 +351,7 @@ class Label(Widget):
     defaults to (None, None), meaning no size restriction by default.
     '''
 
-    font_name = StringProperty('DroidSans')
+    font_name = StringProperty(_default_font)
     '''Filename of the font to use. The path can be absolute or relative.
     Relative paths are resolved by the :func:`~kivy.resources.resource_find`
     function.


### PR DESCRIPTION
User can set builtin_font in config and core/text/__init__.py will no longer error whenever default font files not built into apk.  Can build smaller apk's if the default is set correctly to a user-defined font file or unset, in which case label doesn't try to load a font by default.  Docs built.