### PR TITLE
Use wrap to give correct name to mainthread wrapped func. Fixes #2027.

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -208,6 +208,7 @@ __all__ = ('Clock', 'ClockBase', 'ClockEvent', 'mainthread')
 
 from sys import platform
 from os import environ
+from functools import wraps
 from kivy.context import register_context
 from kivy.weakmethod import WeakMethod
 from kivy.config import Config
@@ -654,6 +655,7 @@ def mainthread(func):
 
     .. versionadded:: 1.8.0
     '''
+    @wraps(func)
     def delayed_func(*args, **kwargs):
         def callback_func(dt):
             func(*args, **kwargs)


### PR DESCRIPTION
Fixes #2027.
