### PR TITLE
rearrange order of returns in button behavior to ensure consistency across interaction

### DIFF
--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -109,8 +109,6 @@ class ButtonBehavior(object):
 
     def on_touch_up(self, touch):
         super_result = super(ButtonBehavior, self).on_touch_up(touch)
-        if super_result:
-            return True
         if touch.grab_current is not self:
             return super_result
         assert(self in touch.ud)


### PR DESCRIPTION
Previously, the order of returns in on_touch_move and on_touch_up meant that multiple Behaviors that had touch logic were order of subclassing dependent. on_touch_down did not have this problem because its first check was to super(). I reordered the returns in the move and up behaviors to match the behavior in down. I'm not super experienced with heavy inheritance, but I don't think there are any changes in logic here other than the order of return in on_touch_move
