### PR TITLE
remove try/except from grab/ungrab

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -322,11 +322,7 @@ class MotionEvent(MotionEventBase):
             raise Exception('Grab works only for Touch MotionEvents.')
         if self.grab_exclusive_class is not None:
             raise Exception('Cannot grab the touch, touch is exclusive')
-        try:
-            class_instance = weakref.ref(class_instance)
-        except TypeError:
-            # handle weakproxy objects which cannot be weakref'd
-            class_instance = weakref.ref(class_instance.__self__)
+        class_instance = weakref.ref(class_instance.__self__)
         if exclusive:
             self.grab_exclusive_class = class_instance
         self.grab_list.append(class_instance)
@@ -334,11 +330,7 @@ class MotionEvent(MotionEventBase):
     def ungrab(self, class_instance):
         '''Ungrab a previously grabbed touch
         '''
-        try:
-            class_instance = weakref.ref(class_instance)
-        except TypeError:
-            # handle weakproxy objects which cannot be weakref'd
-            class_instance = weakref.ref(class_instance.__self__)
+        class_instance = weakref.ref(class_instance.__self__)
         if self.grab_exclusive_class == class_instance:
             self.grab_exclusive_class = None
         if class_instance in self.grab_list:


### PR DESCRIPTION
I realized shortly after I did this that there was no need for a try/except. Every widget should have a `__self__` attribute, whether it's a weakproxy or not.
