### PR TITLE
respect keyboard height when providing window height in softinput resize mode

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -345,9 +345,10 @@ class WindowBase(EventDispatcher):
     def _get_height(self):
         '''Rotated window height'''
         r = self._rotation
+        kb = self.keyboard_height if self.softinput_mode == 'resize' else 0
         if r == 0 or r == 180:
-            return self._size[1]
-        return self._size[0]
+            return self._size[1] - kb
+        return self._size[0] - kb
 
     height = AliasProperty(_get_height, None, bind=('_rotation', '_size'))
     '''Rotated window height.


### PR DESCRIPTION
Fixes popups not centering properly when keyboard is opened and closed (fixes #2385).

![screenshot_2014-08-05-11-51-02](https://cloud.githubusercontent.com/assets/1126441/3815029/bd3ddd64-1cc0-11e4-9a95-615e232ba18c.png)
