### PR TITLE
Inspector: handle bad properties/values

### DIFF
--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -169,7 +169,7 @@ Builder.load_string('''
         size_hint_x: None
     Label:
         id: ltext
-        text: [repr(getattr(root.widget, root.key)), root.refresh][0]\
+        text: [repr(getattr(root.widget, root.key, '')), root.refresh][0]\
                 if root.widget else ''
         text_size: (self.width, None)
 ''')
@@ -412,8 +412,10 @@ class Inspector(FloatLayout):
             text = '%s' % key
             node = TreeViewProperty(text=text, key=key, widget_ref=wk_widget)
             node.bind(is_selected=self.show_property)
-            widget.bind(**{key: partial(
-                self.update_node_content, weakref.ref(node))})
+            try:
+                widget.bind(**{key: partial(
+                    self.update_node_content, weakref.ref(node))})
+            except: pass
             treeview.add_node(node)
 
     def update_node_content(self, node, *l):


### PR DESCRIPTION
Avoids a few exceptions which can occur when selecting widgets and properties in inspector.
