### PR TITLE
fix issues with recent chnages to CheckBoxes

### DIFF
--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -194,6 +194,8 @@ class ToggleButtonBehavior(ButtonBehavior):
             widget.state = 'normal'
 
     def _do_press(self):
+        if self.group and self.state == 'down':
+            return
         self._release_group(self)
         self.state = 'normal' if self.state == 'down' else 'down'
 

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -56,6 +56,5 @@ class CheckBox(ToggleButtonBehavior, Widget):
         else:
             self.active = False
 
-    def _toggle_active(self):
-        self._do_press()
-
+    def on_active(self, instance, value):
+        self.state = 'down' if value else 'normal'


### PR DESCRIPTION
This fixes a issue where setting checkbox.active didn't change the widget `state`.

This also stops the checkbox/toggle button from being unselected through touch if it is in a `group` and already selected. Earlier selecting a active radio button unselected it.
