### PR TITLE
Fix Image.test_keep_data test failing.

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -153,6 +153,7 @@ class ImageLoaderBase(object):
         self.filename = filename
         self._data = self.load(filename)
         self._textures = None
+        self.populate()
 
     def load(self, filename):
         '''Load an image'''
@@ -175,7 +176,6 @@ class ImageLoaderBase(object):
                          (self.filename, len(self._data)))
 
         for count in range(len(self._data)):
-
             # first, check if a texture with the same name already exist in the
             # cache
             uid = '%s|%s|%s' % (self.filename, self._mipmap, count)


### PR DESCRIPTION
When an image is instantiated for the first time from a simple source like 'test.png', populate of ImageLoaderBase is never actually called, a second instantiation will trigger this call as part of logic I don't quite understand. The end result is that keep_data is not respected for the first call, but is for the second. This can be prevented by guaranting the call to populate during **init**. 
