### PR TITLE
basic bidi support

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -216,6 +216,17 @@ Available configuration tokens
     Check the specific module's documentation for a list of accepted
     arguments.
 
+:i18n:
+
+    `bidi`: int, 0 or 1
+        Support bi-directional text by default on all widgets subclassing
+        :class:`~kivy.uix.label.Label` or
+        :class:`~kivy.uix.textinput.TextInput`, if supported. Support can
+        still be toggled for an individual widget, regardless of this setting.
+
+.. versionchanged:: 1.9.0
+    `i18n` section added.
+
 .. versionchanged:: 1.8.0
     `systemanddock` and `systemandmulti` has been added as possible values for
     `keyboard_mode` in the kivy section. `exit_on_escape` has been added
@@ -255,7 +266,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 10
+KIVY_CONFIG_VERSION = 11
 
 Config = None
 '''Kivy configuration object. Its :attr:`~kivy.config.ConfigParser.name` is
@@ -718,6 +729,10 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 9:
             Config.setdefault('kivy', 'exit_on_escape', '1')
+
+        elif version == 10:
+            Config.adddefaultsection('i18n')
+            Config.setdefault('i18n', 'bidi', '0')
 
         #elif version == 1:
         #   # add here the command for upgrading from configuration 0 to 1

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -38,7 +38,7 @@ import re
 import os
 from functools import partial
 from copy import copy
-from kivy import kivy_data_dir
+from kivy import kivy_data_dir, Config
 from kivy.graphics.texture import Texture
 from kivy.core import core_select_lib
 from kivy.core.text.text_layout import layout_text, LayoutWord
@@ -51,6 +51,18 @@ FONT_REGULAR = 0
 FONT_ITALIC = 1
 FONT_BOLD = 2
 FONT_BOLDITALIC = 3
+
+
+def get_display_text_noop(text):
+    return text
+
+try:
+    from pyfribidi import log2vis as get_display_text
+except ImportError:
+    try:
+        from bidi.algorithm import get_display as get_display_text
+    except ImportError:
+        get_display_text = get_display_text_noop
 
 
 class LabelBase(object):
@@ -104,6 +116,11 @@ class LabelBase(object):
         `strip` : bool, defaults to False
             Whether each row of text has its leading and trailing spaces
             stripped. If `halign` is `justify` it is implicitly True.
+        `bidi` : bool, defaults to :class:`~kivy.config.Config` setting.
+            Whether text should be treated as bi-directional (if supported).
+
+    .. versionchanged:: 1.9.0
+        `bidi` parameter was added.
 
     .. versionchanged:: 1.8.1
         `strip`, `shorten_from`, and `split_str` were added.
@@ -139,14 +156,15 @@ class LabelBase(object):
                  bold=False, italic=False, halign='left', valign='bottom',
                  shorten=False, text_size=None, mipmap=False, color=None,
                  line_height=1.0, strip=False, shorten_from='center',
-                 split_str=' ', **kwargs):
+                 split_str=' ', bidi=None, **kwargs):
 
+        bidi = bidi if bidi is not None else bool(int(Config.getint('i18n', 'bidi')))
         options = {'text': text, 'font_size': font_size,
                    'font_name': font_name, 'bold': bold, 'italic': italic,
                    'halign': halign, 'valign': valign, 'shorten': shorten,
                    'mipmap': mipmap, 'line_height': line_height,
                    'strip': strip, 'shorten_from': shorten_from,
-                   'split_str': split_str}
+                   'split_str': split_str, 'bidi': bidi}
 
         options['color'] = color or (1, 1, 1, 1)
         options['padding'] = kwargs.get('padding', (0, 0))
@@ -502,6 +520,7 @@ class LabelBase(object):
         text = self.text
         if strip:
             text = text.strip()
+        text = get_display_text(text) if options['bidi'] else text
         if uw is not None and options['shorten']:
             text = self.shorten(text)
         self._cached_lines = lines = []

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -178,7 +178,7 @@ class Label(Widget):
                         'halign', 'valign', 'padding_x', 'padding_y',
                         'text_size', 'shorten', 'mipmap', 'markup',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
-                        'split_str')
+                        'split_str', 'bidi')
 
     def __init__(self, **kwargs):
         self._trigger_texture = Clock.create_trigger(self.texture_update, -1)
@@ -575,6 +575,15 @@ class Label(Widget):
 
     :attr:`split_str` is a :class:`~kivy.properties.StringProperty` and
     defaults to `''` (the empty string).
+    '''
+
+    bidi = BooleanProperty(None, allownone=True)
+    '''Whether to treat text as bi-directional (if supported).
+    
+    .. versionadded:: 1.9.0
+    
+    :attr:`bidi` is a :class:`~kivy.properties.BooleanProperty` and defaults
+    to the :class:`~kivy.config.Config` setting.
     '''
 
     markup = BooleanProperty(False)

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -396,7 +396,8 @@ class TextInput(Widget):
                   font_size=self._update_text_options,
                   font_name=self._update_text_options,
                   size=self._update_text_options,
-                  password=self._update_text_options)
+                  password=self._update_text_options,
+                  bidi=self._update_text_options)
 
         self.bind(pos=self._trigger_update_graphics)
 
@@ -1778,6 +1779,7 @@ class TextInput(Widget):
             self._line_options = kw = {
                 'font_size': self.font_size,
                 'font_name': self.font_name,
+                'bidi': self.bidi,
                 'anchor_x': 'left',
                 'anchor_y': 'top',
                 'padding_x': 0,
@@ -2572,6 +2574,15 @@ class TextInput(Widget):
 
     :attr:`auto_indent` is a :class:`~kivy.properties.BooleanProperty` and
     defaults to False.
+    '''
+
+    bidi = BooleanProperty(None, allownone=True)
+    '''Whether to treat text as bi-directional (if supported).
+    
+    .. versionadded:: 1.9.0
+    
+    :attr:`bidi` is a :class:`~kivy.properties.BooleanProperty` and defaults
+    to the :class:`~kivy.config.Config` setting.
     '''
 
     allow_copy = BooleanProperty(True)


### PR DESCRIPTION
Support bi-directional text using [pyfribidi](http://pyfribidi.sourceforge.net/) or [python-bidi](https://pypi.python.org/pypi/python-bidi), if available. This just handles bidi text, and does not do any reshaping (I tested with Hebrew).

bidi support is added to core `LabelBase` and exposed via properties in `Label` and `TextInput`, and should work with any widget subclassing those (I tested `Button` as well).

Also adds a config section `i18n` and setting `bidi`, which controls the default value for the core label setting.

This will help with #1619.
