### PR TITLE
make fonts easier to load; add default font function

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -53,6 +53,16 @@ FONT_BOLD = 2
 FONT_BOLDITALIC = 3
 
 
+def set_default_font(fontname):
+    global DEFAULT_FONT
+    DEFAULT_FONT = fontname
+
+    from kivy.uix.label import Label
+    Label.font_name.defaultvalue = fontname
+    from kivy.uix.textinput import TextInput
+    TextInput.font_name.defaultvalue = fontname
+
+
 class LabelBase(object):
     '''Core text label.
     This is the abstract class used by different backends to render text.
@@ -135,12 +145,13 @@ class LabelBase(object):
 
     _texture_1px = None
 
-    def __init__(self, text='', font_size=12, font_name=DEFAULT_FONT,
+    def __init__(self, text='', font_size=12, font_name=None,
                  bold=False, italic=False, halign='left', valign='bottom',
                  shorten=False, text_size=None, mipmap=False, color=None,
                  line_height=1.0, strip=False, shorten_from='center',
                  split_str=' ', **kwargs):
 
+        font_name = font_name or DEFAULT_FONT
         options = {'text': text, 'font_size': font_size,
                    'font_name': font_name, 'bold': bold, 'italic': italic,
                    'halign': halign, 'valign': valign, 'shorten': shorten,
@@ -228,9 +239,14 @@ class LabelBase(object):
             filename = resource_find(fontname)
             if filename is None:
                 # XXX for compatibility, check directly in the data dir
+                if '.' not in fontname:
+                    fontname += '.ttf'
                 filename = os.path.join(kivy_data_dir, fontname)
                 if not os.path.exists(filename):
-                    raise IOError('Label: File %r not found' % fontname)
+                    filename = os.path.join(kivy_data_dir, 'fonts', fontname)
+                    print filename
+                    if not os.path.exists(filename):
+                        raise IOError('Label: File %r not found' % fontname)
             fontscache[fontname] = filename
             options['font_name_r'] = filename
 

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -157,6 +157,7 @@ __all__ = ('Label', )
 from functools import partial
 from kivy.clock import Clock
 from kivy.uix.widget import Widget
+from kivy.core import text as core_text
 from kivy.core.text import Label as CoreLabel
 from kivy.core.text.markup import MarkupLabel as CoreMarkupLabel
 from kivy.properties import StringProperty, OptionProperty, \
@@ -344,7 +345,7 @@ class Label(Widget):
     defaults to (None, None), meaning no size restriction by default.
     '''
 
-    font_name = StringProperty('DroidSans')
+    font_name = StringProperty(core_text.DEFAULT_FONT)
     '''Filename of the font to use. The path can be absolute or relative.
     Relative paths are resolved by the :func:`~kivy.resources.resource_find`
     function.

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -152,6 +152,7 @@ from kivy.logger import Logger
 from kivy.metrics import inch
 from kivy.utils import boundary, platform
 
+from kivy.core import text as core_text
 from kivy.core.text import Label
 from kivy.graphics import Color, Rectangle
 from kivy.graphics.texture import Texture
@@ -2516,7 +2517,7 @@ class TextInput(Widget):
     :attr:`text` a :class:`~kivy.properties.StringProperty`.
     '''
 
-    font_name = StringProperty('DroidSans')
+    font_name = StringProperty(core_text.DEFAULT_FONT)
     '''Filename of the font to use. The path can be absolute or relative.
     Relative paths are resolved by the :func:`~kivy.resources.resource_find`
     function.


### PR DESCRIPTION
Quick font fixes, primarily to make it easier to support non-Latin languages.

1) Add a `set_default_font()` function to change the global default.
2) Make it easier to load fonts. Kivy includes DroidSans.ttf and DejaVuSans.ttf in the same folder (data/fonts). The default `font_name` is 'DroidSans', but setting the `font_name` to 'DejaVuSans' didn't work when it seems like it should.

Just give feedback for now, do not merge yet. This probably won't apply cleanly with #2411 due to adjacent hunks, and I will still need to add some docstrings.
