### PR TITLE
fix test_keep_data so that it looks up the texture

### DIFF
--- a/kivy/tests/test_image.py
+++ b/kivy/tests/test_image.py
@@ -13,6 +13,7 @@ class ImageTestCase(unittest.TestCase):
 
     def test_keep_data(self):
         root = self.root
+        texture = root.texture
         self.assertEqual(root._image._data[0].data, None)
         i1 = self.cls(self.image, keep_data=True)
         if not i1._image._data[0].data:


### PR DESCRIPTION
Looking up texture ensures triggering the populate function of texture so that we properly check for data being kept and get a negative. Before, since we do not load until the texture is actually needed it was still there when testing for it to be gone.
