### PR TITLE
Fix on_selection_change error

### DIFF
--- a/kivy/adapters/listadapter.py
+++ b/kivy/adapters/listadapter.py
@@ -257,7 +257,7 @@ class ListAdapter(Adapter, EventDispatcher):
 
         return view_instance
 
-    def on_selection_change(self, adapter):
+    def on_selection_change(self, *args):
         '''on_selection_change() is the default handler for the
         on_selection_change event. You can bind to this event to get notified
         of selection changes.


### PR DESCRIPTION
I currently seem to be getting a "TypeError: on_selection_change() takes
exactly 2 arguments (1 given)" on the kivy list examples. It can't be
just me? This seems to fix it.
