### PR TITLE
Changed vertex format to bytestring in svg.pyx

### DIFF
--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -237,9 +237,9 @@ cdef object RE_POLYLINE = re.compile(
     r'(-?[0-9]+\.?[0-9]*(?:e-?[0-9]*)?)')
 
 cdef VertexFormat VERTEX_FORMAT = VertexFormat(
-    ('v_pos', 2, 'float'),
-    ('v_tex', 2, 'float'),
-    ('v_color', 4, 'float'))
+    (b'v_pos', 2, 'float'),
+    (b'v_tex', 2, 'float'),
+    (b'v_color', 4, 'float'))
 
 def _tokenize_path(pathdef):
     for x in RE_COMMAND.split(pathdef):


### PR DESCRIPTION
This would resolve https://github.com/kivy/kivy/issues/2491

This has come up before...I've always just solved it by making the strings bytestrings, but maybe we should change how they're handled internally.
