### PR TITLE
Fix carousel crash on load_next if empty, replace float(nan) with None

### DIFF
--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -409,7 +409,7 @@ class Carousel(StencilView):
         width = self.width
         height = self.height
         index = self.index
-        if self._skip_slide is not None:
+        if self._skip_slide is not None or index is None:
             return
 
         if direction[0] == 'r':


### PR DESCRIPTION
Carousel currently crashes if you have it load_next and it is empty. This makes it difficult to run an automated carousel with photos added/removed programmatically. Also the float('nan') seemed like a weird way around not using allownone for _index property. I think it would be more pythonic to switch this to None.
