### PR TITLE
Show anchors in the doc

### DIFF
--- a/doc/sources/.static/fresh.css
+++ b/doc/sources/.static/fresh.css
@@ -18,7 +18,9 @@ a, a:link, a:visited {
 }
 
 a.headerlink {
-	display: none;
+        font-size: 1.2em;
+        color: #bdc3c7;
+        margin-left: 10px;
 }
 
 h1:hover a.headerlink,


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy/issues/2539, when clicking on method anchors, the respective method will contract, that's a separate issue that needs to be solved.
Having an anchor to copy is still better at this point.
