### PR TITLE
Move garden to its own directory and allow loading flowers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ kivy/lib/gstplayer/_gstplayer.c
 kivy/core/camera/camera_avfoundation.c
 kivy/tests/build
 kivy/tests/results
+kivy/garden
 .last_known_portable_deps_hash
 deps.zip
 Kivy.dmg

--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -42,7 +42,7 @@ them with the garden tool installed by the pip package::
 
 All the garden packages are installed by default in `~/.kivy/garden`.
 
-.. Note:: In previous versions of Kivy, garden was a tool at 
+.. Note:: In previous versions of Kivy, garden was a tool at
           kivy/tools/garden. This no longer exists, but the
           kivy-garden module provides exactly the same functionality.
 
@@ -65,11 +65,13 @@ __path__ = 'kivy.garden'
 
 import sys
 import imp
-from os.path import dirname, join, realpath, exists
+from os.path import dirname, join, realpath, exists, abspath
 from kivy import kivy_home_dir
+import kivy
 
 #: system path where garden modules can be installed
 garden_system_dir = join(kivy_home_dir, 'garden')
+garden_kivy_dir = abspath(join(dirname(kivy.__file__), 'garden'))
 
 #: application path where garden modules can be installed
 if getattr(sys, 'frozen', False) and getattr(sys, '_MEIPASS', False):
@@ -85,7 +87,12 @@ class GardenImporter(object):
             return self
 
     def load_module(self, fullname):
-        assert(fullname.startswith('kivy.'))
+        assert(fullname.startswith('kivy.garden'))
+
+        moddir = join(garden_kivy_dir, fullname.split('.', 2)[-1])
+        if exists(moddir):
+            return self._load_module(fullname, moddir)
+
         modname = fullname.split('.', 1)[-1]
         for directory in (garden_app_dir, garden_system_dir):
             moddir = join(directory, modname)


### PR DESCRIPTION
This creates a kivy/garden directory and allows one to install flowers there directly using garden install --kivy flower. The corresponding PR in garden is https://github.com/kivy-garden/garden/pull/5.

I really dislike the hackishness of installing and redirecting to .kivy/garden so this allows you to install directly to kivy/garden and hopfully for e.g. pyinstaller to discover these mods naturally. It doesn't change any old functionality, just adds a new option.
