### PR TITLE
Support for CompositeListItem selection initialization

### DIFF
--- a/kivy/uix/listview.py
+++ b/kivy/uix/listview.py
@@ -742,9 +742,13 @@ class CompositeListItem(SelectableView, BoxLayout):
 
     def select(self, *args):
         self.background_color = self.selected_color
+        for child in self.children:
+            child.select()
 
     def deselect(self, *args):
         self.background_color = self.deselected_color
+        for child in self.children:
+            child.deselect()
 
     def select_from_child(self, child, *args):
         for c in self.children:


### PR DESCRIPTION
Currently, it only seems possible to initialize a CompositeListItem with the first item selected using the 'allow_empty_selection=False' parameter to the adapter. This PR adds support for specifying any amount of items to be selected by default.

This gist can be used to demonstrate and test:
https://gist.github.com/Zen-CODE/db169c77416c78da12e2

It seems the CompositeListItem needs to manually delegate the initial selection to it's children.
The 'select' and 'unselect' events seem to be fired only on initialization (tested via print statements in the functions), so this seems like an optimal solution. The forced subclassing of 'SelectableView' ensures that the children will all have 'select' and 'unselect' methods to invoke, so there should be no issue with missing methods.