### PR TITLE
BoxLayout honour padding when using pos_hint

### DIFF
--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -162,7 +162,6 @@ class BoxLayout(Layout):
 
                 for key, value in c.pos_hint.items():
                     posy = value * (selfh - padding_y)
-                    print posy
                     if key == 'y':
                         cy += posy
                     elif key == 'top':


### PR DESCRIPTION
Test code

```
BoxLayout
    padding: 20
    spacing: 10
    Button
        pos_hint: {'top': 1}
        size_hint: 1, None
    Button
        size_hint: 1, .5
    Button
```
