### PR TITLE
fix: allow unicode paths in image source

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -194,7 +194,7 @@ class ImageLoaderBase(object):
             # if not create it and append to the cache
             if texture is None:
                 imagedata = self._data[count]
-                imagedata.source = '{}{}|{}'.format(
+                imagedata.source = u'{}{}|{}'.format(
                     'zip|' if self.filename.endswith('.zip') else '',
                     self._nocache, uid)
                 texture = Texture.create_from_data(


### PR DESCRIPTION
I am getting this error when trying to use image inside a unicode folder

   File "/home/fruitbat/Documents/kivy/kivy/kivy/core/image/**init**.py", line 202, in populate
     self._nocache, uid)
 UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 51: ordinal not in range(128)

This PR seems to correct this error. Example code to demo issue here:

```
https://gist.github.com/Zen-CODE/81a943a653425fedb216
```
