### PR TITLE
Fix stacklayout size hint

### DIFF
--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -142,6 +142,8 @@ class StackLayout(Layout):
         padding_top = self.padding[1]
         padding_right = self.padding[2]
         padding_bottom = self.padding[3]
+        children = self.children
+        num_children = len(children)
 
         padding_x = padding_left + padding_right
         padding_y = padding_top + padding_bottom
@@ -201,16 +203,16 @@ class StackLayout(Layout):
 
         urev = (deltau < 0)
         vrev = (deltav < 0)
-        for c in reversed(self.children):
+        for c in reversed(children):
             if c.size_hint[0]:
                 if urev:
-                    modified_x = (selfsize[0] - padding_x - spacing_x)
+                    modified_x = (selfsize[0] - padding_x - (num_children-1)*spacing_x)
                 else:
                     modified_x = (selfsize[0] - padding_x)
                 c.width = c.size_hint[0] * modified_x
             if c.size_hint[1]:
                 if vrev:
-                    modified_y = (selfsize[1] - padding_y - spacing_y)
+                    modified_y = (selfsize[1] - padding_y - (num_children-1)*spacing_y)
                 else:
                     modified_y = (selfsize[1] - padding_y)
 


### PR DESCRIPTION
Example of problem: green is StackLayout size, red is Child size.

![layoutfix](https://cloud.githubusercontent.com/assets/1936976/4963323/c305e956-6709-11e4-88db-ac2df9add0e4.png)

This solution is only accurate for stacklayouts that go in one direction. Our layout algorithm is totally incorrect for a variety of other potential orientations as is, this at least fixes sizing for the simple case. StackLayout will still often place a widget outside of its bounds instead of properly slotting it in. This occurs if you try to do an arrangement such as widgets with size_hints 1: (.5, 1.0), 2: (.5, .5), 3: (.5, .5) which should look like:
12
13
if arranged lr-tb, but often ends up:
123
1
