### PR TITLE
Sdl2 screenshot leads to slanted image

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -157,10 +157,13 @@ class WindowSDL(WindowBase):
         self._win.set_window_icon(filename)
 
     def screenshot(self, *largs, **kwargs):
+        filename = super(WindowSDL, self).screenshot(*largs, **kwargs)
+        if filename is None:
+            return
+
         from kivy.graphics.opengl import glReadPixels, GL_RGB, GL_UNSIGNED_BYTE
         width, height = self.size
         data = glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE)
-        filename = super(WindowSDL, self).screenshot(*largs, **kwargs)
         self._win.save_bytes_in_png(filename, data, width, height)
         return
         # TODO


### PR DESCRIPTION
Not for merging right now!

I implemented this a while ago, and made the pr for easy reference. This code doesn't quite work, because the flipVert function doesn't flip the texture properly - there's an offest or something, and you get a slant instead. It's probably a small fix, and it works otherwise.

Fixes https://github.com/kivy/kivy/issues/2514.
