### PR TITLE
fix stripping for wrapped text

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -500,14 +500,22 @@ class LabelBase(object):
                                     options['halign'][-1] == 'y')
         uw, uh = options['text_size'] = self._text_size
         text = self.text
-        if strip:
-            text = text.strip()
+        if not strip:
+            # all text will be stripped by default. unicode NO-BREAK SPACE
+            # characters will be preserved, so we replace the leading and
+            # trailing spaces with \u00a0
+            text = text.decode('utf8') if isinstance(text, bytes) else text
+            lspace = len(text) - len(text.lstrip())
+            rspace = len(text) - len(text.rstrip())
+            text = (u'\u00a0' * lspace) + text.strip() + (u'\u00a0' * rspace)
         if uw is not None and options['shorten']:
             text = self.shorten(text)
         self._cached_lines = lines = []
         if not text:
             return 0, 0
 
+        ostrip = options['strip']
+        strip = options['strip'] = True
         if uh is not None and options['valign'][-1] == 'e':  # middle
             center = -1  # pos of newline
             if len(text) > 1:
@@ -533,6 +541,7 @@ class LabelBase(object):
         else:  # top or bottom
             w, h, clipped = layout_text(text, lines, (0, 0), (uw, uh), options,
                 self.get_cached_extents(), options['valign'][-1] == 'p', True)
+        options['strip'] = ostrip
         self._internal_size = w, h
         if uw:
             w = uw

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -6,6 +6,7 @@ An internal module for laying out text according to options and constraints.
 This is not part of the API and may change at any time.
 '''
 
+import string
 
 __all__ = ('layout_text', 'LayoutWord', 'LayoutLine')
 
@@ -147,7 +148,7 @@ cdef inline void final_strip(LayoutLine line):
             line.w -= last_word.lw  # likely 0
             continue
 
-        stripped = last_word.text.rstrip()  # ends with space
+        stripped = last_word.text.rstrip(string.whitespace)  # ends with space
         # subtract ending space length
         diff = ((len(last_word.text) - len(stripped)) *
                 last_word.options['space_width'])
@@ -187,10 +188,10 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             k = n - 1
         if strip:
             if not _line.w:  # no proceeding text: strip leading
-                line = line.lstrip()
+                line = line.lstrip(string.whitespace)
             # ends this line so right strip
             if complete or (dwn and n > 1 or not dwn and pos > 1):
-                line = line.rstrip()
+                line = line.rstrip(string.whitespace)
         lw, lh = get_extents(line)
 
         old_lh = _line.h
@@ -217,9 +218,9 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
         # the last line is only stripped from left
         if strip:
             if complete or (dwn and i < n - 1 or not dwn and i > s):
-                line = line.strip()
+                line = line.strip(string.whitespace)
             else:
-                line = line.lstrip()
+                line = line.lstrip(string.whitespace)
         lw, lh = get_extents(line)
         lhh = int(lh * line_height)
         if uh != -1 and h + lhh > uh and pos:  # too high
@@ -424,9 +425,9 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
         line = new_lines[i]
         if strip:
             if not _line.w:  # there's no proceeding text, so strip leading
-                line = line.lstrip()
+                line = line.lstrip(string.whitespace)
             if ends_line:
-                line = line.rstrip()
+                line = line.rstrip(string.whitespace)
         k = len(line)
         if not k:  # just add empty line if empty
             _line.is_last_line = ends_line  # nothing will be appended
@@ -474,7 +475,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
                 if s != m:
                     _do_last_line = 1
                     if strip and line[m - 1] == ' ':
-                        ln = line[s:m].rstrip()
+                        ln = line[s:m].rstrip(string.whitespace)
                         lww, lhh = get_extents(ln)
                     else:
                         ln = line[s:m]
@@ -494,7 +495,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
                 # try to fit word on new line, if it doesn't fit we'll
                 # have to break the word into as many lines needed
                 if strip:
-                    s = e - len(line[s:e].lstrip())
+                    s = e - len(line[s:e].lstrip(string.whitespace))
                 if s == e:  # if it was only a stripped space, move on
                     m = s
                     continue


### PR DESCRIPTION
Fix #2503 by making text stripping skip unicode NO-BREAK SPACE characters (`\u00a0`) and automatically strip all text. If the text string contains leading and/or trailing spaces and the `strip` option is not enabled, those leading/trailing spaces are replaced with `\u00a0` to prevent stripping.
