### PR TITLE
fix export_to_png with img_sdl2

### DIFF
--- a/kivy/core/image/_img_sdl2.pyx
+++ b/kivy/core/image/_img_sdl2.pyx
@@ -23,14 +23,16 @@ def init():
 
     _is_init = 1
 
-
 def save(filename, w, h, fmt, pixels, flipped):
     # this only saves in png for now.
     cdef bytes c_filename = filename.encode('utf-8')
     cdef int pitch
     pitch = w * 4
 
-    cdef SDL_Surface *image = SDL_CreateRGBSurfaceFrom(<void *>pixels, w, h, 32, pitch, 0x00000000ff, 0x0000ff00, 0x00ff0000, 0xff000000)
+    if flipped:
+        Logger.warn(
+            'ImageSDL2: saving flipped textures not supported; image will be flipped')
+    cdef SDL_Surface *image = SDL_CreateRGBSurfaceFrom(<void *>pixels + 36, w, h, 32, pitch, 0x00000000ff, 0x0000ff00, 0x00ff0000, 0xff000000)
 
     IMG_SavePNG(image, c_filename)
     SDL_FreeSurface(image)

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -172,7 +172,7 @@ from kivy.factory import Factory
 from kivy.properties import (NumericProperty, StringProperty, AliasProperty,
                              ReferenceListProperty, ObjectProperty,
                              ListProperty, DictProperty, BooleanProperty)
-from kivy.graphics import Canvas, Translate, Fbo, ClearColor, ClearBuffers
+from kivy.graphics import Canvas, Translate, Fbo, ClearColor, ClearBuffers, Scale
 from kivy.base import EventLoop
 from kivy.lang import Builder
 from kivy.context import get_current_context
@@ -555,11 +555,12 @@ class Widget(WidgetBase):
         with fbo:
             ClearColor(0, 0, 0, 1)
             ClearBuffers()
-            Translate(-self.x, -self.y, 0)
+            Scale(1, -1, 1)
+            Translate(-self.x, -self.y - self.height, 0)
 
         fbo.add(self.canvas)
         fbo.draw()
-        fbo.texture.save(filename)
+        fbo.texture.save(filename, flipped=False)
         fbo.remove(self.canvas)
 
         if self.parent is not None:


### PR DESCRIPTION
Fixes #2659 by flipping the texture before saving.

Also fixes the offset error displayed in that image - but I'm not sure this is a good fix. I don't know why I need to offset by 36 bytes, and I don't know if it will always be 36 bytes or if this should be calculated somehow. Feedback on this would be appreciated. :)
