### PR TITLE
assert that event callbacks are actually callable

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -395,6 +395,7 @@ cdef class EventDispatcher(ObjectWithUid):
         cdef PropertyStorage ps
 
         for key, value in kwargs.iteritems():
+            assert callable(value), '{!r} is not callable'.format(value)
             if key[:3] == 'on_':
                 observers = self.__event_stack.get(key)
                 if observers is None:


### PR DESCRIPTION
To avoid having to dig through code and guess at where the bad callback is bound.

```
 Traceback (most recent call last):
   File "evttest.py", line 21, in <module>
     TestApp().run()
   File "/home/ryan/git/aeris2/kivy/kivy/app.py", line 799, in run
     root = self.build()
   File "evttest.py", line 17, in build
     root.bind(text=True)
   File "kivy/_event.pyx", line 398, in kivy._event.EventDispatcher.bind (kivy/_event.c:4947)
     assert callable(value), '{!r} is not callable'.format(value)
 AssertionError: True is not callable
```
