### PR TITLE
prevent flicker when using shader transitions

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -487,6 +487,12 @@ class ShaderTransition(TransitionBase):
         self.render_ctx['t'] = 1.
         super(ShaderTransition, self).on_complete()
 
+    def _remove_out_canvas(self, *args):
+        if (self.screen_out
+                and self.screen_out.canvas in self.manager.canvas.children
+                and self.screen_out not in self.manager.children):
+            self.manager.canvas.remove(self.screen_out.canvas)
+
     def add_screen(self, screen):
         self.screen_in.pos = self.screen_out.pos
         self.screen_in.size = self.screen_out.size
@@ -494,9 +500,7 @@ class ShaderTransition(TransitionBase):
         self.manager.canvas.add(self.screen_out.canvas)
 
         def remove_screen_out(instr):
-            Clock.schedule_once(
-                lambda dt: self.manager.canvas.remove(self.screen_out.canvas),
-                -1)
+            Clock.schedule_once(self._remove_out_canvas, -1)
             self.render_ctx.remove(instr)
 
         self.fbo_in = self.make_screen_fbo(self.screen_in)
@@ -523,7 +527,12 @@ class ShaderTransition(TransitionBase):
         self.manager.canvas.remove(self.fbo_in)
         self.manager.canvas.remove(self.fbo_out)
         self.manager.canvas.remove(self.render_ctx)
+        self._remove_out_canvas()
         self.manager.real_add_widget(self.screen_in)
+
+    def stop(self):
+        self._remove_out_canvas()
+        super(ShaderTransition, self).stop()
 
 
 class NoTransition(TransitionBase):


### PR DESCRIPTION
Keeps rendering the screen-out's canvas until the render context has actually rendered its first frame. Prevents flicker at the beginning of shader transitions.

Fixes #2748.
