### PR TITLE
fixed LoadIdentity constructor

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -396,7 +396,7 @@ cdef class LoadIdentity(ContextInstruction):
     .. versionadded:: 1.6.0
     '''
     def __init__(self, **kwargs):
-        self.context_state = kwargs.get('stack', 'modelview_mat')
+        self.stack = kwargs.get('stack', 'modelview_mat')
 
     property stack:
         '''Name of the matrix stack to use. Can be 'modelview_mat' or

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -104,3 +104,11 @@ class FBOInstructionTestCase(GraphicUnitTest):
         import pygame
         surface = pygame.image.fromstring(data, (512, 512), 'RGBA', True)
         pygame.image.save(surface, "results.png")
+
+
+class TransformationsTestCase(unittest.TestCase):
+
+    def test_identity_creation(self):
+        from kivy.graphics import LoadIdentity
+        mat = LoadIdentity()
+        self.assertTrue(mat.stack)


### PR DESCRIPTION
Fixed exception due to property expectation of dictionary instead of string. It seems that was a typo.