### PR TITLE
Fixed multitouch emulation in sdl2

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -381,7 +381,11 @@ class WindowSDL(WindowBase):
                 except KeyError:
                     pass
 
-                self._update_modifiers(mod)
+                if action == 'keydown':
+                    self._update_modifiers(mod, key)
+                else:
+                    self._update_modifiers(mod) # ignore the key, it
+                                                # has been released
                 if 'shift' in self._modifiers and key\
                         not in self.command_keys.keys():
                     return
@@ -491,23 +495,36 @@ class WindowSDL(WindowBase):
     #
     # Pygame wrapper
     #
-    def _update_modifiers(self, mods=None):
+    def _update_modifiers(self, mods=None, key=None):
         # Available mod, from dir(pygame)
         # 'KMOD_ALT', 'KMOD_CAPS', 'KMOD_CTRL', 'KMOD_LALT',
         # 'KMOD_LCTRL', 'KMOD_LMETA', 'KMOD_LSHIFT', 'KMOD_META',
         # 'KMOD_MODE', 'KMOD_NONE'
-        if mods is None:
+        if mods is None and key is None:
             return
-        self._modifiers = []
+        modifiers = set()
 
-        if mods & (KMOD_RSHIFT | KMOD_LSHIFT):
-            self._modifiers.append('shift')
-        if mods & (KMOD_RALT | KMOD_LALT):
-            self._modifiers.append('alt')
-        if mods & (KMOD_RCTRL | KMOD_LCTRL):
-            self._modifiers.append('ctrl')
-        if mods & (KMOD_RMETA | KMOD_LMETA):
-            self._modifiers.append('meta')
+        if mods is not None:
+            if mods & (KMOD_RSHIFT | KMOD_LSHIFT):
+                modifiers.add('shift')
+            if mods & (KMOD_RALT | KMOD_LALT):
+                modifiers.add('alt')
+            if mods & (KMOD_RCTRL | KMOD_LCTRL):
+                modifiers.add('ctrl')
+            if mods & (KMOD_RMETA | KMOD_LMETA):
+                modifiers.add('meta')
+
+        if key is not None:
+            if key in (KMOD_RSHIFT, KMOD_LSHIFT):
+                modifiers.add('shift')
+            if key in (KMOD_RALT, KMOD_LALT):
+                modifiers.add('alt')
+            if key in (KMOD_RCTRL, KMOD_LCTRL):
+                modifiers.add('ctrl')
+            if key in (KMOD_RMETA, KMOD_LMETA):
+                modifiers.add('meta')
+
+        self._modifiers = list(modifiers)
         return
 
     def request_keyboard(self, callback, target, input_type='text'):


### PR DESCRIPTION
~~(Not for merging yet, as below)~~

Resolves https://github.com/kivy/kivy/issues/2507

I think this is the right way to do things, maintaining a list of current touches and not recording movement if no button is pressed (this seems to be what pygame did).

~~The issue isn't entirely resolved, ctrl+click doesn't work with the multitouch red dots, but I think this is a separate issue. I'm looking at it and will add to this pr, so this shouldn't be merged quite yet.~~
