### PR TITLE
Minor fix in slider.py. slider.value now set to slider.min at init

### DIFF
--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -97,17 +97,15 @@ class Slider(Widget):
     :attr:`step` is a :class:`~kivy.properties.NumericProperty` and defaults
     to 1.'''
 
-
-    # adding a constructor to slider to correct following misbehaviour:
-    # ...
-    # slider = Slider(min=1.0, max=200.0)
-    # root.add_widget(slider)
-    # slider.value should be set to min (1.0 here) but is in reality set to 0 and then only when a on_value event occurs does it
-    # get 1.0 as minimum value
-
-    def __init__(self, **kwargs):
-        super(Slider, self).__init__(**kwargs)
-        self.value = self.min
+    # The following two methods constrain the slider's value
+    # to range(min,max). Otherwise it may happen that self.value < self.min
+    # at init.
+    
+    def on_min(self, *largs):
+        self.value = min(self.max, max(self.min,self.value))
+        
+    def on_max(self, *largs):
+        self.value = min(self.max, max(self.min,self.value))
     
     def get_norm_value(self):
         vmin = self.min

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -97,6 +97,18 @@ class Slider(Widget):
     :attr:`step` is a :class:`~kivy.properties.NumericProperty` and defaults
     to 1.'''
 
+
+    # adding a constructor to slider to correct following misbehaviour:
+    # ...
+    # slider = Slider(min=1.0, max=200.0)
+    # root.add_widget(slider)
+    # slider.value should be set to min (1.0 here) but is in reality set to 0 and then only when a on_value event occurs does it
+    # get 1.0 as minimum value
+
+    def __init__(self, **kwargs):
+        super(Slider, self).__init__(**kwargs)
+        self.value = self.min
+    
     def get_norm_value(self):
         vmin = self.min
         d = self.max - vmin


### PR DESCRIPTION
While I was coding some software using sliders, a DivisionByZero exception made me realise that the slider's value was not set to slider.min at init but rather to 0. Simply adding a constructor to Slider and calling self.value = self.min fixed the issue

EDIT: the fix works when specifying the Slider in python code. Still trying to get it work with kv lang