### PR TITLE
Fix cutoff last line when line_height is less than 1.0

### DIFF
--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -410,18 +410,20 @@ class MarkupLabel(MarkupLabelBase):
             psp = pph = 0
             for word in layout_line.words:
                 options = self.options = word.options
+                # the word height is not scaled by line_height, only lh was
+                wh = options['line_height'] * word.lh
                 # calculate sub/super script pos
                 if options['script'] == 'superscript':
                     script_pos = max(0, psp if psp else self.get_descent())
                     psp = script_pos
-                    pph = word.lh
+                    pph = wh
                 elif options['script'] == 'subscript':
-                    script_pos = min(lh - word.lh, ((psp + pph) - word.lh)
-                                     if pph else (lh - word.lh))
-                    pph = word.lh
+                    script_pos = min(lh - wh, ((psp + pph) - wh)
+                                     if pph else (lh - wh))
+                    pph = wh
                     psp = script_pos
                 else:
-                    script_pos = (lh - word.lh) / 1.25
+                    script_pos = (lh - wh) / 1.25
                     psp = pph = 0
                 if len(word.text):
                     render_text(word.text, x, y + script_pos)
@@ -431,7 +433,7 @@ class MarkupLabel(MarkupLabelBase):
                 if ref is not None:
                     if not ref in refs:
                         refs[ref] = []
-                    refs[ref].append((x, y, x + word.lw, y + word.lh))
+                    refs[ref].append((x, y, x + word.lw, y + wh))
 
                 # Should we record anchors?
                 anchor = options['_anchor']

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -212,6 +212,8 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             # if we finish this line, make sure it doesn't end in spaces
             final_strip(_line)
             add_h = _line.h
+        else:
+            add_h = _line.h
 
         w = max(w, _line.w + 2 * xpad)
         h += add_h - old_lh

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -107,11 +107,15 @@ cdef inline LayoutLine add_line(object text, int lw, int lh, LayoutLine line,
         This assumes that global h is accurate and includes the text previously
         added to the line.
         '''
-        cdef int old_lh = line.h
+        cdef int old_lh = line.h, count = len(lines)
         if lw:
             line.words.append(LayoutWord(options, lw, lh, text))
             line.w += lw
-        line.h = max(int(lh * line_height), line.h)
+
+        if count:
+            line.h = max(int(lh * line_height), line.h)
+        else:
+            line.h = max(lh, line.h)
         # if we're appending to existing line don't add height twice
         h[0] = h[0] + line.h - old_lh
         w[0] = max(w[0], line.w + 2 * xpad)
@@ -222,10 +226,15 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             else:
                 line = line.lstrip(string.whitespace)
         lw, lh = get_extents(line)
-        lhh = int(lh * line_height)
+
+        if pos:
+            lhh = int(lh * line_height)
+        else:  # for the first line, always use full height
+            lhh = lh
         if uh != -1 and h + lhh > uh and pos:  # too high
             i += -1 if dwn else 1
             break
+
         pos += 1
         w = max(w, int(lw + 2 * xpad))
         h += lhh


### PR DESCRIPTION
Fixes #2502.

Sorry guys for the delay, but this should fix #2502.

It doesn't completely fix it for when markup is True with more than one line, but I don't think it's quite possible to to fix there as well without a lot more effort. The reason being that imagine for the various lines we use different `line_height`. Then to find the total required height so that nothing is cut off, we'd need to keep track of the various leftovers that doesn't fit vertically on each line to get the maximum total. Because keep in mind that `line_height` just moves lines rather than actually rescaling. But for markup, I imagine the user has the option to just use a smaller font size rather than changing the line size.