### PR TITLE
Fixing converstion error #2777, "Expected basestring got str"

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -142,7 +142,7 @@ cdef class EventDispatcher(ObjectWithUid):
         cdef dict attrs_found
         cdef list attrs
         cdef Property attr
-        cdef basestring k
+        cdef object k
 
         self.__event_stack = {}
         self.__storage = {}


### PR DESCRIPTION
This might be due to a cython change.
