### PR TITLE
Fix to Issue #2795

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -184,6 +184,7 @@ class DropDown(ScrollView):
         self.bind(size=self._reposition)
 
     def on_key_down(self, instance, key, scancode, codepoint, modifiers):
+        # key: 27 is the key code for "escape"
         if key == 27 and self.get_parent_window():
             self.dismiss()
             return True

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -278,6 +278,8 @@ class DropDown(ScrollView):
             return True
         if 'button' in touch.profile and touch.button.startswith('scroll'):
             return
+        if self.attach_to and self.attach_to.collide_point(*touch.pos):
+            return True
         if self.auto_dismiss:
             self.dismiss()
 

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -89,6 +89,7 @@ And then, create the associated python class and use it::
 
 __all__ = ('DropDown', )
 
+from kivy.uix.togglebutton import ToggleButton
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty
 from kivy.core.window import Window
@@ -236,6 +237,9 @@ class DropDown(ScrollView):
         '''
         self.dispatch('on_select', data)
         if self.dismiss_on_select:
+            attach_to = self.attach_to
+            if attach_to and isinstance(attach_to, ToggleButton):
+                attach_to.state = "normal"
             self.dismiss()
 
     def on_select(self, data):
@@ -269,8 +273,11 @@ class DropDown(ScrollView):
             return True
         if self.collide_point(*touch.pos):
             return True
-        if self.attach_to and self.attach_to.collide_point(*touch.pos):
+        attach_to = self.attach_to
+        if attach_to and attach_to.collide_point(*touch.pos):
             return True
+        if attach_to and isinstance(attach_to, ToggleButton):
+            attach_to.state = "normal"
         if self.auto_dismiss:
             self.dismiss()
 
@@ -279,8 +286,9 @@ class DropDown(ScrollView):
             return True
         if 'button' in touch.profile and touch.button.startswith('scroll'):
             return
-        if self.attach_to and self.attach_to.collide_point(*touch.pos):
-            return True
+        attach_to = self.attach_to
+        if attach_to and isinstance(attach_to, ToggleButton):
+            attach_to.state = "normal"
         if self.auto_dismiss:
             self.dismiss()
 
@@ -329,6 +337,7 @@ class DropDown(ScrollView):
 
 if __name__ == '__main__':
     from kivy.uix.button import Button
+    from kivy.uix.togglebutton import ToggleButton
     from kivy.base import runTouchApp
 
     def show_dropdown(button, *largs):
@@ -345,5 +354,9 @@ if __name__ == '__main__':
 
     btn = Button(text='SHOW', size_hint=(None, None), pos=(300, 200))
     btn.bind(on_release=show_dropdown, on_touch_move=touch_move)
-
     runTouchApp(btn)
+
+    # For testing the ToggleButton() case
+    #tog_btn = ToggleButton(text='SHOW', size_hint=(None, None), pos=(300, 200))
+    #tog_btn.bind(on_release=show_dropdown, on_touch_move=touch_move)
+    #runTouchApp(tog_btn)

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -89,7 +89,7 @@ And then, create the associated python class and use it::
 
 __all__ = ('DropDown', )
 
-from kivy.uix.togglebutton import ToggleButton
+from kivy.uix.behaviors import ToggleButtonBehavior
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty
 from kivy.core.window import Window
@@ -238,7 +238,7 @@ class DropDown(ScrollView):
         self.dispatch('on_select', data)
         if self.dismiss_on_select:
             attach_to = self.attach_to
-            if attach_to and isinstance(attach_to, ToggleButton):
+            if attach_to and isinstance(attach_to, ToggleButtonBehavior):
                 attach_to.state = "normal"
             self.dismiss()
 
@@ -276,7 +276,7 @@ class DropDown(ScrollView):
         attach_to = self.attach_to
         if attach_to and attach_to.collide_point(*touch.pos):
             return True
-        if attach_to and isinstance(attach_to, ToggleButton):
+        if attach_to and isinstance(attach_to, ToggleButtonBehavior):
             attach_to.state = "normal"
         if self.auto_dismiss:
             self.dismiss()
@@ -287,7 +287,7 @@ class DropDown(ScrollView):
         if 'button' in touch.profile and touch.button.startswith('scroll'):
             return
         attach_to = self.attach_to
-        if attach_to and isinstance(attach_to, ToggleButton):
+        if attach_to and isinstance(attach_to, ToggleButtonBehavior):
             attach_to.state = "normal"
         if self.auto_dismiss:
             self.dismiss()


### PR DESCRIPTION
Fixes issue https://github.com/kivy/kivy/issues/2795 when I press down on a toggle button attached to a
DropDown() widget, with the auto_dismiss parameter set to True, the
drop down list is dismissed when it should not be dismissed.