### PR TITLE
properly handle StackLayout size_hint and spacing

### DIFF
--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -208,7 +208,6 @@ class StackLayout(Layout):
         vrev = (deltav < 0)
         firstchild = self.children[0]
         sizes = []
-        testsizes = []
         for c in reversed(self.children):
             if c.size_hint[outerattr]:
                 c.size[outerattr] = max(
@@ -283,6 +282,7 @@ class StackLayout(Layout):
                 c.size[innerattr] = max(
                     1, c.size_hint[innerattr] *
                        (selfsize[innerattr] - padding_u))
+            sizes = [c.size[innerattr]]
             u = ustart
 
         if lc:

--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -136,6 +136,14 @@ class StackLayout(Layout):
             size=self._trigger_force_layout,
             pos=self._trigger_force_layout)
 
+    def add_widget(self, widget, index=0):
+        widget.bind(size=self._trigger_force_layout)
+        super(StackLayout, self).add_widget(widget, index)
+
+    def remove_widget(self, widget):
+        widget.unbind(size=self._trigger_force_layout)
+        super(StackLayout, self).remove_widget(widget)
+
     def _force_layout(self, *largs):
         self._needs_layout = True
         self.do_layout()

--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -278,11 +278,11 @@ class StackLayout(Layout):
             v += deltav * spacing_v
             lc = [c]
             lv = c.size[outerattr]
-            if c.size_hint[innerattr] and c is firstchild:
-                c.size[innerattr] = max(
-                    1, c.size_hint[innerattr] *
-                       (selfsize[innerattr] - padding_u))
-            sizes = [c.size[innerattr]]
+            if c.size_hint[innerattr]:
+                sizes = [max(1, c.size_hint[innerattr] *
+                             (selfsize[innerattr] - padding_u))]
+            else:
+                sizes = [max(0, c.size[innerattr])]
             u = ustart
 
         if lc:


### PR DESCRIPTION
Makes `StackLayout` take spacing into account when computing the size of `size_hint`ed children in the constrained direction. Also clamps computed sizes to prevent negative dimensions which cause funky UI bugs, and fixes #2750.