### PR TITLE
Sdl2 scroll fix

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -286,6 +286,8 @@ class WindowSDL(WindowBase):
                 if action == 'mousebuttonup':
                     eventname = 'on_mouse_up'
                     self._mouse_buttons_down.remove(button)
+                self._mouse_x = x
+                self._mouse_y = y
                 self.dispatch(eventname, x, y, btn, self.modifiers)
             elif action.startswith('mousewheel'):
                 self._update_modifiers()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -266,11 +266,11 @@ class WindowSDL(WindowBase):
             if action == 'mousemotion':
                 x, y = args
                 self.mouse_pos = x, self.system_size[1] - y
+                self._mouse_x = x
+                self._mouse_y = y
                 # don't dispatch motion if no button are pressed
                 if len(self._mouse_buttons_down) == 0:
                     continue
-                self._mouse_x = x
-                self._mouse_y = y
                 self._mouse_meta = self.modifiers
                 self.dispatch('on_mouse_move', x, y, self.modifiers)
 


### PR DESCRIPTION
This resolves https://github.com/kivy/kivy/issues/2807

The problem seems to occur because sdl2 treats the scroll event differently to a touch. In pygame, the _mouse_x and _mouse_y are set in the mouse down event handler, which occurs even if the 'button' is the scroll wheel, but with sdl2 the scroll event doesn't receive the mouse position as input.

I couldn't think of a better fix than setting it on every mouse move, though I also set it on every mouse down/up because I'm not clear if we're guaranteed to receive movement events for some devices that otherwise appear as mice. Maybe this isn't necessary at all.