### PR TITLE
add ClockEvent trigger detail to exceptions

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -629,7 +629,7 @@ class ClockBase(_ClockBase):
                     # event may be already removed from original list
                     if event in events:
                         event.tick(self._last_tick, remove)
-        except Exception, e:
+        except Exception as e:
             if event:
                 if PY2:
                     raise type(e), type(e)(e.message + event.stack_string), \
@@ -664,7 +664,7 @@ class ClockBase(_ClockBase):
                         # event may be already removed from original list
                         if event in events:
                             event.tick(self._last_tick, remove)
-        except Exception, e:
+        except Exception as e:
             if event:
                 if PY2:
                     raise type(e), type(e)(e.message + event.stack_string), \

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -299,11 +299,11 @@ class ClockEvent(object):
         self._dt = 0.
         self._tb = None
         if trigger:
-            self._collect_stack()
+            self._collect_stack(3)
             clock._events[cid].append(self)
 
-    def _collect_stack(self):
-        self._tb = traceback.extract_stack()[:-2]
+    def _collect_stack(self, skip):
+        self._tb = traceback.extract_stack()[:-skip]
 
     @property
     def stack_string(self):
@@ -320,7 +320,7 @@ class ClockEvent(object):
             self._is_triggered = True
             # update starttime
             self._last_dt = self.clock._last_tick
-            self._collect_stack()
+            self._collect_stack(2)
             self.clock._events[self.cid].append(self)
             return True
 


### PR DESCRIPTION
Adds the traceback from the point where the ClockEvent was triggered (`schedule_once`/`schedule_interval`, or `__call__` for triggers) to aid in debugging.

Example output:

````
[INFO   ] [Base        ] Leaving application in progress...
 Traceback (most recent call last):
   File "layouttest.py", line 66, in <module>
     GameApp().run()
   File "/home/ryan/git/kivy/kivy/kivy/app.py", line 825, in run
     runTouchApp()
   File "/home/ryan/git/kivy/kivy/kivy/base.py", line 484, in runTouchApp
     EventLoop.window.mainloop()
   File "/home/ryan/git/kivy/kivy/kivy/core/window/window_pygame.py", line 381, in mainloop
     self._mainloop()
   File "/home/ryan/git/kivy/kivy/kivy/core/window/window_pygame.py", line 285, in _mainloop
     EventLoop.idle()
   File "/home/ryan/git/kivy/kivy/kivy/base.py", line 324, in idle
     Clock.tick()
   File "/home/ryan/git/kivy/kivy/kivy/clock.py", line 497, in tick
     self._process_events()
   File "/home/ryan/git/kivy/kivy/kivy/clock.py", line 631, in _process_events
     event.tick(self._last_tick, remove)
   File "/home/ryan/git/kivy/kivy/kivy/clock.py", line 388, in tick
     ret = callback(self._dt)
   File "/home/ryan/git/kivy/kivy/kivy/uix/stacklayout.py", line 284, in do_layout
     (selfsize[outerattr] - padding_v))
   File "kivy/properties.pyx", line 1162, in kivy.properties.ObservableReferenceList.__setitem__ (kivy/properties.c:16651)
     self.prop.setitem(self.obj(), key, value)
   File "kivy/properties.pyx", line 1266, in kivy.properties.ReferenceListProperty.setitem (kivy/properties.c:19570)
     cpdef setitem(self, EventDispatcher obj, key, value):
   File "kivy/properties.pyx", line 1278, in kivy.properties.ReferenceListProperty.setitem (kivy/properties.c:19429)
     prop.set(obj, value)
   File "kivy/properties.pyx", line 406, in kivy.properties.Property.set (kivy/properties.c:5310)
     cpdef set(self, EventDispatcher obj, value):
   File "kivy/properties.pyx", line 429, in kivy.properties.Property.set (kivy/properties.c:5189)
     self.dispatch(obj)
   File "kivy/properties.pyx", line 480, in kivy.properties.Property.dispatch (kivy/properties.c:5765)
     ps.observers.dispatch(obj, ps.value, None, None, 0)
   File "kivy/_event.pyx", line 1056, in kivy._event.EventObservers.dispatch (kivy/_event.c:11033)
     result = f(obj, value)
   File "/home/ryan/git/kivy/kivy/kivy/uix/stacklayout.py", line 170, in _t
     raise Exception('hi')
 Exception: hi
 
 ClockEvent triggered from:
   File "layouttest.py", line 66, in <module>
     GameApp().run()
   File "/home/ryan/git/kivy/kivy/kivy/app.py", line 799, in run
     root = self.build()
   File "layouttest.py", line 56, in build
     rw = RootWidget()
   File "layouttest.py", line 34, in __init__
     self.spacing = 80
````

With only the original Exception message and traceback, it's unclear where the error is actually coming from because the callback is delayed. With the additional info here it is easy to see that this callback was triggered by setting the `spacing` property.

This could use some additional testing. It has not been tested in Python 3, though the `raise` format should be correct.