### PR TITLE
Kivycatalog fix

### DIFF
--- a/examples/demo/kivycatalog/main.py
+++ b/examples/demo/kivycatalog/main.py
@@ -39,7 +39,8 @@ class Container(BoxLayout):
 
     def __init__(self, **kwargs):
         super(Container, self).__init__(**kwargs)
-        parser = Parser(content=open(self.kv_file).read())
+        self.previous_text = open(self.kv_file).read()
+        parser = Parser(content=self.previous_text)
         widget = Factory.get(parser.root.name)()
         Builder._apply_rule(widget, parser.root, parser.root)
         self.add_widget(widget)
@@ -112,15 +113,18 @@ class Catalog(BoxLayout):
         child = self.screen_manager.current_screen.children[0]
         with open(child.kv_file, 'rb') as file:
             self.language_box.text = file.read().decode('utf8')
+        Clock.unschedule(self.change_kv)
+        self.change_kv()
         # reset undo/redo history
         self.language_box.reset_undo()
 
     def schedule_reload(self):
         if self.auto_reload:
             txt = self.language_box.text
-            if txt == self._previously_parsed_text:
+            child = self.screen_manager.current_screen.children[0]
+            if txt == child.previous_text:
                 return
-            self._previously_parsed_text = txt
+            child.previous_text = txt
             Clock.unschedule(self.change_kv)
             Clock.schedule_once(self.change_kv, 2)
 

--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -116,7 +116,7 @@ class Spinner(Button):
     def _build_dropdown(self, *largs):
         if self._dropdown:
             self._dropdown.unbind(on_select=self._on_dropdown_select)
-            self._dropdown.unbind(on_dismiss=self._toggle_dropdown)
+            self._dropdown.unbind(on_dismiss=self._close_dropdown)
             self._dropdown.dismiss()
             self._dropdown = None
         cls = self.dropdown_cls
@@ -124,7 +124,7 @@ class Spinner(Button):
             cls = Factory.get(cls)
         self._dropdown = cls()
         self._dropdown.bind(on_select=self._on_dropdown_select)
-        self._dropdown.bind(on_dismiss=self._toggle_dropdown)
+        self._dropdown.bind(on_dismiss=self._close_dropdown)
         self._update_dropdown()
 
     def _update_dropdown(self, *largs):
@@ -140,6 +140,9 @@ class Spinner(Button):
 
     def _toggle_dropdown(self, *largs):
         self.is_open = not self.is_open
+
+    def _close_dropdown(self, *largs):
+        self.is_open = False
 
     def _on_dropdown_select(self, instance, data, *largs):
         self.text = data


### PR DESCRIPTION
Fixes an issue with how KivyCatalog reloads when changing screens, which I think may have caused #2791. Also prevents `Spinner` from trying to reopen itself when selecting an item (on select changes is_open to False which calls dismiss which triggers on_dismiss which calls toggle_dropdown setting is_open back to True).