### PR TITLE
handle invalid font paths in CodeInput example

### DIFF
--- a/examples/widgets/codeinput.py
+++ b/examples/widgets/codeinput.py
@@ -134,8 +134,9 @@ class CodeInputTest(App):
         self.codeinput.font_size = float(size)
 
     def _update_font(self, instance, fnt_name):
-        instance.font_name = self.codeinput.font_name =\
-            fonts.match_font(fnt_name)
+        font_name = fonts.match_font(fnt_name)
+        if os.path.exists(font_name):
+            instance.font_name = self.codeinput.font_name = font_name
 
     def _file_menu_selected(self, instance, value):
         if value == 'File':

--- a/examples/widgets/codeinputtest.kv
+++ b/examples/widgets/codeinputtest.kv
@@ -2,7 +2,8 @@
 #:import os os
 <Fnt_SpinnerOption>:
     fnt_name: fonts.match_font(self.text)
-    font_name: self.fnt_name if self.fnt_name else self.font_name
+    resolved_name: self.fnt_name if os.path.exists(self.fnt_name) else self.font_name
+    font_name: self.resolved_name if self.resolved_name else self.font_name
 
 <LoadDialog>:
     title: filechooser.path


### PR DESCRIPTION
Ignore any invalid font paths - the paths are returned by pygame, so if we get an invalid path we just have to skip it.

Fixes #2798