### PR TITLE
Removed 'this is experimental' tags from a couple of places

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -264,11 +264,6 @@ Pause mode
 
 .. versionadded:: 1.1.0
 
-.. warning::
-
-    This mode is experimental, and designed for phones/tablets. There are some
-    cases where your application could crash on resume.
-
 On tablets and phones, the user can switch at any moment to another
 application.  By default, your application will close and the
 :meth:`App.on_stop` event will be fired.

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -3,11 +3,6 @@
 
 .. versionadded:: 1.4.0
 
-.. warning::
-
-    This widget is still experimental, and its API is subject to change in a
-    future version.
-
 The screen manager is a widget dedicated to managing multiple screens for your
 application. The default :class:`ScreenManager` displays only one
 :class:`Screen` at a time and uses a :class:`TransitionBase` to switch from one


### PR DESCRIPTION
We have this in a few places, mostly still justified, but I think these two should be removed.

Screenmanager is stable and used by many people (the main change I think is worth making is renaming switch_to or modifying its behaviour for sceens that are already added), and I've seen users discouraged by it being labelled this way.

Pause mode is similarly popular and seems to work fine. I'm not sure if the warning about crashes is still needed, but if so I think it should be instead of the experimental label.