### PR TITLE
Horizontal align for popup title

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -501,6 +501,7 @@
             height: self.texture_size[1] + 16
             text_size: self.width - 16, None
             font_size: root.title_size
+            font_name: root.title_font
             halign: root.title_align
 
         Widget:

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -501,6 +501,7 @@
             height: self.texture_size[1] + 16
             text_size: self.width - 16, None
             font_size: root.title_size
+            halign: root.title_align
 
         Widget:
             size_hint_y: None

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -118,6 +118,13 @@ class Popup(ModalView):
     defaults to '14sp'.
     '''
 
+    title_align = StringProperty('left')
+    '''Vertical alignment of the title, can be 'left','middle' or 'right'.
+
+    :attr:`title_align` is a :class:`~kivy.properties.StringProperty` and
+    defaults to 'left'.
+    '''
+
     content = ObjectProperty(None)
     '''Content of the popup that is displayed just under the title.
 

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -79,7 +79,7 @@ popup from closing by explictly returning True from your callback::
 __all__ = ('Popup', 'PopupException')
 
 from kivy.uix.modalview import ModalView
-from kivy.properties import (StringProperty, ObjectProperty,
+from kivy.properties import (StringProperty, ObjectProperty, OptionProperty,
                              NumericProperty, ListProperty)
 
 
@@ -118,11 +118,11 @@ class Popup(ModalView):
     defaults to '14sp'.
     '''
 
-    title_align = StringProperty('left')
-    '''Vertical alignment of the title, can be 'left','middle' or 'right'.
+    title_align = OptionProperty('left', options=['left', 'center', 'right','justify'])
+    '''Horizontal alignment of the title.
 
-    :attr:`title_align` is a :class:`~kivy.properties.StringProperty` and
-    defaults to 'left'.
+    :attr:`title_align` is a :class:`~kivy.properties.OptionProperty` and
+    defaults to 'left'. Available options are left, middle, right and justify.
     '''
 
     content = ObjectProperty(None)

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -125,6 +125,13 @@ class Popup(ModalView):
     defaults to 'left'. Available options are left, middle, right and justify.
     '''
 
+    title_font = StringProperty('DroidSans')
+    '''Font used to render the title text.
+
+    :attr:`title_font` is a :class:`~kivy.properties.StringProperty` and
+    defaults to 'DroidSans'.
+    '''
+
     content = ObjectProperty(None)
     '''Content of the popup that is displayed just under the title.
 


### PR DESCRIPTION
This will allow to center the text of the popup title.
![popup-title-centered](https://cloud.githubusercontent.com/assets/1446790/5616134/ce415ec4-9501-11e4-82bd-e20cfc0ebd42.png)

Can be used just by passing 'title_align' to the Popup options.