### PR TITLE
Fixes 2823, zip files not loaded by ImageLoaderPygame.

### DIFF
--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -47,7 +47,7 @@ class ImageLoaderPygame(ImageLoaderBase):
             im = None
             if self._inline:
                 im = pygame.image.load(filename, 'x.{}'.format(self._ext))
-            elif isfile(filename):
+            elif isfile(str(filename)):
                 with open(filename, 'rb') as fd:
                     im = pygame.image.load(fd)
             elif isinstance(filename, bytes):


### PR DESCRIPTION
Must be tested on all other platforms. Was developed with python 2.7.9, Windows 7 Home 64-bit.
See #2823 for details.