### PR TITLE
core:Image:zip_loader start using the new functions for loading from mem...

### DIFF
--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -47,7 +47,7 @@ class ImageLoaderPygame(ImageLoaderBase):
             im = None
             if self._inline:
                 im = pygame.image.load(filename, 'x.{}'.format(self._ext))
-            elif isfile(str(filename)):
+            elif isfile(filename):
                 with open(filename, 'rb') as fd:
                     im = pygame.image.load(fd)
             elif isinstance(filename, bytes):


### PR DESCRIPTION
...ory

Closes https://github.com/kivy/kivy/issues/2823

~~DO NOT MERGE YET!. This  leads to a crash in imageio~~
UPDATE: now Fixed with tito's latest fixes. this should also work with SDL2 now that SDL2 supports loading from BytesIO.
