### PR TITLE
Fix text stripping issues

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -550,23 +550,14 @@ class LabelBase(object):
                                     options['halign'][-1] == 'y')
         uw, uh = options['text_size'] = self._text_size
         text = self.text
-        if not strip:
-            # all text will be stripped by default. unicode NO-BREAK SPACE
-            # characters will be preserved, so we replace the leading and
-            # trailing spaces with \u00a0
-            text = text.decode('utf8', errors=options['unicode_errors'])\
-                if isinstance(text, bytes) else text
-            lspace = len(text) - len(text.lstrip())
-            rspace = len(text) - len(text.rstrip())
-            text = (u'\u00a0' * lspace) + text.strip() + (u'\u00a0' * rspace)
+        if strip:
+            text = text.strip()
         if uw is not None and options['shorten']:
             text = self.shorten(text)
         self._cached_lines = lines = []
         if not text:
             return 0, 0
 
-        ostrip = options['strip']
-        strip = options['strip'] = True
         if uh is not None and options['valign'][-1] == 'e':  # middle
             center = -1  # pos of newline
             if len(text) > 1:
@@ -592,7 +583,6 @@ class LabelBase(object):
         else:  # top or bottom
             w, h, clipped = layout_text(text, lines, (0, 0), (uw, uh), options,
                 self.get_cached_extents(), options['valign'][-1] == 'p', True)
-        options['strip'] = ostrip
         self._internal_size = w, h
         if uw:
             w = uw

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -105,12 +105,18 @@ class LabelBase(object):
         `strip` : bool, defaults to False
             Whether each row of text has its leading and trailing spaces
             stripped. If `halign` is `justify` it is implicitly True.
+        `strip_reflow` : bool, defaults to True
+            Whether text that has been reflowed into a second line should
+            be striped, even if `strip` is False. This is only in effect when
+            ``size_hint_x` is not None, because otherwise lines are never
+            split.
         `unicode_errors` : str, defaults to `'replace'`
             How to handle unicode decode errors. Can be `'strict'`, `'replace'`
             or `'ignore'`.
 
     .. versionchanged:: 1.9.0
-        `strip`, `shorten_from`, `split_str`, and `unicode_errors` were added.
+        `strip`, `strip_reflow`, `shorten_from`, `split_str`, and
+        `unicode_errors` were added.
 
     .. versionchanged:: 1.9.0
         `padding_x` and `padding_y` has been fixed to work as expected.
@@ -141,11 +147,12 @@ class LabelBase(object):
 
     _texture_1px = None
 
-    def __init__(self, text='', font_size=12, font_name=DEFAULT_FONT,
-                 bold=False, italic=False, halign='left', valign='bottom',
-                 shorten=False, text_size=None, mipmap=False, color=None,
-                 line_height=1.0, strip=False, shorten_from='center',
-                 split_str=' ', unicode_errors='replace', **kwargs):
+    def __init__(
+        self, text='', font_size=12, font_name=DEFAULT_FONT, bold=False,
+        italic=False, halign='left', valign='bottom', shorten=False,
+        text_size=None, mipmap=False, color=None, line_height=1.0, strip=False,
+        strip_reflow=True, shorten_from='center', split_str=' ',
+        unicode_errors='replace', **kwargs):
 
         # Include system fonts_dir in resource paths.
         # This allows us to specify a font from those dirs.
@@ -155,8 +162,9 @@ class LabelBase(object):
                    'font_name': font_name, 'bold': bold, 'italic': italic,
                    'halign': halign, 'valign': valign, 'shorten': shorten,
                    'mipmap': mipmap, 'line_height': line_height,
-                   'strip': strip, 'shorten_from': shorten_from,
-                   'split_str': split_str, 'unicode_errors': unicode_errors}
+                   'strip': strip, 'strip_reflow': strip_reflow,
+                   'shorten_from': shorten_from, 'split_str': split_str,
+                   'unicode_errors': unicode_errors}
 
         options['color'] = color or (1, 1, 1, 1)
         options['padding'] = kwargs.get('padding', (0, 0))

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -410,18 +410,20 @@ class MarkupLabel(MarkupLabelBase):
             psp = pph = 0
             for word in layout_line.words:
                 options = self.options = word.options
+                # the word height is not scaled by line_height, only lh was
+                wh = options['line_height'] * word.lh
                 # calculate sub/super script pos
                 if options['script'] == 'superscript':
                     script_pos = max(0, psp if psp else self.get_descent())
                     psp = script_pos
-                    pph = word.lh
+                    pph = wh
                 elif options['script'] == 'subscript':
-                    script_pos = min(lh - word.lh, ((psp + pph) - word.lh)
-                                     if pph else (lh - word.lh))
-                    pph = word.lh
+                    script_pos = min(lh - wh, ((psp + pph) - wh)
+                                     if pph else (lh - wh))
+                    pph = wh
                     psp = script_pos
                 else:
-                    script_pos = (lh - word.lh) / 1.25
+                    script_pos = (lh - wh) / 1.25
                     psp = pph = 0
                 if len(word.text):
                     render_text(word.text, x, y + script_pos)
@@ -431,7 +433,7 @@ class MarkupLabel(MarkupLabelBase):
                 if ref is not None:
                     if not ref in refs:
                         refs[ref] = []
-                    refs[ref].append((x, y, x + word.lw, y + word.lh))
+                    refs[ref].append((x, y, x + word.lw, y + wh))
 
                 # Should we record anchors?
                 anchor = options['_anchor']

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -212,6 +212,8 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             # if we finish this line, make sure it doesn't end in spaces
             final_strip(_line)
             add_h = _line.h
+        else:
+            add_h = _line.h
 
         w = max(w, _line.w + 2 * xpad)
         h += add_h - old_lh

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -6,7 +6,6 @@ An internal module for laying out text according to options and constraints.
 This is not part of the API and may change at any time.
 '''
 
-import string
 
 __all__ = ('layout_text', 'LayoutWord', 'LayoutLine')
 
@@ -153,7 +152,7 @@ cdef inline void final_strip(LayoutLine line):
             line.w -= last_word.lw  # likely 0
             continue
 
-        stripped = last_word.text.rstrip(string.whitespace)  # ends with space
+        stripped = last_word.text.rstrip()  # ends with space
         # subtract ending space length
         diff = ((len(last_word.text) - len(stripped)) *
                 last_word.options['space_width'])
@@ -193,10 +192,10 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             k = n - 1
         if strip:
             if not _line.w:  # no proceeding text: strip leading
-                line = line.lstrip(string.whitespace)
+                line = line.lstrip()
             # ends this line so right strip
             if complete or (dwn and n > 1 or not dwn and pos > 1):
-                line = line.rstrip(string.whitespace)
+                line = line.rstrip()
         lw, lh = get_extents(line)
 
         old_lh = _line.h
@@ -230,9 +229,9 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
         # the last line is only stripped from left
         if strip:
             if complete or (dwn and i < n - 1 or not dwn and i > s):
-                line = line.strip(string.whitespace)
+                line = line.strip()
             else:
-                line = line.lstrip(string.whitespace)
+                line = line.lstrip()
         lw, lh = get_extents(line)
 
         lhh = int(lh * line_height)
@@ -443,9 +442,9 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
         line = new_lines[i]
         if strip:
             if not _line.w:  # there's no proceeding text, so strip leading
-                line = line.lstrip(string.whitespace)
+                line = line.lstrip()
             if ends_line:
-                line = line.rstrip(string.whitespace)
+                line = line.rstrip()
         k = len(line)
         if not k:  # just add empty line if empty
             _line.is_last_line = ends_line  # nothing will be appended
@@ -493,7 +492,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
                 if s != m:
                     _do_last_line = 1
                     if strip and line[m - 1] == ' ':
-                        ln = line[s:m].rstrip(string.whitespace)
+                        ln = line[s:m].rstrip()
                         lww, lhh = get_extents(ln)
                     else:
                         ln = line[s:m]
@@ -513,7 +512,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
                 # try to fit word on new line, if it doesn't fit we'll
                 # have to break the word into as many lines needed
                 if strip:
-                    s = e - len(line[s:e].lstrip(string.whitespace))
+                    s = e - len(line[s:e].lstrip())
                 if s == e:  # if it was only a stripped space, move on
                     m = s
                     continue

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -107,11 +107,15 @@ cdef inline LayoutLine add_line(object text, int lw, int lh, LayoutLine line,
         This assumes that global h is accurate and includes the text previously
         added to the line.
         '''
-        cdef int old_lh = line.h
+        cdef int old_lh = line.h, count = len(lines)
         if lw:
             line.words.append(LayoutWord(options, lw, lh, text))
             line.w += lw
-        line.h = max(int(lh * line_height), line.h)
+
+        if count:
+            line.h = max(int(lh * line_height), line.h)
+        else:
+            line.h = max(lh, line.h)
         # if we're appending to existing line don't add height twice
         h[0] = h[0] + line.h - old_lh
         w[0] = max(w[0], line.w + 2 * xpad)
@@ -222,10 +226,15 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             else:
                 line = line.lstrip(string.whitespace)
         lw, lh = get_extents(line)
-        lhh = int(lh * line_height)
+
+        if pos:
+            lhh = int(lh * line_height)
+        else:  # for the first line, always use full height
+            lhh = lh
         if uh != -1 and h + lhh > uh and pos:  # too high
             i += -1 if dwn else 1
             break
+
         pos += 1
         w = max(w, int(lw + 2 * xpad))
         h += lhh


### PR DESCRIPTION
This fixes both #2503 and #2723.

When the universe began, after my changes to text a while back, there was a new issue, where when `strip` was False, lines split because `size_hint_x`, was not `None` may have began with a space (#2503). @kived fixed it ( #2677) by always stripping internal spaces. This had a few issues, in particular, it didn't work for markup and it lead to #2723.

This pr, reverts  #2677 and instead provides an explicit option called `strip_reflow` which when `strip` is False, and `size_hint_x` is not None, will strip only the ends and starts of lines that are broken due to reflow. This will not strip lines that are not broken, because I believe if the user wanted to strip such lines, they should have selected `strip` to be True. Only lines that they could not know will be split due to size constraints will be stripped. I think this is the best of both worlds.

Please test to see if #2503 is still fixed and then merge :)

__Note__ #2502 should be merged first, because this branch starts after that. Only the last two commits are new for this issue.