### PR TITLE
image_overlay_play and image_loading attributes of VideoPlayer fixed

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -943,14 +943,16 @@
 
 <VideoPlayerPreview>:
     pos_hint: {'x': 0, 'y': 0}
+    image_overlay_play: 'atlas://data/images/defaulttheme/player-play-overlay'
+    image_loading: 'atlas://data/images/image-loading.gif'
     Image:
         source: root.source
         color: (.5, .5, .5, 1)
         pos_hint: {'x': 0, 'y': 0}
-
     Image:
-        source: 'atlas://data/images/defaulttheme/player-play-overlay' if not root.click_done else 'data/images/image-loading.gif'
+        source: root.image_overlay_play if not root.click_done else root.image_loading
         pos_hint: {'x': 0, 'y': 0}
+
 
 <VideoPlayerAnnotation>:
     canvas.before:

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -503,6 +503,12 @@ class VideoPlayer(GridLayout):
         if value:
             self._trigger_video_load()
 
+    def on_image_overlay_play(self, instance, value):
+        self._image.image_overlay_play = value
+
+    def on_image_loading(self, instance, value):
+        self._image.image_loading = value
+
     def _load_thumbnail(self):
         if not self.container:
             return


### PR DESCRIPTION
The image_overlay_play and image_loading attributes of VideoPlayer were not working. 

The paths for the images in VideoPlayerPreview were hard coded. I created the respective attributes and associate them to the existen attributes in the VideoPlayer class with the definition of the on_image_overlay_play and on_image_loading attribute methods.