### PR TITLE
Make doc build failsave

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ clean:
 	-rm -rf doc/build
 	-rm -rf build
 	-rm -rf htmlcov
-	-rm .coverage
-	-rm .noseids
+	-rm -f .coverage
+	-rm -f .noseids
 	-rm -rf kivy/tests/build
 	-find kivy -iname '*.so' -exec rm {} \;
 	-find kivy -iname '*.pyc' -exec rm {} \;

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ios:
 	cp -R "iosbuild/usr/local/lib/python2.7/site-packages/kivy" "$(BUILDROOT)/python/lib/python2.7/site-packages"
 
 pdf:
-	$(MAKE) -C doc latex && make -C doc/build/latex all-pdf
+	$(MAKE) -C doc pdf
 
 html:
 	env USE_EMBEDSIGNATURE=1 $(MAKE) force

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ ENDUSER_BUILD	= yes
 # You can set these variables from the command line.
 PYTHON		= python
 SPHINXOPTS	= -Q
-SPHINXOPTS_TEST	= -W
+SPHINXOPTS_TEST	= -W -T
 SPHINXBUILD	= sphinx-build
 PAPER		=
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -102,9 +102,16 @@ latex:
 	      "run these through (pdf)latex."
 
 pdf: latex
-	$(MAKE) -C build$(P)latex all-pdf LATEXOPTS=$(LATEXOPTS$(_TESTS))
+	rm -f build$(P)latex$(P)Kivy.pdf
+	-$(MAKE) -C build$(P)latex all-pdf LATEXOPTS=$(LATEXOPTS$(_TESTS))
+ifneq ("$(wildcard build$(P)latex$(P)Kivy.pdf)","")
 	@echo
-	@echo "Build finished; the PDF files are in build/latex."
+	@echo "Build finished; the PDF file(s) are in build/latex."
+else
+	@echo
+	@echo "Build failed; there is no PDF file(s) in build/latex."
+	exit 1
+endif
 
 ps: latex
 	$(MAKE) -C build$(P)latex all-ps

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,11 +2,11 @@
 #
 
 # You can set these variables from the command line.
-PYTHON		  = python
-SPHINXOPTS    = -W
-#SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
+PYTHON		= python
+SPHINXOPTS	= -Q
+SPHINXOPTS_TEST	= -W
+SPHINXBUILD	= sphinx-build
+PAPER		=
 
 # platform indepnt path separator
 # only system calls need to use $(P), b/c on win system calls have issues with /
@@ -20,10 +20,12 @@ endif
 P=$(strip $(PATHSEP2))
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
-ALLSPHINXOPTSGT = -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
+PAPEROPT_a4		= -D latex_paper_size=a4
+PAPEROPT_letter		= -D latex_paper_size=letter
+ALLSPHINXOPTS		= -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
+ALLSPHINXOPTS_TEST	= -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS_TEST) sources
+ALLSPHINXOPTSGT		= -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
+ALLSPHINXOPTSGT_TEST	= -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS_TEST) sources
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck gettext
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,8 @@
 # Makefile for Sphinx documentation
 #
 
+ENDUSER_BUILD	= yes
+
 # You can set these variables from the command line.
 PYTHON		= python
 SPHINXOPTS	= -Q
@@ -27,6 +29,12 @@ ALLSPHINXOPTS_TEST	= -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS_TEST) s
 ALLSPHINXOPTSGT		= -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
 ALLSPHINXOPTSGT_TEST	= -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS_TEST) sources
 
+ifeq ($(ENDUSER_BUILD),yes)
+	_TESTS = 
+else
+	_TESTS = _TEST
+endif
+
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck gettext
 
 help:
@@ -35,6 +43,8 @@ help:
 	@echo "  pickle    to make pickle files (usable by e.g. sphinx-web)"
 	@echo "  htmlhelp  to make HTML files and a HTML help project"
 	@echo "  latex     to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  pdf       to make standalone PDF files"
+	@echo "  ps        to make standalone PS files"
 	@echo "  changes   to make an overview over all changed/added/deprecated items"
 	@echo "  linkcheck to check all external links for integrity"
 
@@ -49,14 +59,14 @@ endif
 html:
 	$(MKDIR) build$(P)html build$(P)doctrees
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS$(_TESTS)) build/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
 gettext:
 	$(MKDIR) build$(P)html build$(P)doctrees_gettext
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b gettext $(ALLSPHINXOPTSGT) build/gettext
+	$(SPHINXBUILD) -b gettext $(ALLSPHINXOPTSGT$(_TESTS)) build/gettext
 	@echo
 	@echo "Build finished. The Gettext pages are in build/gettext."
 
@@ -64,7 +74,7 @@ gettext:
 pickle:
 	$(MKDIR) build$(P)pickle build$(P)doctrees
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) build/pickle
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS$(_TESTS)) build/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files or run"
 	@echo "  sphinx-web build/pickle"
@@ -75,7 +85,7 @@ web: pickle
 htmlhelp:
 	$(MKDIR) build$(P)htmlhelp build$(P)doctrees
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) build/htmlhelp
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS$(_TESTS)) build/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in build/htmlhelp."
@@ -83,23 +93,45 @@ htmlhelp:
 latex:
 	$(MKDIR) build$(P)latex build$(P)doctrees
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) build/latex
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS$(_TESTS)) build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in build/latex."
-	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
+	@echo "Run \`make all-pdf' or \`make all-ps' to" \
 	      "run these through (pdf)latex."
+
+pdf: latex
+	$(MAKE) -C build$(P)latex all-pdf
+	@echo
+	@echo "Build finished; the PDF files are in build/latex."
+
+ps: latex
+	$(MAKE) -C build$(P)latex all-ps
+	@echo
+	@echo "Build finished; the PS files are in build/latex."
 
 changes:
 	$(MKDIR) build$(P)changes build$(P)doctrees
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) build/changes
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS$(_TESTS)) build/changes
 	@echo
 	@echo "The overview file is in build/changes."
 
 linkcheck:
 	$(MKDIR) build$(P)linkcheck build$(P)doctrees
 	$(PYTHON) autobuild.py
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) build/linkcheck
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS$(_TESTS)) build/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in build/linkcheck/output.txt."
+
+enable-ENDUSER_BUILD:
+	$(ENDUSER_BUILD) = yes
+	$(_TESTS) =
+
+disable-ENDUSER_BUILD:
+	$(ENDUSER_BUILD) = no
+	$(_TESTS) = _TEST
+
+build-all: html pickle htmlhelp pdf ps gettext
+
+test: disable-ENDUSER_BUILD build-all

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,6 +28,8 @@ ALLSPHINXOPTS		= -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
 ALLSPHINXOPTS_TEST	= -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS_TEST) sources
 ALLSPHINXOPTSGT		= -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sources
 ALLSPHINXOPTSGT_TEST	= -d build/doctrees_gettext $(PAPEROPT_$(PAPER)) $(SPHINXOPTS_TEST) sources
+LATEXOPTS		= -interaction=batchmode
+LATEXOPTS_TESTS		= 
 
 ifeq ($(ENDUSER_BUILD),yes)
 	_TESTS = 
@@ -100,7 +102,7 @@ latex:
 	      "run these through (pdf)latex."
 
 pdf: latex
-	$(MAKE) -C build$(P)latex all-pdf
+	$(MAKE) -C build$(P)latex all-pdf LATEXOPTS=$(LATEXOPTS$(_TESTS))
 	@echo
 	@echo "Build finished; the PDF files are in build/latex."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -126,14 +126,7 @@ linkcheck:
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in build/linkcheck/output.txt."
 
-enable-ENDUSER_BUILD:
-	$(ENDUSER_BUILD) = yes
-	$(_TESTS) =
-
-disable-ENDUSER_BUILD:
-	$(ENDUSER_BUILD) = no
-	$(_TESTS) = _TEST
-
 build-all: html pickle htmlhelp pdf ps gettext
 
-test: disable-ENDUSER_BUILD build-all
+# TODO: Make test run in non-enduser-build mode 
+test: build-all

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -58,14 +58,14 @@ endif
 
 html:
 	$(MKDIR) build$(P)html build$(P)doctrees
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS$(_TESTS)) build/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
 gettext:
 	$(MKDIR) build$(P)html build$(P)doctrees_gettext
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b gettext $(ALLSPHINXOPTSGT$(_TESTS)) build/gettext
 	@echo
 	@echo "Build finished. The Gettext pages are in build/gettext."
@@ -73,7 +73,7 @@ gettext:
 
 pickle:
 	$(MKDIR) build$(P)pickle build$(P)doctrees
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS$(_TESTS)) build/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files or run"
@@ -84,7 +84,7 @@ web: pickle
 
 htmlhelp:
 	$(MKDIR) build$(P)htmlhelp build$(P)doctrees
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS$(_TESTS)) build/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
@@ -92,7 +92,7 @@ htmlhelp:
 
 latex:
 	$(MKDIR) build$(P)latex build$(P)doctrees
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS$(_TESTS)) build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in build/latex."
@@ -111,14 +111,14 @@ ps: latex
 
 changes:
 	$(MKDIR) build$(P)changes build$(P)doctrees
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS$(_TESTS)) build/changes
 	@echo
 	@echo "The overview file is in build/changes."
 
 linkcheck:
 	$(MKDIR) build$(P)linkcheck build$(P)doctrees
-	$(PYTHON) autobuild.py
+	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS$(_TESTS)) build/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \

--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -261,4 +261,4 @@ for module in m:
 
 
 # Generation finished
-print('Generation finished, do make html')
+print('Auto-generation finished')

--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -60,6 +60,13 @@ import kivy.interactive
 import kivy.garden
 from kivy.factory import Factory
 
+# check for silenced build
+BE_QUIET = False
+for arg in sys.argv:
+    if "silenced=" in arg:
+        arg.split("=")[1] == "yes":
+            BE_QUIET = True
+
 # force loading of all classes from factory
 for x in list(Factory.classes.keys())[:]:
     getattr(Factory, x)
@@ -75,7 +82,7 @@ def writefile(filename, data):
     global dest_dir
     # avoid to rewrite the file if the content didn't change
     f = os.path.join(dest_dir, filename)
-    print('write', filename)
+    if not BE_QUIET: print('write', filename)
     if os.path.exists(f):
         with open(f) as fd:
             if fd.read() == data:

--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -64,7 +64,7 @@ from kivy.factory import Factory
 BE_QUIET = False
 for arg in sys.argv:
     if "silenced=" in arg:
-        arg.split("=")[1] == "yes":
+        if arg.split("=")[1] == "yes":
             BE_QUIET = True
 
 # force loading of all classes from factory


### PR DESCRIPTION
* Includes fix for #2889
* Made autobuild.py more silent
* Moved make pdf to doc/Makefile and made it failsave as long as file is created
* Made use of some options making sphinx-build and pdflatex more silent and non-interactive (user might be confused to be prompted to make any inputs)
* ENDUSER_BUILD=no will skip all my changes (in case there is a purpose to have all these long outputs)