### PR TITLE
Fix binding issues

### DIFF
--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -1512,10 +1512,11 @@ def update_intermediates(base, keys, bound, s, fn, args, instance, value):
     del bound[s:]
 
     # find the first attr from which we need to start rebinding.
-    if len(bound):
-        f = bound[-1][0]
-    else:  # if it's the very first attr, we start with the base.
-        f = base
+    f = getattr(*bound[-1][:2])
+    if f is None:
+        fn(args, None, None)
+        return
+    s += 1
     append = bound.append
 
     # bind all attrs, except last to update_intermediates

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -758,6 +758,7 @@ import codecs
 import re
 import sys
 import traceback
+import types
 from re import sub, findall
 from os import environ
 from os.path import join
@@ -795,6 +796,9 @@ lang_str = re.compile('([\'"][^\'"]*[\'"])')
 lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile('([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile('(_\()')
+
+# class types to check with isinstance
+_cls_type = (type, types.ClassType)
 
 
 # all the widget handlers, used to correctly unbind all the callbacks then the
@@ -1594,8 +1598,10 @@ def create_handler(iself, element, key, value, rule, idmap, delayed=False):
                         was_bound = True
                     else:
                         append([f.proxy_ref, val, None, None])
-                else:
+                elif not isinstance(f, _cls_type):
                     append([getattr(f, 'proxy_ref', f), val, None, None])
+                else:
+                    append([f, val, None, None])
                 f = getattr(f, val, None)
                 if f is None:
                     break

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -1498,15 +1498,14 @@ def update_intermediates(base, keys, bound, s, fn, args, instance, value):
             The function to be called args, `args` on bound callback.
     '''
     # first remove all the old bound functions from `s` and down.
-    j = s - 1
-    for f, k, fun, uid in bound[j:]:
+    for f, k, fun, uid in bound[s:]:
         if fun is None:
             continue
         try:
             f.unbind_uid(k, uid)
         except ReferenceError:
             pass
-    del bound[j:]
+    del bound[s:]
 
     # find the first attr from which we need to start rebinding.
     if len(bound):


### PR DESCRIPTION
This resolves two issues:

- When rebinding, we unbound too far and didn't account for it. It is fixed here not unbind more than needed. The following code demonstrates the issue:
```py
from kivy.lang import Builder
from kivy.uix.widget import Widget
from kivy.properties import ObjectProperty, NumericProperty

class MyWidget(Widget):
    num = NumericProperty(0)
    prop = ObjectProperty(None, rebind=True)

class MyWidget2(Widget):
    p = ObjectProperty(None, rebind=True)

class MyWidget3(Widget):
    p2 = ObjectProperty(None, rebind=True)

kv = '''
MyWidget:
    num: self.prop.p.p2.num if self.prop and self.prop.p else 5.3
    on_num: print(self.num)
'''

w1 = MyWidget2(p=MyWidget3(p2=MyWidget(num=1)))
w2 = MyWidget3(p2=MyWidget(num=2))
root = Builder.load_string(kv)
root.prop = w1
w1.p.p2.num = 1.5
root.prop.p = w2
w2.p2.num = 2.5
```
On master it prints:
```
1
1.5
2
```

but on the pr it prints correctly:
```
1
1.5
2
2.5
```
- When a rule said e.g. `MyWidget.obj.prop` When storing `MyWidget` it'd try `getattr(f, 'proxy_ref', f)` where `f` was the `MyWidget` class. `proxy_ref` returned the property itself, because `MyWidget` is a class, which is wrong, so the code fixes to skip this on classes.