### PR TITLE
Updated to correct cython version

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -157,7 +157,8 @@ The following software is needed, even if your distribution is not listed above:
 - `PyGame <http://www.pygame.org/>`_
 - `PyEnchant <http://packages.python.org/pyenchant/>`_
 - `gst-python <http://gstreamer.freedesktop.org/modules/gst-python.html>`_
-- `Cython >= 0.15 <http://cython.org/>`_
+- `Cython == 0.20 <http://cython.org/`_
+Don't install Cython 0.21. It does not work with Kivy 1.8. This bug is fixed in Kivy 1.9, which we're trying to release soon.
 
 We prefer to use a package-manager to provide these dependencies.
 


### PR DESCRIPTION
Was cython >= 0.15, now is cython==0.20.
A lot of people complained that they didn't manage to install kivy because they installed cython 0.21