### PR TITLE
Fix the default of border property (in PageLayout) in the documentation

### DIFF
--- a/kivy/uix/pagelayout.py
+++ b/kivy/uix/pagelayout.py
@@ -52,7 +52,7 @@ class PageLayout(Layout):
     the previous/next page when needed.
 
     :data:`border` is a :class:`~kivy.properties.NumericProperty` and
-    defaults to 0.
+    defaults to 50.
     '''
 
     swipe_threshold = NumericProperty(.5)


### PR DESCRIPTION
The documentation says that the default value for border is 0, but is 50.