### PR TITLE
Get the configparse object during linking if it exists already.

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1614,8 +1614,6 @@ cdef class ConfigParserProperty(Property):
 
         if isinstance(config, string_types) and config:
             self.config_name = config
-            # if the parser already exists, get it now
-            self.config = ConfigParser.get_configparser(config)
         elif isinstance(config, ConfigParser):
             self.config = config
         elif config is not None:
@@ -1642,6 +1640,7 @@ cdef class ConfigParserProperty(Property):
         Property.link_deps(self, obj, name)
         self.obj = ref(obj)
 
+        # if the parser already exists, get it now
         if self.config is None:
             self.config = ConfigParser.get_configparser(self.config_name)
         if self.config is not None:

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1642,6 +1642,8 @@ cdef class ConfigParserProperty(Property):
         Property.link_deps(self, obj, name)
         self.obj = ref(obj)
 
+        if self.config is None:
+            self.config = ConfigParser.get_configparser(self.config_name)
         if self.config is not None:
             self.config.adddefaultsection(self.section)
             self.config.setdefault(self.section, self.key, self.defaultvalue)


### PR DESCRIPTION
This is based on #2351, where the correct solution is to at least get it during linking. The reason is if the Config object is created after the property is created but before linking, then `_register_named_property` won't call us back since it already exists so we'll never be notified that Config object exists. This removes the first `get` since doing it in link is sufficient.

Merging based on @kived prior review in #2351 :).