### PR TITLE
Fix escape exiting on unfocus in kivycatalog

### DIFF
--- a/examples/demo/kivycatalog/main.py
+++ b/examples/demo/kivycatalog/main.py
@@ -71,7 +71,7 @@ class KivyRenderTextInput(CodeInput):
                     self.catalog.change_kv(True)
                     return
 
-        super(KivyRenderTextInput, self).keyboard_on_key_down(
+        return super(KivyRenderTextInput, self).keyboard_on_key_down(
             window, keycode, text, modifiers)
 
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -439,7 +439,7 @@ class TextInput(FocusBehavior, Widget):
                   password=self._update_text_options)
 
         self.bind(pos=self._trigger_update_graphics, focus=set_focused,
-                  readonly=handle_readonly)
+                  readonly=handle_readonly, focused=self._on_textinput_focused)
         handle_readonly(self, self.readonly)
 
         self._trigger_position_handles = Clock.create_trigger(
@@ -1315,7 +1315,7 @@ class TextInput(FocusBehavior, Widget):
         if wr in _textinput_list:
             _textinput_list.remove(wr)
 
-    def on_focused(self, instance, value, *largs):
+    def _on_textinput_focused(self, instance, value, *largs):
         self.focus = value
 
         win = self._win


### PR DESCRIPTION
It forgot to do `return super(...)`. It also directly binds `on_focused` so that there's no possibility of user accidentally overwriting it because users are not used to calling super on `on_xxx` methods.