### PR TITLE
.gitignore should ignore htmlcov directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ python
 python.exe
 .idea
 dist
+htmlcov
 
 MANIFEST
 


### PR DESCRIPTION
The ./htmlcov directory is generated by 'make cover' and holds coverage statistics.