### PR TITLE
Have unittest destroy its test file.

### DIFF
--- a/kivy/tests/test_fonts.py
+++ b/kivy/tests/test_fonts.py
@@ -19,3 +19,9 @@ class FontTestCase(unittest.TestCase):
         lbl = Label(font_name=self.font_name)
         lbl.refresh()
         self.assertNotEqual(lbl.get_extents(''), None)
+
+    def tearDown(self):
+        import os
+        if os.path.exists(self.font_name):
+            os.unlink(self.font_name)
+


### PR DESCRIPTION
test_font.py now deletes it unicode named .ttf file during tear-down