### PR TITLE
Add new checks to kivy/tools/pep8.py

### DIFF
--- a/kivy/tools/pep8checker/sample_for_pep8.py
+++ b/kivy/tools/pep8checker/sample_for_pep8.py
@@ -1,0 +1,34 @@
+""" A docstring only file.  With double spaces.
+"""
+pass
+""" Another comment. With single spaces. OK. """
+pass
+""" Another comment.  With double spaces.   And triple. """
+pass
+""" A mulitline one with initials C.C.M.
+    And a double space in the middle.  Here.
+    But not on the third. Line. """
+pass
+if True:
+    " Single quotes.  Same issue.  With indent. "
+    pass
+else:
+    """
+
+    A multiline.
+
+
+
+    On the third line.
+         With odd indents.  Here.
+    """
+
+""" One with.  1 number doesn't count. lowercase doesn't.    Four doesn't.  """
+pass
+""" And then lots of blank lines. """
+
+
+
+
+
+


### PR DESCRIPTION
Check for files ending in multiple blank lines (E389) and using two or
three spaces after a period in a comment.  Also fix a minor issue for
the —show-pep8 option.