### PR TITLE
Fix spacing and long lines.  'make style' is now clean.

### DIFF
--- a/kivy/adapters/listadapter.py
+++ b/kivy/adapters/listadapter.py
@@ -87,7 +87,7 @@ class ListAdapter(Adapter, EventDispatcher):
          is here so that selection can be turned off, momentarily or
          permanently, for an existing list adapter.
          A :class:`~kivy.adapters.listadapter.ListAdapter` is not meant to be
-         used as a primary no-selection list adapter.  Use a
+         used as a primary no-selection list adapter. Use a
          :class:`~kivy.adapters.simplelistadapter.SimpleListAdapter` for that.
 
        * 'single': multi-touch/click ignored. Single item selection only.
@@ -237,7 +237,7 @@ class ListAdapter(Adapter, EventDispatcher):
         if self.propagate_selection_to_data:
             # The data item must be a subclass of SelectableDataItem, or must
             # have an is_selected boolean or function, so it has is_selected
-            # available.  If is_selected is unavailable on the data item, an
+            # available. If is_selected is unavailable on the data item, an
             # exception is raised.
             #
             if isinstance(item, SelectableDataItem):

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -3,7 +3,7 @@ Application
 ===========
 
 The :class:`App` class is the base for creating Kivy applications.
-Think of it as your main entry point into the Kivy run loop.  In most
+Think of it as your main entry point into the Kivy run loop. In most
 cases, you subclass this class and make your own app. You create an
 instance of your specific app class and then, when you are ready to
 start the application's life cycle, you call your instance's
@@ -265,7 +265,7 @@ Pause mode
 .. versionadded:: 1.1.0
 
 On tablets and phones, the user can switch at any moment to another
-application.  By default, your application will close and the
+application. By default, your application will close and the
 :meth:`App.on_stop` event will be fired.
 
 If you support Pause mode, when switching to another application, your

--- a/kivy/atlas.py
+++ b/kivy/atlas.py
@@ -6,8 +6,8 @@ Atlas
 
 Atlas manages texture atlases: packing multiple textures into
 one. With it, you reduce the number of images loaded and speedup the
-application loading.  This module contains both the Atlas class and command line
-processing for creating an atlas from a set of individual PNG files.   The
+application loading. This module contains both the Atlas class and command line
+processing for creating an atlas from a set of individual PNG files. The
 command line section requires the Pillow library, or the defunct Python Imaging
 Library (PIL), to be installed.
 
@@ -389,13 +389,13 @@ class Atlas(EventDispatcher):
 
 
 if __name__ == '__main__':
-    """ Main line program.   Process command line arguments
+    """ Main line program. Process command line arguments
     to make a new atlas. """
 
     import sys
     argv = sys.argv[1:]
     # earlier import of kivy has already called getopt to remove kivy system
-    # arguments from this line.  That is all arguments up to the first '--'
+    # arguments from this line. That is all arguments up to the first '--'
     if len(argv) < 3:
         print('Usage: python -m kivy.atlas [-- [--use-path] '
               '[--padding=2]] <outname> '

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -49,7 +49,7 @@ to write a short function that does accept dt. For Example::
 .. note::
 
     You cannot unschedule an anonymous function unless you keep a
-    reference to it.  It's better to add \*args to your function
+    reference to it. It's better to add \*args to your function
     definition so that it can be called with an arbitrary number of
     parameters.
 
@@ -94,7 +94,7 @@ from 1.0.5, you can use a timeout of -1::
 
 The Clock will execute all the callbacks with a timeout of -1 before the
 next frame even if you add a new callback with -1 from a running
-callback.  However, :class:`Clock` has an iteration limit for these
+callback. However, :class:`Clock` has an iteration limit for these
 callbacks: it defaults to 10.
 
 If you schedule a callback that schedules a callback that schedules a .. etc

--- a/kivy/core/clipboard/__init__.py
+++ b/kivy/core/clipboard/__init__.py
@@ -1,4 +1,3 @@
-
 '''
 Clipboard
 =========
@@ -129,7 +128,7 @@ elif platform == 'win':
 elif platform == 'linux':
     _clipboards.append(
         ('dbusklipper', 'clipboard_dbusklipper', 'ClipboardDbusKlipper'))
-    
+
 if USE_SDL2:
     _clipboards.append(
         ('sdl2', 'clipboard_sdl2', 'ClipboardSDL2'))

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -45,5 +45,3 @@ class ClipboardWindows(ClipboardBase):
 
     def get_types(self):
         return list('text/plain',)
-
-

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -328,12 +328,14 @@ class ImageLoader(object):
                 ext = zfilename.split('.')[-1].lower()
                 im = None
                 for loader in ImageLoader.loaders:
-                    if ext not in loader.extensions() or not loader.can_load_memory():
+                    if (ext not in loader.extensions()
+                        or not loader.can_load_memory()):
                         continue
                     Logger.debug('Image%s: Load <%s> from <%s>' %
                                  (loader.__name__[11:], zfilename, filename))
                     try:
-                        im = loader(zfilename, ext=ext, rawdata=tmpfile, inline=True, **kwargs)
+                        im = loader(zfilename, ext=ext, rawdata=tmpfile,
+                                    inline=True, **kwargs)
                     except:
                         # Loader failed, continue trying.
                         continue

--- a/kivy/core/image/img_gif.py
+++ b/kivy/core/image/img_gif.py
@@ -7,7 +7,7 @@
 #
 #    this program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -468,7 +468,7 @@ class MarkupLabel(MarkupLabelBase):
             `lines`: list of `LayoutLine` instances describing the text.
             `w`: int, the width of the text in lines, including padding.
             `h`: int, the height of the text in lines, including padding.
-            `margin` int, the additional space left on the sides.  This is in
+            `margin` int, the additional space left on the sides. This is in
             addition to :attr:`padding_x`.
 
         :returns:

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -262,7 +262,7 @@ class WindowSDL(WindowBase):
                 # for finger, pass the raw event to SDL motion event provider
                 # XXX this is problematic. On OSX, it generates touches with 0,
                 # 0 coordinates, at the same times as mouse. But it works.
-                # We have a conflict of using either the mouse or the finger. 
+                # We have a conflict of using either the mouse or the finger.
                 # Right now, we have no mechanism that we could use to know
                 # which is the preferred one for the application.
                 #SDL2MotionEventProvider.q.appendleft(event)

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -49,7 +49,7 @@ Profiles
 A capability is the ability of a :class:`MotionEvent` to store new
 information or a way to indicate what is supported by the MotionEvent.
 For example, you can receive a MotionEvent that has an angle, a fiducial
-ID, or even a shape.  You can check the :attr:`~MotionEvent.profile`
+ID, or even a shape. You can check the :attr:`~MotionEvent.profile`
 attribute to check what is currently supported by the MotionEvent and
 how to access it.
 

--- a/kivy/input/providers/tuio.py
+++ b/kivy/input/providers/tuio.py
@@ -3,7 +3,7 @@ TUIO Input Provider
 ===================
 
 TUIO is the de facto standard network protocol for the transmission of
-touch and fiducial information between a server and a client.  To learn
+touch and fiducial information between a server and a client. To learn
 more about TUIO (which is itself based on the OSC protocol), please
 refer to http://tuio.org -- The specification should be of special
 interest.

--- a/kivy/interactive.py
+++ b/kivy/interactive.py
@@ -11,7 +11,7 @@ interactively.
 .. note::
 
     The Kivy API intends for some functions to only be run once or before the
-    main EventLoop has started.  Methods that can normally be called during the
+    main EventLoop has started. Methods that can normally be called during the
     course of an application will work as intended, but specifically overriding
     methods such as :meth:`on_touch` dynamically leads to trouble.
 
@@ -74,7 +74,7 @@ code in an Ipython shell.::
     i.       # press 'tab' to list attributes of the app
     i.root.  # press 'tab' to list attributes of the root widget
 
-    # App is boring.  Attach a new widget!
+    # App is boring. Attach a new widget!
     i.root.add_widget(MyPaintWidget())
 
     i.safeIn()
@@ -136,7 +136,7 @@ To threadsafe these external references, simply assign them to
     interactiveLauncher.attribute = myNewObject
     # myNewObject is unsafe
     myNewObject = SafeMembrane(myNewObject)
-    # myNewObject is now safe.  Call at will.
+    # myNewObject is now safe. Call at will.
     myNewObject.method()
 
 TODO
@@ -207,7 +207,7 @@ class SafeMembrane(object):
 
     # Everything from this point on is just a series of thread-safing proxy
     # methods that make calls against _ref and threadsafe whenever data will be
-    # written to or if a method will be called.  SafeMembrane instances should
+    # written to or if a method will be called. SafeMembrane instances should
     # be unwrapped whenever passing them into the thread
     #use type() to determine if an object is a SafeMembrane while debugging
     def __repr__(self):
@@ -315,7 +315,7 @@ class InteractiveLauncher(SafeMembrane):
 
     def run(self):
         self.thread.start()
-        #Proxy behavior starts after this is set.  Before this point, attaching
+        #Proxy behavior starts after this is set. Before this point, attaching
         #widgets etc can only be done through the Launcher's app attribute
         self._ref = self.app
 

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -382,7 +382,7 @@ to subclass. The Python equivalent would have been:
         pass
 
 Any new properties, usually added in python code, should be declared
-first.  If the property doesn't exist in the dynamic class, it will be
+first. If the property doesn't exist in the dynamic class, it will be
 automatically created as an :class:`~kivy.properties.ObjectProperty`
 (pre 1.8.0) or as an appropriate typed property (from version
 1.8.0).

--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -83,7 +83,7 @@ Create a file in your `HOME/.kivy/mods`, and create 2 functions::
         pass
 
 Start/stop are functions that will be called for every window opened in
-Kivy.  When you are starting a module, you can use these to store and
+Kivy. When you are starting a module, you can use these to store and
 manage the module state. Use the `ctx` variable as a dictionary. This
 context is unique for each instance/start() call of the module, and will
 be passed to stop() too.

--- a/kivy/storage/__init__.py
+++ b/kivy/storage/__init__.py
@@ -67,7 +67,7 @@ asynchronous version.
 
 For example, the *get* method has a `callback` parameter. If set, the
 `callback` will be used to return the result to the user when available:
-the request will be asynchronous.  If the `callback` is None, then the
+the request will be asynchronous. If the `callback` is None, then the
 request will be synchronous and the result will be returned directly.
 
 

--- a/kivy/tests/test_audio.py
+++ b/kivy/tests/test_audio.py
@@ -63,5 +63,3 @@ class AudioPygameTestCase(AudioTestCase):
     def make_sound(self, source):
         from kivy.core.audio import audio_pygame
         return audio_pygame.SoundPygame(source)
-
-

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -110,6 +110,3 @@ class FBOInstructionTestCase(unittest.TestCase):
         import os
         if os.path.exists('results.png'):
             os.unlink('results.png')
-
-
-

--- a/kivy/tools/pep8checker/pep8kivy.py
+++ b/kivy/tools/pep8checker/pep8kivy.py
@@ -60,7 +60,8 @@ if __name__ == '__main__':
     exclude_dirs = ['/lib', '/coverage', '/pep8', '/doc']
     exclude_files = ['kivy/gesture.py', 'osx/build.py', 'win32/build.py',
                      'kivy/tools/stub-gl-debug.py',
-                     'kivy/modules/webdebugger.py']
+                     'kivy/modules/webdebugger.py',
+                     'kivy/modules/_webdebugger.py']
     for target in targets:
         if isdir(target):
             if htmlmode:

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -30,7 +30,7 @@ Example::
     :attr:`Carousel.scroll_distance`.
 
     In addition, the container used for adding a slide is now hidden in
-    the API.  We made a mistake by exposing it to the user. The impacted
+    the API. We made a mistake by exposing it to the user. The impacted
     properties are:
     :attr:`Carousel.slides`, :attr:`Carousel.current_slide`,
     :attr:`Carousel.previous_slide` and :attr:`Carousel.next_slide`.

--- a/kivy/uix/listview.py
+++ b/kivy/uix/listview.py
@@ -794,13 +794,13 @@ class ListView(AbstractView, EventDispatcher):
     :class:`~kivy.uix.abstractview.AbstractView` class.
 
     :class:`~kivy.uix.listview.ListView` also subclasses
-    :class:`EventDispatcher` for scrolling.  The event *on_scroll_complete* is
+    :class:`EventDispatcher` for scrolling. The event *on_scroll_complete* is
     used in refreshing the main view.
 
     For a simple list of string items, without selection, use
     :class:`~kivy.adapters.simplelistadapter.SimpleListAdapter`. For list items
     that respond to selection, ranging from simple items to advanced
-    composites, use :class:`~kivy.adapters.listadapter.ListAdapter`.  For an
+    composites, use :class:`~kivy.adapters.listadapter.ListAdapter`. For an
     alternate powerful adapter, use
     :class:`~kivy.adapters.dictadapter.DictAdapter`, rounding out the choice
     for designing highly interactive lists.

--- a/kivy/uix/pagelayout.py
+++ b/kivy/uix/pagelayout.py
@@ -27,7 +27,6 @@ areas on the right or left hand side. If you wish to display multiple widgets
 in a page, we suggest you use a containing layout. Ideally, each page should
 consist of a single :mod:`~kivy.uix.layout` widget that contains the remaining
 widgets on that page.
-            
 """
 
 __all__ = ('PageLayout', )

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -118,7 +118,8 @@ class Popup(ModalView):
     defaults to '14sp'.
     '''
 
-    title_align = OptionProperty('left', options=['left', 'center', 'right','justify'])
+    title_align = OptionProperty('left',
+                                 options=['left', 'center', 'right', 'justify'])
     '''Horizontal alignment of the title.
 
     .. versionadded:: 1.9.0

--- a/kivy/uix/relativelayout.py
+++ b/kivy/uix/relativelayout.py
@@ -233,7 +233,7 @@ This also applies to the position of sub-widgets. Instead of positioning a
     Prior to version 1.7.0, the :class:`RelativeLayout` was implemented as a
     :class:`~kivy.uix.floatlayout.FloatLayout` inside a
     :class:`~kivy.uix.scatter.Scatter`. This behaviour/widget has
-    been renamed to `ScatterLayout`.  The :class:`RelativeLayout` now only
+    been renamed to `ScatterLayout`. The :class:`RelativeLayout` now only
     supports relative positions (and can't be rotated, scaled or translated on
     a multitouch system using two or more fingers). This was done so that the
     implementation could be optimized and avoid the heavier calculations of

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -170,7 +170,7 @@ You can easily switch transitions by changing the
 
     Currently, none of Shader based Transitions use
     anti-aliasing. This is because they use the FBO which doesn't have
-    any logic to handle supersampling.  This is a known issue and we
+    any logic to handle supersampling. This is a known issue and we
     are working on a transparent implementation that will give the
     same results as if it had been rendered on screen.
 

--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -210,9 +210,8 @@ class StackLayout(Layout):
         sizes = []
         for c in reversed(self.children):
             if c.size_hint[outerattr]:
-                c.size[outerattr] = max(
-                    1, c.size_hint[outerattr] *
-                       (selfsize[outerattr] - padding_v))
+                c.size[outerattr] = max(1,
+                    c.size_hint[outerattr] * (selfsize[outerattr] - padding_v))
 
             # does the widget fit in the row/column?
             ccount = len(lc)

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -658,7 +658,7 @@ class TextInput(FocusBehavior, Widget):
         .. versionadded:: 1.3.0
 
         This action re-does any command that has been un-done by
-        do_undo/ctrl+z.  This function is automatically called when
+        do_undo/ctrl+z. This function is automatically called when
         `ctrl+r` keys are pressed.
         '''
         try:


### PR DESCRIPTION
Fix spacing, ending whitespace, and long lines in many files.   Most were issues of having two spaces after the
end of a sentence inside documentation.   Added _webdebugger.py to the ignore list.   'make style' now does have any warnings.