### PR TITLE
Video fixes

### DIFF
--- a/kivy/core/image/img_ffpyplayer.py
+++ b/kivy/core/image/img_ffpyplayer.py
@@ -24,7 +24,7 @@ logger_func = {'quiet': Logger.critical, 'panic': Logger.critical,
 def _log_callback(message, level):
     message = message.strip()
     if message:
-        logger_func[level]('ImageLoaderFFPy: {}'.format(message))
+        logger_func[level]('ffpyplayer: {}'.format(message))
 
 if not get_log_callback():
     set_log_callback(_log_callback)

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -77,6 +77,9 @@ def _log_callback(message, level):
     if message:
         logger_func[level]('ffpyplayer: {}'.format(message))
 
+if not get_log_callback():
+    set_log_callback(_log_callback)
+
 
 class VideoFFPy(VideoBase):
 
@@ -102,13 +105,8 @@ class VideoFFPy(VideoBase):
         self._thread = None
         self._next_frame = None
         self._ffplayer_need_quit = False
-        self._log_callback_set = False
         self._callback_ref = WeakMethod(self._player_callback)
         self._trigger = Clock.create_trigger(self._redraw)
-
-        if not get_log_callback():
-            set_log_callback(_log_callback)
-            self._log_callback_set = True
 
         super(VideoFFPy, self).__init__(**kwargs)
 

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -309,6 +309,7 @@ class VideoFFPy(VideoBase):
                 loglevel='info', ff_opts=ff_opts)
 
         self._thread = Thread(target=self._next_frame_run, name='Next frame')
+        self._thread.daemon = True
         self._thread.start()
 
     def load(self):

--- a/kivy/tests/test_video.py
+++ b/kivy/tests/test_video.py
@@ -10,9 +10,10 @@ class AnimationTestCase(unittest.TestCase):
         from kivy.uix.video import Video
         from kivy.clock import Clock
         from kivy.base import runTouchApp, stopTouchApp
-        from os.path import join, dirname
+        from os.path import join, dirname, abspath
         here = dirname(__file__)
-        source = join(here, "..", "..", "examples", "widgets", "softboy.avi")
+        source = abspath(join(
+            here, "..", "..", "examples", "widgets", "softboy.mpg"))
         video = Video(source=source, play=True)
         Clock.schedule_once(lambda x: stopTouchApp(), 1)
 

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -129,7 +129,7 @@ class Video(Image):
 
     def __init__(self, **kwargs):
         self._video = None
-        super(Image, self).__init__(**kwargs)
+        super(Video, self).__init__(**kwargs)
         self.bind(source=self._trigger_video_load)
 
         if "eos" in kwargs:


### PR DESCRIPTION
- Fixes an bad super call in uix/video which resulted in the incorrect super being called.
- Fixes a filepath issue with video test.
- Fixes ffpyplayer to use a daemon thread, otherwise kivy doesn't exit if you don't unload directly.
- Fixes ffpyplayer (img and video) to keep forwarding logs to kivy.