### PR TITLE
Modify Makefile's 'make style' to check entire tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,10 @@ html-embedded:
 	$(MAKE) -C doc html
 
 style:
-	$(PYTHON) $(CHECKSCRIPT) $(KIVY_DIR)
+	$(PYTHON) $(CHECKSCRIPT) .
 
 stylereport:
-	$(PYTHON) $(CHECKSCRIPT) -html $(KIVY_DIR)
+	$(PYTHON) $(CHECKSCRIPT) -html .
 
 hook:
 	# Install pre-commit git hook to check your changes for styleguide


### PR DESCRIPTION
The makefile targets 'style' and 'stylereport' had only checked
the kivy/ directory.  This allowed style errors to creep into
the examples/ directory.   Now 'style' will check all python
files from the kivy root directory, excluding those
explicitly ignored in kivy/tools/pep8checker/pep8kivy.py.