### PR TITLE
Fixed the get_pos method(tested with two files).

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -644,7 +644,6 @@ class ClockBase(_ClockBase):
 ClockBase.time.__doc__ = '''Proxy method for time.time() or time.clock(), 
 whichever is more suitable for the running OS'''
     
-
 def mainthread(func):
     '''Decorator that will schedule the call of the function for the next
     available frame in the mainthread. It can be useful when you use

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -211,7 +211,7 @@ __all__ = ('Clock', 'ClockBase', 'ClockEvent', 'mainthread')
 
 from sys import platform
 from os import environ
-from functools import wraps,partial
+from functools import wraps, partial
 from kivy.context import register_context
 from kivy.weakmethod import WeakMethod
 from kivy.config import Config
@@ -643,7 +643,6 @@ class ClockBase(_ClockBase):
 
 ClockBase.time.__doc__ = '''Proxy method for time.time() or time.clock(), 
 whichever is more suitable for the running OS'''
-# creates a static object
     
 
 def mainthread(func):

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -639,6 +639,14 @@ class ClockBase(_ClockBase):
                     if event in events:
                         event.tick(self._last_tick, remove)
 
+    @staticmethod
+    def time():
+        '''Decorated staticmethod time returns the value of object _default_time
+        which stores the value of current time which is most accurate based on
+        the operating system being used. It is the time used by kivy clock.
+        '''
+        return _default_time()
+
 
 def mainthread(func):
     '''Decorator that will schedule the call of the function for the next

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -211,7 +211,7 @@ __all__ = ('Clock', 'ClockBase', 'ClockEvent', 'mainthread')
 
 from sys import platform
 from os import environ
-from functools import wraps
+from functools import wraps,partial
 from kivy.context import register_context
 from kivy.weakmethod import WeakMethod
 from kivy.config import Config
@@ -639,14 +639,12 @@ class ClockBase(_ClockBase):
                     if event in events:
                         event.tick(self._last_tick, remove)
 
-    @staticmethod
-    def time():
-        '''Decorated staticmethod time returns the value of object _default_time
-        which stores the value of current time which is most accurate based on
-        the operating system being used. It is the time used by kivy clock.
-        '''
-        return _default_time()
+    time = staticmethod(partial(_default_time))
 
+ClockBase.time.__doc__ = '''Proxy method for time.time() or time.clock(), 
+whichever is more suitable for the running OS'''
+# creates a static object
+    
 
 def mainthread(func):
     '''Decorator that will schedule the call of the function for the next

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -34,12 +34,7 @@ class SoundPygame(Sound):
     # SoundPygame object. Otherwise, it failed with:
     # TypeError: cannot create weak reference to 'SoundPygame' object
     # We use our clock in play() method.
-    # __slots__ = ('_data', '_channel')
-    # The get_pos method uses Clock.time imported from time module.
-    # It is essentially the same time as used in kivy clock.
-    # The play function stores the start time into the sound object when called.
-    # The get_pos function returns the difference of current_time and start_time.
-    
+    # __slots__ = ('_data', '_channel')    
     @staticmethod
     def extensions():
         if _platform == 'android':
@@ -69,10 +64,10 @@ class SoundPygame(Sound):
             return
         self._data.set_volume(self.volume)
         self._channel = self._data.play()
+        self.start_time = Clock.time()
         # schedule event to check if the sound is still playing or not
         Clock.schedule_interval(self._check_play, 0.1)
         super(SoundPygame, self).play()
-        self.start_time = Clock.time()
 
     def stop(self):
         if not self._data:
@@ -100,10 +95,10 @@ class SoundPygame(Sound):
             self._channel.seek(position)
 
     def get_pos(self):
-        if self._data is not None:
-            time_now = Clock.time()
-            if _platform == 'android' and self._channel:
+        if self._data is not None and self._channel:
+            if _platform == 'android':
                 return self._channel.get_pos()
+            time_now = Clock.time()
             return  time_now - self.start_time
         return 0
 

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -27,8 +27,6 @@ mixer.pre_init(44100, -16, 2, 1024)
 mixer.init()
 mixer.set_num_channels(32)
 
-start_time = 0.0
-
 class SoundPygame(Sound):
 
     # XXX we don't set __slots__ here, to automaticly add

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -34,7 +34,7 @@ class SoundPygame(Sound):
     # SoundPygame object. Otherwise, it failed with:
     # TypeError: cannot create weak reference to 'SoundPygame' object
     # We use our clock in play() method.
-    # __slots__ = ('_data', '_channel')    
+    # __slots__ = ('_data', '_channel')
     @staticmethod
     def extensions():
         if _platform == 'android':

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -35,7 +35,7 @@ class SoundPygame(Sound):
     # TypeError: cannot create weak reference to 'SoundPygame' object
     # We use our clock in play() method.
     # __slots__ = ('_data', '_channel')
-    # The get_pos method uses ClockBase.time imported from time module.
+    # The get_pos method uses Clock.time imported from time module.
     # It is essentially the same time as used in kivy clock.
     # The play function stores the start time into the sound object when called.
     # The get_pos function returns the difference of current_time and start_time.

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -27,7 +27,7 @@ mixer.pre_init(44100, -16, 2, 1024)
 mixer.init()
 mixer.set_num_channels(32)
 
-start_time = _default_time()
+start_time = 0.0
 
 class SoundPygame(Sound):
 
@@ -69,7 +69,7 @@ class SoundPygame(Sound):
         # schedule event to check if the sound is still playing or not
         Clock.schedule_interval(self._check_play, 0.1)
         super(SoundPygame, self).play()
-        start_time = _default_time()
+        self.start_time = _default_time()
 
     def stop(self):
         if not self._data:
@@ -101,7 +101,7 @@ class SoundPygame(Sound):
             time_now = _default_time()
             if _platform == 'android' and self._channel:
                 return self._channel.get_pos()
-            return  time_now - start_time
+            return  time_now - self.start_time
         return 0
 
     def on_volume(self, instance, volume):

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -4,7 +4,6 @@ AudioPygame: implementation of Sound with Pygame
 
 __all__ = ('SoundPygame', )
 
-from kivy.clock import ClockBase
 from kivy.clock import Clock
 from kivy.utils import platform
 from kivy.core.audio import Sound, SoundLoader
@@ -73,7 +72,7 @@ class SoundPygame(Sound):
         # schedule event to check if the sound is still playing or not
         Clock.schedule_interval(self._check_play, 0.1)
         super(SoundPygame, self).play()
-        self.start_time = ClockBase.time()
+        self.start_time = Clock.time()
 
     def stop(self):
         if not self._data:
@@ -102,7 +101,7 @@ class SoundPygame(Sound):
 
     def get_pos(self):
         if self._data is not None:
-            time_now = ClockBase.time()
+            time_now = Clock.time()
             if _platform == 'android' and self._channel:
                 return self._channel.get_pos()
             return  time_now - self.start_time

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -4,6 +4,7 @@ AudioPygame: implementation of Sound with Pygame
 
 __all__ = ('SoundPygame', )
 
+from kivy.clock import _default_time
 from kivy.clock import Clock
 from kivy.utils import platform
 from kivy.core.audio import Sound, SoundLoader
@@ -26,6 +27,7 @@ mixer.pre_init(44100, -16, 2, 1024)
 mixer.init()
 mixer.set_num_channels(32)
 
+start_time = _default_time()
 
 class SoundPygame(Sound):
 
@@ -67,6 +69,7 @@ class SoundPygame(Sound):
         # schedule event to check if the sound is still playing or not
         Clock.schedule_interval(self._check_play, 0.1)
         super(SoundPygame, self).play()
+        start_time = _default_time()
 
     def stop(self):
         if not self._data:
@@ -95,9 +98,10 @@ class SoundPygame(Sound):
 
     def get_pos(self):
         if self._data is not None:
+            time_now = _default_time()
             if _platform == 'android' and self._channel:
                 return self._channel.get_pos()
-            return mixer.music.get_pos()
+            return  time_now - start_time
         return 0
 
     def on_volume(self, instance, volume):

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -27,6 +27,7 @@ mixer.pre_init(44100, -16, 2, 1024)
 mixer.init()
 mixer.set_num_channels(32)
 
+
 class SoundPygame(Sound):
 
     # XXX we don't set __slots__ here, to automaticly add

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -4,7 +4,7 @@ AudioPygame: implementation of Sound with Pygame
 
 __all__ = ('SoundPygame', )
 
-from kivy.clock import _default_time
+from kivy.clock import ClockBase
 from kivy.clock import Clock
 from kivy.utils import platform
 from kivy.core.audio import Sound, SoundLoader
@@ -36,6 +36,11 @@ class SoundPygame(Sound):
     # TypeError: cannot create weak reference to 'SoundPygame' object
     # We use our clock in play() method.
     # __slots__ = ('_data', '_channel')
+    # The get_pos method uses ClockBase.time imported from time module.
+    # It is essentially the same time as used in kivy clock.
+    # The play function stores the start time into the sound object when called.
+    # The get_pos function returns the difference of current_time and start_time.
+    
     @staticmethod
     def extensions():
         if _platform == 'android':
@@ -68,7 +73,7 @@ class SoundPygame(Sound):
         # schedule event to check if the sound is still playing or not
         Clock.schedule_interval(self._check_play, 0.1)
         super(SoundPygame, self).play()
-        self.start_time = _default_time()
+        self.start_time = ClockBase.time()
 
     def stop(self):
         if not self._data:
@@ -97,7 +102,7 @@ class SoundPygame(Sound):
 
     def get_pos(self):
         if self._data is not None:
-            time_now = _default_time()
+            time_now = ClockBase.time()
             if _platform == 'android' and self._channel:
                 return self._channel.get_pos()
             return  time_now - self.start_time

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -98,8 +98,7 @@ class SoundPygame(Sound):
         if self._data is not None and self._channel:
             if _platform == 'android':
                 return self._channel.get_pos()
-            time_now = Clock.time()
-            return  time_now - self.start_time
+            return  Clock.time() - self.start_time
         return 0
 
     def on_volume(self, instance, volume):


### PR DESCRIPTION
Previously the get_pos method used to return pygame.mixer.music.get_pos() which does not work on mixer.sound objects. It has been changed to return (time_now - self. start_time) which is a float value. The time used is the one in kivy (from kivy.clock import _default_time). This is the code I used to test it.   https://gist.github.com/rastogiachyut/aff9b2eeeba2e8c212c4