### PR TITLE
Keep `make build` the default proxy for `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,25 +31,6 @@ endif
 
 .PHONY: build force mesabuild pdf style stylereport hook test batchtest cover clean distclean theming
 
-help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  build          for a standard build"
-	@echo "  clean          remove generated and compiled files"
-	@echo "  cover          create an html coverage report of unittests"
-	@echo "  debug          for a debug build (with -g)"
-	@echo "  dist-clean     clean then use 'git clean'"
-	@echo "  force          for a forced build (with -f)"
-	@echo "  hook           add Pep-8 checking as a git precommit hook"
-	@echo "  html           to make standalone HTML files"
-	@echo "  install        run a setup.py install"
-	@echo "  mesabuild      for a build with MesaGL"
-	@echo "  style          to check Python code for style hints."
-	@echo "  style-report   make html version of style hints"
-	@echo "  test           run unittests (nosetests)"
-	@echo "  theming        create a default theme atlas"
-	@echo "  "
-	@echo "You can also 'cd doc && make help' to build more documentation types"
-
 build:
 	$(PYTHON) setup.py $(BUILD_OPTS)
 
@@ -136,3 +117,22 @@ endif
 
 theming:
 	$(PYTHON) -m kivy.atlas kivy/data/images/defaulttheme 512 kivy/tools/theming/defaulttheme/*.png
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  build          for a standard build"
+	@echo "  clean          remove generated and compiled files"
+	@echo "  cover          create an html coverage report of unittests"
+	@echo "  debug          for a debug build (with -g)"
+	@echo "  dist-clean     clean then use 'git clean'"
+	@echo "  force          for a forced build (with -f)"
+	@echo "  hook           add Pep-8 checking as a git precommit hook"
+	@echo "  html           to make standalone HTML files"
+	@echo "  install        run a setup.py install"
+	@echo "  mesabuild      for a build with MesaGL"
+	@echo "  style          to check Python code for style hints."
+	@echo "  style-report   make html version of style hints"
+	@echo "  test           run unittests (nosetests)"
+	@echo "  theming        create a default theme atlas"
+	@echo "  "
+	@echo "You can also 'cd doc && make help' to build more documentation types"


### PR DESCRIPTION
https://github.com/kivy/kivy/commit/58af726d4e53b8cdf6b716ae58c0b4ebe29fd7bc changed the default behavior of our `make` command from `make build` to `make help`.
This pr restores the original behavior.