### PR TITLE
core/text: allow others font extension to be loaded

### DIFF
--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -97,8 +97,9 @@ cdef TTF_Font *_get_font(self):
     # try first the file if it's a filename
     fontname = self.options['font_name_r']
     bytes_fontname = <bytes>fontname.encode('utf-8')
-    ext = fontname.split('.')[-1]
-    if ext.lower() == 'ttf':
+    ext = fontname.rsplit('.', 1)
+    if len(ext) == 2:
+        # try to open the fount if it has an extension
         fontobject = TTF_OpenFont(bytes_fontname,
                                   int(self.options['font_size']))
 

--- a/kivy/core/text/text_pygame.py
+++ b/kivy/core/text/text_pygame.py
@@ -43,9 +43,9 @@ class LabelPygame(LabelBase):
             # try first the file if it's a filename
             font_handle = fontobject = None
             fontname = self.options['font_name_r']
-            ext = fontname.split('.')[-1]
-            if ext.lower() == 'ttf':
-                # fontobject
+            ext = fontname.rsplit('.', 1)
+            if len(ext) == 2:
+                # try to open the font if it has an extension
                 font_handle = open(fontname, 'rb')
                 fontobject = pygame.font.Font(font_handle,
                                               int(self.options['font_size']))

--- a/kivy/core/text/text_sdlttf.pyx
+++ b/kivy/core/text/text_sdlttf.pyx
@@ -106,8 +106,8 @@ cdef TTF_Font *_get_font(self):
     if fontid not in pygame_cache:
         # try first the file if it's a filename
         fontname = self.options['font_name_r']
-        ext = fontname.split('.')[-1]
-        if ext.lower() == 'ttf':
+        ext = fontname.rsplit('.', 1)
+        if len(ext) == 2:
             fontobject = TTF_OpenFont(fontname, int(self.options['font_size']))
 
         # fallback to search a system font


### PR DESCRIPTION
Freetype itself supports much more than ttf: otf, woff, etc.
See the full list at http://www.freetype.org/freetype2/

It can prevent sdl2 issue like this when you load otf: 

```
 Exception AssertionError in 'kivy.core.text._text_sdl2._get_font' ignored
There are 0 joysticks available
```
