### PR TITLE
gallery - Avoid rewriting unchanged files.

### DIFF
--- a/doc/gallery.py
+++ b/doc/gallery.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-''' Create rst documentaiton of the examples directory.
+''' Create rst documentation of the examples directory.
 
 This uses screenshots in the screenshots_dir
 (currently doc/sources/images/examples) along with source code and files
@@ -280,7 +280,16 @@ def make_detail_page(info):
 
 
 def write_file(name, s):
-    ''' write the string to the filename '''
+    ''' write the string to the filename, unless the file is unchanged. '''
+    try:
+        with open(name) as f:
+            old_s = ''
+            old_s = f.read()
+            if old_s == s:
+                return
+    except IOError:
+        pass
+
     with open(name, 'w') as f:
         f.write(s)
 

--- a/kivy/tests/test_doc_gallery.py
+++ b/kivy/tests/test_doc_gallery.py
@@ -1,14 +1,49 @@
+import unittest
 from doc.gallery import *
+import time
+import os
+
+class Test_write_duplicates(unittest.TestCase):
+    def safe_remove(self, filename):
+        try:
+            os.unlink(filename)
+        except OSError:
+            pass
+
+    def setUp(self):
+        self.safe_remove('gallery1.txt')
+        self.safe_remove('gallery2.txt')
+
+    def tearDown(self):
+        self.safe_remove('gallery1.txt')
+        self.safe_remove('gallery2.txt')
+
+    def test_write_duplicates(self):
+        start_time = time.time()
+        def is_new(filename):
+            mod_time = os.path.getmtime(filename)
+            return mod_time - start_time > 1.0
+        s = "This is a\nmultiline file."
+        write_file('gallery1.txt', s)
+        time.sleep(2)  # yes, slows down running tests.  Can't be helped.
+        write_file('gallery1.txt', s)
+        assert not is_new('gallery1.txt'), 'Should ignore exact rewrite'
+        write_file('gallery2.txt', s)
+        assert is_new('gallery2.txt'), 'Should write new file'
+        write_file('gallery1.txt', 'Something different')
+        assert is_new('gallery1.txt'), 'Should write new content'
 
 
-def test_parse_docstring_info():
-    assert 'error' in parse_docstring_info("No Docstring")
-    assert 'error' in parse_docstring_info("'''No Docstring Title'''")
-    assert 'error' in parse_docstring_info("'''No Sentence\n======\nPeriods'''")
-    assert 'error' in parse_docstring_info(
-        "'\nSingle Quotes\n===\n\nNo singles.'")
+class Test_parse_docstring_info(unittest.TestCase):
 
-    d = parse_docstring_info("""'''
+    def test_parse_docstring_info(self):
+        assert 'error' in parse_docstring_info("No Docstring")
+        assert 'error' in parse_docstring_info("'''No Docstring Title'''")
+        assert 'error' in parse_docstring_info("'''No Sentence\n======\nPeriods'''")
+        assert 'error' in parse_docstring_info(
+            "'\nSingle Quotes\n===\n\nNo singles.'")
+
+        d = parse_docstring_info("""'''
 3D Rendering Monkey Head
 ========================
 
@@ -24,11 +59,9 @@ a simple vertex and fragment shader written in GLSL.
 '''
 blah blah
 blah blah
-""")
-    assert 'error' not in d
-    assert '3D Rendering' in d['docstring'] and 'This example' in d['docstring']
-    assert '3D Rendering' in d['title']
-    assert 'monkey head' in d['first_sentence']
+    """)
+        assert 'error' not in d
+        assert '3D Rendering' in d['docstring'] and 'This example' in d['docstring']
+        assert '3D Rendering' in d['title']
+        assert 'monkey head' in d['first_sentence']
 
-if __name__ == '__main__':
-    test_parse_docstring_info()


### PR DESCRIPTION
Rewriting unchanged files causes the ‘make html’ and sphinx to waste
time rebuilding every example page.   Added code to skip writing
unchanged files and associated UnitTest test case.

Diff got confused here, as I converted the existing test case from nose to UnitTest.
Now at MaxPR.
