### PR TITLE
Use distutils for cython version comparision.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,6 @@
 # http://kivy.org/
 #
 
-MIN_CYTHON_VERSION = (0, 20, 0)
-MIN_CYTHON_STRING = '.'.join(map(str, MIN_CYTHON_VERSION))
-MAX_CYTHON_VERSION = (0, 21, 1)
-MAX_CYTHON_STRING = '.'.join(map(str, MAX_CYTHON_VERSION))
-
 import sys
 
 from copy import deepcopy
@@ -16,7 +11,14 @@ from os.path import join, dirname, sep, exists, basename
 from os import walk, environ
 from distutils.core import setup
 from distutils.extension import Extension
+from distutils.version import LooseVersion
 from collections import OrderedDict
+
+
+MIN_CYTHON_STRING = '0.20.0'
+MIN_CYTHON_VERSION = LooseVersion(MIN_CYTHON_STRING)
+MAX_CYTHON_STRING = '0.21.1'
+MAX_CYTHON_VERSION = LooseVersion(MAX_CYTHON_STRING)
 
 if sys.version > '3':
     PY3 = True
@@ -112,13 +114,13 @@ else:
         have_cython = True
         import Cython
         cy_version_str = Cython.__version__
-        cy_version = tuple(map(int, cy_version_str.split('.')))
+        cy_ver = LooseVersion(cy_version_str)
         print('\nDetected Cython version {}'.format(cy_version_str))
-        if cy_version < MIN_CYTHON_VERSION:
+        if cy_ver < MIN_CYTHON_VERSION:
             print('  This version of Cython is not compatible with Kivy. ' +
                   'Please upgrade to at least {}'.format(MIN_CYTHON_STRING))
             raise ImportError('Incompatible Cython Version')
-        if cy_version > MAX_CYTHON_VERSION:
+        if cy_ver > MAX_CYTHON_VERSION:
             print('  This version of Cython is untested with Kivy. If you ' +
                   'experience issues, please downgrade to {}'
                   .format(MAX_CYTHON_STRING))


### PR DESCRIPTION
Fixes #3003 (well, at least it won't raise an error... Hopefully, LooseVersion is the correct cython version format).