### PR TITLE
Joystick support on WindowPygame

### DIFF
--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -333,6 +333,23 @@ class WindowPygame(WindowBase):
                 self._mouse_down = eventname == 'on_mouse_down'
                 self.dispatch(eventname, x, y, btn, self.modifiers)
 
+            # joystick action
+            elif event.type == pygame.JOYAXISMOTION:
+                self.dispatch('on_joy_axis', event.joy, event.axis, event.value)
+
+            elif event.type == pygame.JOYHATMOTION:
+                self.dispatch('on_joy_hat', event.joy, event.hat, event.value)
+
+            elif event.type == pygame.JOYBALLMOTION:
+                self.dispatch('on_joy_ball', event.joy, event.ballid,
+                            event.rel[0], event.rel[1])
+
+            elif event.type == pygame.JOYBUTTONDOWN:
+                self.dispatch('on_joy_button_down', event.joy, event.button)
+
+            elif event.type == pygame.JOYBUTTONUP:
+                self.dispatch('on_joy_button_up', event.joy, event.button)
+
             # keyboard action
             elif event.type in (pygame.KEYDOWN, pygame.KEYUP):
                 self._pygame_update_modifiers(event.mod)


### PR DESCRIPTION
Joystick event implementation added to enable joystick on desktop platforms running WindowPygame.
Code deeply inspired by WindowSDL2 joystick event implementation.

Regards,
Laurent