### PR TITLE
Fixed filechooser path incorrectly updated when going to parent directory

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -263,7 +263,6 @@ class FileChooserController(FloatLayout):
             root is refreshed.
         `on_subentry_to_entry`: entry, parent
             Fired when a sub-entry is added to an existing entry.
-        `on_remove_subentry`: entry, parent
             Fired when entries are removed from an entry, usually when
             a node is closed.
         `on_submit`: selection, touch
@@ -576,6 +575,7 @@ class FileChooserController(FloatLayout):
             # parent directory
             if entry.path == "../":
                 self.path = abspath(join(self.path, pardir))
+                self.selection = []
             else:
                 self.path = join(self.path, entry.path)
                 self.selection = []

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -50,7 +50,7 @@ from kivy.properties import (
 from os import listdir
 from os.path import (
     basename, join, sep, normpath, expanduser, altsep,
-    splitdrive, realpath, getsize, isdir)
+    splitdrive, realpath, getsize, isdir, abspath, pardir)
 from fnmatch import fnmatch
 import collections
 
@@ -572,8 +572,13 @@ class FileChooserController(FloatLayout):
         except OSError:
             entry.locked = True
         else:
-            self.path = join(self.path, entry.path)
-            self.selection = []
+            # If entry.path is to jump to previous directory, update path with
+            # parent directory
+            if entry.path == "../":
+                self.path = abspath(join(self.path, pardir))
+            else:
+                self.path = join(self.path, entry.path)
+                self.selection = []
 
     def _apply_filters(self, files):
         if not self.filters:


### PR DESCRIPTION
In the current version of FileChooser, the path attribute does not seem to properly update when selecting the parent ("../") directory. I often use a Label on top of the FileChooser widget showing the current path, and everytime I clicked on the "../" item to go to the parent directory, this would append the string "../" to the path. For example, if I wanted to go to the parent directory from my home ("/home/diogo"), I would get this on my label: "/home/diogo/../". This would also create errors when opening files with the "../" strings on the path. This issue can be replicated using a slightly modified version of the basic filechooser widget in kivy/uix/filechooser.py - https://gist.github.com/ODiogoSilva/ef7d78551c89e6c636d6

This commit seems to have fixed things for me, though I only tested it on Linux.