### PR TITLE
move TextInput handles/bubble to window with transformation

### DIFF
--- a/kivy/uix/relativelayout.py
+++ b/kivy/uix/relativelayout.py
@@ -265,6 +265,10 @@ class RelativeLayout(FloatLayout):
     def to_local(self, x, y, **k):
         return (x - self.x, y - self.y)
 
+    def _apply_transform(self, m):
+        m.translate(self.x, self.y, 0)
+        return super(RelativeLayout, self)._apply_transform(m)
+
     def on_touch_down(self, touch):
         x, y = touch.x, touch.y
         touch.push()

--- a/kivy/uix/scatter.py
+++ b/kivy/uix/scatter.py
@@ -390,6 +390,10 @@ class Scatter(Widget):
         p = self.transform_inv.transform_point(x, y, 0)
         return (p[0], p[1])
 
+    def _apply_transform(self, m):
+        m = self.transform.multiply(m)
+        return super(Scatter, self)._apply_transform(m)
+
     def apply_transform(self, trans, post_multiply=False, anchor=(0, 0)):
         '''
         Transforms the scatter by applying the "trans" transformation

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -536,6 +536,12 @@ class ScrollView(StencilView):
         tx, ty = self.g_translate.xy
         return x + tx, y + ty
 
+    def _apply_transform(self, m):
+        tx, ty = self.g_translate.xy
+        m.translate(tx, ty, 0)
+        m.translate(self.x, self.y, 0)
+        return super(ScrollView, self)._apply_transform(m)
+
     def simulate_touch_down(self, touch):
         # at this point the touch is in parent coords
         touch.push()

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -244,6 +244,9 @@ class Selector(ButtonBehavior, Image):
         touch.apply_transform_2d(lambda x, y: matrix.transform_point(x, y, 0)[:2])
 
     def on_window_touch_down(self, win, touch):
+        if self.parent is not win:
+            return
+
         try:
             touch.push()
             self.transform_touch(touch)

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -164,6 +164,7 @@ propogated before taking action. You can use the
                 return super(MyLabel, self).on_touch_down(touch)
 
 '''
+from kivy.graphics.transformation import Matrix
 
 __all__ = ('Widget', 'WidgetException')
 
@@ -808,6 +809,24 @@ class Widget(WidgetBase):
         if relative:
             return (x - self.x, y - self.y)
         return (x, y)
+
+    def _apply_transform(self, m):
+        return self.parent._apply_transform(m) if self.parent else m
+
+    def get_window_matrix(self, x=0, y=0):
+        '''Calculate the transformation matrix to convert between window and
+        widget coordinates.
+
+        :Parameters:
+            `x`: float, defaults to 0
+                Translates the matrix on the x axis.
+            `y`: float, defaults to 0
+                Translates the matrix on the y axis.
+        '''
+        m = Matrix()
+        m.translate(self.x + x, self.y + y, 0)
+        m = self._apply_transform(m)
+        return m
 
     x = NumericProperty(0)
     '''X position of the widget.


### PR DESCRIPTION
Fixes #2939. Moves rendering of the handles and bubble back to the Window, but provides the appropriate transformations. I set up RelativeLayout, Scatter and ScrollView to apply transformations; if other widgets cause similar transformations they will need to override _apply_transform().