### PR TITLE
Fixed two bugs with incompatibilities with python3 in hidinput.py.

### DIFF
--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -590,8 +590,8 @@ else:
             fd = open(input_fn, 'rb')
 
             # get the controler name (EVIOCGNAME)
-            device_name = fcntl.ioctl(fd, EVIOCGNAME + (256 << 16),
-                                      " " * 256).split('\x00')[0]
+            device_name = str(fcntl.ioctl(fd, EVIOCGNAME + (256 << 16),
+                                      " " * 256)).split('\x00')[0]
             Logger.info('HIDMotionEvent: using <%s>' % device_name)
 
             # get abs infos
@@ -670,7 +670,7 @@ else:
                     break
 
                 # extract each event
-                for i in range(len(data) / struct_input_event_sz):
+                for i in range(int(len(data) / struct_input_event_sz)):
                     ev = data[i * struct_input_event_sz:]
 
                     # extract timeval + event infos


### PR DESCRIPTION
First was on line 593. Second was 673.

First:  Return result of fcntl.ioctl needs to convert to string first.

Second: Simple, range (float) doesn't work. In py2 this would have worked since int/int is int, while py3 int/int is float

Found when trying to run Kivy App on Raspberry Pi with compiled Cython 0.20.1 and compiled Python 3.4