### PR TITLE
more general css selectors for kv rules

### DIFF
--- a/kivy/css_selectors.py
+++ b/kivy/css_selectors.py
@@ -192,8 +192,7 @@ class IdSelector(FilterSelectorBase):
     op = "#"
 
     def match(self, elt):
-        name = self.name
-        return name == elt.id
+        return self.name == elt.id
 
 
 class PrecedenceSelector(SelectorBase):

--- a/kivy/css_selectors.py
+++ b/kivy/css_selectors.py
@@ -22,6 +22,23 @@ late (too late for rule selection), class selectors and id selectors also
 consult the information stored in the rule responsible for creatng the widget.
 If that information can be evaluated statically, then it can influence rule
 selection (presence of an `id` or `cls` property).
+
+After rule selection has occurred, the selected rules will also be used to
+get more precise information about `id` and `cls` before they have taken effect
+on the widget.  In this fashion, the context for descendent widgets becomes
+more precise.
+
+If you don't use contextual rules, nothing changes.  However, if you do, then
+the rule match cache is deactivated; it probably won't have a measurable
+incidence on your application, but "caveat emptor!".
+
+A widget that is created from Python code, rather than in from a kv-lang
+specification, does not have a context in which to evaluate contextual rules
+that might or might not apply to it.  For this reason, the :class:`Widget`
+constructor also accepts a `css_ctx` keyword parameter whose value maybe
+either the intended :class:`Widget` parent or an explicit :class:`CSSCtx`
+instance describing the hierarchy into which the new widget will be
+inserted.
 '''
 import re
 

--- a/kivy/css_selectors.py
+++ b/kivy/css_selectors.py
@@ -14,6 +14,78 @@ of a widget whose python class inherits from `B` and whose `cls` property has
 elements `p1`and `p2`, and which itself is a descendant of a widget whose Python
 class inherits from `A`.
 
+Here is a (not very good) example::
+
+    ScreenManager:
+        Screen:
+            id: one
+        Screen:
+            id: two
+    
+    <Screen>:
+        id: screen
+        BoxLayout:
+            orientation: "vertical"
+            id: screen-layout
+            Label:
+                id: banner
+                size_hint: 1,None
+                height: dp(50)
+            Button:
+                id: button1
+                screen: screen
+    
+    <<Screen#one>>:
+        name: "un"
+    
+    <<Screen#two>>:
+        name: "deux"
+    
+    <<Screen#one Label#banner>>:
+        text: "Screen 1"
+    
+    <<Screen#two Label#banner>>:
+        text: "Screen 2"
+    
+    <<Screen#one Button#button1>>:
+        text: "To Screen 2"
+        on_release:
+            root.screen.manager.transition.direction = "left"
+            root.screen.manager.current = "deux"
+    
+    <<Screen#two Button#button1>>:
+        text: "To Screen 1"
+        on_release:
+            root.screen.manager.transition.direction = "right"
+            root.screen.manager.current = "un"
+
+
+It is also possible to use nesting of contextual rules: a nested contextual
+rule inherits as a prefix the css selectors of the contextual rules it is
+nested in.  For example, the above contextual rules could also equivalently
+be written as follows::
+
+    <<Screen#one>>:
+        name: "un"
+        <<Label#banner>>:
+            text: "Screen 1"
+        <<Button#button1>>:
+            text: "To Screen 2"
+            on_release:
+                root.screen.manager.transition.direction = "left"
+                root.screen.manager.current = "deux"
+    
+    <<Screen#two>>:
+        name: "deux"
+        <<Label#banner>>:
+            text: "Screen 2"
+        <<Button#button1>>:
+            text: "To Screen 1"
+            on_release:
+                root.screen.manager.transition.direction = "right"
+                root.screen.manager.current = "un"
+
+
 Caveats
 -------
 

--- a/kivy/css_selectors.py
+++ b/kivy/css_selectors.py
@@ -1,0 +1,226 @@
+'''CSS-like Rule Selectors
+=======================
+
+The Kivy language allows you to write rules that may be selected depending
+on context.  These rules use a very small subset of CSS3 selectors.  For
+example::
+
+    <<A B.p1.p2 > C *#i3>>:
+        ...
+
+Such a rule applies to any (`*`) widget with `id=i3`, that is a descendant of a
+widget whose Python class inherits from `C`, which itself is an immediate child
+of a widget whose python class inherits from `B` and whose `cls` property has
+elements `p1`and `p2`, and which itself is a descendant of a widget whose Python
+class inherits from `A`.
+
+Caveats
+-------
+
+Since widgets, created from kv-lang specifications, get their properties very
+late (too late for rule selection), class selectors and id selectors also
+consult the information stored in the rule responsible for creatng the widget.
+If that information can be evaluated statically, then it can influence rule
+selection (presence of an `id` or `cls` property).
+'''
+import re
+
+SELECTOR_ID = "#."
+SELECTOR_OP = ">*"
+SELECTOR_CHARS = SELECTOR_ID + SELECTOR_OP
+RE_SELECTOR = re.compile(r"([%s]|\w[\w_-]*)\s*" % SELECTOR_CHARS)
+
+def parse_css_selector(s):
+    pos = 0
+    tokens = []
+    for m in RE_SELECTOR.finditer(s):
+        if m.start() != pos:
+            raise Exception("in selector <%s> unexpected: %s" % (s, s[pos:m.start()]))
+        pos = m.end()
+        tok = m.group(1)
+        tokens.append(m.group(1))
+    if pos != len(s):
+        raise Exception("in selector <%s> unexpected: %s" % (s, s[pos:]))
+
+    selectors = []
+    element_selector = None
+    immediate_precedence = False
+    new_element_selector = None
+    new_filter_selector = None
+
+    i = 0
+    imax = len(tokens)
+
+    while i < imax:
+        tokA = tokens[i]
+        i += 1
+        
+        if tokA == "*":
+            new_element_selector = AnySelector()
+        elif tokA == "#":
+            if i >= imax:
+                raise Exception("in selector <%s>, missing ID after `#'" % s)
+            name = tokens[i]
+            i += 1
+            new_filter_selector = IdSelector(name)
+        elif tokA == ".":
+            if i >= imax:
+                raise Exception("in selector <%s>, missing ID after `.'" % s)
+            name = tokens[i]
+            i += 1
+            new_filter_selector = ClassSelector(name)
+        elif tokA == ">":
+            if immediate_precedence:
+                raise Exception("in selector <%s>, two > in a row" % s)
+            immediate_precedence = True
+            element_selector = None
+            continue
+        else:
+            new_element_selector = NameSelector(tokA)
+
+        if new_filter_selector:
+            if not element_selector:
+                element_selector = new_element_selector = AnySelector()
+            element_selector.add_filter(new_filter_selector)
+            new_filter_selector = None
+
+        if new_element_selector:
+            if immediate_precedence:
+                immediate_precedence = False
+                if selectors:
+                    selectors.append(NextSelector())
+            elif selectors:
+                selectors.append(SkipSelector())
+            selectors.append(new_element_selector)
+            element_selector = new_element_selector
+            new_element_selector = None
+
+    # build the chain of continuations
+    head = tail = selectors.pop()
+    while selectors:
+        curr = selectors.pop()
+        tail._next = curr
+        tail = curr
+
+    return head
+
+
+class SelectorBase(object):
+
+    def __init__(self):
+        self._next = None
+
+    def match_next(self, ctx, i):
+        n = self._next
+        return not n or n.match(ctx, i)
+
+
+class ElementSelectorBase(SelectorBase):
+
+    css_selector = True
+
+    def __init__(self):
+        super(ElementSelectorBase, self).__init__()
+        self.filters = []
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return "<%s %s%s -> %s>" % (type(self).__name__, str(self), "".join(map(str,self.filters)), 
+                                    repr(self._next) if self._next else "ACCEPT")
+
+    def add_filter(self, filter):
+        self.filters.append(filter)
+
+    def match_next(self, ctx, i):
+        elt = ctx[i]
+        for f in self.filters:
+            if not f.match(elt):
+                return False
+        return super(ElementSelectorBase, self).match_next(ctx, i)
+
+
+class AnySelector(ElementSelectorBase):
+
+    name = "*"
+
+    def match(self, ctx, i):
+        return self.match_next(ctx, i)
+
+
+class NameSelector(ElementSelectorBase):
+
+    def __init__(self, name):
+        super(NameSelector, self).__init__()
+        self.name = name
+
+    def match(self, ctx, i):
+        elt = ctx[i]
+        classes = type(elt.widget).__mro__
+        name = self.name
+        for c in classes:
+            if c.__name__ == name:
+                return self.match_next(ctx, i)
+            elif c.__name__ == "Widget":
+                break
+        return False
+
+
+class FilterSelectorBase(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return "%s%s" % (self.op, self.name)
+
+    def __repr__(self):
+        return "<%s %s>" % (type(self).__name__, str(self))
+
+
+class ClassSelector(FilterSelectorBase):
+
+    op = "."
+
+    def match(self, elt):
+        return self.name in elt.cls
+
+
+class IdSelector(FilterSelectorBase):
+
+    op = "#"
+
+    def match(self, elt):
+        name = self.name
+        return name == elt.id
+
+
+class PrecedenceSelector(SelectorBase):
+
+    def __repr__(self):
+        return "<%s -> %s>" % (type(self).__name__, repr(self._next) if self._next else "ACCEPT")
+    
+
+class SkipSelector(PrecedenceSelector):
+
+    def __str__(self):
+        return ">"
+
+    def match(self, ctx, i):
+        # match using backtracking.
+        # we could also compile into a DFA, but would that be worth it?
+        while i > 0:
+            i -= 1
+            if self.match_next(ctx, i):
+                return True
+        return False
+
+
+class NextSelector(PrecedenceSelector):
+
+    def __str__(self):
+        return " "
+
+    def match(self, ctx, i):
+        return i > 0 and self.match_next(ctx, i-1)

--- a/kivy/css_selectors.py
+++ b/kivy/css_selectors.py
@@ -151,9 +151,9 @@ class ElementSelectorBase(SelectorBase):
         self.filters.append(filter)
 
     def match_next(self, ctx, i):
-        elt = ctx[i]
+        widget = ctx[i]
         for f in self.filters:
-            if not f.match(elt):
+            if not f.match(widget):
                 return False
         return super(ElementSelectorBase, self).match_next(ctx, i)
 
@@ -173,8 +173,8 @@ class NameSelector(ElementSelectorBase):
         self.name = name
 
     def match(self, ctx, i):
-        elt = ctx[i]
-        classes = type(elt.widget).__mro__
+        widget = ctx[i]
+        classes = type(widget).__mro__
         name = self.name
         for c in classes:
             if c.__name__ == name:
@@ -200,16 +200,16 @@ class ClassSelector(FilterSelectorBase):
 
     op = "."
 
-    def match(self, elt):
-        return self.name in elt.cls
+    def match(self, widget):
+        return self.name in widget.cls
 
 
 class IdSelector(FilterSelectorBase):
 
     op = "#"
 
-    def match(self, elt):
-        return self.name == elt.id
+    def match(self, widget):
+        return self.name == widget.id
 
 
 class PrecedenceSelector(SelectorBase):

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -816,7 +816,7 @@ Cache.register('kv.lang')
 __KV_INCLUDES__ = []
 
 # precompile regexp expression
-lang_str = re.compile('([\'"][^\'"]*[\'"])')
+lang_str = re.compile('(\'(?:[^\'"]|\\.)*\'|"(?:[^\'"]|\\.)*")')
 lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile('([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile('(_\()')

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -1885,8 +1885,8 @@ class BuilderBase(object):
                 self.files.append(fn)
 
             if parser.root:
-                widget = Factory.get(parser.root.name)()
-                self._apply_rule(widget, parser.root, parser.root)
+                widget = Factory.get(parser.root.name)(__no_builder=True)
+                self.apply(widget, parser.root, parser.root)
                 return widget
         finally:
             self._current_filename = None

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -268,7 +268,7 @@ class Widget(WidgetBase):
         if '__no_builder' not in kwargs:
             #current_root = Builder.idmap.get('root')
             #Builder.idmap['root'] = self
-            Builder.apply(self)
+            Builder.apply(self, css_ctx=kwargs.get('css_ctx', None))
             #if current_root is not None:
             #    Builder.idmap['root'] = current_root
             #else:


### PR DESCRIPTION
I would like some feedback on a prototype for a pure extension to kv-lang introducing css-like contextual selectors for kv rules. 

The new contextual rule selectors are enclosed in `<< ... >>` which makes them entirely separate from existing selectors.  Here is an example selector:

```
 <<A B.p1.p2 > C *#i3>>
```

Such a rule applies to any (`*`) widget with `id=i3`, that is a descendant of a widget whose Python class inherits from `C`, which itself is an immediate child of a widget whose python class inherits from `B` and whose `cls` property has elements `p1`and `p2`, and which itself is a descendant of a widget whose Python
class inherits from `A`.

Since widgets get their properties constrained fairly late in the build process, contextual selection uses statically evaluable properties `id` and `cls` of rules whenever possible and as early as possible.

An advantage of this extension is that you can more easily modularize your design: you can provide a common pattern as a rule that is instantiated many time, and contextual rules to specialize that pattern for each instantiation.

Here is a (not very good) example:

```
ScreenManager:
    Screen:
        id: one
    Screen:
        id: two

<Screen>:
    id: screen
    BoxLayout:
        orientation: "vertical"
        id: screen-layout
        Label:
            id: banner
            size_hint: 1,None
            height: dp(50)
        Button:
            id: button1
            screen: screen

<<Screen#one>>:
    name: "un"

<<Screen#two>>:
    name: "deux"

<<Screen#one Label#banner>>:
    text: "Screen 1"

<<Screen#two Label#banner>>:
    text: "Screen 2"

<<Screen#one Button#button1>>:
    text: "To Screen 2"
    on_release:
        root.screen.manager.transition.direction = "left"
        root.screen.manager.current = "deux"

<<Screen#two Button#button1>>:
    text: "To Screen 1"
    on_release:
        root.screen.manager.transition.direction = "right"
        root.screen.manager.current = "un"
```
