### PR TITLE
fix animation with new WeakProxy objects

### DIFF
--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -87,7 +87,7 @@ from math import sqrt, cos, sin, pi
 from kivy.event import EventDispatcher
 from kivy.clock import Clock
 from kivy.compat import string_types, iterkeys
-from weakref import ProxyType
+from kivy.weakproxy import WeakProxy
 
 
 class Animation(EventDispatcher):
@@ -312,7 +312,7 @@ class Animation(EventDispatcher):
             anim = widgets[uid]
             widget = anim['widget']
 
-            if isinstance(widget, ProxyType) and not len(dir(widget)):
+            if isinstance(widget, WeakProxy) and not len(dir(widget)):
                 # empty proxy, widget is gone. ref: #2458
                 del widgets[uid]
                 continue

--- a/kivy/weakproxy.pyx
+++ b/kivy/weakproxy.pyx
@@ -29,7 +29,10 @@ cdef class WeakProxy(object):
             return self.__ref__().__class__
 
     def __dir__(self):
-        return dir(self.__ref__())
+        r = self.__ref()
+        if not r:
+            return []
+        return dir(r)
 
     def __reversed__(self):
         return reversed(self.__ref__())
@@ -276,14 +279,14 @@ cdef class WeakProxy(object):
         return iter(self.__ref__())
 
     def __bytes__(self):
-        return bytes(self.__ref__())
+        return bytes(self.__ref())
 
     def __str__(self):
-        return str(self.__ref__())
+        return str(self.__ref())
 
     def __unicode__(self):
-        return unicode(self.__ref__())
+        return unicode(self.__ref())
 
     def __repr__(self):
-        return b'<WeakProxy to {!r}>'.format(self.__ref__())
+        return b'<WeakProxy to {!r}>'.format(self.__ref())
 


### PR DESCRIPTION
Fixes failing tests. The failed tests incorrectly report as random App tests, but the actual failing tests are the Animation tests. Since Animation was checking if the object is a ProxyType it didn't detect the WeakProxy and thought the object was still alive. The error didn't present itself until later, when App tests are run causing the Clock to start ticking again.