### PR TITLE
Don't create a prop named popup in content. Fixes 3103.

### DIFF
--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -185,9 +185,6 @@ class Popup(ModalView):
             super(Popup, self).add_widget(widget)
 
     def on_content(self, instance, value):
-        if not hasattr(value, 'popup'):
-            value.create_property('popup')
-        value.popup = self
         if self._container:
             self._container.clear_widgets()
             self._container.add_widget(value)


### PR DESCRIPTION
Fixes #3103.