### PR TITLE
make icons scale properly in actionbar

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -573,6 +573,7 @@
     color: self.color[:3] + [0 if (root.icon and not root.inside_group) else 1]
 
     Image:
+        allow_stretch: True
         opacity: 1 if (root.icon and not root.inside_group) else 0
         source: root.icon
         mipmap: root.mipmap
@@ -590,22 +591,26 @@
     size_hint_x: 1
     minimum_width: '100sp'
     important: True
+    previous_image_width: dp(prev_icon_image.texture_size[0])
+    app_icon_width: dp(app_icon_image.texture_size[0])
     BoxLayout:
         orientation: 'horizontal'
         pos: root.pos
         size: root.size
         Image:
+            id: prev_icon_image
             source: root.previous_image
             opacity: 1 if root.with_previous else 0
             allow_stretch: True
             size_hint_x: None
-            width: self.texture_size[0] if root.with_previous else dp(8)
+            width: root.previous_image_width if root.with_previous else dp(8)
             mipmap: root.mipmap
         Image:
+            id: app_icon_image
             source: root.app_icon
             allow_stretch: True
             size_hint_x: None
-            width: min(self.height, self.texture_size[0]) if self.texture else self.height
+            width: root.app_icon_width if self.texture else self.height
             mipmap: root.mipmap
         Widget:
             size_hint_x: None

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -591,8 +591,6 @@
     size_hint_x: 1
     minimum_width: '100sp'
     important: True
-    previous_image_width: dp(prev_icon_image.texture_size[0])
-    app_icon_width: dp(app_icon_image.texture_size[0])
     BoxLayout:
         orientation: 'horizontal'
         pos: root.pos
@@ -603,14 +601,18 @@
             opacity: 1 if root.with_previous else 0
             allow_stretch: True
             size_hint_x: None
-            width: root.previous_image_width if root.with_previous else dp(8)
+            width:
+                (root.previous_image_width or self.height) \
+                if root.with_previous else dp(8)
             mipmap: root.mipmap
         Image:
             id: app_icon_image
             source: root.app_icon
             allow_stretch: True
             size_hint_x: None
-            width: root.app_icon_width if self.texture else self.height
+            width:
+                (root.app_icon_width or self.height) \
+                if self.texture else self.height
             mipmap: root.mipmap
         Widget:
             size_hint_x: None

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -587,6 +587,10 @@
 <ActionCheck>:
     background_normal: 'atlas://data/images/defaulttheme/action_bar' if self.inside_group else 'atlas://data/images/defaulttheme/action_item'
 
+<ActionPreviousImage@Image>:
+    temp_width: 0
+    temp_height: 0
+
 <ActionPrevious>:
     size_hint_x: 1
     minimum_width: '100sp'
@@ -595,24 +599,30 @@
         orientation: 'horizontal'
         pos: root.pos
         size: root.size
-        Image:
+        ActionPreviousImage:
             id: prev_icon_image
             source: root.previous_image
             opacity: 1 if root.with_previous else 0
             allow_stretch: True
             size_hint_x: None
+            temp_width: root.previous_image_width or dp(prev_icon_image.texture_size[0])
+            temp_height: root.previous_image_height or dp(prev_icon_image.texture_size[1])
             width:
-                (root.previous_image_width or self.height) \
-                if root.with_previous else dp(8)
+                (self.temp_width if self.temp_height <= self.height else \
+                self.temp_width * (self.height / self.temp_height)) \
+                if self.texture else dp(8)
             mipmap: root.mipmap
-        Image:
+        ActionPreviousImage:
             id: app_icon_image
             source: root.app_icon
             allow_stretch: True
             size_hint_x: None
+            temp_width: root.app_icon_width or dp(app_icon_image.texture_size[0])
+            temp_height: root.app_icon_height or dp(app_icon_image.texture_size[1])
             width:
-                (root.app_icon_width or self.height) \
-                if self.texture else self.height
+                (self.temp_width if self.temp_height <= self.height else \
+                self.temp_width * (self.height / self.temp_height)) \
+                if self.texture else dp(8)
             mipmap: root.mipmap
         Widget:
             size_hint_x: None

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -157,12 +157,20 @@ class ActionPrevious(ActionButton):
        'data/logo/kivy-icon-32.png'.
     '''
 
+    app_icon_width = NumericProperty(10)
+    '''Width of app_icon image.
+    '''
+
     previous_image = StringProperty(
         'atlas://data/images/defaulttheme/previous_normal')
     '''Image for the 'previous' ActionButtons default graphical representation.
 
        :attr:`previous_image` is a :class:`~kivy.properties.StringProperty` and
        defaults to 'atlas://data/images/defaulttheme/previous_normal'.
+    '''
+
+    previous_image_width = NumericProperty(10)
+    '''Width of previous_image image.
     '''
 
     title = StringProperty('')

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -161,6 +161,10 @@ class ActionPrevious(ActionButton):
     '''Width of app_icon image.
     '''
 
+    app_icon_height = NumericProperty(0)
+    '''Height of app_icon image.
+    '''
+
     previous_image = StringProperty(
         'atlas://data/images/defaulttheme/previous_normal')
     '''Image for the 'previous' ActionButtons default graphical representation.
@@ -171,6 +175,10 @@ class ActionPrevious(ActionButton):
 
     previous_image_width = NumericProperty(0)
     '''Width of previous_image image.
+    '''
+
+    previous_image_height = NumericProperty(0)
+    '''Height of previous_image image.
     '''
 
     title = StringProperty('')

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -157,7 +157,7 @@ class ActionPrevious(ActionButton):
        'data/logo/kivy-icon-32.png'.
     '''
 
-    app_icon_width = NumericProperty(10)
+    app_icon_width = NumericProperty(0)
     '''Width of app_icon image.
     '''
 
@@ -169,7 +169,7 @@ class ActionPrevious(ActionButton):
        defaults to 'atlas://data/images/defaulttheme/previous_normal'.
     '''
 
-    previous_image_width = NumericProperty(10)
+    previous_image_width = NumericProperty(0)
     '''Width of previous_image image.
     '''
 


### PR DESCRIPTION
When I used the actionbar on my note4, the icons appeared extremely tiny.  This patch fixes the issue for me while also making the icon-sizing kv-parametrable.