### PR TITLE
The type of data is converted to bytes from str for packing

### DIFF
--- a/kivy/lib/osc/OSC.py
+++ b/kivy/lib/osc/OSC.py
@@ -179,7 +179,7 @@ def OSCArgument(data):
 
     if isinstance(data, string_types):
         OSCstringLength = math.ceil((len(data)+1) / 4.0) * 4
-        binary = struct.pack(">%ds" % (OSCstringLength), data)
+        binary = struct.pack(">i%ds" % (OSCstringLength), bytes(data, 'utf-8')
         tag = "s"
     elif isinstance(data, float):
         binary = struct.pack(">f", data)


### PR DESCRIPTION
According to documentation of format for struct.pack(fmt, val1,val2..) , the argument for ">s" must be a "bytes" object and not string (https://docs.python.org/3.2/library/struct.html#format-characters ). 
 