### PR TITLE
Fixes 3120 Credit to @merriam

### DIFF
--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -38,7 +38,7 @@ from kivy.base import EventLoop
 from kivy.logger import Logger
 from functools import partial
 from weakref import ref
-from time import clock, time
+from time import time
 import string
 
 # When we are generating documentation, Config doesn't exist
@@ -1177,11 +1177,11 @@ class CompoundSelectionBehavior(object):
             keys.append(scancode[1])
         else:
             if scancode[1] in self._printable:
-                if clock() - self._last_key_time <= 1.:
+                if time() - self._last_key_time <= 1.:
                     self._word_filter += scancode[1]
                 else:
                     self._word_filter = scancode[1]
-                self._last_key_time = clock()
+                self._last_key_time = time()
                 node, idx = self.goto_node(self._word_filter, node_src,
                                            idx_src)
             else:


### PR DESCRIPTION
The keyboard input would clump characters together in a continuously
growing stream instead of timing out after a seond.  That is, typing
’12’, pausing, then typing ’34’ would register as a single string
‘1234’.   This showed up in the widgets/compound_selection.py example
and possible in issues with keyboard recognition problems.  The issue
is that time.clock() returns a vaguely defined ‘time on processor’
whereas time.time() is the number of seconds.