### PR TITLE
introduce ActionGroup.dropdown_width property

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -265,6 +265,10 @@ class ActionGroup(ActionItem, Spinner):
        defaults to 'normal'.
     '''
 
+    dropdown_width = NumericProperty(0)
+    '''If non zero, provides the width for the associated DropDown.
+    '''
+
     def __init__(self, **kwargs):
         self.list_action_item = []
         self._list_overflow_items = []
@@ -307,7 +311,7 @@ class ActionGroup(ActionItem, Spinner):
         children = ddn.container.children
 
         if children:
-            ddn.width = max([self.width, children[0].minimum_width])
+            ddn.width = self.dropdown_width or max([self.width, children[0].minimum_width])
         else:
             ddn.width = self.width
 

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -267,6 +267,9 @@ class ActionGroup(ActionItem, Spinner):
 
     dropdown_width = NumericProperty(0)
     '''If non zero, provides the width for the associated DropDown.
+    This is useful when some items to be displayed in the ActionGroup's
+    DropDown are wider than usual and you don't want to make the ActionGroup
+    widget itself wider.
     '''
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This patch adds the dropdown_width property to ActionGroup and makes it easy to accommodate a dropdown list with wide items.  Full disclosure: it is already possible (but imho much less intuitive) to do something similar using the minimum_width property on the LAST item.
