### PR TITLE
fix in OSC.py:OSCArgument TypeError: str() takes at most 1 argument (2 given) for python 2.*

### DIFF
--- a/kivy/lib/osc/OSC.py
+++ b/kivy/lib/osc/OSC.py
@@ -179,7 +179,10 @@ def OSCArgument(data):
 
     if isinstance(data, string_types):
         OSCstringLength = math.ceil((len(data)+1) / 4.0) * 4
-        binary = struct.pack(">i%ds" % (OSCstringLength), bytes(data, 'utf-8'))
+        if sys.version_info >= (3, 0):
+            binary = struct.pack(">i%ds" % (OSCstringLength), bytes(data, 'utf-8'))
+        else:
+            binary = struct.pack(">%ds" % (OSCstringLength), bytes(data))
         tag = "s"
     elif isinstance(data, float):
         binary = struct.pack(">f", data)


### PR DESCRIPTION
when you try to send a message to the OSC in python 2

The following error:
```
python OSC.py 
[INFO   ] [Logger      ] Record log in /home/smglab/.kivy/logs/kivy_15-03-13_13.txt
[DEBUG  ] [Cache       ] register <kv.image> with limit=None, timeout=60s
[DEBUG  ] [Cache       ] register <kv.atlas> with limit=None, timeout=Nones
[INFO   ] [Image       ] Providers: img_tex, img_dds, img_gif, img_sdl2, img_pil (img_ffpyplayer ignored)
[DEBUG  ] [Cache       ] register <kv.texture> with limit=1000, timeout=60s
[DEBUG  ] [Cache       ] register <kv.shader> with limit=1000, timeout=3600s
[INFO   ] [Factory     ] 173 symbols loaded
[DEBUG  ] [Cache       ] register <kv.lang> with limit=None, timeout=Nones
[INFO   ] [Text        ] Provider: sdl2
[DEBUG  ] [Cache       ] register <textinput.label> with limit=None, timeout=60.0s
[DEBUG  ] [Cache       ] register <textinput.width> with limit=None, timeout=60.0s
[INFO   ] [Kivy        ] v1.9.0-dev
[INFO   ] [Python      ] v2.7.6 (default, Mar 22 2014, 22:59:56) 
[GCC 4.8.2]
57 65 6c 63 6f 6d 65 20 'Welcome '
74 6f 20 74 68 65 20 4f 'to the O'
53 43 20 74 65 73 74 69 'SC testi'
6e 67 20 70 72 6f 67 72 'ng progr'
61 6d 2e ('           ', "'ram.'")
()
 Traceback (most recent call last):
   File "OSC.py", line 326, in <module>
     message.append("the white cliffs of dover")
   File "OSC.py", line 85, in append
     binary = OSCArgument(argument)
   File "OSC.py", line 182, in OSCArgument
     binary = struct.pack(">i%ds" % OSCstringLength, bytes(data, 'utf-8'))
 TypeError: str() takes at most 1 argument (2 given)
```