### PR TITLE
Add maximized, minimized and hidden config options to the graphics section

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -239,7 +239,7 @@ Available configuration tokens
     is required for value changes to take effect.
 
 .. versionchanged:: 1.9.0
-    `borderless`, `maximized`, `minimized` and `hidden` has been added
+    `borderless`, `maximized`, `minimized` and `hidden` have been added
     to the graphics section.
     The `fake` option of `fullscreen` in the graphics section has been
     deprecated, use the `borderless` option instead.

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -113,7 +113,16 @@ Available configuration tokens
 
 :graphics:
     `borderless`: int , one of 0 or 1
-        If set to `1`, removes the window border/decoration.
+        If set to `1`, it removes the window border/decoration.
+    `maximized`: int , one of 0 or 1
+        If set to `1`, it maximizes the window. This option is available only
+        for the SDL2 window provider and it should be used on desktop OSes.
+    `minimized`: int , one of 0 or 1
+        If set to `1`, it minimizes the window. This option is available only
+        for the SDL2 window provider and it should be used on desktop OSes.
+    `hidden`: int , one of 0 or 1
+        If set to `1`, it hides the window. This option is available only
+        for the SDL2 window provider and it should be used on desktop OSes.
     `fbo`: string, one of 'hardware', 'software' or 'force-hardware'
         Selects the FBO backend to use.
     `fullscreen`: int or string, one of 0, 1, 'fake' or 'auto'
@@ -230,7 +239,8 @@ Available configuration tokens
     is required for value changes to take effect.
 
 .. versionchanged:: 1.9.0
-    `borderless` has been added to the graphics section.
+    `borderless`, `maximized`, `minimized` and `hidden` has been added
+    to the graphics section.
     The `fake` option of `fullscreen` in the graphics section has been
     deprecated, use the `borderless` option instead.
     `pause_on_minimize` has been added to the kivy section.
@@ -274,7 +284,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 12
+KIVY_CONFIG_VERSION = 13
 
 Config = None
 '''Kivy configuration object. Its :attr:`~kivy.config.ConfigParser.name` is
@@ -743,6 +753,11 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 11:
             Config.setdefault('kivy', 'pause_on_minimize', '0')
+
+        elif version == 12:
+            Config.setdefault('graphics', 'maximized', '0')
+            Config.setdefault('graphics', 'minimized', '0')
+            Config.setdefault('graphics', 'hidden', '0')
 
         #elif version == 1:
         #   # add here the command for upgrading from configuration 0 to 1

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -19,7 +19,8 @@ cdef class _WindowSDL2Storage:
         raise RuntimeError(<bytes> SDL_GetError())
 
     def setup_window(self, x, y, width, height, borderless, fullscreen,
-                     resizable, shaped=False):
+                     resizable, maximized, minimized, hidden, is_desktop,
+                     shaped=False):
         self.win_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN
         if resizable:
             self.win_flags |= SDL_WINDOW_RESIZABLE
@@ -29,6 +30,13 @@ cdef class _WindowSDL2Storage:
             self.win_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP
         elif fullscreen is True:
             self.win_flags |= SDL_WINDOW_FULLSCREEN
+        if is_desktop:
+            if maximized:
+                self.win_flags |= SDL_WINDOW_MAXIMIZED
+            elif minimized:
+                self.win_flags |= SDL_WINDOW_MINIMIZED
+            elif hidden:
+                self.win_flags |= SDL_WINDOW_HIDDEN
 
         if SDL_Init(SDL_INIT_VIDEO| SDL_INIT_JOYSTICK) < 0:
             self.die()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -144,9 +144,13 @@ class WindowSDL(WindowBase):
             # setup !
             w, h = self._size
             resizable = Config.getboolean('graphics', 'resizable')
+            maximized = Config.getboolean('graphics', 'maximized')
+            minimized = Config.getboolean('graphics', 'minimized')
+            hidden = Config.getboolean('graphics', 'hidden')
             gl_size = self._win.setup_window(pos[0], pos[1], w, h,
                                              self.borderless, self.fullscreen,
-                                             resizable)
+                                             resizable, maximized, minimized,
+                                             hidden, self._is_desktop)
             # never stay with a None pos, application using w.center
             # will be fired.
             self._pos = (0, 0)


### PR DESCRIPTION
This is a continuation of https://github.com/kivy/kivy/pull/2590 and should fix https://github.com/kivy/kivy/issues/1456.

For some reason `minimized` has no effect on Debian Jessie with Gnome, but `Window.minimize()` works regardless.

```python
from kivy.config import Config
Config.set('graphics', 'maximized', 1)
# Config.set('graphics', 'minimized', 1)
# Config.set('graphics', 'hidden', 1)

# from kivy.core.window import Window
# Window.minimize()

from kivy.app import App
from kivy.uix.button import Button


class TestApp(App):
    def build(self):
        return Button()

if __name__ == '__main__':
    TestApp().run()
```