### PR TITLE
clear the Window.canvas in setUp for GraphicUnitTest (partial fix for  #3130)

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -69,6 +69,7 @@ class GraphicUnitTest(unittest.TestCase):
 
         # ensure our window is correcly created
         Window.create_window()
+        Window.canvas.clear()
 
     def on_window_flip(self, window):
         '''Internal method to be called when the window have just displayed an


### PR DESCRIPTION
This fixes the bleeding issues between graphics tests reported in  #3130 for pygame.  The totally messed up output for SDL2 is unchanged.