### PR TITLE
prevent spurious resize with SDL2

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -92,7 +92,8 @@ cdef class _WindowSDL2Storage:
         SDL_GetWindowDisplayMode(self.win, &mode)
 
     def resize_window(self, w, h):
-        SDL_SetWindowSize(self.win, w, h)
+        if self.window_size != [w, h]:
+            SDL_SetWindowSize(self.win, w, h)
 
     def maximize_window(self):
         SDL_MaximizeWindow(self.win)
@@ -260,6 +261,11 @@ cdef class _WindowSDL2Storage:
         cdef SDL_Surface *flipped_surface = flipVert(surface)
         IMG_SavePNG(flipped_surface, real_filename)
 
+    property window_size:
+        def __get__(self):
+            cdef int w, h
+            SDL_GetWindowSize(self.win, &w, &h)
+            return [w, h]
 
 
 # Based on the example at


### PR DESCRIPTION
Fixes bug with resizing SDL2 window in Gnome Shell.