### PR TITLE
ButtonBehavior `release_on_exit` Bool

### DIFF
--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -149,11 +149,12 @@ class ButtonBehavior(object):
         touch.ungrab(self)
         self.last_touch = touch
         
-        if not self.release_on_exit:
+        if (not self.release_on_exit
+             and not self.collide_point(*touch.pos)):
             self.state = 'normal'
             return
 
-        touchtime = time() - self.__touch_timei
+        touchtime = time() - self.__touch_time
         if touchtime < self.MIN_STATE_TIME:
             self.__state_event = Clock.schedule_once(
                 self._do_release, self.MIN_STATE_TIME - touchtime)

--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -89,6 +89,16 @@ class ButtonBehavior(object):
     :attr:`MIN_STATE_TIME` is a float.
     '''
 
+    release_on_exit = BooleanProperty(True)
+    '''This determines if the widget fires a `on_release` event if
+    the touch_up is outside the widget.
+
+    ..versionadded:: 1.9.0  
+
+    :attr:`release_on_exit` is a :class:`~kivy.properties.BooleanProperty`,
+    defaults to `True`.
+    '''
+
     def __init__(self, **kwargs):
         self.register_event_type('on_press')
         self.register_event_type('on_release')
@@ -138,7 +148,12 @@ class ButtonBehavior(object):
         assert(self in touch.ud)
         touch.ungrab(self)
         self.last_touch = touch
-        touchtime = time() - self.__touch_time
+        
+        if not self.release_on_exit:
+            self.state = 'normal'
+            return
+
+        touchtime = time() - self.__touch_timei
         if touchtime < self.MIN_STATE_TIME:
             self.__state_event = Clock.schedule_once(
                 self._do_release, self.MIN_STATE_TIME - touchtime)


### PR DESCRIPTION
Set this to False to stop `on_release` from firing when touch is outside the widget when released.