### PR TITLE
fix scaling for border image

### DIFF
--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -876,13 +876,17 @@ cdef class BorderImage(Rectangle):
         tb[2] = b2 / th * tch
         tb[3] = b3 / tw * tcw
 
-
+        cdef float sb0, sb1, sb2, sb3
+        sb0 = min((b0/th) * h, b0)
+        sb1 = min((b1/tw) * w, b1)
+        sb2 = min((b2/th) * h, b2)
+        sb3 = min((b3/tw) * w, b3)
         # horizontal and vertical sections
         cdef float hs[4]
         cdef float vs[4]
         hs[0] = x;            vs[0] = y
-        hs[1] = x + b3;       vs[1] = y + b0
-        hs[2] = x + w - b1;   vs[2] = y + h - b2
+        hs[1] = x + sb3;       vs[1] = y + sb0
+        hs[2] = x + w - sb1;   vs[2] = y + h - sb2
         hs[3] = x + w;        vs[3] = y + h
 
         cdef float ths[4]


### PR DESCRIPTION
Currently if the value of borders greatly exceeds the size of the image on rendering we can get some very odd results:
With the default image:
1's size is 10, 10
2's size is 25, 25
however they appear roughly the same size. The issue appears even more obvious if we use a very large button graphic.

If the image is being displayed much smaller than its true size we want to find the normalized size of the borders values and then scale them by the actual size being displayed, however we never want to exceed the original value of borders.

![example1](https://cloud.githubusercontent.com/assets/1936976/6755196/f5e8bb88-cee6-11e4-8c94-95f1317ca596.png)

After changes:
![example2](https://cloud.githubusercontent.com/assets/1936976/6755233/30d2529a-cee7-11e4-8240-0f265c7dae6a.png)

Test code:

```python
from kivy.app import App
from kivy.lang import Builder
from kivy.factory import Factory
from kivy.uix.floatlayout import FloatLayout

kv = """
<Test>:
    Button:
        text: '1'
        size_hint: (None, None)
        pos: 50, 50
        size: 10, 10
    Button:
        text: '2'
        size_hint: (None, None)
        pos: 80, 45
        size: 25, 25
    Button:
        text: '1'
        size_hint: (None, None)
        pos: 150, 50
        background_normal: 'big_button.png'
        size: 400, 400
        border: [125, 125, 125, 125]
    Button:
        text: '2'
        size_hint: (None, None)
        background_normal: 'big_button.png'
        pos: 550, 350
        size: 200, 200
        border: [125, 125, 125, 125]

"""

Builder.load_string(kv)


class Test(FloatLayout):
    def __init__(self, *args, **kwargs):
        super(Test, self).__init__(*args, **kwargs)

class TestApp(App):
    def build(self):
        return Test()

if __name__ == '__main__':
    TestApp().run()
```
test large button:
![big_button](https://cloud.githubusercontent.com/assets/1936976/6755248/464a975e-cee7-11e4-9454-9dd5bdcfa3f0.png)
