### PR TITLE
Open store as b.

### DIFF
--- a/kivy/storage/dictstore.py
+++ b/kivy/storage/dictstore.py
@@ -37,7 +37,7 @@ class DictStore(AbstractStore):
             return
         if not exists(self.filename):
             return
-        with open(self.filename, 'r') as fd:
+        with open(self.filename, 'rb') as fd:
             data = fd.read()
             if data:
                 self._data = pickle.loads(data)
@@ -48,7 +48,7 @@ class DictStore(AbstractStore):
         if not self._is_changed:
             return
 
-        with open(self.filename, 'w') as fd:
+        with open(self.filename, 'wb') as fd:
             pickle.dump(self._data, fd)
 
         self._is_changed = False


### PR DESCRIPTION
Fixes test in py3:

```py
ERROR: test_dict_storage (kivy.tests.test_storage.StorageTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kivy/Buildbot-3.3/tests-lin-py3/build/kivy/tests/test_storage.py", line 20, in test_dict_storage
    self._do_store_test_empty(DictStore(tmpfn))
  File "/home/kivy/Buildbot-3.3/tests-lin-py3/build/kivy/tests/test_storage.py", line 54, in _do_store_test_empty
    self.assertTrue(store.put('plop', name='Hello', age=30))
  File "/home/kivy/Buildbot-3.3/tests-lin-py3/build/kivy/storage/__init__.py", line 179, in put
    self.store_sync()
  File "/home/kivy/Buildbot-3.3/tests-lin-py3/build/kivy/storage/dictstore.py", line 52, in store_sync
    pickle.dump(self._data, fd)
TypeError: must be str, not bytes
```