### PR TITLE
Fixed Fbo pixels saving in graphics test

### DIFF
--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -100,11 +100,8 @@ class FBOInstructionTestCase(unittest.TestCase):
             ClearBuffers()
             Ellipse(pos=(100, 100), size=(100, 100))
         fbo.draw()
-        data = fbo.pixels
 
-        import pygame
-        surface = pygame.image.fromstring(data, (512, 512), 'RGBA', True)
-        pygame.image.save(surface, "results.png")
+        fbo.texture.save('results.png')
 
     def tearDown(self):
         import os


### PR DESCRIPTION
I haven't been able to test this due to another issue, but it seems like the right solution. It should fix #3139 .