### PR TITLE
clipboard_dbusklipper and clipboard_xel: return list not string

### DIFF
--- a/kivy/core/clipboard/clipboard_dbusklipper.py
+++ b/kivy/core/clipboard/clipboard_dbusklipper.py
@@ -38,4 +38,4 @@ class ClipboardDbusKlipper(ClipboardBase):
 
     def get_types(self):
         self.init()
-        return 'text/plain'
+        return list('text/plain',)

--- a/kivy/core/clipboard/clipboard_xsel.py
+++ b/kivy/core/clipboard/clipboard_xsel.py
@@ -30,4 +30,4 @@ class Clipboardxsel(ClipboardBase):
         p.communicate(data)
 
     def get_types(self):
-        return 'text/plain'
+        return list('text/plain',)


### PR DESCRIPTION
the get_types in clipboard_dbusklipper and clipboard_xel return string, rewrite it to let it return list.This is a small contribution that prepare for GSoC 2015.