### PR TITLE
gtk3 clipboard + fixes

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -192,7 +192,7 @@ kivy_options = {
     'spelling': ('enchant', 'osxappkit', ),
     'clipboard': (
         'android', 'winctypes', 'xsel', 'dbusklipper', 'nspaste', 'sdl2',
-        'pygame', 'dummy')}
+        'pygame', 'dummy', 'gtk3', )}
 
 # Read environment
 for option in kivy_options:

--- a/kivy/core/clipboard/clipboard_gtk3.py
+++ b/kivy/core/clipboard/clipboard_gtk3.py
@@ -1,0 +1,44 @@
+'''
+Clipboard Gtk3: an implementation of the Clipboard using Gtk3.
+'''
+
+__all__ = ('ClipboardGtk3',)
+
+from kivy.utils import platform
+from kivy.support import install_gobject_iteration
+from kivy.core.clipboard import ClipboardBase
+
+if platform != 'linux':
+    raise SystemError('unsupported platform for gtk3 clipboard')
+
+from gi.repository import Gtk, Gdk
+clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+
+
+class ClipboardGtk3(ClipboardBase):
+
+    _is_init = False
+
+    def init(self):
+        if self._is_init:
+            return
+        install_gobject_iteration()
+        self._is_init = True
+
+    def get(self, mimetype='text/plain;charset=utf-8'):
+        self.init()
+        if mimetype == 'text/plain;charset=utf-8':
+            contents = clipboard.wait_for_text()
+            if contents:
+                return contents
+        return ''
+
+    def put(self, data, mimetype='text/plain;charset=utf-8'):
+        self.init()
+        if mimetype == 'text/plain;charset=utf-8':
+            text = data.decode(self._encoding)
+            clipboard.set_text(text, -1)
+
+    def get_types(self):
+        self.init()
+        return ['text/plain;charset=utf-8']

--- a/kivy/core/clipboard/clipboard_pygame.py
+++ b/kivy/core/clipboard/clipboard_pygame.py
@@ -21,6 +21,11 @@ except:
 class ClipboardPygame(ClipboardBase):
 
     _is_init = False
+    _types = None
+
+    _aliases = {
+        'text/plain;charset=utf-8': 'UTF8_STRING'
+    }
 
     def init(self):
         if ClipboardPygame._is_init:
@@ -30,18 +35,24 @@ class ClipboardPygame(ClipboardBase):
 
     def get(self, mimetype='text/plain'):
         self.init()
+        mimetype = self._aliases.get(mimetype, mimetype)
         text = pygame.scrap.get(mimetype)
-        if PY2:
-            text = text.encode('utf-8')
         return text
 
     def put(self, data, mimetype='text/plain'):
         self.init()
-        if platform == 'macosx' and data.endswith('\x00'):
-            data = data[:-1]
+        mimetype = self._aliases.get(mimetype, mimetype)
         pygame.scrap.put(mimetype, data)
 
     def get_types(self):
-        self.init()
-        return pygame.scrap.get_types()
+        if not self._types:
+            self.init()
+            types = pygame.scrap.get_types()
+            for mime, pygtype in self._aliases.items()[:]:
+                if mime in types:
+                    del self._aliases[mime]
+                if pygtype in types:
+                    types.append(mime)
+            self._types = types
+        return self._types
 


### PR DESCRIPTION
Adds a Gtk3 clipboard provider. Also fixes some encoding issues and disables SDL2 clipboard on Linux (as it is buggy).

This code has been tested on the following configurations:

Linux, py2.7, clipboard providers: pygame, gtk3, xsel
Linux, py3.3, clipboard providers: gtk3, xsel
Windows 7, py2.7, clipboard providers: pygame, sdl2, winctypes