### PR TITLE
fix winctypes clipboard encoding

### DIFF
--- a/kivy/core/clipboard/__init__.py
+++ b/kivy/core/clipboard/__init__.py
@@ -59,8 +59,8 @@ class ClipboardBase(object):
 
         if platform == 'win':
             self._clip_mime_type = 'text/plain;charset=utf-8'
-            # windows clipboard uses a utf-16 encoding
-            self._encoding = 'utf-16'
+            # windows clipboard uses a utf-16 little endian encoding
+            self._encoding = 'utf-16-le'
         elif platform == 'linux':
             self._clip_mime_type = 'UTF8_STRING'
             self._encoding = 'utf-8'

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -26,7 +26,7 @@ class ClipboardWindows(ClipboardBase):
         pcontents = user32.GetClipboardData(13)
         if not pcontents:
             return ''
-        data = c_wchar_p(pcontents).value.encode('utf-16')
+        data = c_wchar_p(pcontents).value.encode(self._encoding)
         #ctypes.windll.kernel32.GlobalUnlock(pcontents)
         user32.CloseClipboard()
         return data


### PR DESCRIPTION
Tested on Windows 7; fixes issue with extra chars at beginning of pasted string due to BOM. [Microsoft uses UTF-16, little endian byte order](https://msdn.microsoft.com/en-us/library/windows/desktop/dd374101%28v=vs.85%29.aspx), and specifying `utf-16-le` causes Python to omit the BOM.