### PR TITLE
force sdl2 clipboard encoding to utf8

### DIFF
--- a/kivy/core/clipboard/clipboard_sdl2.py
+++ b/kivy/core/clipboard/clipboard_sdl2.py
@@ -22,8 +22,11 @@ class ClipboardSDL2(ClipboardBase):
     def get(self, mimetype):
         return _get_text() if _has_text() else ''
 
-    def put(self, data='', mimetype='text/plain'):
-        data = data.encode('utf-8')
+    def _ensure_clipboard(self):
+        super(ClipboardSDL2, self)._ensure_clipboard()
+        self._encoding = 'utf8'
+
+    def put(self, data=b'', mimetype='text/plain'):
         _set_text(data)
 
     def get_types(self):


### PR DESCRIPTION
[SDL2 clipboard functions expect utf8 text](https://wiki.libsdl.org/SDL_GetClipboardText), so this forces the text to always be treated as utf8, regardless of platform settings.

Tested on Windows 7, py2.7.