### PR TITLE
Add window_state config option

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -114,6 +114,11 @@ Available configuration tokens
 :graphics:
     `borderless`: int , one of 0 or 1
         If set to `1`, removes the window border/decoration.
+    `window_state`: string , one of `visible`, `hidden`, `maximized`
+        or `minimized`
+        Sets the window state, defaults to `visible`. This option is available
+        only for the SDL2 window provider and it should be used on desktop
+        OSes.
     `fbo`: string, one of 'hardware', 'software' or 'force-hardware'
         Selects the FBO backend to use.
     `fullscreen`: int or string, one of 0, 1, 'fake' or 'auto'
@@ -230,9 +235,9 @@ Available configuration tokens
     is required for value changes to take effect.
 
 .. versionchanged:: 1.9.0
-    `borderless` has been added to the graphics section.
-    The `fake` option of `fullscreen` in the graphics section has been
-    deprecated, use the `borderless` option instead.
+    `borderless` and `window_state` have been added to the graphics section.
+    The `fake` setting of the `fullscreen` option has been deprecated,
+    use the `borderless` option instead.
     `pause_on_minimize` has been added to the kivy section.
 
 .. versionchanged:: 1.8.0
@@ -274,7 +279,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 12
+KIVY_CONFIG_VERSION = 13
 
 Config = None
 '''Kivy configuration object. Its :attr:`~kivy.config.ConfigParser.name` is
@@ -743,6 +748,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 11:
             Config.setdefault('kivy', 'pause_on_minimize', '0')
+
+        elif version == 12:
+            Config.set('graphics', 'window_state', 'visible')
 
         #elif version == 1:
         #   # add here the command for upgrading from configuration 0 to 1

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -21,11 +21,11 @@ cdef class _WindowSDL2Storage:
         raise RuntimeError(<bytes> SDL_GetError())
 
     def setup_window(self, x, y, width, height, borderless, fullscreen,
-                     resizable):
+                     resizable, state):
         self.win_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI
 
         IF USE_IOS:
-            self.win_flags |= SDL_WINDOW_BORDERLESS | SDL_WINDOW_RESIZABLE | SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_ALLOW_HIGHDPI
+            self.win_flags |= SDL_WINDOW_BORDERLESS | SDL_WINDOW_RESIZABLE | SDL_WINDOW_FULLSCREEN_DESKTOP
         ELSE:
             if resizable:
                 self.win_flags |= SDL_WINDOW_RESIZABLE
@@ -35,8 +35,14 @@ cdef class _WindowSDL2Storage:
                 self.win_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP
             elif fullscreen is True:
                 self.win_flags |= SDL_WINDOW_FULLSCREEN
+        if state == 'maximized':
+            self.win_flags |= SDL_WINDOW_MAXIMIZED
+        elif state == 'minimized':
+            self.win_flags |= SDL_WINDOW_MINIMIZED
+        elif state == 'hidden':
+            self.win_flags |= SDL_WINDOW_HIDDEN
 
-        if SDL_Init(SDL_INIT_VIDEO| SDL_INIT_JOYSTICK) < 0:
+        if SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0:
             self.die()
 
         # Set default orientation (force landscape for now)

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -164,9 +164,11 @@ class WindowSDL(WindowBase):
             # setup !
             w, h = self.system_size
             resizable = Config.getboolean('graphics', 'resizable')
+            state = (Config.get('graphics', 'window_state')
+                     if self._is_desktop else None)
             self.system_size = _size = self._win.setup_window(
                 pos[0], pos[1], w, h, self.borderless,
-                self.fullscreen, resizable)
+                self.fullscreen, resizable, state)
             sz = self.size[0]
             self._density = density = sz / _size[0]
             if self._is_desktop and self.size[0] != _size[0]:


### PR DESCRIPTION
This is a continuation of #2590 and should fix #1456.

```python
from kivy.config import Config
Config.set('graphics', 'window_state', 'maximized')
# Config.set('graphics', 'window_state', 'minimized')
# Config.set('graphics', 'window_state', 'hidden')

from kivy.app import App
from kivy.uix.button import Button


class TestApp(App):
    def build(self):
        return Button()

if __name__ == '__main__':
    TestApp().run()
```