### PR TITLE
respect PYTHON var when running make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON = python
 CHECKSCRIPT = kivy/tools/pep8checker/pep8kivy.py
 KIVY_DIR = kivy/
-NOSETESTS = nosetests
+NOSETESTS = $(PYTHON) -m nose.core
 KIVY_USE_DEFAULTCONFIG = 1
 HOSTPYTHON = $(KIVYIOSROOT)/tmp/Python-$(PYTHON_VERSION)/hostpython
 


### PR DESCRIPTION
So that `make PYTHON=python3 test` works like `make PYTHON=python3` does, as would be expected.