### PR TITLE
fix popup weakref

### DIFF
--- a/examples/demo/showcase/data/screens/popups.kv
+++ b/examples/demo/showcase/data/screens/popups.kv
@@ -1,5 +1,5 @@
 ShowcaseScreen:
-    popup: popup
+    popup: popup.__self__
     fullscreen: True
     name: 'Popups'
     BoxLayout:


### PR DESCRIPTION
When the popup is first created, it has a parent `BoxLayout`. When it is shown, its parent becomes `Window`. When it is closed, then it has no parent, and garbage collection can destroy it. This makes the `ShowcaseScreen` keep a strong reference to prevent the issue.

I can consistently duplicate this by running Showcase, going to the Popups screen, opening and closing the popup, then using the `>` button to cycle through all the screens. When I come all the way around to the Popups screen again, and try to open the popup, it will throw a weakref exception.