### PR TITLE
Adding binary files at usr/lib/python2.7/dist-packages/kivy/core/audio/

### DIFF
--- a/python-kivy-bin.install
+++ b/python-kivy-bin.install
@@ -1,6 +1,7 @@
 usr/lib/python2.7/dist-packages/kivy/*.so
 usr/lib/python2.7/dist-packages/kivy/core/clipboard/*.so
 usr/lib/python2.7/dist-packages/kivy/graphics/*.so
+usr/lib/python2.7/dist-packages/kivy/core/audio/*.so
 usr/lib/python2.7/dist-packages/kivy/core/image/*.so
 usr/lib/python2.7/dist-packages/kivy/core/text/*.so
 usr/lib/python2.7/dist-packages/kivy/core/text/*.so

--- a/python3-kivy-bin.install
+++ b/python3-kivy-bin.install
@@ -1,6 +1,7 @@
 usr/lib/python3/dist-packages/kivy/*.so
 usr/lib/python3/dist-packages/kivy/core/clipboard/*.so
 usr/lib/python3/dist-packages/kivy/graphics/*.so
+usr/lib/python3/dist-packages/kivy/core/audio/*.so
 usr/lib/python3/dist-packages/kivy/core/image/*.so
 usr/lib/python3/dist-packages/kivy/core/text/*.so
 usr/lib/python3/dist-packages/kivy/core/text/*.so


### PR DESCRIPTION
Should fix broken builds because of:

```
dh_install: usr/lib/python3/dist-packages/kivy/core/audio/audio_sdl2.cpython-34m-x86_64-linux-gnu.so exists in debian/tmp but is not installed to anywhere
dh_install: usr/lib/python2.7/dist-packages/kivy/core/audio/audio_sdl2.so exists in debian/tmp but is not installed to anywhere
dh_install: missing files, aborting
```