### PR TITLE
fix py3 builds

### DIFF
--- a/kivy/tools/packaging/linux/debian/rules
+++ b/kivy/tools/packaging/linux/debian/rules
@@ -14,10 +14,10 @@ export DH_VERBOSE=1
 
 override_dh_auto_build:
 	for PYX in $(shell pyversions -i) $(shell py3versions -r) ; do \
+	    $(MAKE) clean; \
 	    $(MAKE) build PYTHON=$$PYX; \
-	done
-
-	cd doc && PYTHONPATH=.. make html
+	done; \
+	cd doc && PYTHONPATH=.. make PYTHON=$$PYX html
 
 override_dh_auto_install:
 	for PYX in $(shell pyversions -i) $(shell py3versions -r) ; do \


### PR DESCRIPTION
Runs `make clean` between builds, and uses the last built Python version to build the docs.

Fixes #3225