### PR TITLE
Release TouchInput handles in wm_touch

### DIFF
--- a/kivy/input/providers/wm_touch.py
+++ b/kivy/input/providers/wm_touch.py
@@ -216,6 +216,7 @@ else:
                                             sizeof(TOUCHINPUT))
             for i in range(wParam):
                 self.touch_events.appendleft(touches[i])
+            windll.user32.CloseTouchInputHandle(HANDLE(lParam))
             return True
 
         # filter fake mouse events, because touch and stylus


### PR DESCRIPTION
TouchInput handles are not released after being used in wm_touch.
This will result in touches being completely ignored after some times (after ~1900 touches, in my tests) and the application no longer responding if a touch screen is the only input device
