### PR TITLE
fix async exception and make async methods save

### DIFF
--- a/kivy/storage/__init__.py
+++ b/kivy/storage/__init__.py
@@ -352,7 +352,7 @@ class AbstractStore(EventDispatcher):
 
     def store_put_async(self, key, value, callback):
         try:
-            value = self.store_put(key, value)
+            value = self.put(key, **value)
             callback(self, key, value)
         except:
             callback(self, key, None)
@@ -366,7 +366,7 @@ class AbstractStore(EventDispatcher):
 
     def store_delete_async(self, key, callback):
         try:
-            value = self.store_delete(key)
+            value = self.delete(key)
             callback(self, key, value)
         except:
             callback(self, key, None)
@@ -400,4 +400,4 @@ class AbstractStore(EventDispatcher):
 
     def _schedule(self, cb, **kwargs):
         # XXX not entirely sure about the best value (0 or -1).
-        Clock.schedule_once(partial(cb, **kwargs), 0)
+        Clock.schedule_once(lambda dt: cb(**kwargs), 0)


### PR DESCRIPTION
Fixes exception due to dt being passed to the callback. Also makes `store_put_async` call `put` instead of `store_put`, and `store_delete_async` call `delete` instead of `store_delete`, because the save handling happens within these functions. Otherwise the store does not get saved when values are changed asynchronously.