### PR TITLE
Fixes iOS density. 

### DIFF
--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -197,9 +197,8 @@ class MetricsBase(object):
             Hardware = jnius.autoclass('org.renpy.android.Hardware')
             return Hardware.metrics.scaledDensity
         elif platform == 'ios':
-            # 0.75 is for mapping the same density as android tablet
             import ios
-            return ios.get_scale() * 0.75
+            return ios.get_scale()
         elif platform == 'macosx':
             from kivy.base import EventLoop
             EventLoop.ensure_window()


### PR DESCRIPTION
This was a big mistake, leading to smaller element than the actual screen density, weird aliasing and more. Dunno why nobody reported it before (not even me.)

I didn't understand why my app on the ipad 3 (retina) was having the whole UI smaller than the equivalent on desktop. This was due to the * 0.75. The previous comment i put was a mistake, like my analysis. This must go away.