### PR TITLE
Fix AttributeError in py3

### DIFF
--- a/kivy/weakproxy.pyx
+++ b/kivy/weakproxy.pyx
@@ -288,5 +288,5 @@ cdef class WeakProxy(object):
         return unicode(self.__ref())
 
     def __repr__(self):
-        return b'<WeakProxy to {!r}>'.format(self.__ref())
+        return '<WeakProxy to {!r}>'.format(self.__ref())
 


### PR DESCRIPTION
The ``__repr__`` method should always return a string. It was returning a bytes object instead.

In py2 this made no difference. In py3 it USUALLY made no difference, but if you were using the inspector, and tried to inspect an object that contained a WeakProxy, the whole app would crash.