### PR TITLE
use internal caching for keyboard_height property

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -467,7 +467,8 @@ class WindowBase(EventDispatcher):
         return 0
 
     keyboard_height = AliasProperty(_get_kheight, None,
-                                    bind=('_keyboard_changed',))
+                                    bind=('_keyboard_changed',),
+                                    cache=True)
     '''Rerturns the height of the softkeyboard/IME on mobile platforms.
     Will return 0 if not on mobile platform or if IME is not active.
 


### PR DESCRIPTION
keyboard_height is an AliasProperty, and it has an optional cache.  this patch activates it.  I verified that qua-non's latest fix to p4a actually causes the cache to be updated.