### PR TITLE
allow NumericProperties to accept type double

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -528,7 +528,7 @@ cdef class NumericProperty(Property):
         if x is None:
             return x
         tp = type(x)
-        if tp is int or tp is float or tp is long:
+        if tp is int or tp is float or tp is long or tp is double:
             return x
         if tp is tuple or tp is list:
             if len(x) != 2:


### PR DESCRIPTION
There's no reason not to, is there?