### PR TITLE
Replace bind with fast_bind where appropriate.

### DIFF
--- a/kivy/adapters/dictadapter.py
+++ b/kivy/adapters/dictadapter.py
@@ -61,7 +61,7 @@ class DictAdapter(ListAdapter):
 
         super(DictAdapter, self).__init__(**kwargs)
 
-        self.bind(sorted_keys=self.initialize_sorted_keys)
+        self.fast_bind('sorted_keys', self.initialize_sorted_keys)
 
     def bind_triggers_to_view(self, func):
         self.bind(sorted_keys=func)

--- a/kivy/adapters/listadapter.py
+++ b/kivy/adapters/listadapter.py
@@ -180,9 +180,10 @@ class ListAdapter(Adapter, EventDispatcher):
     def __init__(self, **kwargs):
         super(ListAdapter, self).__init__(**kwargs)
 
-        self.bind(selection_mode=self.selection_mode_changed,
-                  allow_empty_selection=self.check_for_empty_selection,
-                  data=self.update_for_new_data)
+        fbind = self.fast_bind
+        fbind('selection_mode', self.selection_mode_changed)
+        fbind('allow_empty_selection', self.check_for_empty_selection)
+        fbind('data', self.update_for_new_data)
 
         self.update_for_new_data()
 

--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -257,10 +257,12 @@ class AccordionItem(FloatLayout):
         self._trigger_title = Clock.create_trigger(self._update_title, -1)
         self._anim_collapse = None
         super(AccordionItem, self).__init__(**kwargs)
-        self.bind(title=self._trigger_title,
-                  title_template=self._trigger_title,
-                  title_args=self._trigger_title)
-        self._trigger_title()
+        trigger_title = self._trigger_title
+        fbind = self.fast_bind
+        fbind('title', trigger_title)
+        fbind('title_template', trigger_title)
+        fbind('title_args', trigger_title)
+        trigger_title()
 
     def add_widget(self, widget):
         if self.container is None:
@@ -357,13 +359,14 @@ class Accordion(Widget):
 
     def __init__(self, **kwargs):
         super(Accordion, self).__init__(**kwargs)
-        self._trigger_layout = Clock.create_trigger(self._do_layout, -1)
-        self.bind(
-            orientation=self._trigger_layout,
-            children=self._trigger_layout,
-            size=self._trigger_layout,
-            pos=self._trigger_layout,
-            min_space=self._trigger_layout)
+        update = self._trigger_layout = \
+            Clock.create_trigger(self._do_layout, -1)
+        fbind = self.fast_bind
+        fbind('orientation', update)
+        fbind('children', update)
+        fbind('size', update)
+        fbind('pos', update)
+        fbind('min_space', update)
 
     def add_widget(self, widget, *largs):
         if not isinstance(widget, AccordionItem):

--- a/kivy/uix/anchorlayout.py
+++ b/kivy/uix/anchorlayout.py
@@ -66,14 +66,15 @@ class AnchorLayout(Layout):
 
     def __init__(self, **kwargs):
         super(AnchorLayout, self).__init__(**kwargs)
-        self.bind(
-            children=self._trigger_layout,
-            parent=self._trigger_layout,
-            padding=self._trigger_layout,
-            anchor_x=self._trigger_layout,
-            anchor_y=self._trigger_layout,
-            size=self._trigger_layout,
-            pos=self._trigger_layout)
+        fbind = self.fast_bind
+        update = self._trigger_layout
+        fbind('children', update)
+        fbind('parent', update)
+        fbind('padding', update)
+        fbind('anchor_x', update)
+        fbind('anchor_y', update)
+        fbind('size', update)
+        fbind('pos', update)
 
     def do_layout(self, *largs):
         _x, _y = self.pos

--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -105,7 +105,7 @@ class ButtonBehavior(object):
         super(ButtonBehavior, self).__init__(**kwargs)
         self.__state_event = None
         self.__touch_time = None
-        self.bind(state=self.cancel_event)
+        self.fast_bind('state', self.cancel_event)
 
     def _do_press(self):
         self.state = 'down'
@@ -771,10 +771,12 @@ class FocusBehavior(object):
         super(FocusBehavior, self).__init__(**kwargs)
 
         self._keyboard_mode = _keyboard_mode
-        self.bind(focus=self._on_focus, disabled=self._on_focusable,
-                  is_focusable=self._on_focusable,
-                  focus_next=self._set_on_focus_next,
-                  focus_previous=self._set_on_focus_previous)
+        fbind = self.fast_bind
+        fbind('focus', self._on_focus)
+        fbind('disabled', self._on_focusable)
+        fbind('is_focusable', self._on_focusable)
+        fbind('focus_next', self._set_on_focus_next)
+        fbind('focus_previous', self._set_on_focus_previous)
 
     def _on_focusable(self, instance, value):
         if self.disabled or not self.is_focusable:
@@ -1108,10 +1110,14 @@ class CompoundSelectionBehavior(object):
         def ensure_single_select(*l):
             if (not self.multiselect) and len(self.selected_nodes) > 1:
                 self.clear_selection()
-        self._update_counts()
-        self.bind(multiselect=ensure_single_select,
-        page_count=self._update_counts, up_count=self._update_counts,
-        right_count=self._update_counts, scroll_count=self._update_counts)
+        update_counts = self._update_counts
+        update_counts()
+        fbind = self.fast_bind
+        fbind('multiselect', ensure_single_select)
+        fbind('page_count', update_counts)
+        fbind('up_count', update_counts)
+        fbind('right_count', update_counts)
+        fbind('scroll_count', update_counts)
 
     def select_with_touch(self, node, touch=None):
         '''(internal) Processes a touch on the node. This should be called by

--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -100,14 +100,15 @@ class BoxLayout(Layout):
 
     def __init__(self, **kwargs):
         super(BoxLayout, self).__init__(**kwargs)
-        self.bind(
-            spacing=self._trigger_layout,
-            padding=self._trigger_layout,
-            children=self._trigger_layout,
-            orientation=self._trigger_layout,
-            parent=self._trigger_layout,
-            size=self._trigger_layout,
-            pos=self._trigger_layout)
+        update = self._trigger_layout
+        fbind = self.fast_bind
+        fbind('spacing', update)
+        fbind('padding', update)
+        fbind('children', update)
+        fbind('orientation', update)
+        fbind('parent', update)
+        fbind('size', update)
+        fbind('pos', update)
 
     def do_layout(self, *largs):
         # optimize layout by preventing looking at the same attribute in a loop

--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -84,9 +84,11 @@ class Camera(Image):
         super(Camera, self).__init__(**kwargs)
         if self.index == -1:
             self.index = 0
-        self.bind(index=self._on_index,
-                  resolution=self._on_index)
-        self._on_index()
+        on_index = self._on_index
+        fbind = self.fast_bind
+        fbind('index', on_index)
+        fbind('resolution', on_index)
+        on_index()
 
     def on_tex(self, *l):
         self.canvas.ask_update()

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -186,7 +186,7 @@ class DropDown(ScrollView):
             super(DropDown, self).add_widget(c)
             self.on_container(self, c)
         Window.bind(on_key_down=self.on_key_down)
-        self.bind(size=self._reposition)
+        self.fast_bind('size', self._reposition)
 
     def on_key_down(self, instance, key, scancode, codepoint, modifiers):
         if key == 27 and self.get_parent_window():

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -378,9 +378,11 @@ class EffectBase(EventDispatcher):
 
     def __init__(self, *args, **kwargs):
         super(EffectBase, self).__init__(*args, **kwargs)
-        self.bind(fbo=self.set_fbo_shader)
-        self.bind(glsl=self.set_fbo_shader)
-        self.bind(source=self._load_from_source)
+        fbind = self.fast_bind
+        fbo_shader = self.set_fbo_shader
+        fbind('fbo', fbo_shader)
+        fbind('glsl', fbo_shader)
+        fbind('source', self._load_from_source)
 
     def set_fbo_shader(self, *args):
         '''Sets the :class:`~kivy.graphics.Fbo`'s shader by splicing
@@ -434,7 +436,7 @@ class AdvancedEffectBase(EffectBase):
 
     def __init__(self, *args, **kwargs):
         super(AdvancedEffectBase, self).__init__(*args, **kwargs)
-        self.bind(uniforms=self._update_uniforms)
+        self.fast_bind('uniforms', self._update_uniforms)
 
     def _update_uniforms(self, *args):
         if self.fbo is None:
@@ -656,9 +658,11 @@ class EffectWidget(RelativeLayout):
 
         Clock.schedule_interval(self._update_glsl, 0)
 
-        self.bind(size=self.refresh_fbo_setup,
-                  effects=self.refresh_fbo_setup,
-                  background_color=self._refresh_background_color)
+        fbind = self.fast_bind
+        fbo_setup = self.refresh_fbo_setup
+        fbind('size', fbo_setup)
+        fbind('effects', fbo_setup)
+        fbind('background_color', self._refresh_background_color)
 
         self.refresh_fbo_setup()
         self._refresh_background_color()  # In case thi was changed in kwargs

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -226,7 +226,7 @@ class FileChooserListLayout(FileChooserLayout):
 
     def __init__(self, **kwargs):
         super(FileChooserListLayout, self).__init__(**kwargs)
-        self.bind(on_entries_cleared=self.scroll_to_top)
+        self.fast_bind('on_entries_cleared', self.scroll_to_top)
 
     def scroll_to_top(self, *args):
         self.ids.scrollview.scroll_y = 1.0
@@ -243,7 +243,7 @@ class FileChooserIconLayout(FileChooserLayout):
 
     def __init__(self, **kwargs):
         super(FileChooserIconLayout, self).__init__(**kwargs)
-        self.bind(on_entries_cleared=self.scroll_to_top)
+        self.fast_bind('on_entries_cleared', self.scroll_to_top)
 
     def scroll_to_top(self, *args):
         self.ids.scrollview.scroll_y = 1.0
@@ -456,14 +456,16 @@ class FileChooserController(RelativeLayout):
         super(FileChooserController, self).__init__(**kwargs)
 
         self._items = []
-        self.bind(selection=self._update_item_selection)
+        fbind = self.fast_bind
+        fbind('selection', self._update_item_selection)
 
         self._previous_path = [self.path]
-        self.bind(path=self._save_previous_path)
-        self.bind(path=self._trigger_update,
-                  filters=self._trigger_update,
-                  rootpath=self._trigger_update)
-        self._trigger_update()
+        fbind('path', self._save_previous_path)
+        update = self._trigger_update
+        fbind('path', update)
+        fbind('filters', update)
+        fbind('rootpath', update)
+        update()
 
     def on_touch_down(self, touch):
         # don't respond to touchs outside self
@@ -874,7 +876,7 @@ class FileChooser(FileChooserController):
 
         self.trigger_update_view = Clock.create_trigger(self.update_view)
 
-        self.bind(view_mode=self.trigger_update_view)
+        self.fast_bind('view_mode', self.trigger_update_view)
 
     def add_widget(self, widget, **kwargs):
         if widget is self._progress:

--- a/kivy/uix/floatlayout.py
+++ b/kivy/uix/floatlayout.py
@@ -64,12 +64,13 @@ class FloatLayout(Layout):
     def __init__(self, **kwargs):
         kwargs.setdefault('size', (1, 1))
         super(FloatLayout, self).__init__(**kwargs)
-        self.bind(
-            children=self._trigger_layout,
-            pos=self._trigger_layout,
-            pos_hint=self._trigger_layout,
-            size_hint=self._trigger_layout,
-            size=self._trigger_layout)
+        fbind = self.fast_bind
+        update = self._trigger_layout
+        fbind('children', update)
+        fbind('pos', update)
+        fbind('pos_hint', update)
+        fbind('size_hint', update)
+        fbind('size', update)
 
     def do_layout(self, *largs, **kwargs):
         # optimization, until the size is 1, 1, don't do layout

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -246,20 +246,20 @@ class GridLayout(Layout):
     def __init__(self, **kwargs):
         self._cols = self._rows = None
         super(GridLayout, self).__init__(**kwargs)
-
-        self.bind(
-            col_default_width=self._trigger_layout,
-            row_default_height=self._trigger_layout,
-            col_force_default=self._trigger_layout,
-            row_force_default=self._trigger_layout,
-            cols=self._trigger_layout,
-            rows=self._trigger_layout,
-            parent=self._trigger_layout,
-            spacing=self._trigger_layout,
-            padding=self._trigger_layout,
-            children=self._trigger_layout,
-            size=self._trigger_layout,
-            pos=self._trigger_layout)
+        fbind = self.fast_bind
+        update = self._trigger_layout
+        fbind('col_default_width', update)
+        fbind('row_default_height', update)
+        fbind('col_force_default', update)
+        fbind('row_force_default', update)
+        fbind('cols', update)
+        fbind('rows', update)
+        fbind('parent', update)
+        fbind('spacing', update)
+        fbind('padding', update)
+        fbind('children', update)
+        fbind('size', update)
+        fbind('pos', update)
 
     def get_max_widgets(self):
         if self.cols and self.rows:

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -235,10 +235,12 @@ class Image(Widget):
         self._coreimage = None
         self._loops = 0
         super(Image, self).__init__(**kwargs)
-        self.bind(source=self.texture_update,
-                  mipmap=self.texture_update)
+        fbind = self.fast_bind
+        update = self.texture_update
+        fbind('source', update)
+        fbind('mipmap', update)
         if self.source:
-            self.texture_update()
+            update()
 
     def texture_update(self, *largs):
         if not self.source:
@@ -329,7 +331,7 @@ class AsyncImage(Image):
         global Loader
         if not Loader:
             from kivy.loader import Loader
-        self.bind(source=self._load_source)
+        self.fast_bind('source', self._load_source)
         if self.source:
             self._load_source()
 

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -220,10 +220,10 @@ class Label(Widget):
 
         # bind all the property for recreating the texture
         d = Label._font_properties
-        dkw = {}
+        fbind = self.fast_bind
+        update = self._trigger_texture_update
         for x in d:
-            dkw[x] = partial(self._trigger_texture_update, x)
-        self.bind(**dkw)
+            fbind(x, update, x)
 
         self._label = None
         self._create_label()
@@ -233,9 +233,9 @@ class Label(Widget):
 
     def on_markup(self, inst, markup):
         if markup:
-            self.bind(color=self._trigger_markup_color)
+            self.fast_bind('color', self._trigger_markup_color)
         else:
-            self.unbind(color=self._trigger_markup_color)
+            self.fast_unbind('color', self._trigger_markup_color)
 
     def _create_label(self):
         # create the core label class according to markup value

--- a/kivy/uix/listview.py
+++ b/kivy/uix/listview.py
@@ -890,27 +890,29 @@ class ListView(AbstractView, EventDispatcher):
 
         super(ListView, self).__init__(**kwargs)
 
-        self._trigger_populate = Clock.create_trigger(self._spopulate, -1)
+        populate = self._trigger_populate = Clock.create_trigger(
+            self._spopulate, -1)
         self._trigger_reset_populate = \
             Clock.create_trigger(self._reset_spopulate, -1)
 
-        self.bind(size=self._trigger_populate,
-                  pos=self._trigger_populate,
-                  item_strings=self.item_strings_changed,
-                  adapter=self._trigger_populate)
+        fbind = self.fast_bind
+        fbind('size', populate)
+        fbind('pos', populate)
+        fbind('item_strings', self.item_strings_changed)
+        fbind('adapter', populate)
 
-        self._trigger_bind_adapter = Clock.create_trigger(
+        bind_adapter = self._trigger_bind_adapter = Clock.create_trigger(
             lambda dt: self.adapter.bind_triggers_to_view(
                 self._trigger_reset_populate),
             -1)
-        self.bind(adapter=self._trigger_bind_adapter)
+        fbind('adapter', bind_adapter)
 
         # The bindings setup above sets self._trigger_populate() to fire
         # when the adapter changes, but we also need this binding for when
         # adapter.data and other possible triggers change for view updating.
         # We don't know that these are, so we ask the adapter to set up the
         # bindings back to the view updating function here.
-        self._trigger_bind_adapter()
+        bind_adapter()
 
     # Added to set data when item_strings is set in a kv template, but it will
     # be good to have also if item_strings is reset generally.

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -182,7 +182,7 @@ class ModalView(AnchorLayout):
             on_resize=self._align_center,
             on_keyboard=self._handle_keyboard)
         self.center = self._window.center
-        self.bind(size=self._update_center)
+        self.fast_bind('size', self._update_center)
         a = Animation(_anim_alpha=1., d=self._anim_duration)
         a.bind(on_complete=lambda *x: self.dispatch('on_open'))
         a.start(self)

--- a/kivy/uix/pagelayout.py
+++ b/kivy/uix/pagelayout.py
@@ -66,13 +66,14 @@ class PageLayout(Layout):
     def __init__(self, **kwargs):
         super(PageLayout, self).__init__(**kwargs)
 
-        self.bind(
-            border=self._trigger_layout,
-            page=self._trigger_layout,
-            parent=self._trigger_layout,
-            children=self._trigger_layout,
-            size=self._trigger_layout,
-            pos=self._trigger_layout)
+        trigger = self._trigger_layout
+        fbind = self.fast_bind
+        fbind('border', trigger)
+        fbind('page', trigger)
+        fbind('parent', trigger)
+        fbind('children', trigger)
+        fbind('size', trigger)
+        fbind('pos', trigger)
 
     def do_layout(self, *largs):
         l_children = len(self.children) - 1

--- a/kivy/uix/relativelayout.py
+++ b/kivy/uix/relativelayout.py
@@ -253,8 +253,10 @@ class RelativeLayout(FloatLayout):
 
     def __init__(self, **kw):
         super(RelativeLayout, self).__init__(**kw)
-        self.unbind(pos=self._trigger_layout,
-                    pos_hint=self._trigger_layout)
+        funbind = self.fast_unbind
+        trigger = self._trigger_layout
+        funbind('pos', trigger)
+        funbind('pos_hint', trigger)
 
     def do_layout(self, *args):
         super(RelativeLayout, self).do_layout(pos=(0, 0))

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -65,7 +65,7 @@ class ScatterLayout(Scatter):
         if self.content.size != self.size:
             self.content.size = self.size
         super(ScatterLayout, self).add_widget(self.content)
-        self.bind(size=self.update_size)
+        self.fast_bind('size', self.update_size)
 
     def update_size(self, instance, size):
         self.content.size = size

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -860,7 +860,7 @@ class ScreenManager(FloatLayout):
 
     def __init__(self, **kwargs):
         super(ScreenManager, self).__init__(**kwargs)
-        self.bind(pos=self._update_pos)
+        self.fast_bind('pos', self._update_pos)
 
     def _screen_name_changed(self, screen, name):
         self.property('screen_names').dispatch(self)

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -460,19 +460,24 @@ class ScrollView(StencilView):
             self.effect_x = effect_cls(target_widget=self._viewport)
         if self.effect_y is None and effect_cls is not None:
             self.effect_y = effect_cls(target_widget=self._viewport)
-        self.bind(
-            width=self._update_effect_x_bounds,
-            height=self._update_effect_y_bounds,
-            viewport_size=self._update_effect_bounds,
-            _viewport=self._update_effect_widget,
-            scroll_x=self._trigger_update_from_scroll,
-            scroll_y=self._trigger_update_from_scroll,
-            pos=self._trigger_update_from_scroll,
-            size=self._trigger_update_from_scroll)
 
-        self._update_effect_widget()
-        self._update_effect_x_bounds()
-        self._update_effect_y_bounds()
+        trigger_update_from_scroll = self._trigger_update_from_scroll
+        update_effect_widget = self._update_effect_widget
+        update_effect_x_bounds = self._update_effect_x_bounds
+        update_effect_y_bounds = self._update_effect_y_bounds
+        fbind = self.fast_bind
+        fbind('width', update_effect_x_bounds)
+        fbind('height', update_effect_y_bounds)
+        fbind('viewport_size', self._update_effect_bounds)
+        fbind('_viewport', update_effect_widget)
+        fbind('scroll_x', trigger_update_from_scroll)
+        fbind('scroll_y', trigger_update_from_scroll)
+        fbind('pos', trigger_update_from_scroll)
+        fbind('size', trigger_update_from_scroll)
+
+        update_effect_widget()
+        update_effect_x_bounds()
+        update_effect_y_bounds()
 
     def on_effect_x(self, instance, value):
         if value:
@@ -933,15 +938,15 @@ class ScrollView(StencilView):
         # New in 1.2.0, show bar when scrolling happens and (changed in 1.9.0)
         # fade to bar_inactive_color when no scroll is happening.
         Clock.unschedule(self._bind_inactive_bar_color)
-        self.unbind(bar_inactive_color=self._change_bar_color)
+        self.fast_unbind('bar_inactive_color', self._change_bar_color)
         Animation.stop_all(self, '_bar_color')
-        self.bind(bar_color=self._change_bar_color)
+        self.fast_bind('bar_color', self._change_bar_color)
         self._bar_color = self.bar_color
         Clock.schedule_once(self._bind_inactive_bar_color, .5)
 
     def _bind_inactive_bar_color(self, *l):
-        self.unbind(bar_color=self._change_bar_color)
-        self.bind(bar_inactive_color=self._change_bar_color)
+        self.fast_unbind('bar_color', self._change_bar_color)
+        self.fast_bind('bar_inactive_color', self._change_bar_color)
         Animation(
             _bar_color=self.bar_inactive_color, d=.5, t='out_quart').start(self)
 

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -366,7 +366,7 @@ class SettingString(SettingItem):
     def on_panel(self, instance, value):
         if value is None:
             return
-        self.bind(on_release=self._create_popup)
+        self.fast_bind('on_release', self._create_popup)
 
     def _dismiss(self, *largs):
         if self.textinput:
@@ -443,7 +443,7 @@ class SettingPath(SettingItem):
     def on_panel(self, instance, value):
         if value is None:
             return
-        self.bind(on_release=self._create_popup)
+        self.fast_bind('on_release', self._create_popup)
 
     def _dismiss(self, *largs):
         if self.textinput:
@@ -540,7 +540,7 @@ class SettingOptions(SettingItem):
     def on_panel(self, instance, value):
         if value is None:
             return
-        self.bind(on_release=self._create_popup)
+        self.fast_bind('on_release', self._create_popup)
 
     def _set_option(self, instance):
         self.value = instance.text

--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -106,12 +106,13 @@ class Spinner(Button):
     def __init__(self, **kwargs):
         self._dropdown = None
         super(Spinner, self).__init__(**kwargs)
-        self.bind(
-            on_release=self._toggle_dropdown,
-            dropdown_cls=self._build_dropdown,
-            option_cls=self._build_dropdown,
-            values=self._update_dropdown)
-        self._build_dropdown()
+        fbind = self.fast_bind
+        build_dropdown = self._build_dropdown
+        fbind('on_release', self._toggle_dropdown)
+        fbind('dropdown_cls', build_dropdown)
+        fbind('option_cls', build_dropdown)
+        fbind('values', self._update_dropdown)
+        build_dropdown()
 
     def _build_dropdown(self, *largs):
         if self._dropdown:

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -177,9 +177,12 @@ class Splitter(BoxLayout):
         self._container = None
         self._strip = None
         super(Splitter, self).__init__(**kwargs)
-        self.bind(max_size=self._do_size,
-                  min_size=self._do_size,
-                  parent=self._rebind_parent)
+
+        do_size = self._do_size
+        fbind = self.fast_bind
+        fbind('max_size', do_size)
+        fbind('min_size', do_size)
+        fbind('parent', self._rebind_parent)
 
     def on_sizable_from(self, instance, sizable_from):
         if not instance._container:

--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -125,13 +125,14 @@ class StackLayout(Layout):
 
     def __init__(self, **kwargs):
         super(StackLayout, self).__init__(**kwargs)
-        self.bind(
-            padding=self._trigger_layout,
-            spacing=self._trigger_layout,
-            children=self._trigger_layout,
-            orientation=self._trigger_layout,
-            size=self._trigger_layout,
-            pos=self._trigger_layout)
+        trigger = self._trigger_layout
+        fbind = self.fast_bind
+        fbind('padding', trigger)
+        fbind('spacing', trigger)
+        fbind('children', trigger)
+        fbind('orientation', trigger)
+        fbind('size', trigger)
+        fbind('pos', trigger)
 
     def do_layout(self, *largs):
         if not self.children:

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -474,7 +474,7 @@ class TabbedPanel(GridLayout):
 
         super(TabbedPanel, self).__init__(**kwargs)
 
-        self.bind(size=self._reposition_tabs)
+        self.fast_bind('size', self._reposition_tabs)
         if not self.do_default_tab:
             Clock.schedule_once(self._switch_to_first_tab)
             return

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -484,35 +484,40 @@ class TextInput(FocusBehavior, Widget):
 
         super(TextInput, self).__init__(**kwargs)
 
-        self.bind(font_size=self._trigger_refresh_line_options,
-                  font_name=self._trigger_refresh_line_options)
+        fbind = self.fast_bind
+        refresh_line_options = self._trigger_refresh_line_options
+        update_text_options = self._update_text_options
+
+        fbind('font_size', refresh_line_options)
+        fbind('font_name', refresh_line_options)
 
         def handle_readonly(instance, value):
             if value and (not _is_desktop or not self.allow_copy):
                 self.is_focusable = False
 
-        self.bind(padding=self._update_text_options,
-                  tab_width=self._update_text_options,
-                  font_size=self._update_text_options,
-                  font_name=self._update_text_options,
-                  size=self._update_text_options,
-                  password=self._update_text_options)
+        fbind('padding', update_text_options)
+        fbind('tab_width', update_text_options)
+        fbind('font_size', update_text_options)
+        fbind('font_name', update_text_options)
+        fbind('size', update_text_options)
+        fbind('password', update_text_options)
 
-        self.bind(pos=self._trigger_update_graphics,
-                  readonly=handle_readonly, focus=self._on_textinput_focused)
+        fbind('pos', self._trigger_update_graphics)
+        fbind('readonly', handle_readonly)
+        fbind('focus', self._on_textinput_focused)
         handle_readonly(self, self.readonly)
 
-        self._trigger_position_handles = Clock.create_trigger(
+        handles = self._trigger_position_handles = Clock.create_trigger(
             self._position_handles)
         self._trigger_show_handles = Clock.create_trigger(
             self._show_handles, .05)
         self._trigger_update_cutbuffer = Clock.create_trigger(
             self._update_cutbuffer)
-        self._trigger_refresh_line_options()
+        refresh_line_options()
         self._trigger_refresh_text()
 
-        self.bind(pos=self._trigger_position_handles,
-                  size=self._trigger_position_handles)
+        fbind('pos', handles)
+        fbind('size', handles)
 
         # when the gl context is reloaded, trigger the text rendering again.
         _textinput_list.append(ref(self, TextInput._reload_remove_observer))
@@ -1306,8 +1311,7 @@ class TextInput(FocusBehavior, Widget):
         bubble = self._bubble
         if bubble is None:
             self._bubble = bubble = TextInputCutCopyPaste(textinput=self)
-            self.bind(parent=partial(self._show_cut_copy_paste,
-                                     pos, win, True))
+            self.fast_bind('parent', self._show_cut_copy_paste, pos, win, True)
             win.bind(
                 size=lambda *args: self._hide_cut_copy_paste(win))
             self.bind(cursor_pos=lambda *args: self._hide_cut_copy_paste(win))

--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -269,12 +269,14 @@ class TreeView(Widget):
         for key, value in self.root_options.items():
             setattr(tvlabel, key, value)
         self._root = self.add_node(tvlabel, None)
-        self.bind(
-            pos=self._trigger_layout,
-            size=self._trigger_layout,
-            indent_level=self._trigger_layout,
-            indent_start=self._trigger_layout)
-        self._trigger_layout()
+
+        trigger = self._trigger_layout
+        fbind = self.fast_bind
+        fbind('pos', trigger)
+        fbind('size', trigger)
+        fbind('indent_level', trigger)
+        fnind('indent_start', trigger)
+        trigger()
 
     def add_node(self, node, parent=None):
         '''Add a new node to the tree.
@@ -301,7 +303,7 @@ class TreeView(Widget):
             parent.nodes.append(node)
             node.parent_node = parent
             node.level = parent.level + 1
-        node.bind(size=self._trigger_layout)
+        node.fast_bind('size', self._trigger_layout)
         self._trigger_layout()
         return node
 
@@ -329,7 +331,7 @@ class TreeView(Widget):
                 nodes.remove(node)
             parent.is_leaf = not bool(len(nodes))
             node.parent_node = None
-            node.unbind(size=self._trigger_layout)
+            node.fast_unbind('size', self._trigger_layout)
             self._trigger_layout()
 
     def on_node_expand(self, node):

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -130,7 +130,7 @@ class Video(Image):
     def __init__(self, **kwargs):
         self._video = None
         super(Video, self).__init__(**kwargs)
-        self.bind(source=self._trigger_video_load)
+        self.fast_bind('source', self._trigger_video_load)
 
         if "eos" in kwargs:
             self.options["eos"] = kwargs["eos"]

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -163,9 +163,12 @@ class VideoPlayerProgressBar(ProgressBar):
         self.bubble_label = Factory.Label(text='0:00')
         self.bubble.add_widget(self.bubble_label)
         self.add_widget(self.bubble)
-        self.bind(pos=self._update_bubble,
-                  size=self._update_bubble,
-                  seek=self._update_bubble)
+
+        update = self._update_bubble
+        fbind = self.fast_bind
+        fbind('pos', update)
+        fbind('size', update)
+        fbind('seek', update)
 
     def on_video(self, instance, value):
         self.video.bind(position=self._update_bubble,

--- a/kivy/uix/vkeyboard.py
+++ b/kivy/uix/vkeyboard.py
@@ -332,19 +332,20 @@ class VKeyboard(Scatter):
         kwargs.setdefault('scale_max', 1.6)
         kwargs.setdefault('size', (700, 200))
         kwargs.setdefault('docked', False)
-        self._trigger_update_layout_mode = Clock.create_trigger(
+        layout_mode = self._trigger_update_layout_mode = Clock.create_trigger(
             self._update_layout_mode)
-        self._trigger_load_layouts = Clock.create_trigger(
+        layouts = self._trigger_load_layouts = Clock.create_trigger(
             self._load_layouts)
-        self._trigger_load_layout = Clock.create_trigger(
+        layout = self._trigger_load_layout = Clock.create_trigger(
             self._load_layout)
-        self.bind(
-            docked=self.setup_mode,
-            have_shift=self._trigger_update_layout_mode,
-            have_capslock=self._trigger_update_layout_mode,
-            have_special=self._trigger_update_layout_mode,
-            layout_path=self._trigger_load_layouts,
-            layout=self._trigger_load_layout)
+        fbind = self.fast_bind
+
+        fbind('docked', self.setup_mode)
+        fbind('have_shift', layout_mode)
+        fbind('have_capslock', layout_mode)
+        fbind('have_special', layout_mode)
+        fbind('layout_path', layouts)
+        fbind('layout', layout)
         super(VKeyboard, self).__init__(**kwargs)
 
         # load all the layouts found in the layout_path directory


### PR DESCRIPTION
Replaces instances of `bind` with `fast_bind` where appropriate. Basically, whenever we do `self.bind(name=self.func)` we can replace it with `fast_bind` because saving a direct reference to `self.func` in `self` will not cause a memory leak.

When testing with e.g. https://github.com/tshirtman/pycon-fr-2014-kivy/blob/master/pres.kv it improved over master by 2.78s vs. 3.2s with the following code:

```py
import timeit
from kivy.lang import Builder
from kivy.factory import Factory
from kivy.base import EventLoop
EventLoop.ensure_window()

Builder.load_file(r'G:\Python\dev2\pycon-fr-2014-kivy-master\pres.kv')
RootRule = Factory.RootRule
r = RootRule()
setup = 'from kivy.factory import Factory; RootRule = Factory.RootRule'
print timeit.timeit(stmt='RootRule()', setup=setup, number=50)

```