### PR TITLE
ensure that only the last property constraint takes effect

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -890,14 +890,13 @@ cdef class EventObservers:
         cdef BoundCallback new_callback
 
         while callback is not None:
-            if is_ref and not callback.is_ref:
-                cb_equal = callback.func == observer()
-            elif callback.is_ref and not is_ref:
-                cb_equal = callback.func() == observer
-            else:
-                cb_equal = callback.func == observer
-            if (callback.lock != deleted and callback.largs is None and
-                callback.kwargs is None and cb_equal):
+            cb_equal = ((callback.func() if callback.is_ref else callback.func)
+                        ==
+                        (observer() if is_ref else observer))
+            if (cb_equal
+                and callback.lock != deleted
+                and callback.largs is None
+                and callback.kwargs is None):
                 return
             callback = callback.next
 

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -1614,7 +1614,8 @@ def create_handler(iself, element, key, value, rule, idmap, delayed=False):
     # if there is already a constraint on iself/key then remove it before
     # posting a new one.  there should be at most one constraint for any
     # property iself/key.
-    current_constraint_bindings = clear_constraint(iself, key)
+    if not delayed:
+        current_constraint_bindings = clear_constraint(iself, key)
 
     # we need a hash for when delayed, so we don't execute duplicate canvas
     # callbacks from the same handler during a sync op
@@ -1672,7 +1673,7 @@ def create_handler(iself, element, key, value, rule, idmap, delayed=False):
                     was_bound = True
             if was_bound:
                 handler_append(bound)
-            if bound:
+            if bound and not delayed:
                 current_constraint_bindings.append(bound)
 
     try:


### PR DESCRIPTION
Using the kv language, the same property of a widget can be constrained multiple times.  When all constraints are static, then only the last one takes effect:

```
from kivy.app import App
from kivy.lang import Builder

root = Builder.load_string("""
BoxLayout:
    Label:
        text: "Hello World"

<Label>:
    color: (0,1,0,1)

<Label>:
    color: (0,0,1,1)

<Label>:
    color: (1,0,0,1)
""")


class MyApp(App):

    def build(self):
        return root

MyApp().run()
```

When they are all dynamic, then they are all evaluated, but only the last one wins:

```
from kivy.app import App
from kivy.lang import Builder, global_idmap

def show(x):
    print(x)

global_idmap["show"] = show

root = Builder.load_string("""
<MyLabel@Label>:
    tick: True

BoxLayout:
    MyLabel:
        id: label
        text: "Hello World"
    Button:
        text: "Click Me!"
        on_release:
            label.tick = not label.tick

<MyLabel>:
    color: (show('Green'),(0,1,0,1) if self.tick else (0,0.5,0,1))[1]

<MyLabel>:
    color: (show('Blue'),(0,0,1,1) if self.tick else (0,0,0.5,1))[1]

<MyLabel>:
    color: (show('Red'),(1,0,0,1) if self.tick else (0.5,0,0,1))[1]
""")


class MyApp(App):

    def build(self):
        return root

MyApp().run()
```
When there is a mix and the last one is static, then it wins at first, but when dynamic rules need to be reevaluated, then the last dynamic rule wins:

```
from kivy.app import App
from kivy.lang import Builder, global_idmap

def show(x):
    print(x)

global_idmap["show"] = show

root = Builder.load_string("""
<MyLabel@Label>:
    tick: True

BoxLayout:
    MyLabel:
        id: label
        text: "Hello World"
    Button:
        text: "Click Me!"
        on_release:
            label.tick = not label.tick

<MyLabel>:
    color: (show('Green'),(0,1,0,1) if self.tick else (0,0.5,0,1))[1]

<MyLabel>:
    color: (show('Blue'),(0,0,1,1) if self.tick else (0,0,0.5,1))[1]

<MyLabel>:
    color: (show('Red'),(1,0,0,1) if self.tick else (0.5,0,0,1))[1]

<MyLabel>:
    color: (1,1,0,1)
""")


class MyApp(App):

    def build(self):
        return root

MyApp().run()
```
This PR proposes that only the last applied constraint to a widget's property remains in effect.  If there was a previously applied constraint, then it is removed (all its bindings are removed).

This makes kv much more predictable, and makes it possible for kivy to provide default constraints that are generally useful, while still allowing the user to override these constraints.