### PR TITLE
Adds minimum window size support for SDL

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -213,8 +213,13 @@ class WindowBase(EventDispatcher):
             Height of the window.
         `minimum_width`: int
             Minimum width of the window
+            
+            .. versionadded:: 1.9.1
+            
         `minimum_height`: int
             Minimum height of the window
+            
+            .. versionadded:: 1.9.1
 
     :Events:
         `on_motion`: etype, motionevent

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -211,6 +211,10 @@ class WindowBase(EventDispatcher):
             Width of the window.
         `height`: int
             Height of the window.
+        `minimum_width`: int
+            Minimum width of the window
+        `minimum_height`: int
+            Minimum height of the window
 
     :Events:
         `on_motion`: etype, motionevent
@@ -328,6 +332,9 @@ class WindowBase(EventDispatcher):
             return True
         else:
             return False
+
+    minimum_width = NumericProperty(0)
+    minimum_height = NumericProperty(0)
 
     size = AliasProperty(_get_size, _set_size, bind=('_size', ))
     '''Get the rotated size of the window. If :attr:`rotation` is set, then the
@@ -583,6 +590,10 @@ class WindowBase(EventDispatcher):
             kwargs['width'] = Config.getint('graphics', 'width')
         if 'height' not in kwargs:
             kwargs['height'] = Config.getint('graphics', 'height')
+        if 'minimum_width' not in kwargs:
+            kwargs['minimum_width'] = Config.getint('graphics', 'minimum_width')
+        if 'minimum_height' not in kwargs:
+            kwargs['minimum_height'] = Config.getint('graphics', 'minimum_height')
         if 'rotation' not in kwargs:
             kwargs['rotation'] = Config.getint('graphics', 'rotation')
         if 'position' not in kwargs:

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -118,6 +118,9 @@ cdef class _WindowSDL2Storage:
         if self.window_size != [w, h]:
             SDL_SetWindowSize(self.win, w, h)
 
+    def set_minimum_size(self, w, h):
+        SDL_SetWindowMinimumSize(self.win, w, h)
+
     def maximize_window(self):
         SDL_MaximizeWindow(self.win)
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -157,7 +157,6 @@ class WindowSDL(WindowBase):
         self._mouse_buttons_down = set()
 
     def create_window(self, *largs):
-
         if self._fake_fullscreen:
             if not self.borderless:
                 self.fullscreen = self._fake_fullscreen = False
@@ -200,6 +199,9 @@ class WindowSDL(WindowBase):
             self._win.resize_window(w, h)
             self._win.set_border_state(self.borderless)
             self._win.set_fullscreen_mode(self.fullscreen)
+
+        if self.minimum_width and self.minimum_height:
+            self._win.set_minimum_size(self.minimum_width, self.minimum_height)
 
         super(WindowSDL, self).create_window()
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -522,6 +522,7 @@ cdef extern from "SDL.h":
     cdef void SDL_GetWindowPosition(SDL_Window * window, int *x, int *y)
     cdef void SDL_SetWindowSize(SDL_Window * window, int w, int h)
     cdef void SDL_GetWindowSize(SDL_Window * window, int *w, int *h)
+    cdef void SDL_SetWindowMinimumSize(SDL_Window * window, int min_w, int min_h)
     cdef void SDL_SetWindowBordered(SDL_Window * window, SDL_bool bordered)
     cdef void SDL_ShowWindow(SDL_Window * window)
     cdef void SDL_HideWindow(SDL_Window * window)


### PR DESCRIPTION
Came across a problem in a desktop app I'm developing where I needed to allow resizing but enforce a minimum size.  Initially I tried listening to the ```on_resize``` callback and setting the window size manually if it fell below a certain threshold, but whilst this worked for the actual window content, the window itself could still be resized.

This PR adds a call to SDL_SetWindowMinimumSize and introduces the ```minimum_width``` and ```minimum_height``` graphics config variables .. e.g:

```
Config.set('graphics', 'width', '1024')
Config.set('graphics', 'height', '768')
Config.set('graphics', 'minimum_width', '800')
Config.set('graphics', 'minimum_height', '600')
```

Followed the coding standards guide and tried to match this up as best possible with what's there already, but it's my first time diving into the guts of the library so it might not be the most elegant of changes.  Happy to help tidy it up if it's of use.