### PR TITLE
Make group public so we can set it from e.g. kv.

### DIFF
--- a/kivy/graphics/instructions.pxd
+++ b/kivy/graphics/instructions.pxd
@@ -21,7 +21,7 @@ cdef class InstructionGroup(Instruction)
 
 cdef class Instruction(ObjectWithUid):
     cdef int flags
-    cdef str group
+    cdef public str group
     cdef InstructionGroup parent
     cdef object __weakref__
     cdef object __proxy_ref


### PR DESCRIPTION
```py
w = Builder.load_string('''
Widget:
    canvas:
        Color:
            rgb: .1, .2, .3
            group: 'my_group'
''')
print w.canvas.get_group('my_group')
print w.canvas.get_group('my_group')[0].rgb
```
Before, results in 
```py
 Traceback (most recent call last):
   File "G:\Python\libs\Playground\src\playground6.py", line 49, in <module>
     ''')
   File "g:\python\dev2\kivy\kivy\lang.py", line 1828, in load_string
     self._apply_rule(widget, parser.root, parser.root)
   File "g:\python\dev2\kivy\kivy\lang.py", line 1925, in _apply_rule
     rule.canvas_root, rootrule)
   File "g:\python\dev2\kivy\kivy\lang.py", line 2139, in _build_canvas
     '{}: {}'.format(e.__class__.__name__, e), cause=tb)
 kivy.lang.BuilderException: Parser: File "<inline>", line 6:
 ...
       4:        Color:
       5:            rgb: .1, .2, .3
 >>    6:            group: 'my_group'
 ...
 AttributeError: 'kivy.graphics.context_instructions.Color' object has no attribute 'group'
   File "g:\python\dev2\kivy\kivy\lang.py", line 2134, in _build_canvas
     setattr(instr, key, value)
```
With pr it prints
```
[<kivy.graphics.context_instructions.Color object at 0x02868D30>]
[0.1, 0.2, 0.3]
```