### PR TITLE
Fix property comparison

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -410,10 +410,10 @@ cdef class Property:
 
     cdef compare_value(self, a, b):
         try:
-            return a == b
+            return bool(a == b)
         except Exception as e:
             Logger.warn(
-                'Value comparison failed for {} with "{}". Consider setting '
+                'Property: Value comparison failed for {} with "{}". Consider setting '
                 'force_dispatch to True to avoid this.'.format(self, e))
             return False
 


### PR DESCRIPTION
For the code
```py
class MyWidget(Widget):
    obj = ObjectProperty(None)

w = MyWidget()
w.obj = np.arange(10)
w.obj = np.arange(10)
```

Before, it'd do 
```py
 Traceback (most recent call last):
   File "G:\Python\libs\Playground\src\playground6.py", line 28, in <module>
     w.obj = np.arange(10)
   File "kivy\properties.pyx", line 404, in kivy.properties.Property.__set__ (kivy\properties.c:4927)
   File "kivy\properties.pyx", line 430, in kivy.properties.Property.set (kivy\properties.c:5449)
 ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Now it does only 
```
[WARNING           ] [Property    ] Value comparison failed for <ObjectProperty name=obj> with "The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()". Consider setting force_dispatch to True to avoid this.
```