### PR TITLE
remove super call from TreeViewNode.__init__

### DIFF
--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -128,7 +128,6 @@ class TreeViewNode(object):
     def __init__(self, **kwargs):
         if self.__class__ is TreeViewNode:
             raise TreeViewException('You cannot use directly TreeViewNode.')
-        super(TreeViewNode, self).__init__(**kwargs)
 
     is_leaf = BooleanProperty(True)
     '''Boolean to indicate whether this node is a leaf or not. Used to adjust


### PR DESCRIPTION
Calling the superclass's initializer is normally a good idea, but ``TreeViewNode`` only has ``object`` for a superclass. ``object.__init__`` doesn't do anything, and trying to call it with ``**kwargs`` was giving me ``TypeError``s.