### PR TITLE
Fix misalignment of multi-touch emu feedback

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -528,6 +528,21 @@ class WindowBase(EventDispatcher):
     '''Real size of the window ignoring rotation.
     '''
 
+    def _get_effective_size(self):
+        w, h = self.system_size
+        if platform == 'ios' or self._density != 1:
+            w, h = self.size
+
+        return w,h
+
+    effective_size = AliasProperty(_get_effective_size, None)
+    '''On density=1 and non-ios displays, return system_size, else
+    return scaled / rotated size.
+
+    Used by MouseMotionEvent.update_graphics() and WindowBase.on_motion().
+    '''
+
+
     borderless = BooleanProperty(False)
     '''When set to True, this property removes the window border/decoration.
 
@@ -942,9 +957,7 @@ class WindowBase(EventDispatcher):
                 The Motion Event currently dispatched.
         '''
         if me.is_touch:
-            w, h = self.system_size
-            if platform == 'ios' or self._density != 1:
-                w, h = self.size
+            w,h = self.effective_size
             me.scale_for_screen(w, h, rotation=self._rotation,
                                 smode=self.softinput_mode,
                                 kheight=self.keyboard_height)

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -528,7 +528,7 @@ class WindowBase(EventDispatcher):
     '''Real size of the window ignoring rotation.
     '''
 
-    def get_effective_size(self):
+    def _get_effective_size(self):
         '''On density=1 and non-ios displays, return system_size, else
         return scaled / rotated size.
 
@@ -954,7 +954,7 @@ class WindowBase(EventDispatcher):
                 The Motion Event currently dispatched.
         '''
         if me.is_touch:
-            w, h = self.get_effective_size()
+            w, h = self._get_effective_size()
             me.scale_for_screen(w, h, rotation=self._rotation,
                                 smode=self.softinput_mode,
                                 kheight=self.keyboard_height)

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -528,20 +528,17 @@ class WindowBase(EventDispatcher):
     '''Real size of the window ignoring rotation.
     '''
 
-    def _get_effective_size(self):
+    def get_effective_size(self):
+        '''On density=1 and non-ios displays, return system_size, else
+        return scaled / rotated size.
+
+        Used by MouseMotionEvent.update_graphics() and WindowBase.on_motion().
+        '''
         w, h = self.system_size
         if platform == 'ios' or self._density != 1:
             w, h = self.size
 
-        return w,h
-
-    effective_size = AliasProperty(_get_effective_size, None)
-    '''On density=1 and non-ios displays, return system_size, else
-    return scaled / rotated size.
-
-    Used by MouseMotionEvent.update_graphics() and WindowBase.on_motion().
-    '''
-
+        return w, h
 
     borderless = BooleanProperty(False)
     '''When set to True, this property removes the window border/decoration.
@@ -957,7 +954,7 @@ class WindowBase(EventDispatcher):
                 The Motion Event currently dispatched.
         '''
         if me.is_touch:
-            w,h = self.effective_size
+            w, h = self.get_effective_size()
             me.scale_for_screen(w, h, rotation=self._rotation,
                                 smode=self.softinput_mode,
                                 kheight=self.keyboard_height)

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -105,10 +105,15 @@ class MouseMotionEvent(MotionEvent):
             self.ud._drawelement = de
         if de is not None:
             self.push()
+
+            # use same logic as WindowBase.on_motion() so we get correct
+            # coordinates when _density != 1
+            w,h = win.effective_size
+
             self.scale_for_screen(
-                win.system_size[0],
-                win.system_size[1],
+                w, h,
                 rotation=win.rotation)
+
             de[1].pos = self.x - 10, self.y - 10
             self.pop()
 

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -108,11 +108,9 @@ class MouseMotionEvent(MotionEvent):
 
             # use same logic as WindowBase.on_motion() so we get correct
             # coordinates when _density != 1
-            w,h = win.effective_size
+            w, h = win.get_effective_size()
 
-            self.scale_for_screen(
-                w, h,
-                rotation=win.rotation)
+            self.scale_for_screen(w, h, rotation=win.rotation)
 
             de[1].pos = self.x - 10, self.y - 10
             self.pop()

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -108,7 +108,7 @@ class MouseMotionEvent(MotionEvent):
 
             # use same logic as WindowBase.on_motion() so we get correct
             # coordinates when _density != 1
-            w, h = win.get_effective_size()
+            w, h = win._get_effective_size()
 
             self.scale_for_screen(w, h, rotation=win.rotation)
 


### PR DESCRIPTION
Visual feedback of multi-touch emulation first touch was being placed
at coordinates uncorrected for density != 1. Fixed by factoring out
and using same scaling as for WindowBase.on_motion().