### PR TITLE
SmoothLine not present in __init__.py graphics

### DIFF
--- a/kivy/graphics/__init__.py
+++ b/kivy/graphics/__init__.py
@@ -95,7 +95,7 @@ from kivy.graphics.context_instructions import BindTexture, Color, \
     UpdateNormalMatrix, gl_init_resources
 from kivy.graphics.vertex_instructions import Bezier, BorderImage, Ellipse, \
     GraphicException, Line, Mesh, Point, Quad, Rectangle, RoundedRectangle, \
-    Triangle
+    Triangle, SmoothLine
 from kivy.graphics.stencil_instructions import StencilPop, StencilPush, \
     StencilUse, StencilUnUse
 from kivy.graphics.gl_instructions import ClearColor, ClearBuffers
@@ -108,11 +108,11 @@ __all__ = (Bezier.__name__, BindTexture.__name__, BorderImage.__name__,
            Color.__name__, ContextInstruction.__name__,
            Ellipse.__name__, Fbo.__name__, GraphicException.__name__,
            Instruction.__name__, InstructionGroup.__name__,
-           Line.__name__, MatrixInstruction.__name__, Mesh.__name__,
-           Point.__name__, PopMatrix.__name__, PushMatrix.__name__,
-           Quad.__name__, Rectangle.__name__, RenderContext.__name__,
-           Rotate.__name__, Scale.__name__, StencilPop.__name__,
-           StencilPush.__name__, StencilUse.__name__,
+           Line.__name__, SmoothLine.__name__, MatrixInstruction.__name__,
+           Mesh.__name__, Point.__name__, PopMatrix.__name__,
+           PushMatrix.__name__, Quad.__name__, Rectangle.__name__,
+           RenderContext.__name__, Rotate.__name__, Scale.__name__,
+           StencilPop.__name__, StencilPush.__name__, StencilUse.__name__,
            StencilUnUse.__name__, Translate.__name__, Triangle.__name__,
            VertexInstruction.__name__, ClearColor.__name__,
            ClearBuffers.__name__, gl_init_resources.__name__,


### PR DESCRIPTION
I think this should be added here, otherwise fails to instantiate SmoothLine.