### PR TITLE
Fix for "disable_multitouch" in config

### DIFF
--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -199,7 +199,7 @@ class MouseMotionEventProvider(MotionEventProvider):
         cur.is_double_tap = is_double_tap
         self.touches[id] = cur
         if do_graphics:
-            cur.update_graphics(EventLoop.window, True)
+            cur.update_graphics(EventLoop.window, not (self.disable_multitouch or self.multitouch_on_demenad))
         self.waiting_event.append(('begin', cur))
         return cur
 


### PR DESCRIPTION
This is a fix for interaction on desktop systems w/no multitouch capability.  Current code does not allow disabling of multitouch and creating the "Red Circle" on right click.

Requires the following config change to take effect:
* Edit /Applications/Kivy.app/Contents/Resources/.kivy/config.ini to add "disable_multitouch" to input/mouse.

So the config file will then read (if changed from default):
[input]
mouse = mouse,disable_multitouch

Credit goes to Bill Janssen and this thread from the Google Group: https://groups.google.com/forum/#!topic/kivy-users/6KuO-DaBNIE