### PR TITLE
add depth+stencil buffer support to fbo

### DIFF
--- a/kivy/graphics/c_opengl.pxd
+++ b/kivy/graphics/c_opengl.pxd
@@ -333,6 +333,7 @@ cdef extern from "gl_redirect.h":
     int GL_RGB565
     int GL_DEPTH_COMPONENT16
     int GL_STENCIL_INDEX8
+    int GL_DEPTH24_STENCIL8
 
     int GL_RENDERBUFFER_WIDTH
     int GL_RENDERBUFFER_HEIGHT

--- a/kivy/graphics/common_subset.h
+++ b/kivy/graphics/common_subset.h
@@ -436,6 +436,7 @@ GL_APICALL void         GL_APIENTRY glViewport (GLint x, GLint y, GLsizei width,
 #define GL_FRAMEBUFFER                    0x8D40
 #define GL_RENDERBUFFER                   0x8D41
 #define GL_STENCIL_INDEX8                 0x8D48
+#define GL_DEPTH24_STENCIL8_OES           0x88F0
 #define GL_RENDERBUFFER_WIDTH             0x8D42
 #define GL_RENDERBUFFER_HEIGHT            0x8D43
 #define GL_RENDERBUFFER_INTERNAL_FORMAT   0x8D44

--- a/kivy/graphics/gl_redirect.h
+++ b/kivy/graphics/gl_redirect.h
@@ -29,10 +29,15 @@
 #			include "common_subset.h"
 #		else
 #			include <GLES2/gl2.h>
+#			include <GLES2/gl2ext.h>
+#		endif
+#		ifndef GL_DEPTH24_STENCIL8
+#			define GL_DEPTH24_STENCIL8                      GL_DEPTH24_STENCIL8_OES
 #		endif
 #	else
 #		ifdef __APPLE__
 #			include <OpenGL/gl.h>
+#			include <OpenGL/glext.h>
 #		else
 #			define GL_GLEXT_PROTOTYPES
 #			include <GL/gl.h>


### PR DESCRIPTION
Adds support for depth+stencil buffer using `GL_DEPTH24_STENCIL8`/`GL_DEPTH24_STENCIL8_OES`. If an FBO is created with only depth or stencil buffers, but not both, and an FBO unsupported error occurs, then it will automatically attempt to create a depth+stencil buffer instead.

Allows stencil buffer to be used on platforms such as OS X, where an FBO cannot be created with solely a stencil buffer. In a perfect world it would work on iOS as well, which has the same limitation, however iOS currently suffers from a freezing issue (#3428). Since it automatically switches to depth+stencil, it works seamlessly with existing code like garden.graph.

This has been tested on OS X 10.10.4 with XCode 7 and Android 5.0 with SDK 21 using the code below. On OS X, the Graph FBO automatically switches to depth+stencil. The `on_start` code checks to ensure that using depth+stencil doesn't immediately crash on other platforms (like Android) which won't need to switch.

````python
import sys, os, math

from kivy.app import App
from kivy.garden.graph import Graph, MeshLinePlot
from kivy.graphics import Fbo

class MyApp(App):
    def build(self):
        print 'create graph'
        graph = Graph(xlabel='X', ylabel='Y', x_ticks_minor=5,
                      x_ticks_major=25, y_ticks_major=1,
                      y_grid_label=True, x_grid_label=True, padding=5,
                      x_grid=True, y_grid=True, xmin=-0, xmax=100, ymin=-1, ymax=1)
        plot = MeshLinePlot(color=[1, 0, 0, 1])
        plot.points = [(x, math.sin(x / 10.)) for x in range(0, 101)]
        graph.add_plot(plot)
        return graph

    def on_start(self):
        print 'create d+s fbo'
        fbo = Fbo(size=(100, 100), with_depthbuffer=True, with_stencilbuffer=True)
        print fbo


if __name__ == '__main__':
    app = MyApp()
    app.run()
````