### PR TITLE
Fix #3558:  text widget search linux font paths on FreeBSD systems

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -268,7 +268,7 @@ class LabelBase(object):
             return LabelBase._fonts_dirs
 
         fdirs = []
-        if platform == 'linux':
+        if platform == 'linux' or platform == 'freebsd':
             fdirs = [
                 '/usr/share/fonts/truetype', '/usr/local/share/fonts',
                 os.path.expanduser('~/.fonts'),


### PR DESCRIPTION
Get text widgets working on FreeBSD (#3558) with this.  Note: Not familiar with internals to know if this conflicts with anything!