### PR TITLE
Fix KIVY_VIDEO provider list

### DIFF
--- a/doc/sources/guide/environment.rst
+++ b/doc/sources/guide/environment.rst
@@ -105,7 +105,7 @@ KIVY_TEXT
 KIVY_VIDEO
     Implementation to use for rendering video
 
-    Values: pygst, gstplayer, pyglet, ffmpeg, null
+    Values: pygst, gstplayer, pyglet, ffpyplayer, null
 
 KIVY_AUDIO
     Implementation to use for playing audio


### PR DESCRIPTION
FFmpeg doesn't seem to work, while ffpyplayer does, so I guess the docs need updating?