### PR TITLE
Use list instead of tuple in AliasProperty

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1311,7 +1311,7 @@ cdef class AliasProperty(Property):
             return self.x + self.width
         def set_right(self, value):
             self.x = value - self.width
-        right = AliasProperty(get_right, set_right, bind=('x', 'width'))
+        right = AliasProperty(get_right, set_right, bind=['x', 'width'])
 
     :Parameters:
         `getter`: function


### PR DESCRIPTION
I tried using AliasProperty today, and I needed to bind to a single property. I used a tuple with my property name as string like the documentation asks - as you guessed, since I didn't put an extra trailing comma, it got passed as a string to Kivy Properties.

Code was something like:
    hpr = AliasProperty(get_hpr, set_hpr, bind=('rot'))

Changing the tuple to a list fixes the issue. I suggest we do the same in the docs, to avoid newbies blindly following it and getting VERY obscure errors because of this (like I did).