### PR TITLE
Make sure negative widget insertions are possible

### DIFF
--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -575,7 +575,7 @@ class Carousel(StencilView):
         slide.add_widget(widget)
         super(Carousel, self).add_widget(slide, index)
         if index != 0:
-            self.slides.insert(index, widget)
+            self.slides.insert(index - len(self.slides), widget)
         else:
             self.slides.append(widget)
 


### PR DESCRIPTION
With the current implementation it's not possible to add a widget at the beginning of the carousel. If the user passes -1, it's added at position -1 because -1 != 0, but when the user passes 0, it's appended, which is the same thing!