### PR TITLE
accept KIVY_SDL2_PATH for darwin builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -378,7 +378,11 @@ if platform not in ('ios', 'android') and (c_options['use_gstreamer']
 sdl2_flags = {}
 if platform not in ('android',) and c_options['use_sdl2'] in (None, True):
 
-    if c_options['use_osx_frameworks'] and platform == 'darwin':
+    if platform == 'darwin' and environ.get('KIVY_SDL2_PATH', None):
+    	# paths and link flags will be configured in determine_sdl2()
+        c_options['use_sdl2'] = True
+
+    elif c_options['use_osx_frameworks'] and platform == 'darwin':
         # check the existence of frameworks
         sdl2_valid = True
         sdl2_flags = {


### PR DESCRIPTION
I'm building Kivy on OS X using homebrew (and python3) and am including SDL2 as homebrew libs (e.g. myhomebrew/lib/libSDL2.a), not as OS X frameworks. Currently setup.py ignores KIVY_SDL2_PATH for darwin and you have to have SDL2 frameworks installed under /Library. With this change, setting KIVY_SDL2_PATH to your homebrew SDL2 header directory, Kivy builds without SDL2 frameworks. The compiled binary works (i.e. the homebrew SDL2 is correctly linked). Tested under OS X 10.10.5.