### PR TITLE
audio_sdl2: support audio formats beyond wav

### DIFF
--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -150,7 +150,8 @@ class SoundSDL2(Sound):
         self.unload()
         if self.filename is None:
             return
-        mc.chunk = Mix_LoadWAV(<char *><bytes>self.filename)
+        fn = self.filename.encode('UTF-8')
+        mc.chunk = Mix_LoadWAV(<char *><bytes>fn)
         if mc.chunk == NULL:
             Logger.warning('AudioSDL2: Unable to load %r' % self.filename)
         else:

--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -32,6 +32,7 @@ cdef mix_init():
     cdef int audio_channels = 2
     cdef int audio_buffers = 4096
     global mix_is_init
+    global mix_flags
 
     # avoid next call
     if mix_is_init != 0:
@@ -42,7 +43,7 @@ cdef mix_init():
         mix_is_init = -1
         return 0
 
-    mix_flags = Mix_Init(0)
+    mix_flags = Mix_Init(MIX_INIT_FLAC|MIX_INIT_MOD|MIX_INIT_MP3|MIX_INIT_OGG)
 
     if Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers):
         Logger.critical('AudioSDL2: Unable to open mixer')

--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -112,13 +112,11 @@ class SoundSDL2(Sound):
         cdef unsigned short fmt
         if mc.chunk == NULL:
             return 0
-        Mix_QuerySpec(&freq, &fmt, &channels)
-        if fmt == AUDIO_S8 or fmt == AUDIO_U8:
-            mixerbytes = 1
-        else:
-            mixerbytes = 2
-        numsamples = mc.chunk.alen / mixerbytes / channels
-        return <double>numsamples / <double>channels
+        if not Mix_QuerySpec(&freq, &fmt, &channels):
+            return 0
+        points = mc.chunk.alen / ((fmt & 0xFF) / 8)
+        frames = points / channels
+        return <double>frames / <double>freq
 
     def play(self):
         cdef MixContainer mc = self.mc

--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -148,7 +148,12 @@ class SoundSDL2(Sound):
         self.unload()
         if self.filename is None:
             return
-        fn = self.filename.encode('UTF-8')
+
+        if isinstance(self.filename, bytes):
+            fn = self.filename
+        else:
+            fn = self.filename.encode('UTF-8')
+
         mc.chunk = Mix_LoadWAV(<char *><bytes>fn)
         if mc.chunk == NULL:
             Logger.warning('AudioSDL2: Unable to load %r' % self.filename)


### PR DESCRIPTION
audio_sdl2 would always only WAV support, because mix_flags was not global and no flags were supplied to Mix_Init(). I successfully played an OGG file with it, **but this needs review/testing**, I'm not familiar with SDL2.