### PR TITLE
fix recursion depth error

### DIFF
--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -873,12 +873,19 @@ class FocusBehavior(object):
                 keyboards[keyboard] = None
 
     def _bind_keyboard(self):
-        self._ensure_keyboard()
-        keyboard = self._keyboard
+        if self.disabled or not self.is_focusable:
+            keyboard = False
+        else:
+            self._ensure_keyboard()
+            keyboard = self._keyboard
 
-        if not keyboard or self.disabled or not self.is_focusable:
-            self.focus = False
+        if not keyboard:
+            # Schedule to prevent recurive event cascading
+            def remove_focus(dt):
+                self.focus = False
+            Clock.schedule_once(remove_focus)
             return
+
         keyboards = FocusBehavior._keyboards
         old_focus = keyboards[keyboard]  # keyboard should be in dict
         if old_focus:


### PR DESCRIPTION
From this ticket. Setting focus = True on a widget inheriting FocusBehavior gives stack overflow or maximum recursion depth exceeded. This happens only when the 'is_focusable' property is True.

https://groups.google.com/forum/#!topic/kivy-users/eGsaZYOrH5Q

A minimal, runnable example follows;

    #!/usr/bin/env python
    from kivy.app import App
    from kivy.lang import Builder

    kv = '''
    <MyTextInput@TextInput>:
        is_focusable: False

    BoxLayout:
        Button:
            text: 'Set focus'
            on_release: ti.focus = True
        MyTextInput:
            id: ti
    '''


    class TestApp(App):
        def build(self):
            return Builder.load_string(kv)

    TestApp().run()