### PR TITLE
Corrected on_frame in doc

### DIFF
--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -45,7 +45,7 @@ class CameraBase(EventDispatcher):
         `on_load`
             Fired when the camera is loaded and the texture has become
             available.
-        `on_frame`
+        `on_texture`
             Fired each time the camera texture is updated.
     '''
 


### PR DESCRIPTION
Couldn't get ```on_frame``` event to work, found that the docs show the event as ```on_frame``` but it is actually ```on_texture```.