### PR TITLE
audio_sdl2: support sequenced formats

### DIFF
--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -21,11 +21,11 @@ Depending the compilation of SDL2 mixer and/or installed libraries:
 .. Warning::
 
     Sequenced formats use the SDL2 Mixer music channel, you can only play
-    one at a time, and .length will be 0 if no music is loaded, and -1
-    if loaded (can't get duration of these formats)
+    one at a time, and .length will be -1 if music fails to load, and 0
+    if loaded successfully (we can't get duration of these formats)
 '''
 
-__all__ = ('SoundSDL2', )
+__all__ = ('SoundSDL2', 'MusicSDL2')
 
 include "../../../kivy/lib/sdl2.pxi"
 
@@ -263,8 +263,8 @@ class MusicSDL2(Sound):
     def _get_length(self):
         cdef MusicContainer mc = self.mc
         if mc.music == NULL:
-            return 0
-        return -1
+            return -1
+        return 0
 
     def play(self):
         cdef MusicContainer mc = self.mc

--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -68,7 +68,7 @@ cdef mix_init():
 
     if Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers):
         Logger.critical('AudioSDL2: Unable to open mixer: {}'.format(
-                        SDL_GetError()))
+                        Mix_GetError()))
         mix_is_init = -1
         return 0
 
@@ -165,8 +165,8 @@ class SoundSDL2(Sound):
         cc.chunk.volume = int(self.volume * 128)
         cc.channel = Mix_PlayChannel(-1, cc.chunk, 0)
         if cc.channel == -1:
-            Logger.warning(
-                'AudioSDL2: Unable to play %r, no more free channel' % self.filename)
+            Logger.warning('AudioSDL2: Unable to play {}: {}'.format(
+                           self.filename, Mix_GetError()))
             return
         # schedule event to check if the sound is still playing or not
         Clock.schedule_interval(self._check_play, 0.1)
@@ -195,7 +195,8 @@ class SoundSDL2(Sound):
 
         cc.chunk = Mix_LoadWAV(<char *><bytes>fn)
         if cc.chunk == NULL:
-            Logger.warning('AudioSDL2: Unable to load %r' % self.filename)
+            Logger.warning('AudioSDL2: Unable to load {}: {}'.format(
+                           self.filename, Mix_GetError()))
         else:
             cc.chunk.volume = int(self.volume * 128)
 
@@ -273,8 +274,8 @@ class MusicSDL2(Sound):
             return
         Mix_VolumeMusic(int(self.volume * 128))
         if Mix_PlayMusic(mc.music, 1) == -1:
-            Logger.warning(
-                'AudioSDL2: Unable to play music file: %r' % self.filename)
+            Logger.warning('AudioSDL2: Unable to play music {}: {}'.format(
+                           self.filename, Mix_GetError()))
             return
         mc.playing = 1
         # schedule event to check if the sound is still playing or not
@@ -303,7 +304,8 @@ class MusicSDL2(Sound):
 
         mc.music = Mix_LoadMUS(<char *><bytes>fn)
         if mc.music == NULL:
-            Logger.warning('AudioSDL2: Unable to load music %r' % self.filename)
+            Logger.warning('AudioSDL2: Unable to load music {}: {}'.format(
+                           self.filename, Mix_GetError()))
         else:
             Mix_VolumeMusic(int(self.volume * 128))
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -878,3 +878,4 @@ cdef extern from "SDL_mixer.h":
     #cdef int  Mix_EachSoundFont(int (*function)( char*, void*), void *data)
     cdef Mix_Chunk *  Mix_GetChunk(int channel)
     cdef void  Mix_CloseAudio()
+    cdef char * Mix_GetError()

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -793,9 +793,10 @@ cdef extern from "SDL_mixer.h":
     ctypedef enum MIX_InitFlags:
         MIX_INIT_FLAC        = 0x00000001
         MIX_INIT_MOD         = 0x00000002
-        MIX_INIT_MP3         = 0x00000004
-        MIX_INIT_OGG         = 0x00000008
-        MIX_INIT_FLUIDSYNTH  = 0x00000010
+        MIX_INIT_MODPLUG     = 0x00000004
+        MIX_INIT_MP3         = 0x00000008
+        MIX_INIT_OGG         = 0x00000010
+        MIX_INIT_FLUIDSYNTH  = 0x00000020
 
     cdef int MIX_MAX_VOLUME
 


### PR DESCRIPTION
Adds support for mod/s3m/midi/etc playback, which can only be done on mixer music channel.

Only tested with libmodplug, assume it will work if built for mikmod or both libraries. (EDIT: works with mikmod and both at once)

* Fixed incorrect MIX_INIT_* bitmasks in lib/sdl2.pxi
* Renamed MixContainer to ChunkContainer. MusicContainer was introduced, and both relate to the mixer, so MixContainer became ambigious
* Added MusicSDL2 to support playing sequenced formats on SDL2-mixer music channel. No support for wave formats - we'd need a mixer abstraction to separate them
* WARNING: Can't _get_length for sequenced formats; using 0 if nothing loaded and -1 if loaded (better suggestions?)