### PR TITLE
Updated Ubuntu installation packages docs for 15.04

### DIFF
--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -91,7 +91,7 @@ that will install all necessary packages::
       build-essential libgl1-mesa-dev-lts-quantal libgles2-mesa-dev-lts-quantal\ 
       python-pip
 
-For older versions of Ubuntu, this one should work::
+For Ubuntu 15.04 and versions older than 12.04, this one should work::
 
     $ sudo apt-get install python-setuptools python-pygame python-opengl \
       python-gst0.10 python-enchant gstreamer0.10-plugins-good python-dev \


### PR DESCRIPTION
As @dec0dedab0de pointed in issue #3630 that the correct apt-get packages for Ubuntu 15.04 were not specified; added it into documentation. Turns out they're the same as < 12.04!