### PR TITLE
fix RPI touchscreen not working with KIVY_BCM_DISPMANX_ID=4

### DIFF
--- a/kivy/lib/vidcore_lite/egl.pyx
+++ b/kivy/lib/vidcore_lite/egl.pyx
@@ -603,7 +603,7 @@ def bcm_display_open(bcm.uint32_t device):
     cdef:
         bcm.DISPMANX_DISPLAY_HANDLE_T disp
         bcm.DisplayHandle D
-    disp = bcm.vc_dispmanx_display_open( 0 )
+    disp = bcm.vc_dispmanx_display_open( device )
     if disp == 0:
         raise bcm.BCMDisplayException("Couldn't open handle to display")
     D = bcm.DisplayHandle()


### PR DESCRIPTION
This fix (for issue #3640) allows it to use the Raspberry Pi official touchscreen besides the HDMI screen.
