### PR TITLE
Fix for sample path in examples

### DIFF
--- a/examples/kv/app_logo.kv
+++ b/examples/kv/app_logo.kv
@@ -1,7 +1,7 @@
 Widget:
     Video:
         id: myvideo
-        source: '/home/tito/code/pymt/examples/apps/videoplayer/softboy.mpg'
+        source: '/usr/share/kivy-examples/widgets/softboy.mpg'
         play: mybutton.state == 'down'
         canvas:
             Color:


### PR DESCRIPTION
Updates path mentioned in issue #3253 to /usr/share/kivy-examples/widgets.