### PR TITLE
Fix breakage in Python < 2.7.9

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -272,7 +272,8 @@ class UrlRequest(Thread):
             ctx.verify_mode = ssl.CERT_REQUIRED
             args['context'] = ctx
 
-        if not verify and parse.scheme == 'https' and hasattr(ssl, 'create_default_context'):
+        if not verify and parse.scheme == 'https' and (
+            hasattr(ssl, 'create_default_context')):
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -272,7 +272,7 @@ class UrlRequest(Thread):
             ctx.verify_mode = ssl.CERT_REQUIRED
             args['context'] = ctx
 
-        if not verify and parse.scheme == 'https':
+        if not verify and parse.scheme == 'https' and hasattr(ssl, 'create_default_context'):
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Checked if ssl has attribute create_default_context before using it.
This was introduced in Python 2.7.9 so in older versions this code would break without the check.