### PR TITLE
Maintain last selection if not allowing empty selection

### DIFF
--- a/kivy/adapters/listadapter.py
+++ b/kivy/adapters/listadapter.py
@@ -299,7 +299,14 @@ class ListAdapter(Adapter, EventDispatcher):
                 else:
                     self.select_item_view(view)
         else:
-            self.deselect_item_view(view)
+            if len(self.selection) == 1 and not self.allow_empty_selection:
+                # Maintain selection rather than always defaulting to first
+                # item. This probably invalidates the next if section, but I
+                # am unable to test all corner cases out, and leaving it in
+                # does not hurt anything.
+                pass
+            else:
+                self.deselect_item_view(view)
             if self.selection_mode != 'none':
                 # If the deselection makes selection empty, the following call
                 # will check allows_empty_selection, and if False, will


### PR DESCRIPTION
Self-explanatory. There doesn't seem any good reason to always default to the first item if the user deselects the last item, in the case where allow_empty_selection is already False.

In particular, this means accidental double/multiple-selections (especially common when using a mouse rather than touch) become less of an issue, and the likely intention of the user is carried through.