### PR TITLE
Add a focusable check to _on_focus

### DIFF
--- a/kivy/uix/behaviors.py
+++ b/kivy/uix/behaviors.py
@@ -856,7 +856,7 @@ class FocusBehavior(object):
             self.focus = False
 
     def _on_focus(self, instance, value, *largs):
-        if self.keyboard_mode == 'auto':
+        if self.is_focusable and self.keyboard_mode == 'auto':
             if value:
                 self._bind_keyboard()
             else:


### PR DESCRIPTION
Previously this would cause stack overflow or similar by trying to focus but not being allowed to. Simply adds a check. Also including below a minimal example which works with this patch but doesn't without.

#!/usr/bin/env python
import kivy
from kivy.app import App
from kivy.clock import Clock
from kivy.uix.button import Button
from kivy.uix.boxlayout import BoxLayout
from kivy.uix.textinput import TextInput


class MyTextInput(TextInput):
    def __init__(self, **kwargs):
        super(MyTextInput, self).__init__(**kwargs)
        self.write_tab = False
        self.is_focusable = False

class TestApp(App):
    def build(self):
        self.box = BoxLayout()
        self.box.add_widget(MyTextInput(text="starting text"))
        Clock.schedule_once(self.test)
        return self.box

    def test(self, dt):
        for widget in self.box.walk():
            if isinstance(widget, TextInput):
                widget.focus = True
                return

if __name__=='__main__':
    TestApp().run()