### PR TITLE
Documentation: update OS X instructions

### DIFF
--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -1,22 +1,21 @@
-.. _installation_macosx:
+.. _installation_osx:
 
-Installation on MacOSX
+Installation on OS X
 ======================
+
+Using The Kivy.app
+------------------
 
 .. note::
 
-    This method has only been tested on Mac OSX 10.7 Lion 64-bit.
+    This method has only been tested on OS X 10.7 Lion 64-bit.
     For versions prior to 10.7 or 10.7 32-bit, you have to install the
     components yourself. We suggest using
-    `homebrew <http://mxcl.github.com/homebrew/>`_ to do that.
+    `homebrew <http://brew.sh>`_ to do that.
 
-    There can be a limitation on some OS X with more than one monitor.
-    The application will crash when you try to start it on the second monitor.
-
-For Mac OS X 10.7 and later, we provide a Kivy.app with all dependencies
+For OS X 10.7 and later, we provide a Kivy.app with all dependencies
 bundled. Download it from our `Download Page <http://kivy.org/#download>`_.
-It comes as a .dmg 
-file that contains:
+It comes as a .dmg file that contains:
 
     * Kivy.app
     * Readme.txt
@@ -34,59 +33,59 @@ You should now have a `kivy` script that you can use to launch your kivy app fro
 
 You can just drag and drop your main.py to run your app too.
 
+
 Installing modules
--------------------
+~~~~~~~~~~~~~~~~~~
 
 Kivy package on osx uses its own virtual env that is activated when you run your app using `kivy` command.
 To install any module you need to install the module like so::
 
-    kivy -m pip install <modulename>
+    $ kivy -m pip install <modulename>
 
-Installing the dev version
---------------------------
-Follow these steps:
-
-    1. Follow the procedure mentioned above to install kivy stable.
-    2. Install the requirements like (sdl2, sdl2_ttf, sdl2_mixerm, gstreamer) as frameworks on your system.
-    3. You need to link these frameworks to /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks.Make file will check /Library/Frameworks but Xcode will use its own folder, the second one.
-    4. Open a terminal and type the following commands into it::
-
-        kivy -m pip install cython
-        cd /Applications/Kivy.app/Contents/Resources/
-        mv kivy kivy_stable
-        git clone http://github.com/kivy/kivy
-        cd kivy
-        kivy setup.py build_ext --inplace
-
-That's it. You now have the latest kivy from github.
 
 Start any Kivy Application
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can run any Kivy application by simply dragging the application's main file
 onto the Kivy.app icon. Just try this with any python file in the examples folder.
 
 .. _macosx-run-app:
 
+
 Start from the Command Line
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to use Kivy from the command line, double-click the ``Make Symlinks`` script
 after you have dragged the Kivy.app into the Applications folder. To test if it worked:
 
     #. Open Terminal.app and enter::
-    
+
            $ kivy
-        
+
        You should get a Python prompt.
-        
+
     #. In there, type::
 
            >>> import kivy
-           
+
        If it just goes to the next line without errors, it worked.
-       
+
     #. Running any Kivy application from the command line is now simply a matter
        of executing a command like the following::
-       
+
            $ kivy yourapplication.py
+
+
+Using pip
+---------
+
+Alternatively you can install Kivy using the following steps:
+
+    1. Install the requirements using `homebrew <http://brew.sh>`_::
+
+        $ brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gstreamer
+
+    2. Install cython 0.21.2 and kivy using pip::
+
+        $ pip install -I Cython==0.21.2
+        $ USE_OSX_FRAMEWORKS=0 pip install kivy

--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -55,11 +55,11 @@ Please refer to the installation instructions for your specific platform:
     :maxdepth: 2
 
     installation-windows
-    installation-macosx
+    installation-osx
     installation-linux
     installation-android
     installation-rpi
-    troubleshooting-macosx
+    troubleshooting-osx
 
 
 .. _installation_devel:
@@ -104,15 +104,12 @@ supported version from pypi:
 
     $ sudo pip install --upgrade |cython_install|
 
-Mac OS X
-++++++++
+OS X
+++++
 
-You will need to install at least the following:
+Install the requirements using `homebrew <http://brew.sh>`_::
 
-* PyGame - we recommend installing from a binary packaged for your version
-  of Mac OS X. Download it from http://www.pygame.org/download.shtml
-
-If you run into problems, please read :ref:`troubleshooting-macosx`.
+     $ brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gstreamer
 
 .. _dev-install:
 
@@ -122,11 +119,13 @@ Installing Kivy for Development
 Now that you've installed all the required dependencies, it's time to
 download and compile a development version of Kivy::
 
-    $ # Download Kivy from GitHub
+Download Kivy from GitHub::
+
     $ git clone git://github.com/kivy/kivy.git
     $ cd kivy
 
-    $ # Compile:
+Compile::
+
     $ python setup.py build_ext --inplace -f
 
 If you have the ``make`` command available, you can also use the
@@ -167,11 +166,11 @@ in Kivy, perhaps a test will show this? If not, it might be a good time to write
 one .)
 
 Kivy tests are based on nosetest, which you can install from your package
-manager or using pip :
+manager or using pip::
 
   $ pip install nose
 
-To run the test suite, do :
+To run the test suite, do::
 
   $ make test
 

--- a/doc/sources/installation/troubleshooting-osx.rst
+++ b/doc/sources/installation/troubleshooting-osx.rst
@@ -1,9 +1,9 @@
-.. _troubleshooting-macosx:
+.. _troubleshooting-osx:
 
-Troubleshooting on Mac OS X
+Troubleshooting on OS X
 ===========================
 
-Having trouble installing Kivy on Mac OS X? This page contains issues 
+Having trouble installing Kivy on OS X? This page contains issues 
 
 "Unable to find any valuable Window provider" Error
 ---------------------------------------------------
@@ -89,6 +89,6 @@ The easiest way to resolve these PyGame import errors is:
 1. Delete the ``pygame`` package. (For example, if you get the error above, 
     delete /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pygame/ 
     and the accompanying egg.
-2. Try installing a PyGame binary for your version of Mac OS X. Download it 
+2. Try installing a PyGame binary for your version of OS X. Download it 
     from http://www.pygame.org/download.shtml.
-3. Repeat this process and try different PyGame Mac OS X binaries until you find one that works.
+3. Repeat this process and try different PyGame OS X binaries until you find one that works.


### PR DESCRIPTION
- remove warning from 4e1704f as we do not use pygame on OS X anymore since 1.9.0
- rename MacOSX to OS X
- add a chapter on using pip and homebrew
- use $ signs
- remove instructions to install dev version in kivy.app

The pip instructions depend on #3682