### PR TITLE
Add option to mimic Spinner height in dropdown

### DIFF
--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -105,6 +105,15 @@ class Spinner(Button):
 
     .. versionadded:: 1.4.0
     '''
+    
+    mimic_size = BooleanProperty(False)
+    '''Each element in the dropdown list uses a default/user-supplied height.
+    Set to True to propagate the Spinner's height value to each dropdown list
+    element.
+    :attr:`mimic_size` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to False.
+    .. versionadded:: No idea
+    '''
 
     def __init__(self, **kwargs):
         self._dropdown = None
@@ -115,6 +124,7 @@ class Spinner(Button):
         fbind('dropdown_cls', build_dropdown)
         fbind('option_cls', build_dropdown)
         fbind('values', self._update_dropdown)
+        fbind('size', self._update_dropdown)
         build_dropdown()
 
     def _build_dropdown(self, *largs):
@@ -139,6 +149,7 @@ class Spinner(Button):
         dp.clear_widgets()
         for value in self.values:
             item = cls(text=value)
+            item.height = self.height if self.mimic_size else item.height
             item.bind(on_release=lambda option: dp.select(option.text))
             dp.add_widget(item)
 


### PR DESCRIPTION

A fairly arbitrary size 48 height is currently the default (where's this set, by the way? Certainly not in this file. I couldn't find it).

This patch adds an option `mimic_size` which would have each dropdown element's height set according to the current size of the Spinner. More visually pleasing IMO. User customization is unaffected, perhaps a note should be made that this overwrites any changes in SpinnerOption.

For consideration before accepting:-
mimic_size or mimic_height?
I only set item.height (based on self.height) as size_hint_x of the default SpinnerOption is 1, hence setting item.size would not make a difference and may be a bit unclear.