### PR TITLE
super in base object should not pass on kwargs

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -250,7 +250,7 @@ cdef class EventDispatcher(ObjectWithUid):
         properties = self.properties()
         prop_args = [
             (k, kwargs.pop(k)) for k in list(kwargs.keys()) if k in properties]
-        super(EventDispatcher, self).__init__(**kwargs)
+        super(EventDispatcher, self).__init__()
 
         __cls__ = self.__class__
         if __cls__ not in cache_events_handlers:


### PR DESCRIPTION
Based on comments in https://github.com/kivy/kivy/issues/3650 - this fixes crashes whenever opening Settings (including in the examples)

GBlame shows that this line was added in commit d7bf6dbd by Matthew Einhorn on 2015-06-29 

Not sure if that commit needs reverting as I don't really understand what was being done. But yes, this fixes a 100% crash.
