### PR TITLE
Prevent SettingTitle from passing panel object up inheritence tree

### DIFF
--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -586,6 +586,8 @@ class SettingTitle(Label):
     '''
 
     title = Label.text
+    
+    panel = ObjectProperty(None)
 
 
 class SettingsPanel(GridLayout):


### PR DESCRIPTION
On python3, this behaviour provokes a crash every time a settings object is opened/used. See discussion here - https://github.com/kivy/kivy/issues/3650#issuecomment-148154997

Probably needs a bit of additional documentation, but as this is an internal value not meant to be used I was not sure if to copy the documentation string from SettingItem or not.