### PR TITLE
Fix directory selection double-selecting

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -601,7 +601,6 @@ class FileChooserController(RelativeLayout):
                 self.selection.append(entry.path)
         else:
             if _dir and not self.dirselect:
-                self.open_entry
                 return
             self.selection = [entry.path, ]
 
@@ -620,7 +619,7 @@ class FileChooserController(RelativeLayout):
                 self.open_entry(entry)
             elif touch.is_double_tap:
                 if self.dirselect and self.file_system.is_dir(entry.path):
-                    self.open_entry(entry)
+                    return
                 else:
                     self.dispatch('on_submit', self.selection, touch)
 


### PR DESCRIPTION
open_entry gets called twice when double-tapping (which is necessary to open/go into a directory with dirselect=True). Remove one of them.

Also remove a line which doesn't do anything (in the dirselect=False case) which prevented this bug from being more obvious, since it would only be hit in the dirselect=True codepath.

Linked to this issue (reported by me) - https://github.com/kivy/kivy/issues/3708