### PR TITLE
Add scrollleft / scrollright to sdl2 backend.

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -416,9 +416,9 @@ class WindowSDL(WindowBase):
                     btn = 'right'
                 elif button == 2:
                     btn = 'middle'
-                if button == 6:  # fix for # 3707 - trackpad scrollleft gets to here
+                if button == 6:
                     btn = 'scrollleft'
-                elif button == 7:  # fix for # 3707 - trackpad scrollright gets to here
+                elif button == 7:
                     btn = 'scrollright'
                 eventname = 'on_mouse_down'
                 self._mouse_buttons_down.add(button)

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -416,6 +416,10 @@ class WindowSDL(WindowBase):
                     btn = 'right'
                 elif button == 2:
                     btn = 'middle'
+                if button == 6:  # fix for # 3707 - trackpad scrollleft gets to here
+                    btn = 'scrollleft'
+                elif button == 7:  # fix for # 3707 - trackpad scrollright gets to here
+                    btn = 'scrollright'
                 eventname = 'on_mouse_down'
                 self._mouse_buttons_down.add(button)
                 if action == 'mousebuttonup':


### PR DESCRIPTION
Not sure why the action of the event for scrolling left/right is being interpreted as "mousebuttondown"/"mousebuttonup" only for scroll left/right, but it is.

This makes all the list examples useable when tested on Ubuntu.