### PR TITLE
Fix postproc:calibration for on_touch_up

### DIFF
--- a/kivy/input/postproc/calibration.py
+++ b/kivy/input/postproc/calibration.py
@@ -82,6 +82,10 @@ class InputPostprocCalibration(object):
         self.frame += 1
         frame = self.frame
         for etype, event in events:
+            # frame-based logic below doesn't account for 
+            # end events having been already processed
+            if etype == 'end':
+                continue
             if event.device not in self.devices:
                 continue
             # some providers use the same event to update and end


### PR DESCRIPTION
on_touch_down and on_touch_move set a new position to the touch, so they need processing, but on_touch_up does not, so it would make the event have calibration applied twice.

How to reproduce:

```
from kivy.app import App
from kivy.uix.widget import Widget

class Test(App):
    def build(self):
        return DebugWidget()

class DebugWidget(Widget):
    def on_touch_down(self, touch):
        print 'on_touch_{}: x={}, y={}'.format('down', touch.x, touch.y)
        print touch.device, touch.ud['calibration:frame']

    def on_touch_move(self, touch):
        print 'on_touch_{}: x={}, y={}'.format('move', touch.x, touch.y)
        print touch.device, touch.ud['calibration:frame']

    def on_touch_up(self, touch):
        print 'on_touch_{}: x={}, y={}'.format('up', touch.x, touch.y)
        print touch.device, touch.ud['calibration:frame']

Test().run()
```
If you click, drag and release the click while dragging, you'll notice positions are correct thanks to the frame-based logic that's already in postproc:calibration. If however on_touch_up happens at a later time, it will be processed for the second time unnecessarily, and you will notice postproc:calibration being applied twice (the coordinates in on_touch_up will reflect that)