### PR TITLE
Make widget kwargs passing higher priority than kv

### DIFF
--- a/kivy/_event.pxd
+++ b/kivy/_event.pxd
@@ -14,6 +14,7 @@ cdef class EventDispatcher(ObjectWithUid):
     cdef dict __properties
     cdef dict __storage
     cdef object __weakref__
+    cdef public set _kwargs_applied_init
     cpdef dict properties(self)
 
 

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -244,12 +244,13 @@ cdef class EventDispatcher(ObjectWithUid):
     def __init__(self, **kwargs):
         cdef basestring func, name, key
         cdef dict properties
-        cdef list prop_args
+        cdef dict prop_args
 
         # Auto bind on own handler if exist
         properties = self.properties()
-        prop_args = [
-            (k, kwargs.pop(k)) for k in list(kwargs.keys()) if k in properties]
+        prop_args = {
+            k: kwargs.pop(k) for k in list(kwargs.keys()) if k in properties}
+        self._kwargs_applied_init = set(prop_args.keys()) if prop_args else set()
         super(EventDispatcher, self).__init__(**kwargs)
 
         __cls__ = self.__class__
@@ -268,7 +269,7 @@ cdef class EventDispatcher(ObjectWithUid):
             self.fbind(func[3:], getattr(self, func))
 
         # Apply the existing arguments to our widget
-        for key, value in prop_args:
+        for key, value in prop_args.items():
             setattr(self, key, value)
 
     def register_event_type(self, basestring event_type):

--- a/kivy/lang.py
+++ b/kivy/lang.py
@@ -1913,7 +1913,7 @@ class BuilderBase(object):
         self._apply_rule(widget, rule, rule, template_ctx=proxy_ctx)
         return widget
 
-    def apply(self, widget, ignored_keys=set()):
+    def apply(self, widget, ignored_consts=set()):
         '''Search all the rules that match the widget and apply them.
         '''
         rules = self.match(widget)
@@ -1922,13 +1922,13 @@ class BuilderBase(object):
         if not rules:
             return
         for rule in rules:
-            self._apply_rule(widget, rule, rule, ignored_keys=ignored_keys)
+            self._apply_rule(widget, rule, rule, ignored_consts=ignored_consts)
 
     def _clear_matchcache(self):
         BuilderBase._match_cache = {}
 
     def _apply_rule(self, widget, rule, rootrule, template_ctx=None,
-                    ignored_keys=set()):
+                    ignored_consts=set()):
         # widget: the current instantiated widget
         # rule: the current rule
         # rootrule: the current root rule (for children of a rule)
@@ -2069,10 +2069,10 @@ class BuilderBase(object):
                             widget_set, widget_set, key, value, rule,
                             rctx['ids'])
                         # if there's a rule
-                        if bound or key not in ignored_keys:
+                        if bound or key not in ignored_consts:
                             setattr(widget_set, key, value)
                     else:
-                        if key not in ignored_keys:
+                        if key not in ignored_consts:
                             setattr(widget_set, key, value)
 
         except Exception as e:

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -226,3 +226,27 @@ class LangTestCase(unittest.TestCase):
         self.assertTrue('on_press' in wid.binded_func)
         wid.binded_func['on_press']()
         self.assertEquals(wid.a, 1)
+
+    def test_kv_python_init(self):
+        from kivy.lang import Builder
+        from kivy.uix.widget import Widget
+
+        class MyObject(object):
+            value = 55
+
+        class MyWidget(Widget):
+            cheese = MyObject()
+
+        Builder.load_string('''
+<MyWidget>:
+    x: 55
+    y: self.width + 10
+    height: self.cheese.value
+    width: 44
+''')
+
+        w = MyWidget(x=22, height=12, y=999)
+        self.assertEqual(w.x, 22)
+        self.assertEqual(w.width, 44)
+        self.assertEqual(w.y, 44 + 10)
+        self.assertEqual(w.height, 12)

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -317,13 +317,7 @@ class Widget(WidgetBase):
 
         # Apply all the styles.
         if not no_builder:
-            #current_root = Builder.idmap.get('root')
-            #Builder.idmap['root'] = self
-            Builder.apply(self, ignored_keys=self._kwargs_applied_init)
-            #if current_root is not None:
-            #    Builder.idmap['root'] = current_root
-            #else:
-            #    Builder.idmap.pop('root')
+            Builder.apply(self, ignored_consts=self._kwargs_applied_init)
 
         # Bind all the events.
         if on_args:

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -319,7 +319,7 @@ class Widget(WidgetBase):
         if not no_builder:
             #current_root = Builder.idmap.get('root')
             #Builder.idmap['root'] = self
-            Builder.apply(self)
+            Builder.apply(self, ignored_keys=self._kwargs_applied_init)
             #if current_root is not None:
             #    Builder.idmap['root'] = current_root
             #else:


### PR DESCRIPTION
Fixes #3118.

This is one solution to that issue. I think ideally if the kv rule has rule bindings than kv has higher priority since it'd be overwritten later anyway. But if the rule is a constant (e.g. `val: 55`) or the rule is not a bindable rule (e.g. `val: self.attr`, where `self.attr` is not a kivy property) then I think kv should have lower priority (i.e. `Widget(val=val)` has higher precedence).

This implements it, although in a bit of a hacky way. But it's the best I could come up with given the problem.

Example code:
```py
from kivy.lang import Builder
from kivy.uix.button import Button

Builder.load_string('''
<Button>:
    text: 'bad'
    height: 55
    width: name.width + 55
    x: (name.swamp + 55) if None else 55
    Widget:
        id: name
''')

b = Button(text='good', height=123, width=123, x=123)
print b.text, b.height, b.width, b.x
```
before prints `bad 55 155 55`.
after prints `good 123 155 123`.