### PR TITLE
OS X: pip install kivy from git

### DIFF
--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -88,4 +88,4 @@ Alternatively you can install Kivy using the following steps:
     2. Install cython 0.21.2 and kivy using pip::
 
         $ pip install -I Cython==0.21.2
-        $ USE_OSX_FRAMEWORKS=0 pip install kivy
+        $ USE_OSX_FRAMEWORKS=0 pip install git+https://github.com/kivy/kivy.git@1.9.0


### PR DESCRIPTION
This is needed until https://github.com/kivy/kivy/issues/3717 can be closed.