### PR TITLE
Make kivy work with new wheels.

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -35,6 +35,7 @@ import shutil
 from getopt import getopt, GetoptError
 from os import environ, mkdir, pathsep
 from os.path import dirname, join, basename, exists, expanduser, isdir
+import pkgutil
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
 
@@ -250,6 +251,16 @@ kivy_config_fn = ''
 kivy_usermodules_dir = ''
 #: Kivy user extensions directory
 kivy_userexts_dir = ''
+
+# if there are deps, import them so they can do their magic.
+try:
+    import kivy.deps
+    for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
+        if not ispkg:
+            continue
+        importer.find_module(modname).load_module(modname)
+except ImportError:
+    pass
 
 
 # Don't go further if we generate documentation


### PR DESCRIPTION
This adds a kivy/deps namespace (https://pythonhosted.org/setuptools/setuptools.html#namespace-packages). Using this namespace binary deps are installed and made available to kivy. 

**What this pr does**
During import, kivy imports all the packages it find in kivy/deps and those packages are responsible for making sure their binaires are available. For us on windows using the wheels, this means adding the bin of the wheel to the dll search path as described at https://github.com/numpy/numpy/wiki/windows-dll-notes#python-dlls.

The other change in this pr is hat if during compiling sdl inlcudes are not provided in an env variable, add python/include to the path. SImilarly, we also look for pkgconfig in python/lib/pkgconfig.

With this, our wheels that will be auto generated with appveryor or manually using (https://github.com/kivy/kivy-sdk-packager/tree/wheels) will work.

**How to test this and wheels with a clean python**

* download and install python and make sure you have the latest pip, wheel and setuptils `pip install --upgrade pip wheel setuptools`.
* open a command prompt.
* Make sure that both python.exe and  python/Scripts is on the path.
* create the python/ib/distutils/distutils.cfg file and add the two lines, `[build]` and `compiler = mingw32`.
* do `pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy`.
* do `pip install cython`.
* download all the wheels from (https://www.dropbox.com/sh/x87fl6g2j5letrl/AADJBbiOAV-ncvB5DSgSqQ15a?dl=0) and add them to python/ so you can do `wheel install kivy.deps.glew_dev-0.1.0-py2-none-any.whl kivy.deps.glew-0.1.0-py2-none-any.whl kivy.deps.gstreamer_dev-0.1.0-py2-none-any.whl kivy.deps.gstreamer-0.1.0-py2-none-any.whl kivy.deps.sdl2_dev-0.1.0-py2-none-any.whl kivy.deps.sdl2-0.1.0-py2-none-any.whl`.
* do `set USE_SDL2=1` and `set USE_GSTREAMER=1`.
* finally do `pip install pygments docutils https://github.com/matham/kivy/archive/deps.zip`.
* to test do `python share\kivy-examples\demo\kivycatalog\main.py`.
* finally, cry with joy for not needing to download anymore kivy's portable package rather then using your existing python.