### PR TITLE
Emacsbahavior fixes

### DIFF
--- a/kivy/uix/behaviors/emacs.py
+++ b/kivy/uix/behaviors/emacs.py
@@ -92,6 +92,8 @@ class EmacsBehavior(object):
         self.do_cursor_movement('cursor_right', control=True)
         end_index = self.cursor_index()
         if start_index != end_index:
+            ss = self.text[start_index:end_index]
+            self._set_unredo_delsel(start_index, end_index, ss, from_undo=False)
             self.text = self.text[:start_index] + self.text[end_index:]
             self._set_cursor(pos=start_cursor)
 
@@ -102,5 +104,7 @@ class EmacsBehavior(object):
         end_cursor = self.cursor
         end_index = self.cursor_index()
         if start_index != end_index:
+            ss = self.text[end_index:start_index]
+            self._set_unredo_delsel(end_index, start_index, ss, from_undo=False)
             self.text = self.text[:end_index] + self.text[start_index:]
             self._set_cursor(pos=end_cursor)

--- a/kivy/uix/behaviors/emacs.py
+++ b/kivy/uix/behaviors/emacs.py
@@ -87,6 +87,8 @@ class EmacsBehavior(object):
 
     def delete_word_right(self):
         '''Delete text right of the cursor to the end of the word'''
+        if self._selection:
+            return
         start_index = self.cursor_index()
         start_cursor = self.cursor
         self.do_cursor_movement('cursor_right', control=True)
@@ -99,6 +101,8 @@ class EmacsBehavior(object):
 
     def delete_word_left(self):
         '''Delete text left of the cursor to the beginning of word'''
+        if self._selection:
+            return
         start_index = self.cursor_index()
         self.do_cursor_movement('cursor_left', control=True)
         end_cursor = self.cursor


### PR DESCRIPTION
Words deleted using `delete_word_left/right()` can now be retrieved/deleted again using undo and redo. Deleting by word disabled when there is a selection.
