### PR TITLE
Add wheel support to kivy on windows

### DIFF
--- a/examples/demo/kivycatalog/container_kvs/TextContainer.kv
+++ b/examples/demo/kivycatalog/container_kvs/TextContainer.kv
@@ -10,8 +10,8 @@ BoxLayout:
         background_color: .8, .8, 0, 1
         size_hint: 1, 3
     TextInput:
-        text: "Password (but you can't see it)"
         password: True
+        text: "Password (but you can't see it)"
         multiline: False
         on_text: viewer.text = self.text
     TextInput:

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -35,6 +35,7 @@ import shutil
 from getopt import getopt, GetoptError
 from os import environ, mkdir, pathsep
 from os.path import dirname, join, basename, exists, expanduser, isdir
+import pkgutil
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
 
@@ -250,6 +251,16 @@ kivy_config_fn = ''
 kivy_usermodules_dir = ''
 #: Kivy user extensions directory
 kivy_userexts_dir = ''
+
+# if there are deps, import them so they can do their magic.
+try:
+    import kivy.deps
+    for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
+        if not ispkg:
+            continue
+        importer.find_module(modname).load_module(modname)
+except ImportError:
+    pass
 
 
 # Don't go further if we generate documentation

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -253,14 +253,14 @@ kivy_usermodules_dir = ''
 kivy_userexts_dir = ''
 
 # if there are deps, import them so they can do their magic.
-try:
-    import kivy.deps
-    for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
-        if not ispkg:
-            continue
+import kivy.deps
+for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
+    if not ispkg:
+        continue
+    try:
         importer.find_module(modname).load_module(modname)
-except ImportError:
-    pass
+    except ImportError as e:
+        Logger.warning("deps: Error importing dependency: {}".format(str(e)))
 
 
 # Don't go further if we generate documentation
@@ -412,9 +412,6 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         Logger.info('Core: Kivy configuration saved.')
         sys.exit(0)
 
-    # add kivy_binary_deps_dir if it exists
-    if exists(kivy_binary_deps_dir):
-        environ["PATH"] = kivy_binary_deps_dir + pathsep + environ["PATH"]
 
     # configure all activated modules
     from kivy.modules import Modules

--- a/kivy/deps/__init__.py
+++ b/kivy/deps/__init__.py
@@ -1,0 +1,6 @@
+'''Kivy module for binary dependencies.
+
+Binary dependencies such as gstreamer is installed as a
+namespace module of kivy.deps. These modules are responsible
+for making sure that the binaries are available to kivy.
+'''


### PR DESCRIPTION
This adds support for kivy wheels. The approach is to offer the binary deps such as gstreamer/sdl2/glew as independent kivy namespace packages that can be downloaded as wheels on their own (https://pythonhosted.org/setuptools/setuptools.html#namespace-packages). With this, namespace binary deps are installed and made available to kivy. 

**What this pr does**
During import, kivy imports all the packages it find in kivy/deps and those packages are responsible for making sure their binaries are available. For us on windows using the wheels, this means adding the bin of the wheel to the dll search path as described and linked at the end of https://github.com/numpy/numpy/wiki/windows-dll-notes#python-dlls. This removes the need to mess with paths or place the dlls in special folders. Each of the deps as they are imported will call this `AddDllDirectory` function with the path to their binaries.

The gstreamer/sdl2/glew wheels are created using the kivy-sdk-packager project, currently in the `wheels` branch.

The other change in this pr is hat if during compiling sdl includes are not provided in an env variable, add python/include to the path. Similarly, we also look for pkgconfig in python/lib/pkgconfig.

Wheels using this `deps` branch and the kivy-sdk-packager `wheels` branch have been generated on appveyor and made available on the testpypi server. Except for the gstreamer package because it's too large (90MB). However, with the new wheels warehouse it's expected that each project will be able to ask for wheel size limit increase.

**How to install kivy to a clean python in two steps**
Open a command window and ensure python.exe is on the path, then do
* `python -m pip install -i https://testpypi.python.org/pypi kivy.deps.sdl2 kivy.deps.glew kivy`
* Download the appropriate gstreamer wheel from https://drive.google.com/drive/folders/0B1_HB9J8mZepNzZ5aW91Q0tJU2s and do `python -m wheel install filename`.

If you're installing to a previous kivy dist that has mingw etc, delete all the folders in the dist except for the python folder. You can also remove all the bat and sh files. Just make sure python is on the path for the above.

**How to compile and install**
* Download and install python and make sure you have the latest pip, wheel and setuptils `python -m pip install --upgrade pip wheel setuptools`. Make sure python/ and python/scripts is on the path for this.
* Create the python/ib/distutils/distutils.cfg file and add the two lines, `[build]` and `compiler = mingw32`.
* Do `python -m pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy`.
* Do `python -m pip install cython pygments docutils`.
* `python -m pip install -i https://testpypi.python.org/pypi kivy.deps.sdl2 kivy.deps.glew kivy.deps.glew_dev kivy.deps.sdl2_dev kivy.deps.gstreamer_dev`
* Download the appropriate gstreamer wheel from https://drive.google.com/drive/folders/0B1_HB9J8mZepNzZ5aW91Q0tJU2s and do `python -m wheel install filename`.
* Do `set USE_SDL2=1` and `set USE_GSTREAMER=1`.
* Finally do `pip install https://github.com/kivy/kivy/archive/deps.zip`.

To test do `python share\kivy-examples\demo\kivycatalog\main.py` and cry with joy for not needing to download anymore kivy's portable package rather then using your existing python.

**How to compile and install into kivy installed not in site-packages**
Unfortunately, the only fly in the ointment is when installing the binary deps when kivy is not installed or going to be installed to site-packages. Due to a issue with wheel (https://github.com/pypa/pip/issues/2677) you have to add the following step.

First, skip the `pip install https://github.com/kivy/kivy/archive/deps.zip` step and instead clone or download kivy to wherever you wish, say `your-path`. Then, move all the contents of `site-packages/kivy/deps` into `your-path/kivy/deps`. And delete all the `kivy.deps*.pth` files from site-packages as well as the kivy folder from site-packages. Once that's done you should be able to do python setup.py build_ext --inplace.


If this is accepted, for the next release we'll not distribute the giant package anymore but host everything on pypi. It should be super easy to upgrade people who downloaded the kivy dist in the past. And we can add the kivy nighties with the old method before that.