### PR TITLE
Add EmacsBehavior to CodeInput and add example

### DIFF
--- a/examples/widgets/codeinput.py
+++ b/examples/widgets/codeinput.py
@@ -3,12 +3,13 @@ from kivy.extras.highlight import KivyLexer
 from kivy.uix.spinner import Spinner, SpinnerOption
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.codeinput import CodeInput
+from kivy.uix.behaviors import EmacsBehavior
 from kivy.uix.popup import Popup
 from kivy.properties import ListProperty
 from kivy.core.window import Window
 from kivy.core.text import LabelBase
 from pygments import lexers
-
+from pygame import font as fonts
 import codecs
 import glob
 import os
@@ -109,6 +110,13 @@ class SaveDialog(Popup):
         self.dismiss()
 
 
+class CodeInputWithBindings(EmacsBehavior, CodeInput):
+    '''CodeInput with keybindings.
+    To add more bindings, add behavior before CodeInput in class definition
+    '''
+    pass
+
+
 class CodeInputTest(App):
 
     files = ListProperty([None, ])
@@ -154,11 +162,12 @@ class CodeInputTest(App):
         menu.add_widget(key_bindings)
         b.add_widget(menu)
 
-        self.codeinput = CodeInput(
-
+        self.codeinput = CodeInputWithBindings(
             lexer=KivyLexer(),
             font_size=12,
-            text=example_text)
+            text=example_text,
+            active_key_bindings='default',
+        )
 
         b.add_widget(self.codeinput)
 

--- a/examples/widgets/codeinput.py
+++ b/examples/widgets/codeinput.py
@@ -57,6 +57,26 @@ public static byte toUnsignedByte(int intVal) {
     s.parentNode.insertBefore(po, s);
   })();
 </script>
+----------------------Emacs key bindings---------------------
+This CodeInput inherits from EmacsBehavior, so you can use Emacs key bindings
+if you want! To try out Emacs key bindings, set the "Key bindings" option to
+"Emacs". Experiment with the shortcuts below on some of the text in this window
+(just be careful not to delete the cheat sheet before you have made note of the
+commands!)
+
+Shortcut           Description
+--------           -----------
+Control + a        Move cursor to the beginning of the line
+Control + e        Move cursor to the end of the line
+Control + f        Move cursor one character to the right
+Control + b        Move cursor one character to the left
+Alt + f            Move cursor to the end of the word to the right
+Alt + b            Move cursor to the start of the word to the left
+Alt + Backspace    Delete text left of the cursor to the beginning of word
+Alt + d            Delete text right of the cursor to the end of the word
+Alt + w            Copy selection
+Control + w        Cut selection
+Control + y        Paste selection
 '''
 
 
@@ -122,11 +142,16 @@ class CodeInputTest(App):
             text='File',
             values=('Open', 'SaveAs', 'Save', 'Close'))
         mnu_file.bind(text=self._file_menu_selected)
+        key_bindings = Spinner(
+            text='Key bindings',
+            values=('Default key bindings', 'Emacs key bindings'))
+        key_bindings.bind(text=self._bindings_selected)
 
         menu.add_widget(mnu_file)
         menu.add_widget(fnt_size)
         menu.add_widget(fnt_name)
         menu.add_widget(languages)
+        menu.add_widget(key_bindings)
         b.add_widget(menu)
 
         self.codeinput = CodeInput(
@@ -168,6 +193,10 @@ class CodeInputTest(App):
             if self.files[0]:
                 self.codeinput.text = ''
                 Window.title = 'untitled'
+
+    def _bindings_selected(self, instance, value):
+        value = value.split(' ')[0]
+        self.codeinput.active_key_bindings = value.lower()
 
     def on_files(self, instance, values):
         if not values[0]:

--- a/kivy/uix/behaviors/emacs.py
+++ b/kivy/uix/behaviors/emacs.py
@@ -35,6 +35,9 @@ Control + y     Paste selection
     cursor to the end of the line, but the inspector will open as well).
 '''
 
+from kivy.properties import StringProperty
+
+
 __all__ = ('EmacsBehavior', )
 
 
@@ -42,6 +45,17 @@ class EmacsBehavior(object):
     '''
     A `mixin <https://en.wikipedia.org/wiki/Mixin>`_ that enables Emacs-style
     keyboard shortcuts for the :class:`~kivy.uix.textinput.TextInput` widget.
+    '''
+
+    active_key_bindings = StringProperty('emacs')
+    '''String name which determines the type of key bindings to use with the
+    :class:`~kivy.uix.textinput.TextInput`. This allows Emacs key bindings to
+    be enabled/disabled programmatically for widgets that inherit from
+    :class:`EmacsBehavior`. If the value is not ``'emacs'`` Emacs bindings will
+    be disabled.
+
+    :attr:`active_key_bindings` is a :class:`~kivy.properties.StringProperty`
+    and defaults to ``'emacs'``
     '''
 
     def __init__(self, **kwargs):
@@ -73,7 +87,7 @@ class EmacsBehavior(object):
         mod = modifiers[0] if modifiers else None
         is_emacs_shortcut = False
 
-        if key in range(256):
+        if key in range(256) and self.active_key_bindings == 'emacs':
             is_emacs_shortcut = ((mod == 'ctrl' and
                                   chr(key) in self.bindings['ctrl'].keys()) or
                                  (mod == 'alt' and

--- a/kivy/uix/behaviors/emacs.py
+++ b/kivy/uix/behaviors/emacs.py
@@ -56,6 +56,8 @@ class EmacsBehavior(object):
 
     :attr:`active_key_bindings` is a :class:`~kivy.properties.StringProperty`
     and defaults to ``'emacs'``
+
+    .. versionadded:: 1.9.2
     '''
 
     def __init__(self, **kwargs):

--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -44,7 +44,7 @@ from kivy.core.text.markup import MarkupLabel as Label
 from kivy.cache import Cache
 from kivy.properties import ObjectProperty, OptionProperty, StringProperty
 from kivy.utils import get_hex_from_color, get_color_from_hex
-from kivy.uix.behaviors import CodeNavigationBehavior, EmacsBehavior
+from kivy.uix.behaviors import CodeNavigationBehavior
 
 Cache_get = Cache.get
 Cache_append = Cache.append
@@ -52,7 +52,7 @@ Cache_append = Cache.append
 # TODO: color chooser for keywords/strings/...
 
 
-class CodeInput(CodeNavigationBehavior, EmacsBehavior, TextInput):
+class CodeInput(CodeNavigationBehavior, TextInput):
     '''CodeInput class, used for displaying highlighted code.
     '''
 

--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -42,9 +42,9 @@ from pygments.formatters import BBCodeFormatter
 from kivy.uix.textinput import TextInput
 from kivy.core.text.markup import MarkupLabel as Label
 from kivy.cache import Cache
-from kivy.properties import ObjectProperty, OptionProperty
+from kivy.properties import ObjectProperty, OptionProperty, StringProperty
 from kivy.utils import get_hex_from_color, get_color_from_hex
-from kivy.uix.behaviors import CodeNavigationBehavior
+from kivy.uix.behaviors import CodeNavigationBehavior, EmacsBehavior
 
 Cache_get = Cache.get
 Cache_append = Cache.append
@@ -52,7 +52,7 @@ Cache_append = Cache.append
 # TODO: color chooser for keywords/strings/...
 
 
-class CodeInput(CodeNavigationBehavior, TextInput):
+class CodeInput(CodeNavigationBehavior, EmacsBehavior, TextInput):
     '''CodeInput class, used for displaying highlighted code.
     '''
 
@@ -83,6 +83,13 @@ class CodeInput(CodeNavigationBehavior, TextInput):
     :attr:`style` is a :class:`~kivy.properties.ObjectProperty` and
     defaults to ``None``
 
+    '''
+
+    active_key_bindings = StringProperty('default')
+    '''String name which determines the type of key bindings to use.
+
+    :attr:`active_key_bindings` is a :class:`~kivy.properties.StringProperty`
+    and defaults to ``'default'``
     '''
 
     def __init__(self, **kwargs):

--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -90,6 +90,8 @@ class CodeInput(CodeNavigationBehavior, EmacsBehavior, TextInput):
 
     :attr:`active_key_bindings` is a :class:`~kivy.properties.StringProperty`
     and defaults to ``'default'``
+
+    .. versionadded:: 1.9.2
     '''
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Have CodeInput inherit EmacsBehavior and add "Key bindings" option to CodeInputTest so that users can try out the bindings. 