### PR TITLE
Support for SDL2's outline rendering

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -46,6 +46,7 @@ from kivy.core.text.text_layout import layout_text, LayoutWord
 from kivy.resources import resource_find, resource_add_path
 from kivy.compat import PY2
 from kivy.setupconfig import USE_SDL2
+from kivy.metrics import dp
 
 DEFAULT_FONT = 'Roboto'
 
@@ -116,6 +117,16 @@ class LabelBase(object):
         `unicode_errors` : str, defaults to `'replace'`
             How to handle unicode decode errors. Can be `'strict'`, `'replace'`
             or `'ignore'`.
+        `outline` : bool, defaults to False
+            Whether text should have an outline applied to it.
+        `outline_color`: tuple, defaults to (0, 0, 0, 1)
+            Color of the outline (black, opaque, to outline the default
+            white, opaque font color)
+        `outline_width`: int, defaults to dp(1)
+            Width in pixels for the outline.
+
+    .. versionchanged:: 1.9.2
+        `outline`, `outline_color`, `outline_width` were added.
 
     .. versionchanged:: 1.9.0
         `strip`, `strip_reflow`, `shorten_from`, `split_str`, and
@@ -156,6 +167,7 @@ class LabelBase(object):
         self, text='', font_size=12, font_name=DEFAULT_FONT, bold=False,
         italic=False, underline=False, strikethrough=False,
         halign='left', valign='bottom', shorten=False,
+        outline=False, outline_color=None, outline_width=None,
         text_size=None, mipmap=False, color=None, line_height=1.0, strip=False,
         strip_reflow=True, shorten_from='center', split_str=' ',
         unicode_errors='replace',
@@ -179,6 +191,9 @@ class LabelBase(object):
                    'font_blended': font_blended}
 
         options['color'] = color or (1, 1, 1, 1)
+        options['outline'] = outline or False
+        options['outline_color'] = outline_color or (0, 0, 0, 1)
+        options['outline_width'] = outline_width or dp(1)
         options['padding'] = kwargs.get('padding', (0, 0))
         if not isinstance(options['padding'], (list, tuple)):
             options['padding'] = (options['padding'], options['padding'])

--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -50,9 +50,15 @@ cdef class _SurfaceContainer:
     def render(self, container, text, x, y):
         cdef TTF_Font *font = _get_font(container)
         cdef SDL_Color c
+        cdef SDL_Color oc
         cdef SDL_Surface *st
+        cdef SDL_Surface *fgst
         cdef SDL_Rect r
+        cdef SDL_Rect fgr
         cdef list color = list(container.options['color'])
+        cdef list outline_color = list(container.options['outline_color'])
+        cdef int outline = <int>container.options['outline']
+        cdef int outline_width = container.options['outline_width']
         if font == NULL:
             return
         c.r = <int>(color[0] * 255)
@@ -82,13 +88,40 @@ cdef class _SurfaceContainer:
             if TTF_GetFontKerning(font) != 0:
                 TTF_SetFontKerning(font, 0)
 
-        st = (
-            TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
-            if container.options['font_blended']
-            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
-            )
+        if outline:
+            TTF_SetFontOutline(font, outline_width)
+            oc.r = <int>(outline_color[0] * 255)
+            oc.g = <int>(outline_color[1] * 255)
+            oc.b = <int>(outline_color[2] * 255)
+	        st = (
+	            TTF_RenderUTF8_Blended(font, <char *>bytes_text, oc)
+	            if container.options['font_blended']
+	            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, oc)
+	            )
+            TTF_SetFontOutline(font, 0)
+        else:
+	        st = (
+	            TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
+	            if container.options['font_blended']
+	            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
+	            )
         if st == NULL:
             return
+        if outline:
+            fgst = (
+	            TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
+	            if container.options['font_blended']
+	            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
+	            )
+            if fgst == NULL:
+                return
+            fgr.x = outline_width
+            fgr.y = outline_width
+            fgr.w = fgst.w
+            fgr.h = fgst.h
+            SDL_SetSurfaceBlendMode(fgst, SDL_BLENDMODE_BLEND);
+            SDL_BlitSurface(fgst, NULL, st, &fgr)
+            SDL_FreeSurface(fgst)
         r.x = x
         r.y = y
         r.w = st.w
@@ -161,12 +194,18 @@ cdef TTF_Font *_get_font(self):
 def _get_extents(container, text):
     cdef TTF_Font *font = _get_font(container)
     cdef int w, h
+    cdef int outline = <int>container.options['outline']
+    cdef int outline_width = container.options['outline_width']
     if font == NULL:
         return 0, 0
     if not PY2:
         text = text.encode('utf-8')
     bytes_text = <bytes>text
+    if outline:
+        TTF_SetFontOutline(font, outline_width)
     TTF_SizeUTF8(font, <char *>bytes_text, &w, &h)
+    if outline:
+        TTF_SetFontOutline(font, 0)
     return w, h
 
 def _get_fontdescent(container):

--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -93,26 +93,26 @@ cdef class _SurfaceContainer:
             oc.r = <int>(outline_color[0] * 255)
             oc.g = <int>(outline_color[1] * 255)
             oc.b = <int>(outline_color[2] * 255)
-	        st = (
-	            TTF_RenderUTF8_Blended(font, <char *>bytes_text, oc)
-	            if container.options['font_blended']
-	            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, oc)
-	            )
+            st = (
+                TTF_RenderUTF8_Blended(font, <char *>bytes_text, oc)
+                if container.options['font_blended']
+                else TTF_RenderUTF8_Solid(font, <char *>bytes_text, oc)
+                )
             TTF_SetFontOutline(font, 0)
         else:
-	        st = (
-	            TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
-	            if container.options['font_blended']
-	            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
-	            )
+            st = (
+                TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
+                if container.options['font_blended']
+                else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
+                )
         if st == NULL:
             return
         if outline:
             fgst = (
-	            TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
-	            if container.options['font_blended']
-	            else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
-	            )
+                TTF_RenderUTF8_Blended(font, <char *>bytes_text, c)
+                if container.options['font_blended']
+                else TTF_RenderUTF8_Solid(font, <char *>bytes_text, c)
+                )
             if fgst == NULL:
                 return
             fgr.x = outline_width

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -262,6 +262,7 @@ class Label(Widget):
     _font_properties = ('text', 'font_size', 'font_name', 'bold', 'italic',
                         'underline', 'strikethrough',
                         'halign', 'valign', 'padding_x', 'padding_y',
+                        'outline', 'outline_color', 'outline_width',
                         'text_size', 'shorten', 'mipmap', 'markup',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
                         'split_str', 'unicode_errors',
@@ -594,6 +595,38 @@ class Label(Widget):
 
     :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults to
     [1, 1, 1, 1].
+    '''
+
+    outline = BooleanProperty(False)
+    '''Indicates addition of an outline around the font.
+
+    .. note::
+
+        SDL2 only
+
+    :attr:`outline` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to False.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    outline_width = NumericProperty('1dp')
+    '''Width in pixels for the outline. e.g. line_height = 2dp will cause
+    a two pixel outline to be rendered around the font.
+
+    :attr:`outline_width` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to 1dp.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    outline_color = ListProperty([0, 0, 0, 1])
+    '''SDL2 outline color, in the format (r, g, b, a)
+
+    :attr:`outline_color` is a :class:`~kivy.properties.ListProperty` and
+    defaults to [0, 0, 0, 1].
+
+    .. versionadded:: 1.9.2
     '''
 
     texture = ObjectProperty(None, allownone=True)


### PR DESCRIPTION
Hi!  Please consider this pull request a starting point for a conversation; while the code works, I'm not sure if I've developed it (particularly the `kivy.uix.label` portion) to project norms or standards.  I'm happy to make changes as recommended and re-create the pull request.

A month and a half ago, someone on _kivy-users_ asked about rendering text with outlines: https://groups.google.com/forum/#!msg/kivy-users/IxH1yT6plAU/VAikQ1FaBAAJ

A few suggestions were made, and the user ended up going with repeated renderings using canvas.before.  I had the same need and experimented with all of the options suggested: http://imgur.com/a/eqpz5

Of the three text renderers in Kivy, only SDL2 supports outline rendering, and you still have to render the font twice if you need the outline color to be different from the font color, which I assume is the most common use case: http://www.archivum.info/sdl@lists.libsdl.org/2010-01/00605/Re-(SDL)-Getting-outlined-text-in-SDL_TTF.html

This code adds support for SDL2's outline rendering, through three properties added to `kivy.core.text`: outline, outline_color, and outline_size.  It handles the outlining in `_text_sdl2.pyx`, and adds support to `kivy.uix.label`.

I'm currently using this code in an application, having also added support for this in `kivy.garden.scrolllabel`.

Looking forward to your comments!

Thanks,
Vitorio