### PR TITLE
Solve a crash when spamming chdir

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -584,7 +584,11 @@ class FileChooserController(RelativeLayout):
                 'scrollup', 'scrolldown', 'scrollleft', 'scrollright')):
             return False
 
-        _dir = self.file_system.is_dir(entry.path)
+        try:
+            path = entry.path
+        except:
+            return
+        _dir = self.file_system.is_dir(path)
         dirselect = self.dirselect
 
         if _dir and dirselect and touch.is_double_tap:


### PR DESCRIPTION
When spamming a dir button, I get this crash:

[INFO              ] [Base        ] Leaving application in progress...
 Traceback (most recent call last):
   File "main.py", line 16, in <module>
     condiment.install()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 229, in install
     Parser(**kwargs).install()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 72, in install
     self.do()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 80, in do
     self.do_rewrite()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 104, in do_rewrite
     self.on_the_fly()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 117, in on_the_fly
     run_path(self.output)
   File "/usr/lib64/python2.7/runpy.py", line 240, in run_path
     return _run_module_code(code, init_globals, run_name, path_name)
   File "/usr/lib64/python2.7/runpy.py", line 82, in _run_module_code
     mod_name, mod_fname, mod_loader, pkg_name)
   File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
     exec code in run_globals
   File "_ft_main.py", line 1366, in <module>
   File "_ft_main.py", line 1361, in run
   File "/usr/lib64/python2.7/site-packages/kivy/app.py", line 828, in run
     runTouchApp()
   File "/usr/lib64/python2.7/site-packages/kivy/base.py", line 487, in runTouchApp
     EventLoop.window.mainloop()
   File "/usr/lib64/python2.7/site-packages/kivy/core/window/window_sdl2.py", line 606, in mainloop
     self._mainloop()
   File "/usr/lib64/python2.7/site-packages/kivy/core/window/window_sdl2.py", line 361, in _mainloop
     EventLoop.idle()
   File "/usr/lib64/python2.7/site-packages/kivy/base.py", line 327, in idle
     Clock.tick()
   File "/usr/lib64/python2.7/site-packages/kivy/clock.py", line 483, in tick
     self._process_events()
   File "/usr/lib64/python2.7/site-packages/kivy/clock.py", line 615, in _process_events
     event.tick(self._last_tick, remove)
   File "/usr/lib64/python2.7/site-packages/kivy/clock.py", line 374, in tick
     ret = callback(self._dt)
   File "_ft_main.py", line 1094, in <lambda>
   File "/usr/lib64/python2.7/site-packages/kivy/uix/filechooser.py", line 587, in entry_touched
     _dir = self.file_system.is_dir(entry.path)
   File "weakproxy.pyx", line 19, in kivy.weakproxy.WeakProxy.__getattr__ (kivy/weakproxy.c:1131)
   File "weakproxy.pyx", line 15, in kivy.weakproxy.WeakProxy.__ref__ (kivy/weakproxy.c:1055)
 ReferenceError: weakly-referenced object no longer exists

The above commit seems to fix it, bliblibli ^__^