### PR TITLE
Solve a crash when spamming multitouch interaction

### DIFF
--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -279,10 +279,16 @@ class Animation(EventDispatcher):
             Animation._instances.remove(self)
 
     def _initialize(self, widget):
-        d = self._widgets[widget.uid] = {
+        try:
+            uid = widget.uid
+        except:
+            return
+
+        d = self._widgets[uid] = {
             'widget': widget,
             'properties': {},
-            'time': None}
+            'time': None
+        }
 
         # get current values
         p = d['properties']

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -220,7 +220,11 @@ class Animation(EventDispatcher):
 
         .. versionadded:: 1.4.0
         '''
-        self._widgets.pop(widget.uid, None)
+        try:
+            uid = widget.uid
+        except:
+            return
+        self._widgets.pop(uid, None)
         self._clock_uninstall()
         if not self._widgets:
             self._unregister()
@@ -413,7 +417,11 @@ class Sequence(Animation):
     def stop(self, widget):
         self.anim1.stop(widget)
         self.anim2.stop(widget)
-        props = self._widgets.pop(widget.uid, None)
+        try:
+            uid = widget.uid
+        except:
+            return
+        props = self._widgets.pop(uid, None)
         if props:
             self.dispatch('on_complete', widget)
         super(Sequence, self).cancel(widget)
@@ -480,7 +488,11 @@ class Parallel(Animation):
     def stop(self, widget):
         self.anim1.stop(widget)
         self.anim2.stop(widget)
-        props = self._widgets.pop(widget.uid, None)
+        try:
+            uid = widget.uid
+        except:
+            return
+        props = self._widgets.pop(uid, None)
         if props:
             self.dispatch('on_complete', widget)
         super(Parallel, self).cancel(widget)

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -204,7 +204,11 @@ class Animation(EventDispatcher):
     def stop(self, widget):
         '''Stop the animation previously applied to a widget, triggering the
         `on_complete` event.'''
-        props = self._widgets.pop(widget.uid, None)
+        try:
+            uid = widget.uid
+        except:
+            return
+        props = self._widgets.pop(uid, None)
         if props:
             self.dispatch('on_complete', widget)
         self.cancel(widget)


### PR DESCRIPTION
Ohai buddies, another crash, this time happens when doing a lot of multitouch interaction at once:

[INFO              ] [Base        ] Leaving application in progress...
 Traceback (most recent call last):
   File "main.py", line 16, in <module>
     condiment.install()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 229, in install
     Parser(**kwargs).install()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 72, in install
     self.do()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 80, in do
     self.do_rewrite()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 104, in do_rewrite
     self.on_the_fly()
   File "/usr/lib64/python2.7/site-packages/condiment.py", line 117, in on_the_fly
     run_path(self.output)
   File "/usr/lib64/python2.7/runpy.py", line 240, in run_path
     return _run_module_code(code, init_globals, run_name, path_name)
   File "/usr/lib64/python2.7/runpy.py", line 82, in _run_module_code
     mod_name, mod_fname, mod_loader, pkg_name)
   File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
     exec code in run_globals
   File "_ft_main.py", line 1366, in <module>
   File "_ft_main.py", line 1361, in run
   File "/usr/lib64/python2.7/site-packages/kivy/app.py", line 828, in run
     runTouchApp()
   File "/usr/lib64/python2.7/site-packages/kivy/base.py", line 487, in runTouchApp
     EventLoop.window.mainloop()
   File "/usr/lib64/python2.7/site-packages/kivy/core/window/window_sdl2.py", line 607, in mainloop
     self._mainloop()
   File "/usr/lib64/python2.7/site-packages/kivy/core/window/window_sdl2.py", line 362, in _mainloop
     EventLoop.idle()
   File "/usr/lib64/python2.7/site-packages/kivy/base.py", line 330, in idle
     self.dispatch_input()
   File "/usr/lib64/python2.7/site-packages/kivy/base.py", line 315, in dispatch_input
     post_dispatch_input(*pop(0))
   File "/usr/lib64/python2.7/site-packages/kivy/base.py", line 281, in post_dispatch_input
     wid.dispatch('on_touch_up', me)
   File "kivy/_event.pyx", line 718, in kivy._event.EventDispatcher.dispatch (kivy/_event.c:7309)
   File "_ft_main.py", line 1122, in on_touch_up
   File "/usr/lib64/python2.7/site-packages/kivy/animation.py", line 171, in stop_all
     animation.stop(widget)
   File "/usr/lib64/python2.7/site-packages/kivy/animation.py", line 410, in stop
     self.anim1.stop(widget)
   File "/usr/lib64/python2.7/site-packages/kivy/animation.py", line 207, in stop
     props = self._widgets.pop(widget.uid, None)
   File "kivy/weakproxy.pyx", line 19, in kivy.weakproxy.WeakProxy.__getattr__ (kivy/weakproxy.c:1110)
   File "kivy/weakproxy.pyx", line 15, in kivy.weakproxy.WeakProxy.__ref__ (kivy/weakproxy.c:1017)
 ReferenceError: weakly-referenced object no longer exists

This commit appears to fix it.