### PR TITLE
Changed the package name for Kivy's examples to the correct one

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -26,8 +26,8 @@ Ubuntu / Kubuntu / Xubuntu / Lubuntu (Saucy and above)
         $ sudo apt-get install python-kivy
     :Python3 - **python3-kivy**:
         $ sudo apt-get install python3-kivy
-    :optionally the examples - **kivy-examples**:
-        $ sudo apt-get install kivy-examples
+    :optionally the examples - **python-kivy-examples**:
+        $ sudo apt-get install python-kivy-examples
 
 
 Debian  (Jessie or newer)


### PR DESCRIPTION
When I tried to install the package with `sudo apt-get install kivy-examples`, I got:

> Reading package lists... Done
> Building dependency tree       
> Reading state information... Done
> E: Unable to locate package kivy-examples

I'm on Ubuntu 15.10 (Wily).