### PR TITLE
Preventing from swiping outside the slides range in Carousel widget

### DIFF
--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -524,10 +524,21 @@ class Carousel(StencilView):
         direction = self.direction
         if ud['mode'] == 'unknown':
             if direction[0] in ('r', 'l'):
-                distance = abs(touch.ox - touch.x)
+                distance = touch.ox - touch.x
             else:
-                distance = abs(touch.oy - touch.y)
-            if distance > self.scroll_distance:
+                distance = touch.oy - touch.y
+            if not self.loop:
+                if direction[0] in ('r', 't'):
+                    if self.index == 0 and distance < 0:
+                        return False
+                    if self.index == len(self.slides)-1 and distance > 0:
+                        return False
+                else:
+                    if self.index == 0 and distance > 0:
+                        return False
+                    if self.index == len(self.slides)-1 and distance < 0:
+                        return False
+            if abs(distance) > self.scroll_distance:
                 Clock.unschedule(self._change_touch_mode)
                 ud['mode'] = 'scroll'
         else:


### PR DESCRIPTION
If `Carousel` widget has its `loop` property set as `False`, then this code blocks attempts to swipe further after reaching last item and swipe back from the first item - the widgets are locked in place.

Tested with:

``` python
from kivy.app import App
from kivy.uix.boxlayout import BoxLayout
from kivy.lang import Builder
from kivy.uix.carousel import Carousel

Builder.load_string("""
<MyWidget>:
    direction: 'left'
    loop: False
    Label:
        text: "Screen 1"
    Label:
        text: "Screen 2"
    Label:
        text: "Screen 3"
""")

class MyWidget(Carousel):
    pass

class MyApp(App):
    def build(self):
        return MyWidget()

if __name__ == '__main__':
    MyApp().run()
```
