### PR TITLE
Added Spinner text property update when values are updated.

### DIFF
--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -63,6 +63,16 @@ class Spinner(Button):
     :attr:`values` is a :class:`~kivy.properties.ListProperty` and defaults to
     [].
     '''
+    
+    text_autoupdate = BooleanProperty(False)
+    '''Indicates if the spinner's :attr:`text` should be automatically updated with the
+    first value of the :attr:`values` property. Setting it to True will cause
+    the spinner to update its :attr:`text` property every time
+    attr:`values` are changed.
+    
+    :attr:`text_autoupdate` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to False.
+    '''
 
     option_cls = ObjectProperty(SpinnerOption)
     '''Class used to display the options within the dropdown list displayed
@@ -134,13 +144,20 @@ class Spinner(Button):
     def _update_dropdown(self, *largs):
         dp = self._dropdown
         cls = self.option_cls
+        values = self.values
+        text_autoupdate = self.text_autoupdate
         if isinstance(cls, string_types):
             cls = Factory.get(cls)
         dp.clear_widgets()
-        for value in self.values:
+        for value in values:
             item = cls(text=value)
             item.bind(on_release=lambda option: dp.select(option.text))
             dp.add_widget(item)
+        if text_autoupdate:
+            if values:
+                self.text = values[0]
+            else:
+                self.text = ''
 
     def _toggle_dropdown(self, *largs):
         self.is_open = not self.is_open


### PR DESCRIPTION
If Spinner's values property is updated, the Spinner text is not changing. This is the wrong behavior. Let's make some examples:

1. User creates the Spinner with the values ('Home', 'Work', 'Holidays') and without the text property set. Spinner will show no text when some options are available; there will be no default option shown - and it is bad for the user experience.
2. User creates the Spinner with the empty values property. Then the Spinner instance is updated with the list of ('Home', 'Work', 'Holidays') but Spinner wont show any default value - empty text string suggests that no options are available to choose from.
3. User creates the Spinner with the values set to ('Home', 'Work', 'Holidays') and text set to 'Home'. Then Spinner values are updated to ('New Home', 'Another Work', 'Next Holidays'). The text will still show 'Home' as selected value, so without the user interaction the selection will be wrong.

I have added the text_autoupdate property that indicates if the user want the Spinner to automatically set the text property to values[0].

If set to True and values is not empty, the Spinner will automatically set its text to values[0]. Else, it will leave the text value untouched.

I believe it will make Spinner widget funtionality and complexity better,