### PR TITLE
Avoid end-dev setting ColorWheel internal values

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -1148,6 +1148,10 @@
         on_value:
             root.mroot._trigger_update_clr(root.mode, root.clr_idx, args[1])
 
+<ColorWheel>:
+    _origin: self.center
+    _radius: 0.45 * min(self.size)
+
 <ColorPicker>:
     foreground_color: (1, 1, 1, 1) if self.hsv[2] * wheel.a < .5 else (0, 0, 0, 1)
     wheel: wheel
@@ -1259,7 +1263,5 @@
 
         ColorWheel:
             id: wheel
-            _origin: (self.center_x, self.center_y)
-            _radius: 0.45 * min(self.size)
             color: root.color
             on_color: root.color[:3] = args[1][:3]


### PR DESCRIPTION
Right now, ColorWheel basically ignores its size, forcing end-devs to use _radius and _origin if they want to use it. There properties not being documented, it makes the widget hardly usable without the whole ColorPicker.

I suggest simply using the current radius/origin logic by default, and this PR should implement just that.