### PR TITLE
fix #3500 actionbar min width

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -73,11 +73,11 @@ class ActionItem(object):
     '''
 
     def get_pack_width(self):
-        return min(self.minimum_width, self.width)
+        return max(self.minimum_width, self.width)
 
     pack_width = AliasProperty(get_pack_width, bind=('minimum_width', 'width'))
     '''(read-only) The actual width to use when packing the item. Equal to the
-       lesser of minimum_width and width.
+       greater of minimum_width and width.
 
        :attr:`pack_width` is an :class:`~kivy.properties.AliasProperty`.
     '''


### PR DESCRIPTION
It was using min, and with min it behaves as maximum_width

example using mininum_width=500: https://gist.github.com/aron-bordin/cfcf77b70380a6857fbf