### PR TITLE
Simplify pip installation instructions

### DIFF
--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -131,4 +131,4 @@ Alternatively you can install Kivy using the following steps:
     2. Install cython 0.23 and kivy using pip::
 
         $ pip install -I Cython==0.23
-        $ USE_OSX_FRAMEWORKS=0 pip install git+https://github.com/kivy/kivy.git@1.9.1
+        $ USE_OSX_FRAMEWORKS=0 pip install kivy


### PR DESCRIPTION
There is no need to install kivy from github anymore after the release of 1.9.1