### PR TITLE
fix PIL deprecated tostring() scrambling the text

### DIFF
--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -54,7 +54,7 @@ class LabelPIL(LabelBase):
 
     def _render_end(self):
         data = ImageData(self._size[0], self._size[1],
-                         self._pil_im.mode.lower(), self._pil_im.tostring())
+                         self._pil_im.mode.lower(), self._pil_im.tobytes())
 
         del self._pil_im
         del self._pil_draw


### PR DESCRIPTION
On my RedHat 6 / CentOS 6 Pygame-backend install, I got scrambled text display with current master, and a bunch of self-describing caught Exceptions:

Exception Exception: Exception('tostring() has been removed. Please call tobytes() instead.',) in 'kivy.graphics.instructions.RenderContext.set_texture' ignored

This trivial PR fixes the problem
Thanks !