### PR TITLE
ButtonBehavior.always_release default to False

### DIFF
--- a/kivy/uix/behaviors/button.py
+++ b/kivy/uix/behaviors/button.py
@@ -108,14 +108,17 @@ class ButtonBehavior(object):
     :attr:`min_state_time` is a float and defaults to 0.035.
     '''
 
-    always_release = BooleanProperty(True)
+    always_release = BooleanProperty(False)
     '''This determines whether or not the widget fires an `on_release` event if
     the touch_up is outside the widget.
 
     .. versionadded:: 1.9.0
 
+    .. versionchanged:: 1.9.2
+        The default value is now False.
+
     :attr:`always_release` is a :class:`~kivy.properties.BooleanProperty` and
-    defaults to `True`.
+    defaults to `False`.
     '''
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy/issues/3312.

There were some discussions on irc about introducing incremental breaking changes after 1.9.1 instead of doing everything in 2.0, the team seemed to be in favor of this route.

We could also post on #kivy-dev for those who might want to now revisit other issues that were previously tagged 2.0: https://github.com/kivy/kivy/milestones/2.0.0.