### PR TITLE
Implement underline,strikethrough styling for Label and MarkupLabel

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -154,7 +154,8 @@ class LabelBase(object):
 
     def __init__(
         self, text='', font_size=12, font_name=DEFAULT_FONT, bold=False,
-        italic=False, halign='left', valign='bottom', shorten=False,
+        italic=False, underline=False, strikethrough=False,
+        halign='left', valign='bottom', shorten=False,
         text_size=None, mipmap=False, color=None, line_height=1.0, strip=False,
         strip_reflow=True, shorten_from='center', split_str=' ',
         unicode_errors='replace', **kwargs):
@@ -165,6 +166,7 @@ class LabelBase(object):
 
         options = {'text': text, 'font_size': font_size,
                    'font_name': font_name, 'bold': bold, 'italic': italic,
+                   'underline': underline, 'strikethrough': strikethrough,
                    'halign': halign, 'valign': valign, 'shorten': shorten,
                    'mipmap': mipmap, 'line_height': line_height,
                    'strip': strip, 'strip_reflow': strip_reflow,
@@ -725,7 +727,7 @@ class LabelBase(object):
     def fontid(self):
         '''Return a unique id for all font parameters'''
         return str([self.options[x] for x in (
-            'font_size', 'font_name_r', 'bold', 'italic')])
+            'font_size', 'font_name_r', 'bold', 'italic', 'underline', 'strikethrough')])
 
     def _get_text_size(self):
         return self._text_size

--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -102,12 +102,19 @@ cdef TTF_Font *_get_font(self):
         # try to open the fount if it has an extension
         fontobject = TTF_OpenFont(bytes_fontname,
                                   int(self.options['font_size']))
-
     # fallback to search a system font
     if fontobject == NULL:
         s_error = (<bytes>SDL_GetError()).encode('utf-8')
         print(s_error)
         assert(0)
+
+    # set underline and strikethrough style    
+    style = TTF_STYLE_NORMAL
+    if self.options['underline']:
+        style = style | TTF_STYLE_UNDERLINE
+    if self.options['strikethrough']:
+        style = style | TTF_STYLE_STRIKETHROUGH
+    TTF_SetFontStyle(fontobject, style)
 
     sdl2_cache[fontid] = ttfc = _TTFContainer()
     ttfc.font = fontobject

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -160,6 +160,20 @@ class MarkupLabel(MarkupLabelBase):
             elif item == '[/i]':
                 spop('italic')
                 self.resolve_font_name()
+            elif item == '[u]':
+                spush('underline')
+                options['underline'] = True
+                self.resolve_font_name()
+            elif item == '[/u]':
+                spop('underline')
+                self.resolve_font_name()
+            elif item == '[s]':
+                spush('strikethrough')
+                options['strikethrough'] = True
+                self.resolve_font_name()
+            elif item == '[/s]':
+                spop('strikethrough')
+                self.resolve_font_name()
             elif item[:6] == '[size=':
                 item = item[6:-1]
                 try:

--- a/kivy/core/text/text_sdl2.py
+++ b/kivy/core/text/text_sdl2.py
@@ -19,11 +19,11 @@ class LabelSDL2(LabelBase):
         if PY2:
             try:
                 return '|'.join([unicode(self.options[x]) for x
-                    in ('font_size', 'font_name_r', 'bold', 'italic')])
+                    in ('font_size', 'font_name_r', 'bold', 'italic', 'underline', 'strikethrough')])
             except UnicodeDecodeError:
                 pass
         return '|'.join([str(self.options[x]) for x
-            in ('font_size', 'font_name_r', 'bold', 'italic')])
+            in ('font_size', 'font_name_r', 'bold', 'italic', 'underline', 'strikethrough')])
 
     def get_extents(self, text):
         try:

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -631,6 +631,11 @@ cdef extern from "SDL_ttf.h":
     ##define TTF_STYLE_ITALIC    0x02
     ##define TTF_STYLE_UNDERLINE 0x04
     ##define TTF_STYLE_STRIKETHROUGH 0x08
+    cdef int TTF_STYLE_NORMAL
+    cdef int TTF_STYLE_BOLD
+    cdef int TTF_STYLE_ITALIC
+    cdef int TTF_STYLE_UNDERLINE
+    cdef int TTF_STYLE_STRIKETHROUGH
     cdef int  TTF_GetFontStyle( TTF_Font *font)
     cdef void  TTF_SetFontStyle(TTF_Font *font, int style)
     cdef int  TTF_GetFontOutline( TTF_Font *font)

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -256,6 +256,7 @@ class Label(Widget):
     __events__ = ['on_ref_press']
 
     _font_properties = ('text', 'font_size', 'font_name', 'bold', 'italic',
+                        'underline', 'strikethrough',
                         'halign', 'valign', 'padding_x', 'padding_y',
                         'text_size', 'shorten', 'mipmap', 'markup',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
@@ -496,6 +497,11 @@ class Label(Widget):
     :attr:`italic` is a :class:`~kivy.properties.BooleanProperty` and defaults
     to False.
     '''
+
+    underline = BooleanProperty(False)
+
+    strikethrough = BooleanProperty(False)
+
 
     padding_x = NumericProperty(0)
     '''Horizontal padding of the text inside the widget box.

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -499,9 +499,28 @@ class Label(Widget):
     '''
 
     underline = BooleanProperty(False)
+    '''Adds an underline to the text.
+
+    .. note::
+        This feature requires a SDL2 window provider.
+
+    .. versionadded:: 2.0.0
+
+    :attr:`underline` is a :class:`~kivy.properties.BooleanProperty` and defaults
+    to False.
+    '''
 
     strikethrough = BooleanProperty(False)
+    '''Adds a strikethrough line to the text.
 
+    .. note::
+        This feature requires a SDL2 window provider.
+
+    .. versionadded:: 2.0.0
+
+    :attr:`strikethrough` is a :class:`~kivy.properties.BooleanProperty` and defaults
+    to False.
+    '''
 
     padding_x = NumericProperty(0)
     '''Horizontal padding of the text inside the widget box.


### PR DESCRIPTION
ref #3903

Added two init boolean arguments 'underline' and 'strikethrough' in kivy.uix.label.Label and two options of same name in kivy.core.text.LabelBase 

Uses the SDL routine TTF_SetFontStyle()

Added tags to MarkupLabel for the same.