### PR TITLE
WM_TOUCH: don't offset touch with caption size when fullscreen

### DIFF
--- a/kivy/input/providers/wm_touch.py
+++ b/kivy/input/providers/wm_touch.py
@@ -14,6 +14,7 @@ from kivy.input.providers.wm_common import (
     TOUCHEVENTF_MOVE, SM_CYCAPTION)
 from kivy.input.motionevent import MotionEvent
 from kivy.input.shape import ShapeRect
+from kivy.core.window import Window
 
 
 class WM_MotionEvent(MotionEvent):
@@ -147,7 +148,10 @@ else:
             self.old_windProc = SetWindowLong_wrapper(
                 self.hwnd, GWL_WNDPROC, self.new_windProc)
 
-            self.caption_size = windll.user32.GetSystemMetrics(SM_CYCAPTION)
+            if Window.borderless or Window.fullscreen:
+                self.caption_size = 0
+            else:
+                self.caption_size = windll.user32.GetSystemMetrics(SM_CYCAPTION)
 
         def update(self, dispatch_fn):
             win_rect = RECT()


### PR DESCRIPTION
fixes #2701 at least for the vertical offset in fullscreen