### PR TITLE
Fix FileListEntry text alignment. references #3922

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -327,6 +327,7 @@
         pos: root.pos
         Label:
             id: filename
+            size_hint_x: None
             width: (self.texture_size[0] + dp(4)) if self.texture_size else dp(10)
             halign: 'left'
             shorten: True


### PR DESCRIPTION
The FileChooser list item currently appear centred, but all screenshots and current examples of file choosers indicate left alignment is intended. The kv even contains the logic for left alignment but seems to now need this change to work.