### PR TITLE
Changed ffpyplayer.version to ffpyplayer.__version__

### DIFF
--- a/kivy/core/audio/audio_ffpyplayer.py
+++ b/kivy/core/audio/audio_ffpyplayer.py
@@ -60,7 +60,7 @@ from kivy.core.audio import Sound, SoundLoader
 from kivy.weakmethod import WeakMethod
 import time
 
-Logger.info('SoundFFPy: Using ffpyplayer {}'.format(ffpyplayer.version))
+Logger.info('SoundFFPy: Using ffpyplayer {}'.format(ffpyplayer.__version__))
 
 
 logger_func = {'quiet': Logger.critical, 'panic': Logger.critical,


### PR DESCRIPTION
I was getting the following error when running make test:

    Traceback (most recent call last):
      File "~/kivydev/kivy/core/__init__.py", line 129, in core_register_libs
        level=0)
      File "~/kivydev/kivy/core/audio/audio_ffpyplayer.py", line 63, in <module>
        Logger.info('SoundFFPy: Using ffpyplayer {}'.format(ffpyplayer.version))
    AttributeError: 'module' object has no attribute 'version'
