### PR TITLE
Altered get_cursor_from_xy to intuitively place cursor

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1147,17 +1147,15 @@ class TextInput(FocusBehavior, Widget):
         scrl_y = scrl_y / dy if scrl_y > 0 else 0
         cy = (self.top - padding_top + scrl_y * dy) - y
         cy = int(boundary(round(cy / dy - 0.5), 0, len(l) - 1))
-        dcx = 0
         _get_text_width = self._get_text_width
         _tab_width = self.tab_width
         _label_cached = self._label_cached
-        for i in range(1, len(l[cy]) + 1):
-            if _get_text_width(l[cy][:i],
-                               _tab_width,
-                               _label_cached) + padding_left >= cx + scrl_x:
+        for i in range(0, len(l[cy])):
+            if _get_text_width(l[cy][:i], _tab_width, _label_cached) + \
+                  _get_text_width(l[cy][i], _tab_width, _label_cached)/2 + \
+                  padding_left > cx + scrl_x:
+                cx = i
                 break
-            dcx = i
-        cx = dcx
         return cx, cy
 
     #

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1152,7 +1152,7 @@ class TextInput(FocusBehavior, Widget):
         _label_cached = self._label_cached
         for i in range(0, len(l[cy])):
             if _get_text_width(l[cy][:i], _tab_width, _label_cached) + \
-                  _get_text_width(l[cy][i], _tab_width, _label_cached)/2 + \
+                  _get_text_width(l[cy][i], _tab_width, _label_cached)*3/5 + \
                   padding_left > cx + scrl_x:
                 cx = i
                 break

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1152,7 +1152,7 @@ class TextInput(FocusBehavior, Widget):
         _label_cached = self._label_cached
         for i in range(0, len(l[cy])):
             if _get_text_width(l[cy][:i], _tab_width, _label_cached) + \
-                  _get_text_width(l[cy][i], _tab_width, _label_cached)*3/5 + \
+                  _get_text_width(l[cy][i], _tab_width, _label_cached)*0.6 + \
                   padding_left > cx + scrl_x:
                 cx = i
                 break


### PR DESCRIPTION
Altered get_cursor_from_xy to provide more natural text positioning with mouse by placing the cursor to the left or right of the clicked on letter depending where on the letter the mouse is clicked, no more pixel perfect placements required.
If the cursor is to the left half of the letter, the cursor is placed on the left.
If the cursor is placed on the right half of the letter, the cursor is placed on the right.

Improved efficiency of the for loop by removing a redundant variable (dcx) and correcting the loop's range.