### PR TITLE
Show disabled_color when disabled=True for markup label

### DIFF
--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -350,7 +350,9 @@ class Label(Widget):
                 if self.halign[-1] == 'y' or self.strip:
                     text = text.strip()
                 self._label.text = ''.join(('[color=',
-                                            get_hex_from_color(self.color),
+                                            get_hex_from_color(
+                                                self.disabled_color if self.disabled
+                                                else self.color),
                                             ']', text, '[/color]'))
                 self._label.refresh()
                 # force the rendering to get the references


### PR DESCRIPTION
Fix for #3959 

Regarding the alpha thing, I dont think markup currently supports alpha because I tried this:

    Label:
        markup: True
        color: 0,0,1,0.5
        text: 'A [color=#77FF0000]B[\color]'

and it outputs [this image](http://imgur.com/xGdAl4z):

![output](http://imgur.com/xGdAl4z)

@dessant please review this.


