### PR TITLE
fix upload uniform without calling useprogram

### DIFF
--- a/kivy/graphics/shader.pyx
+++ b/kivy/graphics/shader.pyx
@@ -235,6 +235,12 @@ cdef class Shader:
     cdef int set_uniform(self, str name, value) except -1:
         if name in self.uniform_values and self.uniform_values[name] == value:
             return 0
+        cdef GLint data
+        glGetIntegerv(GL_CURRENT_PROGRAM, &data)
+        log_gl_error('Shader.set_uniform-glGetIntegerv')
+        if data != self.program:
+            glUseProgram(self.program)
+            log_gl_error('Shader.set_uniform-glUseProgram')
         self.uniform_values[name] = value
         self.upload_uniform(name, value)
         return 0


### PR DESCRIPTION
Shader's set_uniform can be called by RenderContext without first calling the appropriate UseProgram. This appears to happen mainly on window resize (at least for me). 

It's a pretty simple fix, we just check to see if the current program is the expected program and if not we call glUseProgram.

I believe this should address issue #2916 as well. 