### PR TITLE
Bug fix: value of -1 anim_delay setting correctly stops an image anim…

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -574,7 +574,7 @@ class Image(EventDispatcher):
         '''
         # stop animation
         Clock.unschedule(self._anim)
-        if allow_anim and self._anim_available:
+        if allow_anim and self._anim_available and self._anim_delay >= 0:
             Clock.schedule_interval(self._anim, self.anim_delay)
             self._anim()
 

--- a/kivy/core/image/img_gif.py
+++ b/kivy/core/image/img_gif.py
@@ -134,8 +134,13 @@ class ImageLoaderGIF(ImageLoaderBase):
                     rgba_pos += 4
                     i += 1
 
-            img_data_append(ImageData(ls_width, ls_height,
-                'rgba', pixel_map.tostring(), flip_vertical=False))
+            if PY2:
+                img_data_append(ImageData(ls_width, ls_height,
+                    'rgba', pixel_map.tostring(), flip_vertical=False))
+            else:
+                img_data_append(ImageData(ls_width, ls_height,
+                    'rgba', pixel_map.tobytes(), flip_vertical=False))
+
             if draw_method_replace:
                 pixel_map = array('B', [0] * (ls_width * ls_height * 4))
 


### PR DESCRIPTION
The documentation  in kivy.uix.Image.anim_delay states that you can set
an value of -1 to cause an animation to be stopped.
kivy.core.image.Image._set_anim_delay() checks for this, however
kivy.core.image.Image.anim_reset() does not, incorrectly scheduling a
Clock event for -1 (same frame) leading to a “too much iteration”
error. This fix adds a check to anim_reset() to only schedule the Clock
event if anim_delay is >= 0.