### PR TITLE
Remove duplicate code for SelectableView

### DIFF
--- a/examples/widgets/lists/list_cascade_images.py
+++ b/examples/widgets/lists/list_cascade_images.py
@@ -1,8 +1,7 @@
 from kivy.adapters.dictadapter import DictAdapter
-from kivy.uix.selectableview import SelectableView
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.gridlayout import GridLayout
-from kivy.uix.listview import ListView, ListItemButton
+from kivy.uix.listview import ListView, ListItemButton, SelectableView
 from kivy.lang import Builder
 from kivy.factory import Factory
 

--- a/examples/widgets/lists/list_kv.py
+++ b/examples/widgets/lists/list_kv.py
@@ -1,7 +1,6 @@
 from kivy.adapters.dictadapter import DictAdapter
 from kivy.adapters.models import SelectableDataItem
-from kivy.uix.selectableview import SelectableView
-from kivy.uix.listview import ListView, ListItemButton
+from kivy.uix.listview import ListView, ListItemButton, SelectableView
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.boxlayout import BoxLayout
 from kivy.lang import Builder

--- a/kivy/uix/selectableview.py
+++ b/kivy/uix/selectableview.py
@@ -1,35 +1,4 @@
-from kivy.properties import NumericProperty, BooleanProperty
+from kivy.uix.listview import SelectableView
 
-
-class SelectableView(object):
-    '''The :class:`SelectableView` mixin is used with list items and other
-    classes that are to be instantiated in a list view or other classes
-    which use a selection-enabled adapter such as ListAdapter. select() and
-    deselect() can be overridden with display code to mark items as
-    selected or not, if desired.
-    '''
-
-    index = NumericProperty(-1)
-    '''The index into the underlying data list or the data item this view
-    represents.
-    '''
-
-    is_selected = BooleanProperty(False)
-    '''A SelectableView instance carries this property which should be kept
-    in sync with the equivalent property the data item represents.
-    '''
-
-    def __init__(self, **kwargs):
-        super(SelectableView, self).__init__(**kwargs)
-
-    def select(self, *args):
-        '''The list item is responsible for updating the display when
-        being selected, if desired.
-        '''
-        self.is_selected = True
-
-    def deselect(self, *args):
-        '''The list item is responsible for updating the display when
-        being unselected, if desired.
-        '''
-        self.is_selected = False
+# :class:`SelectableView` is defined at :class:`~kivy.uix.listview.SelectableView`.
+# Keep this file for compatibility.


### PR DESCRIPTION
SelectableView is both defined in kivy.uix.selectableview and kivy.uix.listview, using identical code.
This removes duplicate code, but adds an import to maintain compatibility with code importing kivy.uix.selectableview.