### PR TITLE
Index updated too early, results in _sizes holding offset values

### DIFF
--- a/kivy/uix/listview.py
+++ b/kivy/uix/listview.py
@@ -989,11 +989,11 @@ class ListView(AbstractView, EventDispatcher):
             index = istart
             while index <= iend:
                 item_view = self.adapter.get_view(index)
-                index += 1
                 if item_view is None:
                     continue
                 sizes[index] = item_view.height
                 container.add_widget(item_view)
+                index += 1
         else:
             available_height = self.height
             real_height = 0


### PR DESCRIPTION
Updating index before it is used, _sizes will always hold the wrong value by one offset.