### PR TITLE
Use the correct value of index in _sizes

### DIFF
--- a/kivy/uix/listview.py
+++ b/kivy/uix/listview.py
@@ -992,7 +992,7 @@ class ListView(AbstractView, EventDispatcher):
                 index += 1
                 if item_view is None:
                     continue
-                sizes[index] = item_view.height
+                sizes[index-1] = item_view.height
                 container.add_widget(item_view)
         else:
             available_height = self.height


### PR DESCRIPTION
Currently using an offset value. Index does need incrementing in order to prevent an infinite loop, but the sizes dict should be filled using the previous value.