### PR TITLE
Add functions to ListAdapter and DictAdapter to select ListViewItems by key

### DIFF
--- a/kivy/adapters/dictadapter.py
+++ b/kivy/adapters/dictadapter.py
@@ -99,6 +99,20 @@ class DictAdapter(ListAdapter):
             return None
         return self.data[self.sorted_keys[index]]
 
+    def select_key_list(self, key_list, extend=True):
+        '''The select call is made for the items corresponding to the dict keys
+            in the provided key_list.
+
+        Arguments:
+
+            key_list: the list of keys specifying which item views are to become
+            the new selection, or which item views to add to the existing selection
+
+            extend: boolean for whether or not to extend the existing list
+        '''
+        index_list = [self.sorted_keys.index(key) for key in key_list if key in self.sorted_keys]
+        self.select_index_list(index_list, extend)
+
     # [TODO] Also make methods for scroll_to_sel_start, scroll_to_sel_end,
     #        scroll_to_sel_middle.
 

--- a/kivy/adapters/listadapter.py
+++ b/kivy/adapters/listadapter.py
@@ -390,6 +390,20 @@ class ListAdapter(Adapter, EventDispatcher):
 
         self.dispatch('on_selection_change')
 
+    def select_index_list(self, index_list, extend=True):
+        '''The select call is made for the items at indices provided in index_list.
+
+        Arguments:
+
+            index_list: list of indices, views at these indices are to become
+            the new selection, or to add to the existing selection
+
+            extend: boolean for whether or not to extend the existing list
+        '''
+        view_list = [self.get_view(index) for index in index_list]
+        self.select_list(view_list, extend)
+
+
     # [TODO] Could easily add select_all() and deselect_all().
 
     def update_for_new_data(self, *args):

--- a/kivy/tests/test_adapters.py
+++ b/kivy/tests/test_adapters.py
@@ -520,6 +520,45 @@ class AdaptersTestCase(unittest.TestCase):
         view = list_adapter.create_view(100)
         self.assertIsNone(view)
 
+    def test_list_adapter_selection_by_index(self):
+        str_args_converter = lambda row_index, rec: {'text': rec,
+                                                     'size_hint_y': None,
+                                                     'height': 25}
+
+        list_adapter = ListAdapter(data=['cat', 'dog', 'mouse', 'rat', 'goat'],
+                                         args_converter=str_args_converter,
+                                         cls=ListItemButton,
+                                         selection_mode='multiple',
+                                         allow_empty_selection=False)
+
+        c_view = list_adapter.get_view(0)
+        d_view = list_adapter.get_view(1)
+        m_view = list_adapter.get_view(2)
+        r_view = list_adapter.get_view(3)
+        g_view = list_adapter.get_view(4)
+
+        list_adapter.select_list([cat_view], False)
+        self.assertTrue([c_view] == list_adapter.selection)
+
+        list_adapter.select_index_list([2, 4])
+        self.assertTrue([c_view, m_view, g_view] == list_adapter.selection)
+
+        list_adapter.select_index_list([1, 2])
+        self.assertTrue([c_view, g_view, d_view] == list_adapter.selection)
+
+        list_adapter.select_index_list([3, 4], False)
+        self.assertTrue([r_view, g_view] == list_adapter.selection)
+
+        list_adapter.selection_mode = 'single'
+        list_adapter.select_list([d_view], False)
+        list_adapter.select_index_list([0, 2])
+        self.assertTrue([m_view] == list_adapter.selection)
+
+        list_adapter.data.append('aardvark')
+        list_adapter.select_index_list([5], False)
+        self.assertTrue(['aardvark'] == [sv.text
+                for sv in list_adapter.selection])
+
     def test_list_adapter_selection_mode_single(self):
         fruit_data_items[0].is_selected = True
 
@@ -1188,6 +1227,44 @@ class AdaptersTestCase(unittest.TestCase):
         # Bad index:
         self.assertIsNone(dict_adapter.get_data_item(-1))
         self.assertIsNone(dict_adapter.get_data_item(2))
+
+    def test_dict_adapter_selection_by_key(self):
+        str_args_converter = lambda row_index, rec: {'text': rec,
+                                                     'size_hint_y': None,
+                                                     'height': 25}
+
+        dict_adapter = DictAdapter(data={'cat': 'Cat', 'dog': 'Dog',
+                                         'mouse': 'Mouse', 'rat': 'Rat',
+                                         'goat': 'Goat'},
+                                         args_converter=str_args_converter,
+                                         cls=ListItemButton,
+                                         selection_mode='multiple',
+                                         allow_empty_selection=False)
+
+        dict_adapter.select_list([dict_adapter.get_view(0)], False)
+        self.assertTrue(['Cat'] == [sv.text for sv in dict_adapter.selection])
+
+        dict_adapter.select_key_list(['mouse', 'goat'])
+        self.assertTrue(['Cat', 'Mouse', 'Goat'] ==
+                [sv.text for sv in dict_adapter.selection])
+
+        dict_adapter.select_key_list(['dog', 'mouse'])
+        self.assertTrue(['Cat', 'Goat', 'Dog'] ==
+                [sv.text for sv in dict_adapter.selection])
+
+        dict_adapter.select_key_list(['rat', 'goat'], False)
+        self.assertTrue(['Rat', 'Goat'] ==
+                [sv.text for sv in dict_adapter.selection])
+
+        dict_adapter.selection_mode = 'single'
+        dict_adapter.select_list([dict_adapter.get_view(1)], False)
+        dict_adapter.select_key_list(['cat', 'mouse'])
+        self.assertTrue(['Mouse'] == [sv.text for sv in dict_adapter.selection])
+
+        dict_adapter.data['aardvark'] = 'Aardvark'
+        dict_adapter.select_key_list(['aardvark'], False)
+        self.assertTrue(['Aardvark'] ==
+                [sv.text for sv in dict_adapter.selection])
 
     def test_dict_adapter_selection_mode_single_without_propagation(self):
 

--- a/kivy/tests/test_adapters.py
+++ b/kivy/tests/test_adapters.py
@@ -537,7 +537,7 @@ class AdaptersTestCase(unittest.TestCase):
         r_view = list_adapter.get_view(3)
         g_view = list_adapter.get_view(4)
 
-        list_adapter.select_list([cat_view], False)
+        list_adapter.select_list([c_view], False)
         self.assertTrue([c_view] == list_adapter.selection)
 
         list_adapter.select_index_list([2, 4])


### PR DESCRIPTION
Currently, if a `ListAdapter`'s or `DictAdapter`'s selection is to be changed programmatically, the views have to be passed to `select_list`. This may be inconvenient, particularly when the adapter's data are updated and previously selected items should be selected again. This PR adds convenience functions that do the retrieval of the views in the background.