### PR TITLE
DictAdapter: Fix index retrieval in trim* and cut_to_sel methods

### DIFF
--- a/kivy/adapters/dictadapter.py
+++ b/kivy/adapters/dictadapter.py
@@ -109,8 +109,8 @@ class DictAdapter(ListAdapter):
         sorted_keys will be updated by update_for_new_data().
         '''
         if len(self.selection) > 0:
-            selected_keys = [sel.text for sel in self.selection]
-            first_sel_index = self.sorted_keys.index(selected_keys[0])
+            selected_indices = [sel.index for sel in self.selection]
+            first_sel_index = selected_indices[0]
             desired_keys = self.sorted_keys[first_sel_index:]
             self.data = dict([(key, self.data[key]) for key in desired_keys])
 
@@ -121,8 +121,8 @@ class DictAdapter(ListAdapter):
         sorted_keys will be updated by update_for_new_data().
         '''
         if len(self.selection) > 0:
-            selected_keys = [sel.text for sel in self.selection]
-            last_sel_index = self.sorted_keys.index(selected_keys[-1])
+            selected_indices = [sel.index for sel in self.selection]
+            last_sel_index = selected_indices[-1]
             desired_keys = self.sorted_keys[:last_sel_index + 1]
             self.data = dict([(key, self.data[key]) for key in desired_keys])
 
@@ -135,9 +135,9 @@ class DictAdapter(ListAdapter):
         sorted_keys will be updated by update_for_new_data().
         '''
         if len(self.selection) > 0:
-            selected_keys = [sel.text for sel in self.selection]
-            first_sel_index = self.sorted_keys.index(selected_keys[0])
-            last_sel_index = self.sorted_keys.index(selected_keys[-1])
+            selected_indices = [sel.index for sel in self.selection]
+            first_sel_index = selected_indices[0]
+            last_sel_index = selected_indices[-1]
             desired_keys = self.sorted_keys[first_sel_index:last_sel_index + 1]
             self.data = dict([(key, self.data[key]) for key in desired_keys])
 
@@ -148,5 +148,5 @@ class DictAdapter(ListAdapter):
         sorted_keys will be updated by update_for_new_data().
         '''
         if len(self.selection) > 0:
-            selected_keys = [sel.text for sel in self.selection]
+            selected_keys = [self.sorted_keys[sel.index] for sel in self.selection]
             self.data = dict([(key, self.data[key]) for key in selected_keys])

--- a/kivy/tests/test_adapters.py
+++ b/kivy/tests/test_adapters.py
@@ -1313,7 +1313,8 @@ class AdaptersTestCase(unittest.TestCase):
         alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
         letters_dict = \
-           {l: {'text': l, 'is_selected': False} for l in alphabet}
+           {l: {'text': "Letter %s" % l,
+                'is_selected': False} for l in alphabet}
 
         list_item_args_converter = \
                 lambda row_index, rec: {'text': rec['text'],
@@ -1342,7 +1343,7 @@ class AdaptersTestCase(unittest.TestCase):
                         cls=ListItemButton)
 
         a_view = letters_dict_adapter.get_view(0)
-        self.assertEqual(a_view.text, 'A')
+        self.assertEqual(a_view.text, 'Letter A')
 
         letters_dict_adapter.handle_selection(a_view)
         self.assertEqual(len(letters_dict_adapter.selection), 1)
@@ -1365,7 +1366,7 @@ class AdaptersTestCase(unittest.TestCase):
                         cls=ListItemButton)
 
         z_view = letters_dict_adapter.get_view(25)
-        self.assertEqual(z_view.text, 'Z')
+        self.assertEqual(z_view.text, 'Letter Z')
 
         letters_dict_adapter.handle_selection(z_view)
         self.assertEqual(len(letters_dict_adapter.selection), 1)
@@ -1388,11 +1389,11 @@ class AdaptersTestCase(unittest.TestCase):
                         cls=ListItemButton)
 
         g_view = letters_dict_adapter.get_view(6)
-        self.assertEqual(g_view.text, 'G')
+        self.assertEqual(g_view.text, 'Letter G')
         letters_dict_adapter.handle_selection(g_view)
 
         m_view = letters_dict_adapter.get_view(12)
-        self.assertEqual(m_view.text, 'M')
+        self.assertEqual(m_view.text, 'Letter M')
         letters_dict_adapter.handle_selection(m_view)
 
         letters_dict_adapter.trim_to_sel()
@@ -1412,11 +1413,11 @@ class AdaptersTestCase(unittest.TestCase):
                         cls=ListItemButton)
 
         g_view = letters_dict_adapter.get_view(6)
-        self.assertEqual(g_view.text, 'G')
+        self.assertEqual(g_view.text, 'Letter G')
         letters_dict_adapter.handle_selection(g_view)
 
         m_view = letters_dict_adapter.get_view(12)
-        self.assertEqual(m_view.text, 'M')
+        self.assertEqual(m_view.text, 'Letter M')
         letters_dict_adapter.handle_selection(m_view)
 
         letters_dict_adapter.cut_to_sel()


### PR DESCRIPTION
Change trim_*_sel and cut_to_sel tests to use a view text different from the dict key.

Fix bug in DictAdapter.trim_*_sel and cut_to_sel that found index of
selection by text property of the view rather than the index property.