### PR TITLE
store clipboard contents for gtk3 (ClipboardManager spec)

### DIFF
--- a/kivy/core/clipboard/clipboard_gtk3.py
+++ b/kivy/core/clipboard/clipboard_gtk3.py
@@ -38,6 +38,7 @@ class ClipboardGtk3(ClipboardBase):
         if mimetype == 'text/plain;charset=utf-8':
             text = data.decode(self._encoding)
             clipboard.set_text(text, -1)
+            clipboard.store()
 
     def get_types(self):
         self.init()


### PR DESCRIPTION
Allows clipboard contents to persist after application terminates.

https://wiki.ubuntu.com/ClipboardPersistence#How_to_fix_it:_the_ClipboardManager_spec