### PR TITLE
Fix ListAdapter.select_list

### DIFF
--- a/kivy/adapters/listadapter.py
+++ b/kivy/adapters/listadapter.py
@@ -359,10 +359,14 @@ class ListAdapter(Adapter, EventDispatcher):
             extend: boolean for whether or not to extend the existing list
         '''
         if not extend:
-            self.selection = []
+            for selected_view in reversed(self.selection):
+                self.deselect_item_view(selected_view)
 
         for view in view_list:
             self.handle_selection(view, hold_dispatch=True)
+
+        if self.selection_mode != 'none':
+            self.check_for_empty_selection()
 
         self.dispatch('on_selection_change')
 

--- a/kivy/tests/test_adapters.py
+++ b/kivy/tests/test_adapters.py
@@ -555,6 +555,14 @@ class AdaptersTestCase(unittest.TestCase):
         self.assertTrue(isinstance(view, ListItemButton))
         self.assertTrue(view.is_selected)
 
+        view2 = list_adapter.get_view(2)
+        list_adapter.select_list([view2], False)
+        self.assertFalse(view.is_selected)
+
+
+        list_adapter.select_list([], False)
+        self.assertFalse(len(list_adapter.selection)==0)
+
     def test_list_adapter_with_dict_data(self):
         alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 


### PR DESCRIPTION
ListAdapter.select_list has two issues: when `extend=False`, `self.selection` is cleared, but the corresponding views are not marked `is_selected=False`. Thus they keep their selected appearance. Furthermore, if an empty list is passed to `select_list`, the selection is cleared and no item is selected, which may not be allowed (if `selection_mode!='none'` and `allow_empty_selection=False`).
This PR both adds unit tests to discover the issues and introduces a fix for both.