### PR TITLE
Fix delimiter issue #3364

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -33,7 +33,7 @@ Cache.register('kv.lang')
 __KV_INCLUDES__ = []
 
 # precompile regexp expression
-lang_str = re.compile('([\'"][^\'"]*[\'"])')
+lang_str = re.compile(r'((((?<!\\)").*?((?<!\\)"))|(((?<!\\)\').*?((?<!\\)\')))')
 lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile('([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile('(_\()')
@@ -160,7 +160,6 @@ class ParserRuleProperty(object):
 
         # first, remove all the string from the value
         tmp = sub(lang_str, '', self.value)
-
         # detecting how to handle the value according to the key name
         mode = self.mode
         if self.mode is None:

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -269,3 +269,40 @@ class LangTestCase(unittest.TestCase):
         self.assertIsNone(wid.obj)
         Builder.apply_rules(wid, 'TestClassCustom')
         self.assertEqual(wid.obj, 42)
+
+    def test_parse_delimeter(self):
+        Builder = self.import_builder()
+        Builder.load_string('''
+<TestClass>:
+    Label:
+        text: "I'm " + str(root.year) + "years old."
+''')
+
+        rule = Builder.rules[0][1].children[0]
+        watched_keys = rule.properties['text'].watched_keys[0]
+        self.assertTrue('year' in watched_keys)
+
+    def test_parse_delimeter_with_slash(self):
+        Builder = self.import_builder()
+        # Note: When we really load string from file, the parser will
+        # treat the backslash as character.
+        # But in the test because we input the python string,
+        # it will regard the backslash "\" as escape character,
+        # So we have to use "\\" to input backslash Correctly.
+        #
+        # Ex. in the .kv file we will write:
+        # text: "I said \" " + str(root.what_i_said) + "\"!"
+        # to escape double quote.
+        # And in the parser it will be treated as raw string,
+        # So the backslash will be a character.
+        # But in the Test it's python str,
+        # so we have to add one more slash to represent that slash.
+        Builder.load_string('''
+<TestClass>:
+    Label:
+        text: "I said \\" " + str(root.what_i_said) + " \\"!"
+''')
+
+        rule = Builder.rules[0][1].children[0]
+        watched_keys = rule.properties['text'].watched_keys[0]
+        self.assertTrue('what_i_said' in watched_keys)

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -270,7 +270,7 @@ class LangTestCase(unittest.TestCase):
         Builder.apply_rules(wid, 'TestClassCustom')
         self.assertEqual(wid.obj, 42)
 
-    def test_parse_delimeter(self):
+    def test_parse_delimiter(self):
         Builder = self.import_builder()
         Builder.load_string('''
 <TestClass>:
@@ -282,7 +282,7 @@ class LangTestCase(unittest.TestCase):
         watched_keys = rule.properties['text'].watched_keys[0]
         self.assertTrue('year' in watched_keys)
 
-    def test_parse_delimeter_with_slash(self):
+    def test_parse_delimiter_with_slash(self):
         Builder = self.import_builder()
         # Note: When we really load string from file, the parser will
         # treat the backslash as character.


### PR DESCRIPTION
See issue #3364. When we have single quote in the double quoted
string in .kv property definition, It will failed to parse it
correctly.

For example:

```
<TestClass>
    Label:
        text: "I'm " + str(root.year) + " years old"
```

The regex, [lang_str]
(https://github.com/kivy/kivy/blob/master/kivy/lang/parser.py#L36)
in parser.py, will remove the double/single quote incorrectly.
(https://github.com/kivy/kivy/blob/master/kivy/lang/parser.py#L185)

This PR fix that problem.