### PR TITLE
hint_text in TextInput shows when focused and no text entered

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -176,7 +176,7 @@
             pos: [int(x) for x in self.cursor_pos]
             size: 1, -self.line_height
         Color:
-            rgba: self.disabled_foreground_color if self.disabled else (self.hint_text_color if not self.text and not self.focus else self.foreground_color)
+            rgba: self.disabled_foreground_color if self.disabled else (self.hint_text_color if not self.text else self.foreground_color)
 
 <TextInputCutCopyPaste>:
     but_cut: cut.__self__

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1884,8 +1884,8 @@ class TextInput(FocusBehavior, Widget):
         sy = self.scroll_y
 
         # draw labels
-        if not self.focus and (not self._lines or (
-                not self._lines[0] and len(self._lines) == 1)):
+        if not self._lines or (
+                not self._lines[0] and len(self._lines) == 1):
             rects = self._hint_text_rects
             labels = self._hint_text_labels
             lines = self._hint_text_lines


### PR DESCRIPTION
Fixes #3977 

![screenshot from 2016-02-18 02 00 01](https://cloud.githubusercontent.com/assets/7384411/13123690/67319b26-d5e3-11e5-9ebe-7e3005427ee3.png)

Works like the HTML input tag

Sample Code:

```python
from kivy.app import App
from kivy.lang import Builder

kv = """
AnchorLayout:
    TextInput:
        size_hint: 0.4, 0.05
        hint_text: 'hint text'
"""

class TestApp(App):
    def build(self):
        return Builder.load_string(kv)

if __name__ == '__main__':
    TestApp().run()
```