### PR TITLE
Fix label color handling

### DIFF
--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -93,8 +93,8 @@ cdef class _SurfaceContainer:
         r.y = y
         r.w = st.w
         r.h = st.h
-        SDL_SetSurfaceAlphaMod(st, 0xff);
-        SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_NONE);
+        SDL_SetSurfaceAlphaMod(st, <int>(color[3] * 255))
+        SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_NONE)
         SDL_BlitSurface(st, NULL, self.surface, &r)
         SDL_FreeSurface(st)
 

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -3,7 +3,7 @@
 <Label>:
     canvas:
         Color:
-            rgba: (self.disabled_color if not self.markup else (1, 1, 1, 1)) if self.disabled else (self.color if not self.markup else (1, 1, 1, 1))
+            rgba: 1, 1, 1, 1
         Rectangle:
             texture: self.texture
             size: self.texture_size
@@ -21,7 +21,7 @@
             size: self.size
             source: self.disabled_image if self.disabled else self.state_image
         Color:
-            rgba: self.disabled_color if self.disabled else self.color
+            rgba: 1, 1, 1, 1
         Rectangle:
             texture: self.texture
             size: self.texture_size

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -260,7 +260,7 @@ class Label(Widget):
     __events__ = ['on_ref_press']
 
     _font_properties = ('text', 'font_size', 'font_name', 'bold', 'italic',
-                        'underline', 'strikethrough',
+                        'underline', 'strikethrough', 'color', 'disabled_color',
                         'halign', 'valign', 'padding_x', 'padding_y',
                         'text_size', 'shorten', 'mipmap', 'markup',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
@@ -275,24 +275,15 @@ class Label(Widget):
         d = Label._font_properties
         fbind = self.fbind
         update = self._trigger_texture_update
+        fbind('disabled', update, 'disabled')
         for x in d:
             fbind(x, update, x)
 
         self._label = None
         self._create_label()
 
-        fbind('markup', self._bind_for_markup)
-        if self.markup:
-            self._bind_for_markup(self, self.markup)
-
         # force the texture creation
         self._trigger_texture()
-
-    def _bind_for_markup(self, inst, markup):
-        if markup:
-            self.fbind('color', self._trigger_texture_update, 'color')
-        else:
-            self.funbind('color', self._trigger_texture_update, 'color')
 
     def _create_label(self):
         # create the core label class according to markup value
@@ -322,6 +313,9 @@ class Label(Widget):
                 self._label.usersize = value
             elif name == 'font_size':
                 self._label.options[name] = value
+            elif name == 'disabled':
+                self._label.options['color'] = self.disabled_color if value \
+                    else self.color
             else:
                 self._label.options[name] = value
         self._trigger_texture()
@@ -351,8 +345,8 @@ class Label(Widget):
                     text = text.strip()
                 self._label.text = ''.join(('[color=',
                                             get_hex_from_color(
-                                                self.disabled_color if self.disabled
-                                                else self.color),
+                                                self.disabled_color if
+                                                self.disabled else self.color),
                                             ']', text, '[/color]'))
                 self._label.refresh()
                 # force the rendering to get the references

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -313,6 +313,8 @@ class Label(Widget):
                 self._label.usersize = value
             elif name == 'font_size':
                 self._label.options[name] = value
+            elif name == 'disabled_color' and self.disabled:
+                self._label.options['color'] = value
             elif name == 'disabled':
                 self._label.options['color'] = self.disabled_color if value \
                     else self.color


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy/issues/3959.

```python
from kivy.app import App
from kivy.lang import Builder

kv = """
<Lab@Label>:
    font_size: dp(100)
    text: 'O O'
    color: 1, 0, 0, 0.3
    disabled_color: 0, 1, 0, 0.3

AnchorLayout:
    canvas:
        Color:
            rgba: 0, 0, 0, 1
        Rectangle:
            size: self.size
            pos: self.pos
    GridLayout:
        cols: 3
        size_hint_y: None
        height: '300dp'
        Widget:
        Label:
            text: 'disabled: False'
        Label:
            text: 'disabled: True'
        Label:
            text: 'markup: False'
        Lab:
            disabled: False
        Lab:
            disabled: True
        Label:
            text: 'markup: True'
        Lab:
            markup: True
            disabled: False
        Lab:
            markup: True
            disabled: True
        Widget:
        Lab:
            markup: True
            disabled: False
            text: 'O [color=#ff00004c]O[/color]'
        Lab:
            markup: True
            disabled: True
            text: 'O [color=#00ff004c]O[/color]'
"""


class TestApp(App):
    def build(self):
        return Builder.load_string(kv)

if __name__ == '__main__':
    TestApp().run()
```