### PR TITLE
New ColorProperty and rgba function

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -18,6 +18,7 @@ import kivy.lang.builder  # imported as absolute to avoid circular import
 from kivy.logger import Logger
 from kivy.cache import Cache
 from kivy import require
+from kivy.utils import rgba
 import kivy.metrics as Metrics
 
 __all__ = ('Parser', 'ParserException')
@@ -97,6 +98,7 @@ global_idmap['cm'] = Metrics.cm
 global_idmap['mm'] = Metrics.mm
 global_idmap['dp'] = Metrics.dp
 global_idmap['sp'] = Metrics.sp
+global_idmap['rgba'] = rgba
 
 
 class ParserException(Exception):

--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -101,3 +101,6 @@ cdef class ConfigParserProperty(Property):
     cdef object config_name
     cpdef _edit_setting(self, section, key, value)
     cdef inline object _parse_str(self, object value)
+
+cdef class ColorProperty(Property):
+    cdef list parse_str(self, EventDispatcher obj, value)

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -520,3 +520,25 @@ class PropertiesTestCase(unittest.TestCase):
         self.assertEqual(dict_rebind.text, 'Unset')
         self.assertEqual(dict_false.text, 'Unset')
         self.assertEqual(alias_rebind.text, 'Unset')
+
+    def test_color_property(self):
+        from kivy.properties import ColorProperty
+
+        color = ColorProperty()
+        color.link(wid, 'color')
+        color.link_deps(wid, 'color')
+        self.assertEqual(color.get(wid), [1, 1, 1, 1])
+
+        color.set(wid, "#00ff00")
+        self.assertEqual(color.get(wid), [0, 1, 0, 1])
+
+        color.set(wid, "#7f7fff7f")
+        self.assertEqual(color.get(wid)[0], 127 / 255.)
+        self.assertEqual(color.get(wid)[1], 127 / 255.)
+        self.assertEqual(color.get(wid)[2], 1)
+        self.assertEqual(color.get(wid)[3], 127 / 255.)
+
+        color.set(wid, (1, 1, 0))
+        self.assertEqual(color.get(wid), [1, 1, 0, 1])
+        color.set(wid, (1, 1, 0, 0))
+        self.assertEqual(color.get(wid), [1, 1, 0, 0])

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -18,7 +18,7 @@ __all__ = ('intersection', 'difference', 'strtotuple',
            'is_color_transparent', 'hex_colormap', 'colormap', 'boundary',
            'deprecated', 'SafeList',
            'interpolate', 'QueryDict',
-           'platform', 'escape_markup', 'reify')
+           'platform', 'escape_markup', 'reify', 'rgba')
 
 from os import environ
 from sys import platform as _sys_platform
@@ -91,6 +91,8 @@ def strtotuple(s):
 def rgba(s, *args):
     '''Return a kivy color (4 value from 0-1 range) from either a hex string or
        a list of 0-255 values
+
+    .. versionadded:: 1.9.2
     '''
     if isinstance(s, string_types):
         return get_color_from_hex(s)

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -23,6 +23,7 @@ __all__ = ('intersection', 'difference', 'strtotuple',
 from os import environ
 from sys import platform as _sys_platform
 from re import match, split
+from kivy.compat import string_types
 
 
 def boundary(value, minvalue, maxvalue):
@@ -85,6 +86,25 @@ def strtotuple(s):
     if type(r) not in (list, tuple):
         raise Exception('Conversion failed')
     return r
+
+
+def rgba(s, *args):
+    '''Return a kivy color (4 value from 0-1 range) from either a hex string or
+       a list of 0-255 values
+    '''
+    if isinstance(s, string_types):
+        return get_color_from_hex(s)
+    elif isinstance(s, (list, tuple)):
+        s = map(lambda x: x / 255., s)
+        if len(s) == 3:
+            return list(s) + [1]
+        return s
+    elif isinstance(s, (int, float)):
+        s = map(lambda x: x / 255., [s] + list(args))
+        if len(s) == 3:
+            return list(s) + [1]
+        return s
+    raise Exception('Invalid value (not a string / list / tuple)')
 
 
 def get_color_from_hex(s):


### PR DESCRIPTION
This PR intend to improve a little bit the color support in Kivy.
Currently, the 0-1 notation give flexibility, but it's hard to read it.

ColorProperty can accept #rrggbbaa or O-1 value as before. It doesn't accept 0-255.

A new rgba function in kivy.utils is added and exposed in kivy.lang.
rgba function accept 0-255 range value and hex value. rgba outputs always 4 values in 0-1 range, suitable for ColorProperty or ListProperty as today.