### PR TITLE
Revert accidental non-pep8 scrollview changes.

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -648,6 +648,10 @@ class ScrollView(StencilView):
                 e.trigger_velocity_update()
             return True
 
+        in_bar = ud['in_bar_x'] or ud['in_bar_y']
+        if scroll_type == ['bars'] and not in_bar:
+            return self.simulate_touch_down(touch)
+
         # no mouse scrolling, so the user is going to drag the scrollview with
         # this touch.
         self._touch = touch
@@ -669,15 +673,10 @@ class ScrollView(StencilView):
             self.effect_y.start(touch.y)
             self._scroll_y_mouse = self.scroll_y
 
-        if (ud.get('in_bar_x', False) or ud.get('in_bar_y', False)):
-            return True
-
-        Clock.schedule_once(self._change_touch_mode,
-                                self.scroll_timeout / 1000.)
-        if scroll_type == ['bars']:
-            return False
-        else:
-            return True
+        if not in_bar:
+            Clock.schedule_once(self._change_touch_mode,
+                                    self.scroll_timeout / 1000.)
+        return True
 
     def on_touch_move(self, touch):
         if self._touch is not touch:


### PR DESCRIPTION
Reverts the scrollview changes in 2504a3599c45311cee5187885956ba6917f093d3 (https://github.com/kivy/kivy/commit/2504a3599c45311cee5187885956ba6917f093d3#diff-db62621751bc363d71e0329614d71997R648). However, now that it's working properly, this shows a problem with spinner where when a selection is made, the dropdown, being a direct child of window, gets the touch_up first, which dismisses the dropdown. Then the dropdown button gets the touch_up, however, the on_release is not triggered because the dropdown is gone so it doesn't collide anymore.

But I don't have time to fix that secondary issue presently.