### PR TITLE
Make kv string detection more robust.

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -34,7 +34,11 @@ Cache.register('kv.lang')
 __KV_INCLUDES__ = []
 
 # precompile regexp expression
-lang_str = re.compile('([\'"][^\'"]*[\'"])')
+lang_str = re.compile(
+    "((?:'''.*?''')|"
+    "(?:(?:(?<!')|''')'(?:[^']|\\\\')+?'(?:(?!')|'''))|"
+    '(?:""".*?""")|'
+    '(?:(?:(?<!")|""")"(?:[^"]|\\\\")+?"(?:(?!")|""")))', re.DOTALL)
 lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile('([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile('(_\()')


### PR DESCRIPTION
Should make all legal python quoting legal in KV. Including mutliline text. Originally fixed in the compiler branch 12c429d6546ce42bcab91703d1afca896643a476 (https://github.com/matham/kivy/blob/lang-compiler/kivy/lang.py#L905).