### PR TITLE
Add option to sync Spinner dropdown children heights

### DIFF
--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -117,6 +117,15 @@ class Spinner(Button):
 
     .. versionadded:: 1.4.0
     '''
+    
+    sync_height = BooleanProperty(False)
+    '''Each element in a dropdown list uses a default/user-supplied height.
+    Set to True to propagate the Spinner's height value to each dropdown
+    list element.
+    :attr:`sync_height` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to False.
+    .. versionadded:: 1.9.2
+    '''
 
     def __init__(self, **kwargs):
         self._dropdown = None
@@ -127,6 +136,7 @@ class Spinner(Button):
         fbind('dropdown_cls', build_dropdown)
         fbind('option_cls', build_dropdown)
         fbind('values', self._update_dropdown)
+        fbind('size', self._update_dropdown)
         fbind('text_autoupdate', self._update_dropdown)
         build_dropdown()
 
@@ -154,6 +164,7 @@ class Spinner(Button):
         dp.clear_widgets()
         for value in values:
             item = cls(text=value)
+            item.height = self.height if self.sync_height else item.height
             item.bind(on_release=lambda option: dp.select(option.text))
             dp.add_widget(item)
         if text_autoupdate:


### PR DESCRIPTION
Currently the default height is 48 (from style.kv). This patch adds an option `sync_height` which would have each dropdown element's height set according to the current size of the Spinner, which aesthetically makes sense for most cases. If this defaults to True, user will not be able to customize sizes, so a False default makes more sense.

A resubmission of https://github.com/kivy/kivy/pull/3686#issuecomment-186065508 updated for rebasing.