### PR TITLE
Always show the textinput cursor at the moment of touch

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -447,7 +447,6 @@ class TextInput(FocusBehavior, Widget):
 
     def __init__(self, **kwargs):
         self.is_focusable = kwargs.get('is_focusable', True)
-        self._cursor_blink_time = Clock.get_time()
         self._cursor = [0, 0]
         self._selection = False
         self._selection_finished = True
@@ -1721,13 +1720,11 @@ class TextInput(FocusBehavior, Widget):
     def _do_blink_cursor(self, dt):
         # Callback called by the timer to blink the cursor, according to the
         # last activity in the widget
-        b = (Clock.get_time() - self._cursor_blink_time)
-        self.cursor_blink = int(b * 2) % 2
+        self.cursor_blink = not self.cursor_blink
 
     def on_cursor(self, instance, value):
         # When the cursor is moved, reset the activity timer, and update all
         # the graphics.
-        self._cursor_blink_time = Clock.get_time()
         self._trigger_update_graphics()
 
     def _delete_line(self, idx):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1293,6 +1293,12 @@ class TextInput(FocusBehavior, Widget):
         if super(TextInput, self).on_touch_down(touch):
             return True
 
+        if self.focused:
+            Clock.unschedule(self._do_blink_cursor)
+            self.cursor_blink=0
+            self._cursor_blink_time=Clock.get_time()
+            Clock.schedule_interval(self._do_blink_cursor, .5)
+
         # Check for scroll wheel
         if 'button' in touch.profile and touch.button.startswith('scroll'):
             scroll_type = touch.button[6:]

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1296,7 +1296,6 @@ class TextInput(FocusBehavior, Widget):
         if self.focused:
             Clock.unschedule(self._do_blink_cursor)
             self.cursor_blink=0
-            self._cursor_blink_time=Clock.get_time()
             Clock.schedule_interval(self._do_blink_cursor, .5)
 
         # Check for scroll wheel

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1293,9 +1293,7 @@ class TextInput(FocusBehavior, Widget):
             return True
 
         if self.focused:
-            Clock.unschedule(self._do_blink_cursor)
-            self.cursor_blink=0
-            Clock.schedule_interval(self._do_blink_cursor, .5)
+            self._reset_cursor_blink()
 
         # Check for scroll wheel
         if 'button' in touch.profile and touch.button.startswith('scroll'):
@@ -1638,7 +1636,7 @@ class TextInput(FocusBehavior, Widget):
         if value:
             if (not (self.readonly or self.disabled) or _is_desktop and
                 self._keyboard_mode == 'system'):
-                Clock.schedule_interval(self._do_blink_cursor, 1 / 2.)
+                self._reset_cursor_blink()
                 self._editable = True
             else:
                 self._editable = False
@@ -1722,9 +1720,15 @@ class TextInput(FocusBehavior, Widget):
         # last activity in the widget
         self.cursor_blink = not self.cursor_blink
 
+    def _reset_cursor_blink(self):
+        Clock.unschedule(self._do_blink_cursor)
+        self.cursor_blink=0
+        Clock.schedule_interval(self._do_blink_cursor, .5)
+
     def on_cursor(self, instance, value):
-        # When the cursor is moved, reset the activity timer, and update all
-        # the graphics.
+        # When the cursor is moved, reset cursor blinking to keep it showing,
+        # and update all the graphics.
+        self._reset_cursor_blink()
         self._trigger_update_graphics()
 
     def _delete_line(self, idx):


### PR DESCRIPTION
Fixes #4017

@dessant review please :)

A (pretty lame) test for this is repeated clicking, in which case the cursor should stay visible.