### PR TITLE
search for frameworks AND via pkg-config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -411,7 +411,8 @@ if platform not in ('ios', 'android') and (c_options['use_gstreamer']
                     '-framework', 'GStreamer'],
                 'include_dirs': [join(f_path, 'Headers')]}
 
-    else:
+    # use pkgconfig if gstreamer not already configured using frameworks
+    if c_options['use_gstreamer'] is not True:
         # use pkg-config approach instead
         gst_flags = pkgconfig('gstreamer-1.0')
         if 'libraries' in gst_flags:
@@ -423,6 +424,8 @@ if platform not in ('ios', 'android') and (c_options['use_gstreamer']
 sdl2_flags = {}
 if c_options['use_sdl2'] or (
         platform not in ('android',) and c_options['use_sdl2'] is None):
+
+    sdl2_valid = False
 
     if c_options['use_osx_frameworks'] and platform == 'darwin':
         # check the existence of frameworks
@@ -445,24 +448,22 @@ if c_options['use_sdl2'] or (
                 continue
             sdl2_flags['extra_link_args'] += ['-framework', name]
             sdl2_flags['include_dirs'] += [join(f_path, 'Headers')]
-            print('Found sdl2 frameworks: {}'.format(f_path))
+            print('Found SDL2 frameworks: {}'.format(f_path))
             if name == 'SDL2_mixer':
                 _check_and_fix_sdl2_mixer(f_path)
 
-        if not sdl2_valid:
-            c_options['use_sdl2'] = False
-            print('Deactivate SDL2 compilation due to missing frameworks')
-        else:
-            c_options['use_sdl2'] = True
-            print('Activate SDL2 compilation')
-
-    elif platform != "ios":
+    # use pkgconfig if sdl2 not already configured using frameworks
+    if platform != "ios" and c_options['use_sdl2'] is not True:
         # use pkg-config approach instead
         sdl2_flags = pkgconfig('sdl2', 'SDL2_ttf', 'SDL2_image', 'SDL2_mixer')
         if 'libraries' in sdl2_flags:
-            c_options['use_sdl2'] = True
+            sdl2_valid = True
+            print('Found SDL2 libraries: {}'.format(
+                  ', '.join(sdl2_flags['libraries'])))
 
-
+    if sdl2_valid:
+        c_options['use_sdl2'] = True
+        print('Activate SDL2 compilation')
 # -----------------------------------------------------------------------------
 # declare flags
 


### PR DESCRIPTION
This allows installing via pip on brew and non-brew systems without the need for USE_OSX_FRAMEWORKS=0

If both Framework and brewed GStreamer or SDL2 is found. Frameworks will be used. 

This is a rebase of #3685 
Sorry I had to delete my kivy fork some time ago and creating a new PR was the only option to update it.
