### PR TITLE
Fix: Slider.value may exceed Slider.max

### DIFF
--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -117,13 +117,14 @@ class Slider(Widget):
 
     def set_norm_value(self, value):
         vmin = self.min
+        vmax = self.max
         step = self.step
-        val = value * (self.max - vmin) + vmin
+        val = min(value * (vmax - vmin) + vmin, vmax)
         if step == 0:
             self.value = val
         else:
             self.value = min(round((val - vmin) / step) * step + vmin,
-                             self.max)
+                             vmax)
     value_normalized = AliasProperty(get_norm_value, set_norm_value,
                                      bind=('value', 'min', 'max', 'step'))
     '''Normalized value inside the :attr:`range` (min/max) to 0-1 range::


### PR DESCRIPTION
check upper bound of value; under certain circumstances due to floating point inaccuracies, value may be exceeded:

```
from kivy.config import Config
Config.set('graphics', 'width', '800')
Config.set('graphics', 'height', '200')
from kivy.app import App
from kivy.lang import Factory

class NyApp(App):
    def update_value(self, sender, value):
        if sender.max < value:
            print "update_value: value: {}, diff: {}".format(value, sender.max - value)

    def build(self):
        gl = Factory.BoxLayout()
        gl.add_widget(Factory.Widget(size_hint_x=.64))
        sp = Factory.Slider(value=0, min=0, max=60, size_hint_x=.2)
        sp.bind(value=self.update_value)
        gl.add_widget(sp)
        gl.add_widget(Factory.Widget(size_hint_x=.64))
        return gl

if __name__ == '__main__':
    ma = NyApp()
    ma.run()
```