### PR TITLE
Fix ScrollView not properly ignoring touch_up

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -771,7 +771,7 @@ class ScrollView(StencilView):
         return rv
 
     def on_touch_up(self, touch):
-        if self._touch is not touch and self.uid not in touch.ud:
+        if self._touch is not touch and self._get_uid() not in touch.ud:
             # touch is in parents
             touch.push()
             touch.apply_transform_2d(self.to_local)


### PR DESCRIPTION
Hi!

The condition in ScrollView's on_touch_up (added by Ryan in c4fe24c0) looks wrong, self.uid isn't used anywhere else in the code.

Sorry, I don't have a minimal example proving the behaviour to be wrong, it just simply seems self.uid won't ever be added to touch.ud.