### PR TITLE
Respect size_hint in gridlayout.

### DIFF
--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -428,8 +428,11 @@ class GridLayout(Layout):
                 c = children[i]
                 c.x = x
                 c.y = y - row_height
-                c.width = col_width
-                c.height = row_height
+                shx, shy = c.size_hint
+                if shx is not None:
+                    c.width = col_width
+                if shy is not None:
+                    c.height = row_height
                 i = i - 1
                 x = x + col_width + spacing_x
             y -= row_height + spacing_y


### PR DESCRIPTION
I'm not sure how this has not been a issue before? 

Imagine a 3-row 1-column gridlayout. Imagine that the first child has `size_hint_x` `None` and the other two being `1`. Now, the first the first child will always be set to the column's width because the `size_hint_x` is ignored. 

This is a problem if e.g. you use the first child's "fixed" width to set other things. But if the first child is not fixed because the `size_hint_x` is ignored, everything else gets messed up.