### PR TITLE
Fix alpha rendering of text color for pygame

### DIFF
--- a/kivy/core/text/text_pygame.py
+++ b/kivy/core/text/text_pygame.py
@@ -97,6 +97,7 @@ class LabelPygame(LabelBase):
         color[0], color[2] = color[2], color[0]
         try:
             text = font.render(text, True, color)
+            text.set_colorkey(color)
             self._pygame_surface.blit(text, (x, y), None,
                                       pygame.BLEND_RGBA_ADD)
         except pygame.error:


### PR DESCRIPTION
Fixes #4043

set color using set_colorkey, which is the way to include alpha when anti-aliasing=True.
ref: http://www.pygame.org/docs/ref/font.html#pygame.font.Font.render

I haven't gotten to testing this, had problems setting up pygame. I'd appreciate if someone does, but will try by myself too.