### PR TITLE
Performance: compare entire string for Label halign and valign

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -498,15 +498,15 @@ class LabelBase(object):
                 last_word = layout_line.words[0]
                 line = last_word.text
             x = xpad
-            if halign[0] == 'c':  # center
+            if halign == 'center':
                 x = int((w - lw) / 2.)
-            elif halign[0] == 'r':  # right
+            elif halign == 'right':
                 x = max(0, int(w - lw - xpad))
 
             # right left justify
             # divide left over space between `spaces`
             # TODO implement a better method of stretching glyphs?
-            if (uw is not None and halign[-1] == 'y' and line and not
+            if (uw is not None and halign == 'justify' and line and not
                 layout_line.is_last_line):
                 # number spaces needed to fill, and remainder
                 n, rem = divmod(max(uww - lw, 0), sw)
@@ -582,7 +582,7 @@ class LabelBase(object):
         options = copy(self.options)
         options['space_width'] = self.get_extents(' ')[0]
         options['strip'] = strip = (options['strip'] or
-                                    options['halign'][-1] == 'y')
+                                    options['halign'] == 'justify')
         uw, uh = options['text_size'] = self._text_size
         text = self.text
         if strip:
@@ -593,7 +593,7 @@ class LabelBase(object):
         if not text:
             return 0, 0
 
-        if uh is not None and options['valign'][-1] == 'e':  # middle
+        if uh is not None and options['valign'] == 'middle':
             center = -1  # pos of newline
             if len(text) > 1:
                 middle = int(len(text) // 2)
@@ -617,7 +617,7 @@ class LabelBase(object):
                 options, self.get_cached_extents(), True, True)
         else:  # top or bottom
             w, h, clipped = layout_text(text, lines, (0, 0), (uw, uh), options,
-                self.get_cached_extents(), options['valign'][-1] == 'p', True)
+                self.get_cached_extents(), options['valign'] == 'top', True)
         self._internal_size = w, h
         if uw:
             w = uw

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -146,9 +146,9 @@ class MarkupLabel(MarkupLabelBase):
         # mid-word will have space mid-word when lines are joined
         uw_temp = None if shorten else uw
         xpad = options['padding_x']
-        uhh = (None if uh is not None and options['valign'][-1] != 'p' or
+        uhh = (None if uh is not None and options['valign'] != 'top' or
                options['shorten'] else uh)
-        options['strip'] = options['strip'] or options['halign'][-1] == 'y'
+        options['strip'] = options['strip'] or options['halign'] == 'justify'
         for item in self.markup:
             if item == '[b]':
                 spush('bold')
@@ -254,7 +254,7 @@ class MarkupLabel(MarkupLabelBase):
         # when valign is not top, for markup we layout everything (text_size[1]
         # is temporarily set to None) and after layout cut to size if too tall
         elif uh != uhh and h > uh and len(lines) > 1:
-            if options['valign'][-1] == 'm':  # bottom
+            if options['valign'] == 'bottom':
                 i = 0
                 while i < len(lines) - 1 and h > uh:
                     h -= lines[i].h
@@ -274,7 +274,7 @@ class MarkupLabel(MarkupLabelBase):
                 del lines[i + 1:]
 
         # now justify the text
-        if options['halign'][-1] == 'y' and uw is not None:
+        if options['halign'] == 'justify' and uw is not None:
             # XXX: update refs to justified pos
             # when justify, each line shouldv'e been stripped already
             split = partial(re.split, re.compile('( +)'))
@@ -394,9 +394,9 @@ class MarkupLabel(MarkupLabelBase):
         for layout_line in lines:  # for plain label each line has only one str
             lw, lh = layout_line.w, layout_line.h
             x = xpad
-            if halign[0] == 'c':  # center
+            if halign == 'center':
                 x = int((w - lw) / 2.)
-            elif halign[0] == 'r':  # right
+            elif halign == 'right':
                 x = max(0, int(w - lw - xpad))
             layout_line.x = x
             layout_line.y = y

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -389,7 +389,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     cdef int xpad = options['padding_x'], ypad = options['padding_y']
     cdef int max_lines = int(options.get('max_lines', 0))
     cdef float line_height = options['line_height']
-    cdef int strip = options['strip'] or options['halign'][-1] == 'y'
+    cdef int strip = options['strip'] or options['halign'] == 'justify'
     cdef int ref_strip = options['strip_reflow']
     cdef int w = size[0], h = size[1]  # width and height of the texture so far
     cdef list new_lines

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -331,8 +331,8 @@ class Label(Widget):
         mrkup = self._label.__class__ is CoreMarkupLabel
         self.texture = None
 
-        if (not self._label.text or (self.halign[-1] == 'y' or self.strip) and
-            not self._label.text.strip()):
+        if (not self._label.text or (self.halign == 'justify' or self.strip)
+                and not self._label.text.strip()):
             self.texture_size = (0, 0)
             if mrkup:
                 self.refs, self._label._refs = {}, {}
@@ -343,7 +343,7 @@ class Label(Widget):
                 # we must strip here, otherwise, if the last line is empty,
                 # markup will retain the last empty line since it only strips
                 # line by line within markup
-                if self.halign[-1] == 'y' or self.strip:
+                if self.halign == 'justify' or self.strip:
                     text = text.strip()
                 self._label.text = ''.join(('[color=',
                                             get_hex_from_color(


### PR DESCRIPTION
I have used the script below for my tests, comparing the entire string appears to be faster.

```python
import timeit

t1 = timeit.repeat("options = {'valign': 'middle'}; options['valign'][0] == 'm'", repeat=100, number=100000)
t2 = timeit.repeat("options = {'valign': 'middle'}; options['valign'][-1] == 'e'", repeat=100, number=100000)
t3 = timeit.repeat("options = {'valign': 'middle'}; options['valign'] == 'middle'", repeat=100, number=100000)
print(min(t1))
print(min(t2))
print(min(t3))
print(sum(t1) / 100.)
print(sum(t2) / 100.)
print(sum(t3) / 100.)
```

```python
# python 2.7.9
0.0204394898131
0.0210254639652
0.0152120239075
0.021446025372
0.0216670428022
0.015568465453

# python 3.4.4
0.0325066937811308
0.0321727713051132
0.02751594794121015
0.03419724914112318
0.03282620147698605
0.027985079889955893
```
