### PR TITLE
All touches that don't scroll should be skipped in touch move.

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -689,7 +689,7 @@ class ScrollView(StencilView):
         if touch.grab_current is not self:
             return True
 
-        if not (self.do_scroll_y or self.do_scroll_x):
+        if touch.ud.get(self._get_uid()) is None:
             return super(ScrollView, self).on_touch_move(touch)
 
         touch.ud['sv.handled'] = {'x': False, 'y': False}


### PR DESCRIPTION
A touch that has not started a scroll should just be ignored in move as well. Otherwise this leads to a simulated touch down in touch move.