### PR TITLE
In Python 3, bytes are sent, not next. It needs to be decoded.

### DIFF
--- a/kivy/core/clipboard/clipboard_dbusklipper.py
+++ b/kivy/core/clipboard/clipboard_dbusklipper.py
@@ -34,6 +34,7 @@ class ClipboardDbusKlipper(ClipboardBase):
 
     def put(self, data, mimetype='text/plain'):
         self.init()
+        data = data.decode('utf8') if sys.version_info[0] >= 3 else data
         self.iface.setClipboardContents(data.replace('\x00', ''))
 
     def get_types(self):


### PR DESCRIPTION
In Python 3, the `data` argument is of `byte` type. It needs to be decoded. I'm assuming (I don't know) that the encoding can reliably be assumed to be UTF-8 in KDE.
