### PR TITLE
fix #4069 about readonly in TextInput

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -508,6 +508,11 @@ class TextInput(FocusBehavior, Widget):
         def handle_readonly(instance, value):
             if value and (not _is_desktop or not self.allow_copy):
                 self.is_focusable = False
+            if (not (value or self.disabled) or _is_desktop and
+                self._keyboard_mode == 'system'):
+                self._editable = True
+            else:
+                self._editable = False
 
         fbind('padding', update_text_options)
         fbind('tab_width', update_text_options)
@@ -1154,7 +1159,7 @@ class TextInput(FocusBehavior, Widget):
         _label_cached = self._label_cached
         for i in range(0, len(l[cy])):
             if _get_text_width(l[cy][:i], _tab_width, _label_cached) + \
-                  _get_text_width(l[cy][i], _tab_width, _label_cached)*0.6 + \
+                  _get_text_width(l[cy][i], _tab_width, _label_cached) * 0.6 + \
                   padding_left > cx + scrl_x:
                 cx = i
                 break


### PR DESCRIPTION
This commit fixes #4069 

##Illustration
This issue is because in the src we have such bindings:
```Python
def handle_readonly(instance, value):
    if value and (not _is_desktop or not self.allow_copy):
        self.is_focusable = False

fbind('readonly', handle_readonly)
fbind('focus', self._on_textinput_focused)
handle_readonly(self, self.readonly)
```

Notice that here Kivy actually does nothing when you alters `self.readonly`.

However, when `on_double_tap` is triggered, it checks `self.readonly` before you actually sets it tobe `False`, then it sets the `self._editable` to be `False`.
```Python
def _on_textinput_focused(self, instance, value, *largs):
        self.focus = value

        win = EventLoop.window
        self.cancel_selection()
        self._hide_cut_copy_paste(win)

        if value:
            if (not (self.readonly or self.disabled) or _is_desktop and
                self._keyboard_mode == 'system'):
                self._trigger_cursor_reset()
                self._editable = True
            else:
                self._editable = False
        else:
            Clock.unschedule(self._do_blink_cursor)
            self._hide_handles(win)
```

This explains the reason that redundant focus call fixes.

I added the `_editable` property check&change binding to the `readonly` and it makes sense.