### PR TITLE
Fix colorpicker

### DIFF
--- a/examples/widgets/colorpicker.py
+++ b/examples/widgets/colorpicker.py
@@ -99,7 +99,7 @@ Builder.load_string('''
     Button:
         text: 'clear'
         on_release:
-            app.current_image.canvas.after.clear()
+            app.handle_clear()
 
 <MainRootWidget>
     current_image: None
@@ -225,6 +225,9 @@ class MainApp(App):
         self.main_root_widget = MainRootWidget()
         return self.main_root_widget
 
+    def handle_clear(self):
+        if self.current_image:
+            self.current_image.canvas.after.clear()
 
 if __name__ == '__main__':
     MainApp().run()

--- a/examples/widgets/colorpicker.py
+++ b/examples/widgets/colorpicker.py
@@ -78,8 +78,8 @@ Builder.load_string('''
         halign: 'center'
         height: self.texture.size[1] if self.texture else 10
         text:
-            ("Selected Image:\\n' + app.current_image.source.split(os.sep)[2] "
-            "if app.current_image else 'None'")
+            ("Selected Image:\\n" + app.current_image.source.split(os.sep)[-1]
+            if app.current_image else 'None')
     Button:
         text: 'Brush'
         size_hint_y: None


### PR DESCRIPTION
#4090 
The demo crashes when clicking clear button without selecting any image.
Fixed by adding a check on the current_image.

Also fixed the display image name that may happen on different computers.