### PR TITLE
Fix for shader editor example crash when editing on python 2

### DIFF
--- a/examples/demo/shadereditor/main.py
+++ b/examples/demo/shadereditor/main.py
@@ -25,6 +25,7 @@ from kivy.factory import Factory
 from kivy.graphics import RenderContext
 from kivy.properties import StringProperty, ObjectProperty
 from kivy.clock import Clock
+from kivy.compat import PY2
 
 fs_header = '''
 #ifdef GL_ES
@@ -118,8 +119,15 @@ void main (void) {
         print('try compile')
         if not self.viewer:
             return
-        fs = fs_header + self.fs
-        vs = vs_header + self.vs
+
+        # we don't use str() here because it will crash with non-ascii char
+        if PY2:
+            fs = fs_header + self.fs.encode('utf-8')
+            vs = vs_header + self.vs.encode('utf-8')
+        else:
+            fs = fs_header + self.fs
+            vs = vs_header + self.vs
+
         print('-->', fs)
         self.viewer.fs = fs
         print('-->', vs)


### PR DESCRIPTION
The example shader editor crashed when editing on Python. The error is shown below.

> TypeError: Expected str, got unicode

It is due to a mix of unicode and str. We can simply use str() to wrap the variable, like this:

`fs = fs_header + str(self.fs)`

It works except for non-ascii chars. So I decide to use encode('utf-8') to do this.

`fs = fs_header + self.fs.encode('utf-8')`

I have tested it on Python 2.7 and Python 3.5.