### PR TITLE
ScreenManager: fix Screen removal leaving screen.parent property != None

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -913,7 +913,7 @@ class ScreenManager(FloatLayout):
     def real_add_widget(self, *l):
         # ensure screen is removed from it's previous parent before adding'
         if l[0].parent:
-            l[0].parent.remove_widget(l[0])
+            l[0].parent.real_remove_widget(l[0])
         super(ScreenManager, self).add_widget(*l)
 
     def real_remove_widget(self, *l):

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -906,14 +906,16 @@ class ScreenManager(FloatLayout):
             other = next(self)
             if other:
                 self.current = other
+        
+        # ensure screen is removed from it's previous parent
+        if screen.parent:
+            screen.parent.real_remove_widget(screen)
+            
         screen.manager = None
         screen.unbind(name=self._screen_name_changed)
         self.screens.remove(screen)
 
     def real_add_widget(self, *l):
-        # ensure screen is removed from it's previous parent before adding'
-        if l[0].parent:
-            l[0].parent.real_remove_widget(l[0])
         super(ScreenManager, self).add_widget(*l)
 
     def real_remove_widget(self, *l):


### PR DESCRIPTION
Fixes situation where after removal the Screen obj from SM, the obj.parent was the reference of the SM that we have removed the screen from. The parent should be None, so we need to real_remove_widget() from SM widget tree.