### PR TITLE
keyboard patch

### DIFF
--- a/examples/keyboard/main.py
+++ b/examples/keyboard/main.py
@@ -201,7 +201,8 @@ class KeyboardScreen(Screen):
         """ The callback function that catches keyboard events. """
         self.displayLabel.text = u"Key pressed - {0}".format(text)
 
-    def key_up(self, keyboard, keycode):
+    # def key_up(self, keyboard, keycode):
+    def key_up(self, keyboard, keycode, *args):
         """ The callback function that catches keyboard events. """
         self.displayLabel.text += u" (up {0[1]})".format(keycode)
 


### PR DESCRIPTION
	 issues#3853: Select dock mode, restart the app, press Continue and select one of the keyboard layouts, then use the docked keyboard.

	TypeError: key_up() takes exactly 3 arguments (5 given)

	# (<kivy.uix.vkeyboard.VKeyboard object at 0x10ae9c8a0>, u'g', u'g', [])
	# or (keyboard, keycode, text, modifiers)

The crash can be avoided simply by appending a parameter for the function key_up