### PR TITLE
Fixed issue #4092 in dropdown.py

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -279,7 +279,7 @@ class DropDown(ScrollView):
             return True
         if self.collide_point(*touch.pos):
             return True
-        if self.attach_to and self.attach_to.collide_point(*touch.pos):
+        if self.attach_to and self.attach_to.collide_point(*self.attach_to.to_widget(*touch.pos)):
             return True
         if self.auto_dismiss:
             self.dismiss()


### PR DESCRIPTION
Fixed issue #4092.The absolute coordinates of the touch.pos converted to relative coordinates of self.attach_to(dropdown's button) to prevent incorrect processing when the dropdown's button attached to RelaytiveLayout.