### PR TITLE
Move graphical representation attribute into style.kv

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -47,6 +47,7 @@
     border: (0, 0, 0, 0)
 
 <Slider>:
+    padding: sp(16)
     canvas:
         Color:
             rgb: 1, 1, 1

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -50,7 +50,7 @@ class Slider(Widget):
     :attr:`max` is a :class:`~kivy.properties.NumericProperty` and defaults to
     100.'''
 
-    padding = NumericProperty(sp(16))
+    padding = NumericProperty()
     '''Padding of the slider. The padding is used for graphical representation
     and interaction. It prevents the cursor from going out of the bounds of the
     slider bounding box.

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -23,7 +23,6 @@ __all__ = ('Slider', )
 from kivy.uix.widget import Widget
 from kivy.properties import (NumericProperty, AliasProperty, OptionProperty,
                              ReferenceListProperty, BoundedNumericProperty)
-from kivy.metrics import sp
 
 
 class Slider(Widget):


### PR DESCRIPTION
Move `padding` property value into style.kv, where other distances are defined. Ensures style attributes are defined in one place.

Incidentally fixes #4124.