### PR TITLE
Change use of dimension conversion in Slider

### DIFF
--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -23,7 +23,6 @@ __all__ = ('Slider', )
 from kivy.uix.widget import Widget
 from kivy.properties import (NumericProperty, AliasProperty, OptionProperty,
                              ReferenceListProperty, BoundedNumericProperty)
-from kivy.metrics import sp
 
 
 class Slider(Widget):
@@ -50,17 +49,17 @@ class Slider(Widget):
     :attr:`max` is a :class:`~kivy.properties.NumericProperty` and defaults to
     100.'''
 
-    padding = NumericProperty(sp(16))
+    padding = NumericProperty('16sp')
     '''Padding of the slider. The padding is used for graphical representation
     and interaction. It prevents the cursor from going out of the bounds of the
     slider bounding box.
 
-    By default, padding is sp(16). The range of the slider is reduced from
-    padding \*2 on the screen. It allows drawing the default cursor of sp(32)
+    By default, padding is 16sp. The range of the slider is reduced from
+    padding \*2 on the screen. It allows drawing the default cursor of 32sp
     width without having the cursor go out of the widget.
 
     :attr:`padding` is a :class:`~kivy.properties.NumericProperty` and defaults
-    to sp(16).'''
+    to 16sp.'''
 
     orientation = OptionProperty('horizontal', options=(
         'vertical', 'horizontal'))


### PR DESCRIPTION
Change to convert unit at instantiation, as is done in other classes, such as kivy.uix.slider.Slider.

Fixes #4124.

Discussed with @dessant in #4125.