### PR TITLE
Fix ImportError kivy:  (missing -l python3.5m flags)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,9 @@ class KivyBuildExt(build_ext):
         if c != 'msvc':
             for e in self.extensions:
                 e.extra_link_args += ['-lm']
-
+                if PY3:
+                    e.extra_link_args += ['-lpython3.5m']
+                
         build_ext.build_extensions(self)
 
     def update_if_changed(self, fn, content):


### PR DESCRIPTION
Fix [658] (https://github.com/kivy/python-for-android/issues/658)