### PR TITLE
Accept unicode strings as window title in SDL2

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -814,7 +814,7 @@ class App(EventDispatcher):
         window = EventLoop.window
         if window:
             self._app_window = window
-            window.set_title(self.get_application_name())
+            window.set_title(self.get_application_name().encode('utf-8'))
             icon = self.get_application_icon()
             if icon:
                 window.set_icon(icon)

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -210,8 +210,8 @@ cdef class _WindowSDL2Storage:
         IF not USE_IOS:
             SDL_SetWindowFullscreen(self.win, mode)
 
-    def set_window_title(self, str title):
-        SDL_SetWindowTitle(self.win, <bytes>title.encode('utf-8'))
+    def set_window_title(self, bytes title):
+        SDL_SetWindowTitle(self.win, title)
 
     def set_window_icon(self, str filename):
         icon = IMG_Load(<bytes>filename.encode('utf-8'))


### PR DESCRIPTION
Fix #4104

I'm not sure whether this will break other window providers. I looked at the code for pygame and x11, they both seem to accept unicode strings. But I have only tested with SDL2.