### PR TITLE
Improve touch experience in ScrollView widget

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -658,6 +658,8 @@ class ScrollView(StencilView):
             'mode': 'unknown',
             'dx': 0,
             'dy': 0,
+            'y_start': touch.y,
+            'x_start': touch.x,
             'user_stopped': False,
             'frames': Clock.frames,
             'time': touch.time_start}
@@ -809,7 +811,6 @@ class ScrollView(StencilView):
         if self._get_uid() not in touch.ud:
             return False
 
-        self._touch = None
         uid = self._get_uid()
         ud = touch.ud[uid]
         if self.do_scroll_x and self.effect_x:
@@ -827,6 +828,17 @@ class ScrollView(StencilView):
             if not ud['user_stopped']:
                 self.simulate_touch_down(touch)
             Clock.schedule_once(partial(self._do_touch_up, touch), .2)
+
+        #check if we're touch selecting imprecisely
+        #but within range of scroll_distance
+        y_start = ud.get('y_start')
+        x_start = ud.get('x_start')
+        y_select = self.do_scroll_y and y_start and abs(y_start - touch.y) < self.scroll_distance
+        x_select = self.do_scroll_x and x_start and abs(x_start - touch.x) < self.scroll_distance
+        if ud['mode'] == 'scroll' and (x_select or y_select):
+            self.simulate_touch_down(touch)
+            Clock.schedule_once(partial(self._do_touch_up, touch), .1)
+
         Clock.unschedule(self._update_effect_bounds)
         Clock.schedule_once(self._update_effect_bounds)
 


### PR DESCRIPTION
register imprecise touches as touch events instead of scroll events, making mobile / touchscreen UIs work dramatically better when dealing with button or touchable type widgets in a ScrollView. Resolves #4145