### PR TITLE
window_sdl2: fix title and icon_filename to accept bytes or str.

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -210,10 +210,10 @@ cdef class _WindowSDL2Storage:
         IF not USE_IOS:
             SDL_SetWindowFullscreen(self.win, mode)
 
-    def set_window_title(self, str title):
+    def set_window_title(self,  title):
         SDL_SetWindowTitle(self.win, <bytes>title.encode('utf-8'))
 
-    def set_window_icon(self, str filename):
+    def set_window_icon(self, filename):
         icon = IMG_Load(<bytes>filename.encode('utf-8'))
         SDL_SetWindowIcon(self.win, icon)
 


### PR DESCRIPTION
Now compatible with both python3 & 2 closes #4104