### PR TITLE
StringProperty: convert None to empty string

### DIFF
--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -45,7 +45,7 @@ cdef class NumericProperty(Property):
     cdef float parse_list(self, EventDispatcher obj, value, ext)
 
 cdef class StringProperty(Property):
-    pass
+    cdef bint _none_is_empty
 
 cdef class ListProperty(Property):
     pass

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -589,11 +589,19 @@ cdef class StringProperty(Property):
     :Parameters:
         `defaultvalue`: string, defaults to ''
             Specifies the default value of the property.
+        `none_is_empty`: bool, defaults to True
+            Convert None to an empty string '' if None is not an allowed value.
 
     '''
 
     def __init__(self, defaultvalue='', **kw):
+        self._none_is_empty = kw.get('none_is_empty', True)
         super(StringProperty, self).__init__(defaultvalue, **kw)
+
+    cdef convert(self, EventDispatcher obj, x):
+        if x is None and self._none_is_empty and not self.allownone:
+            return ''
+        return x
 
     cdef compare_value(self, a, b):
         return a == b


### PR DESCRIPTION
Makes using `StringProperty` easier. No more `text: root.my_text or ''`. Option `none_is_empty` defaults to `True` but can be disabled, and does nothing if `allownone` is `True`.