### PR TITLE
Added nogil to _WindowSDL2Storage.flip()

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -397,7 +397,9 @@ cdef class _WindowSDL2Storage:
             pass
 
     def flip(self):
-        SDL_GL_SwapWindow(self.win)
+        win = self.win
+        with nogil:
+            SDL_GL_SwapWindow(win)
 
     def save_bytes_in_png(self, filename, data, int width, int height):
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -7,6 +7,7 @@ from kivy.config import Config
 from kivy.logger import Logger
 from kivy import platform
 from kivy.graphics.cgl import cgl_get_backend_name
+from kivy.graphics.cgl cimport *
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 
@@ -400,6 +401,7 @@ cdef class _WindowSDL2Storage:
         win = self.win
         with nogil:
             SDL_GL_SwapWindow(win)
+            cgl.glFinish()
 
     def save_bytes_in_png(self, filename, data, int width, int height):
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -563,7 +563,7 @@ cdef extern from "SDL.h":
     cdef SDL_GLContext SDL_GL_GetCurrentContext()
     cdef int SDL_GL_SetSwapInterval(int interval)
     cdef int SDL_GL_GetSwapInterval()
-    cdef void SDL_GL_SwapWindow(SDL_Window * window)
+    cdef void SDL_GL_SwapWindow(SDL_Window * window) nogil
     cdef void SDL_GL_DeleteContext(SDL_GLContext context)
 
     cdef SDL_Joystick * SDL_JoystickOpen(int index)


### PR DESCRIPTION
Add nogil when calling SDL_GL_SwapWindow().
The reason being SDL_GL_SwapWindow() can block when vsync is turned on, effectively blocking the whole python program and all threads because of the GIL.
