### PR TITLE
Push flags correctly for linebreak in _split_smart

### DIFF
--- a/kivy/tests/test_uix_textinput.py
+++ b/kivy/tests/test_uix_textinput.py
@@ -18,3 +18,19 @@ class TextInputTest(unittest.TestCase):
 
     def on_focused(self, instance, value):
         self.assertTrue(instance.focused, value)
+
+    def test_wordbreak(self):
+        self.test_txt = "Firstlongline\n\nSecondveryverylongline"
+
+        ti = TextInput(width=30, size_hint_x=None)
+        ti.bind(text=self.on_text)
+        ti.text = self.test_txt
+
+    def on_text(self, instance, value):
+        # Check if text is modified while recreating from lines and lines_flags
+        self.assertEquals(instance.text, self.test_txt)
+
+        # Check if wordbreaking is correclty done
+        # If so Secondvery... should start from the 7th line
+        pos_S = self.test_txt.index('S')
+        self.assertEquals(instance.get_cursor_from_index(pos_S), (0,6))

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2204,8 +2204,8 @@ class TextInput(FocusBehavior, Widget):
                 while w > width:
                     split_pos, split_width = self._split_word(word, width)
                     lines_append(word[:split_pos])
-                    lines_flags_append(FL_IS_WORDBREAK)
-                    flags = 0
+                    lines_flags_append(flags)
+                    flags = FL_IS_WORDBREAK
                     word = word[split_pos:]
                     w -= split_width
                 x = w


### PR DESCRIPTION
Fix #4169

In `_split_smart`, when it entered the word splitting routine
the previous stored flags weren't pushed to `lines_flags`.
Hence some of the linebreak flags were missing due to which
`_get_text` wrongly recreated the text from `lines` and `lines_flags`
omitting out a few linebreaks