### PR TITLE
fix stacklayout not sizing if children is empty

### DIFF
--- a/kivy/uix/stacklayout.py
+++ b/kivy/uix/stacklayout.py
@@ -136,6 +136,7 @@ class StackLayout(Layout):
 
     def do_layout(self, *largs):
         if not self.children:
+            self.minimum_size = (0., 0.)
             return
 
         # optimize layout by preventing looking at the same attribute in a loop


### PR DESCRIPTION
Right now if we go from 1 element to 0 element, the bail out on calculation prevents us from properly calculating the size of the stacklayout. If there are no children we should set minimum_size to 0, 0, otherwise it will always be the size of the last element.