### PR TITLE
Xinput2 input provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Kivy.dmg
 iosbuild
 kivy/core/image/osxcoreimage.c
 kivy/core/window/sdl.c
+kivy/input/providers/xinput2.c
 python
 python.exe
 .idea

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -192,11 +192,11 @@ class WindowX11(WindowBase):
         if 'KIVY_WINDOW_X11_CWOR' in environ:
             CWOR = True
 
-        if x11_create_window(size[0], size[1], pos[0], pos[1],
-                resizable, fullscreen, border, above, CWOR,
-                <char *><bytes>self.title) < 0:
+        window_id = x11_create_window(size[0], size[1], pos[0], pos[1], resizable, fullscreen, border, above, CWOR, <char *><bytes>self.title)
+        if window_id < 0:
             Logger.critical('WinX11: Unable to create the window')
             return
+        self.window_id = window_id
 
         size[0] = x11_get_width()
         size[1] = x11_get_height()

--- a/kivy/core/window/window_x11_core.c
+++ b/kivy/core/window/window_x11_core.c
@@ -111,7 +111,7 @@ static Bool WaitForMapNotify(Display *d, XEvent *e, char *arg)
 	}
 #endif
 
-static void createTheWindow(int width, int height, int x, int y, int resizable, int fullscreen, int border, int above, int CWOR, char *title)
+static int createTheWindow(int width, int height, int x, int y, int resizable, int fullscreen, int border, int above, int CWOR, char *title)
 {
 	XEvent event;
 	int attr_mask;
@@ -354,6 +354,8 @@ static void createTheWindow(int width, int height, int x, int y, int resizable, 
 		printf("WinX11 EGL vendor: %s\n", eglQueryString(eglDisplay, EGL_VENDOR));
 		printf("WinX11 EGL version: %s\n", eglQueryString(eglDisplay, EGL_VERSION));
 	#endif
+
+	return window_handle;
 }
 
 #if __USE_EGL == 0
@@ -423,11 +425,12 @@ void x11_set_event_callback(event_cb_t callback) {
 int x11_create_window(int width, int height, int x, int y,
 		int resizable, int fullscreen, int border, int above, int CWOR,
 		char *title) {
-	createTheWindow(width, height, x, y, resizable, fullscreen, border, above, CWOR, title);
+	int window;
+	window = createTheWindow(width, height, x, y, resizable, fullscreen, border, above, CWOR, title);
 	#if __USE_EGL == 0
 		createTheRenderContext();
 	#endif
-	return 1;
+	return window;
 }
 
 void x11_gl_swap(void) {

--- a/kivy/input/providers/__init__.py
+++ b/kivy/input/providers/__init__.py
@@ -51,6 +51,11 @@ if platform == 'linux' or 'KIVY_DOC' in os.environ:
     except:
         err = 'Input: LinuxWacom is not supported by your version of linux'
         Logger.exception(err)
+    try:
+        import kivy.input.providers.xinput2
+    except:
+        err = 'Input: Xinput2 is not supported by your version of linux'
+        Logger.exception(err)
 
 if platform == 'android' or 'KIVY_DOC' in os.environ:
     try:

--- a/kivy/input/providers/__init__.py
+++ b/kivy/input/providers/__init__.py
@@ -53,9 +53,11 @@ if platform == 'linux' or 'KIVY_DOC' in os.environ:
         Logger.exception(err)
     try:
         import kivy.input.providers.xinput2
+    except ImportError:
+        Logger.debug('Input: Did not import xinput2 '
+                     'If you want it you have to compile kivy with USE_X11=1')
     except:
-        err = 'Input: Xinput2 is not supported by your version of linux'
-        Logger.exception(err)
+        Logger.exception('Input: ')
 
 if platform == 'android' or 'KIVY_DOC' in os.environ:
     try:

--- a/kivy/input/providers/xinput2.pyx
+++ b/kivy/input/providers/xinput2.pyx
@@ -1,0 +1,85 @@
+"""
+Xinput2 input provider
+=========================
+"""
+
+cdef extern from "xinput2_core.c":
+    ctypedef struct TouchStruct:
+        int id, state
+        float x, y
+
+cdef extern int start()
+cdef extern int idle()
+
+# Dummy class to bridge between the MotionEventProvider class and C
+from kivy.event import EventDispatcher
+class InputX11(EventDispatcher):
+
+    def start(self):
+        start()
+
+    def x11_idle(self):
+        idle()
+
+    def on_touch_down(self, touch):
+        pass
+
+    def on_touch_move(self, touch):
+        pass
+
+    def on_touch_up(self, touch):
+        pass
+xinput = InputX11()
+
+# Create callback for touch events from C->Cython
+ctypedef int (*touch_cb_type)(TouchStruct *touch)
+cdef extern void x11_set_touch_callback(touch_cb_type callback)
+cdef int event_callback(TouchStruct *touch):
+    touch_down = 0
+    touch_move = 1
+    touch_up = 3
+    py_touch = {"id": touch.id,
+                "x": touch.x,
+                "y": touch.y}
+    print touch.id, touch.state, touch.x, touch.y
+    if touch.state == touch_down:
+        xinput.on_touch_down(py_touch)
+    elif touch.state == touch_move:
+        xinput.on_touch_move(py_touch)
+    elif touch.state == touch_up:
+        xinput.on_touch_up(py_touch)
+x11_set_touch_callback(event_callback)
+
+
+#######
+# Input provider
+__all__ = ('Xinput2EventProvider', 'Xinput2Event')
+
+from kivy.logger import Logger
+from kivy.input.provider import MotionEventProvider
+from kivy.input.factory import MotionEventFactory
+from kivy.input.motionevent import MotionEvent
+
+
+class Xinput2Event(MotionEvent):
+
+    def depack(self, args):
+        super(Xinput2Event, self).depack(args)
+        if args[0] is None:
+            return
+        self.is_touch = True
+
+
+class Xinput2EventProvider(MotionEventProvider):
+
+    __handlers__ = {}
+
+    def start(self):
+        xinput.start()
+
+    def update(self, dispatch_fn):
+        xinput.x11_idle()
+
+
+# registers
+MotionEventFactory.register('xinput2', Xinput2EventProvider)

--- a/kivy/input/providers/xinput2.pyx
+++ b/kivy/input/providers/xinput2.pyx
@@ -8,7 +8,7 @@ cdef extern from "xinput2_core.c":
         int t_id, state
         float x, y
 
-cdef extern int init()
+cdef extern int init(int window_id)
 cdef extern int idle()
 
 # Dummy class to bridge between the MotionEventProvider class and C
@@ -17,9 +17,10 @@ class InputX11():
     def __init__(self):
         self.on_touch = None
 
-    def start(self, on_touch):
+    def start(self, window_id, on_touch):
         self.on_touch = on_touch
-        init()
+        print "forward window id", window_id
+        init(window_id)
 
     def x11_idle(self):
         idle()
@@ -70,7 +71,8 @@ class Xinput2EventProvider(MotionEventProvider):
     __handlers__ = {}
 
     def start(self):
-        xinput.start(on_touch=self.on_touch)
+        from kivy.core.window import Window
+        xinput.start(window_id=Window.window_id, on_touch=self.on_touch)
         self.touch_queue = deque()
         self.touches = {}
 

--- a/kivy/input/providers/xinput2.pyx
+++ b/kivy/input/providers/xinput2.pyx
@@ -44,6 +44,7 @@ __all__ = ('Xinput2EventProvider', 'Xinput2Event')
 
 from kivy.logger import Logger
 from collections import deque
+from kivy.base import EventLoop
 from kivy.input.provider import MotionEventProvider
 from kivy.input.factory import MotionEventFactory
 from kivy.input.motionevent import MotionEvent
@@ -56,8 +57,11 @@ class Xinput2Event(MotionEvent):
         if args[0] is None:
             return
         self.profile = ('pos',)
-        self.sx = args[0]
-        self.sy = args[1]
+        width, height = EventLoop.window.system_size
+        rx = args[0] / float(width)
+        ry = 1. - args[1] / float(height)
+        self.sx = rx
+        self.sy = ry
         self.is_touch = True
 
 

--- a/kivy/input/providers/xinput2_core.c
+++ b/kivy/input/providers/xinput2_core.c
@@ -38,7 +38,6 @@ void x11_set_touch_callback(touch_cb_type callback) {
 
 int init (int windowID){
 	dpy = XOpenDisplay(NULL);
-	int scr = DefaultScreen(dpy);
 
 	int devid = 0;
 	Window win = windowID;
@@ -70,19 +69,6 @@ int init (int windowID){
 
 	/* create window */
 	{
-		XSetWindowAttributes attr = {
-			.background_pixel = 0,
-			.event_mask = KeyPressMask
-		};
-
-		/*win = XCreateWindow(dpy, RootWindow(dpy, scr),
-				0, 0, 500, 500, 0,
-				DefaultDepth(dpy, scr),
-				InputOutput,
-				DefaultVisual(dpy, scr),
-				CWEventMask | CWBackPixel,
-				&attr);*/
-
 		XMapWindow(dpy, win);
 		XSync(dpy, False);
 	}
@@ -179,14 +165,4 @@ int idle(void){
 		}
 	}
 	return 0;
-}
-
-
-// A main loop just for testing when compiling it directly
-int main (void){
-    init(0);
-    while(1){
-    	idle();
-    }
-    return 0;
 }

--- a/kivy/input/providers/xinput2_core.c
+++ b/kivy/input/providers/xinput2_core.c
@@ -32,7 +32,7 @@
 
 #define TOUCH_DOWN 0
 #define TOUCH_MOVE 1
-#define TOUCH_UP 3
+#define TOUCH_UP 2
 
 static Display *dpy;
 static int xi_opcode;

--- a/kivy/input/providers/xinput2_core.c
+++ b/kivy/input/providers/xinput2_core.c
@@ -1,0 +1,222 @@
+/*
+ * event.c - show touch events
+ *
+ * Copyright © 2013 Eon S. Jeon <esjeon@live.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <X11/Xlib.h>
+#include <X11/extensions/XInput2.h>
+
+#define TOUCH_DOWN 0
+#define TOUCH_MOVE 1
+#define TOUCH_UP 3
+
+static Display *dpy;
+static int xi_opcode;
+
+// Cython API
+typedef struct TouchStruct{
+    int id;
+    int state;
+	float  x;
+	float  y;
+} TouchStruct;
+
+typedef int (*touch_cb_type)(TouchStruct *touch);
+touch_cb_type touch_cb = NULL;
+
+void x11_set_touch_callback(touch_cb_type callback) {
+	touch_cb = callback;
+}
+
+
+int start (){
+	dpy = XOpenDisplay(NULL);
+	int scr = DefaultScreen(dpy);
+
+	//int xi_opcode;
+	int devid;
+	Window win;
+
+	/* check XInput extension */
+	{
+		int ev;
+		int err;
+
+		if (!XQueryExtension(dpy, "XInputExtension", &xi_opcode, &ev, &err)) {
+			printf("X Input extension not available.\n");
+			return 1;
+		}
+	}
+
+	/* check the version of XInput */
+	{
+		int rc;
+		int major = 2;
+		int minor = 3;
+
+		rc = XIQueryVersion(dpy, &major, &minor);
+		if (rc != Success)
+		{
+			printf("No XI2 support. (%d.%d only)\n", major, minor);
+			exit(1);
+		}
+	}
+
+	/* create window */
+	{
+		XSetWindowAttributes attr = {
+			.background_pixel = 0,
+			.event_mask = KeyPressMask
+		};
+
+		win = XCreateWindow(dpy, RootWindow(dpy, scr),
+				0, 0, 500, 500, 0,
+				DefaultDepth(dpy, scr),
+				InputOutput,
+				DefaultVisual(dpy, scr),
+				CWEventMask | CWBackPixel,
+				&attr);
+
+		XMapWindow(dpy, win);
+		XSync(dpy, False);
+	}
+
+	/* select device */
+	{
+		XIDeviceInfo *di;
+		XIDeviceInfo *dev;
+		XITouchClassInfo *class;
+		int cnt;
+		int i, j;
+
+		di = XIQueryDevice(dpy, XIAllDevices, &cnt);
+		for (i = 0; i < cnt; i ++)
+		{
+			dev = &di[i];
+			for (j = 0; j < dev->num_classes; j ++)
+			{
+				class = (XITouchClassInfo*)(dev->classes[j]);
+				if (class->type != XITouchClass)
+				{
+					devid = dev->deviceid;
+					goto STOP_SEARCH_DEVICE;
+				}
+			}
+		}
+STOP_SEARCH_DEVICE:
+		XIFreeDeviceInfo(di);
+	}
+
+	/* select events to listen */
+	{
+		XIEventMask mask = {
+			.deviceid = devid, //XIAllDevices,
+			.mask_len = XIMaskLen(XI_TouchEnd)
+		};
+		mask.mask = (unsigned char*)calloc(3, sizeof(char));
+		XISetMask(mask.mask, XI_TouchBegin);
+		XISetMask(mask.mask, XI_TouchUpdate);
+		XISetMask(mask.mask, XI_TouchEnd);
+        XISetMask(mask.mask, XI_Motion); // Only for testing without overlay
+
+		XISelectEvents(dpy, win, &mask, 1);
+
+		free(mask.mask);
+	}
+
+
+	XFlush(dpy);
+
+    printf("INIT finished.\n");
+
+	return 0;
+}
+
+int idle(){
+    TouchStruct touch;
+	XEvent ev;
+	XGenericEventCookie *cookie = &ev.xcookie; // hacks!
+	XIDeviceEvent *devev;
+
+	while (XPending(dpy)){
+		XNextEvent(dpy, &ev);
+		if (XGetEventData(dpy, cookie)) // extended event
+		{
+			// check if this belongs to XInput
+			if(cookie->type == GenericEvent && cookie->extension == xi_opcode)
+			{
+				static int last = -1;
+
+				devev = cookie->data;
+				switch(devev->evtype) {
+				case XI_TouchBegin:
+                        touch.id = devev->detail;
+                        touch.state = TOUCH_DOWN;
+                        touch.x = devev->event_x;
+                        touch.y = devev->event_y;
+                        touch_cb(&touch);
+					break;
+				case XI_TouchUpdate:
+                        touch.id = devev->detail;
+                        touch.state = TOUCH_MOVE;
+                        touch.x = devev->event_x;
+                        touch.y = devev->event_y;
+                        touch_cb(&touch);
+					break;
+				case XI_TouchEnd:
+                        touch.id = devev->detail;
+                        touch.state = TOUCH_UP;
+                        touch.x = devev->event_x;
+                        touch.y = devev->event_y;
+                        touch_cb(&touch);
+					break;
+				case XI_Motion: // Just for testing
+                        touch.id = devev->detail;
+                        touch.state = TOUCH_DOWN;
+                        touch.x = devev->event_x;
+                        touch.y = devev->event_y;
+                        touch_cb(&touch);
+					break;
+				}
+			}
+		}
+		else // normal event
+		{
+			if (ev.type == KeyPress)
+				break;
+		}
+	}
+	return 0;
+}
+
+int main (){
+    start();
+    while(1){
+    	idle();
+    }
+    return 0;
+}

--- a/kivy/input/providers/xinput2_core.c
+++ b/kivy/input/providers/xinput2_core.c
@@ -36,12 +36,12 @@ void x11_set_touch_callback(touch_cb_type callback) {
 }
 
 
-int init (void){
+int init (int windowID){
 	dpy = XOpenDisplay(NULL);
 	int scr = DefaultScreen(dpy);
 
 	int devid = 0;
-	Window win;
+	Window win = windowID;
 
 	/* check XInput extension */
 	{
@@ -75,13 +75,13 @@ int init (void){
 			.event_mask = KeyPressMask
 		};
 
-		win = XCreateWindow(dpy, RootWindow(dpy, scr),
+		/*win = XCreateWindow(dpy, RootWindow(dpy, scr),
 				0, 0, 500, 500, 0,
 				DefaultDepth(dpy, scr),
 				InputOutput,
 				DefaultVisual(dpy, scr),
 				CWEventMask | CWBackPixel,
-				&attr);
+				&attr);*/
 
 		XMapWindow(dpy, win);
 		XSync(dpy, False);
@@ -184,7 +184,7 @@ int idle(void){
 
 // A main loop just for testing when compiling it directly
 int main (void){
-    init();
+    init(0);
     while(1){
     	idle();
     }

--- a/setup.py
+++ b/setup.py
@@ -822,6 +822,11 @@ if c_options['use_x11']:
             #    'core/window/window_x11_core.c'],
             'libraries': libs})
 
+    # Xinput2 input provider
+    sources['input/providers/xinput2.pyx'] = merge(
+        base_flags, gl_flags, {'libraries': ["X11", "Xi"]}
+    )
+
 if c_options['use_gstreamer']:
     sources['lib/gstplayer/_gstplayer.pyx'] = merge(
         base_flags, gst_flags, {


### PR DESCRIPTION
This is an xinput2 input provider for kivy. This allows the use of multiple "native" x11 inputs (mouses) as they are available on some mutltiouch screens on Linux. You are not limited to fullscreen when you have more than one (mouse) input.

This currently only works in combination with the x11-window as I need the window-id.
See: https://groups.google.com/forum/#!topic/kivy-dev/wlrRfIBi-2c
Therefore I needed to slightly alter the x11-window.

I am open for any feedback, or just happy if you could merge as it is.