### PR TITLE
Storage fix: clear() is not syncing the storage file

### DIFF
--- a/kivy/storage/__init__.py
+++ b/kivy/storage/__init__.py
@@ -343,6 +343,7 @@ class AbstractStore(EventDispatcher):
     def store_clear(self):
         for key in self.store_keys():
             self.store_delete(key)
+        self.store_sync()
 
     def store_get_async(self, key, callback):
         try:


### PR DESCRIPTION
Storage.store_clear() uses store_delete() method, which just deletes the key from internal dict, but does not sync the dict with the file. After using internal store_delete inside a loop, we should sync the file too, making sure the file is updated.