### PR TITLE
JsonStore: pep8 fix, do not check if boolean is False

### DIFF
--- a/kivy/storage/jsonstore.py
+++ b/kivy/storage/jsonstore.py
@@ -35,7 +35,7 @@ class JsonStore(AbstractStore):
             self._data = loads(data)
 
     def store_sync(self):
-        if self._is_changed is False:
+        if not self._is_changed:
             return
         with open(self.filename, 'w') as fd:
             dump(self._data, fd)


### PR DESCRIPTION
Do not check if boolean is False, use boolean context instead.