### PR TITLE
adding get_current_display_mode method

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -158,6 +158,11 @@ cdef class _WindowSDL2Storage:
         SDL_GL_GetDrawableSize(self.win, &w, &h)
         return w, h
 
+    def get_currentdisplaymode(self):
+        cdef SDL_DisplayMode mode
+        SDL_GetCurrentDisplayMode(0, &mode)
+        return mode.w, mode.h
+
     def resize_display_mode(self, w, h):
         cdef SDL_DisplayMode mode
         cdef int draw_w, draw_h

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -700,3 +700,6 @@ class WindowSDL(WindowBase):
     def unmap_key(self, key):
         if key in self.key_map:
             del self.key_map[key]
+
+    def get_current_display_mode(self):
+        return self._win.get_currentdisplaymode()


### PR DESCRIPTION
![disp](https://cloud.githubusercontent.com/assets/7335120/15303922/037c09fa-1bd8-11e6-9f6c-e6640d1a1d9c.png)

You may use this code to check.


    from kivy.app import App
    from kivy.lang import Builder
    from kivy.uix.boxlayout import BoxLayout
    from kivy.properties import ListProperty
    from kivy.core.window import Window

    Builder.load_string('''
    <Interface>:

        Label:
            text: str(root.disp)

    ''')


    class Interface(BoxLayout):
        disp = ListProperty()

        def __init__(self, **kwargs):
            super(Interface, self).__init__(**kwargs)
            self.display()

        def display(self):
            self.disp = Window.get_current_display_mode()
            print self.disp


    class DispApp(App):

        def build(self):
            return Interface()

    if __name__ == "__main__":
        app = DispApp()
        app.run()