### PR TITLE
Add Matrix.transform() to easily get transformed 2D coordinate

### DIFF
--- a/kivy/graphics/transformation.pyx
+++ b/kivy/graphics/transformation.pyx
@@ -611,6 +611,20 @@ cdef class Matrix:
 
         return (winx, winy, winz)
 
+    def transform(self, double x, double y):
+        '''Return a transformed point by applying this Matrix's tranformation.
+
+        :Parameters:
+            `point`: 2D point to tranform
+
+        .. versionadded: 2.0.0
+        '''
+
+        cdef double *m = <double *>self.mat
+        transformed_point = (x * m[0] + y * m[4] + m[12],
+                            x * m[1] + y * m[5] + m[13])
+        return transformed_point
+
     def __str__(self):
         cdef double *m = <double *>self.mat
         return '[[ %f %f %f %f ]\n[ %f %f %f %f ]\n' \


### PR DESCRIPTION
Looks like a useful addition. Wanted to use it [here](https://github.com/udiboy1209/kivent/blob/2121e58b905cbf3bd948a88094c1bae5de0484bf/modules/core/kivent_core/systems/gameview.pyx#L128).

Test code:

```
import kivy
from kivy.graphics.transformation import Matrix

m = Matrix()
m.rotate(3.14159/4, 0, 0, 1)

print m.transform([1,1])
```
