### PR TITLE
fix error with py3 results returning wrong

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -406,6 +406,8 @@ class UrlRequest(Thread):
         if content_type is not None:
             ct = content_type.split(';')[0]
             if ct == 'application/json':
+                if isinstance(result, bytes):
+                    result = result.decode('utf-8')
                 try:
                     return loads(result)
                 except:


### PR DESCRIPTION
In py3 it's possible to get back something like 
b'{"access_token":"tokenhere","token_type":"bearer","created_at":1463850271}'

which will then not be successfully decoded into a dict but left as a byte string, needs to be decoded from bytes prior to running the decode_result logic