### PR TITLE
Fixed parser not continuing after warning

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -433,7 +433,7 @@ class Parser(object):
                     if not force_load:
                         Logger.warn('WARNING: {0} has already been included!'
                                     .format(ref))
-                        break
+                        continue
                     else:
                         Logger.debug('Reloading {0} because include was forced.'
                                     .format(ref))


### PR DESCRIPTION
Currently the parser does not continue if the ref has been included elsewhere, causing the order of includes to matter.
For example, building `a.kv`with the following files breaks with message ` kivy.factory.FactoryException: Unknown class <C>`without the fix, but creates the button with the fix.

file `a.kv` contains:
>#:include b.kv
>#:include d.kv
>#:include c.kv
>C:

file `b.kv` contains:
>#:include d.kv

file `c.kv` contains:
>\<C@Button>:

file `d.kv` contains:
>\<D@Button>: