### PR TITLE
[Change] x11-window: implement on_title

### DIFF
--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -59,6 +59,7 @@ cdef extern from "X11/Xutil.h":
 cdef extern int x11_create_window(int width, int height, int x, int y, \
         int resizable, int fullscreen, int border, int above, int CWOR, char *title)
 cdef extern void x11_gl_swap()
+cdef extern void x11_set_title(char *title)
 cdef extern int x11_idle()
 cdef extern int x11_get_width()
 cdef extern int x11_get_height()
@@ -226,6 +227,9 @@ class WindowX11(WindowBase):
     def flip(self):
         x11_gl_swap()
         super(WindowX11, self).flip()
+
+    def on_title(self, *kwargs):
+        x11_set_title(<char *><bytes>self.title)
 
     def on_keyboard(self, key,
         scancode=None, codepoint=None, modifier=None, **kwargs):

--- a/kivy/core/window/window_x11_core.c
+++ b/kivy/core/window/window_x11_core.c
@@ -438,6 +438,10 @@ void x11_gl_swap(void) {
 	#endif
 }
 
+void x11_set_title(char *title){
+	XStoreName(Xdisplay, window_handle, title);
+}
+
 int x11_get_width(void) {
 	return g_width;
 }


### PR DESCRIPTION
This enables to set the window title at runtime. Until now, the window just had the name "Kivy" (as Kivy is the init value of the Window.title property. With this implemented you see the title "Touchtracer" when you launch the demo/touchtracer example.