### PR TITLE
Deleting the _device to release the camera device in opencv

### DIFF
--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -101,3 +101,5 @@ class CameraOpenCV(CameraBase):
     def stop(self):
         super(CameraOpenCV, self).stop()
         Clock.unschedule(self._update)
+        # Release the device
+        del self._device


### PR DESCRIPTION
I noticed that when stopping the camera by setting play=False the device isn't released. (The webcam light stays on for example)
In python-opencv I have to explicit delete the reference to the opencv device so I just added a 'del self._device' to get the same result.
Tested it and the webcam is switched off.

Regards,
Stas (stas@btp.nl) 
