### PR TITLE
Fixing issue #4119

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -531,7 +531,7 @@ class ActionView(BoxLayout):
         super_add(self.action_previous)
 
         width = (self.width - self.overflow_group.pack_width -
-                 self.action_previous.pack_width)
+                 self.action_previous.minimum_width)
 
         if len(self._list_action_items):
             for child in self._list_action_items[1:]:


### PR DESCRIPTION
This commit is not changing the get_pack_width() method - like stated in the issue - instead I only changed the way the value of the width variable within ActionView._layout_random() is calculated which has much less side effects. Please note that this is my first contribution fixing a bug in Kivy and I hope I did the forking and PR correctly.