### PR TITLE
Fix #4251. Exception on remote image error

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -348,7 +348,8 @@ class LoaderBase(object):
             Logger.exception('Loader: Failed to load image <%s>' % filename)
             # close file when remote file not found or download error
             try:
-                close(_out_osfd)
+                if _out_osfd:
+                    close(_out_osfd)
             except OSError:
                 pass
             return self.error_image


### PR DESCRIPTION
Check that temporary file descriptor exists before trying to close it. It was causing an Exception and not loading the corresponding error_image