### PR TITLE
Fix notes example

### DIFF
--- a/examples/tutorials/notes/final/main.py
+++ b/examples/tutorials/notes/final/main.py
@@ -62,6 +62,11 @@ class NoteView(Screen):
 
 class NoteListItem(BoxLayout):
 
+    def __init__(self, **kwargs):
+        print(kwargs)
+        del kwargs['index']
+        super(NoteListItem, self).__init__(**kwargs)
+    note_content = StringProperty()
     note_title = StringProperty()
     note_index = NumericProperty()
 
@@ -91,15 +96,12 @@ class NoteApp(App):
     def load_notes(self):
         if not exists(self.notes_fn):
             return
-        with open(self.notes_fn, 'rb') as fd:
-            # ensure it's str not bytes for json.load()
-            from codecs import getreader
-            reader = getreader('utf-8')
-            data = json.load(reader(fd))
+        with open(self.notes_fn) as fd:
+            data = json.load(fd)
         self.notes.data = data
 
     def save_notes(self):
-        with open(self.notes_fn, 'wb') as fd:
+        with open(self.notes_fn, 'w') as fd:
             json.dump(self.notes.data, fd)
 
     def del_note(self, note_index):

--- a/examples/tutorials/notes/final/main.py
+++ b/examples/tutorials/notes/final/main.py
@@ -36,7 +36,6 @@ class MutableTextInput(FloatLayout):
     def on_touch_down(self, touch):
         if self.collide_point(*touch.pos) and touch.is_double_tap:
             self.edit()
-            return True
         return super(MutableTextInput, self).on_touch_down(touch)
 
     def edit(self):
@@ -93,7 +92,10 @@ class NoteApp(App):
         if not exists(self.notes_fn):
             return
         with open(self.notes_fn, 'rb') as fd:
-            data = json.load(fd)
+            # ensure it's str not bytes for json.load()
+            from codecs import getreader
+            reader = getreader('utf-8')
+            data = json.load(reader(fd))
         self.notes.data = data
 
     def save_notes(self):


### PR DESCRIPTION
Partially fixes #3697 - the part about `json.load()` in Python 3 where you can use only `str` and not bytes. Then there is an issue with `return True` on double-click, which if is present will prevent you from staying in focused MutableTextInput.

However I can't find anything I could catch to fix the whole issue as at [line 254](https://github.com/kivy/kivy/blob/master/kivy/_event.pyx#L254) there is `**kwargs` which should take all parameters into dictionary, am I right? Please help me?

Python 2 works as expected.