### PR TITLE
Fix #4062. Adds on_error event to ProxyImage

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -348,7 +348,8 @@ class LoaderBase(object):
             Logger.exception('Loader: Failed to load image <%s>' % filename)
             # close file when remote file not found or download error
             try:
-                close(_out_osfd)
+                if _out_osfd:
+                    close(_out_osfd)
             except OSError:
                 pass
             return self.error_image

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -63,9 +63,12 @@ class ProxyImage(Image):
     :Events:
         `on_load`
             Fired when the image is loaded or changed.
+        `on_error`
+            Fired when the image cannot be loaded.
+            `error`: Exception data that ocurred
     '''
 
-    __events__ = ('on_load', )
+    __events__ = ('on_load', 'on_error')
 
     def __init__(self, arg, **kwargs):
         loaded = kwargs.pop('loaded', False)
@@ -73,6 +76,9 @@ class ProxyImage(Image):
         self.loaded = loaded
 
     def on_load(self):
+        pass
+
+    def on_error(self, error):
         pass
 
 
@@ -344,7 +350,7 @@ class LoaderBase(object):
             # FIXME create a clean API for that
             for imdata in data._data:
                 imdata.source = filename
-        except Exception:
+        except Exception as ex:
             Logger.exception('Loader: Failed to load image <%s>' % filename)
             # close file when remote file not found or download error
             try:
@@ -352,6 +358,16 @@ class LoaderBase(object):
                     close(_out_osfd)
             except OSError:
                 pass
+
+            # update client
+            for c_filename, client in self._client[:]:
+                if filename != c_filename:
+                    continue
+                # got one client to update
+                client.image = self.error_image
+                client.dispatch('on_error', error=ex)
+                self._client.remove((c_filename, client))
+
             return self.error_image
         finally:
             if fd:


### PR DESCRIPTION
This PR adds the 'on_error' event to ProxyImage, which can be dispatched when a remote image cannot be loaded, as proposed in #4062. The cause of the error (the exception info) is provided as suggested in #1735, so the user code can notify the user, retry the loading, debug or whatever it fits.
If the event is not binded, nothing extra happens, just as now.