### PR TITLE
In textinput, don't try to split lines shorter than 1px

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2200,7 +2200,7 @@ class TextInput(FocusBehavior, Widget):
                 x = 0
             if is_newline:
                 flags |= FL_IS_LINEBREAK
-            elif width > 0 and w > width:
+            elif width >= 1 and w > width:
                 while w > width:
                     split_pos, split_width = self._split_word(word, width)
                     lines_append(word[:split_pos])


### PR DESCRIPTION
A line shorter than 1px, but longer than 0px, can legitimately
occur in layouts with size_hints that make a textinput shorter
than its text or hint_text.

Fixes #4244.