### PR TITLE
clipboard_gtk3: fix warning

### DIFF
--- a/kivy/core/clipboard/clipboard_gtk3.py
+++ b/kivy/core/clipboard/clipboard_gtk3.py
@@ -11,6 +11,8 @@ from kivy.core.clipboard import ClipboardBase
 if platform != 'linux':
     raise SystemError('unsupported platform for gtk3 clipboard')
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
 clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 


### PR DESCRIPTION
fix gtk3 warning by requiring Gtk3 explicit.