### PR TITLE
Fix handling of PermissionError for logger.purge_logs

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -134,9 +134,12 @@ class FileHandler(logging.Handler):
             l = l[:-maxfiles]
             print('Purge %d log files' % len(l))
 
-            # now, unlink every files in the list
+            # now, unlink every file in the list
             for filename in l:
-                unlink(filename['fn'])
+                try:
+                    unlink(filename['fn'])
+                except PermissionError as e:
+                    print('Skipped file {0}, {1}'.format(filename['fn'], e))
 
         print('Purge finished!')
 


### PR DESCRIPTION
`logger.purge_logs` is crashing for me (randomly 1 time in 20 via the call to `purge_logs`) on a Windows machine. If a log file is locked (open in another app, or in my case, another multiprocess process) the app throws an unhandled exception on startup, upon `import kivy`.

Failing configuration is an app with several `multiprocess` processes, and occasionally a process decides to delete another log still being written to by the other process.  

Fix is to handle this PermissionError exception gracefully.

Tested thoroughly on a Windows 7 box, python 3.4, pyInstaller frozen.