### PR TITLE
Add Bubble.background_color explanation

### DIFF
--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -92,7 +92,8 @@ class Bubble(GridLayout):
     '''
 
     background_color = ListProperty([1, 1, 1, 1])
-    '''Background color, in the format (r, g, b, a).
+    '''Background color, in the format (r, g, b, a). To use it you have to set
+    either :attr:`background_image` or :attr:`arrow_image` first.
 
     :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].


### PR DESCRIPTION
Adds explaining how to set the property as it doesn't work alone, but only with bg/arrow_image changed first.