### PR TITLE
logger: Recognize {rxvt,rxvt-unicode}-256color as color capable

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -325,7 +325,13 @@ if 'KIVY_NO_CONSOLELOG' not in os.environ:
             os.name != 'nt' and
             os.environ.get('KIVY_BUILD') not in ('android', 'ios') and
             os.environ.get('TERM') in (
-                'xterm', 'rxvt', 'rxvt-unicode', 'xterm-256color'))
+                'rxvt',
+                'rxvt-256color',
+                'rxvt-unicode',
+                'rxvt-unicode-256color',
+                'xterm',
+                'xterm-256color',
+                ))
         color_fmt = formatter_message(
             '[%(levelname)-18s] %(message)s', use_color)
         formatter = ColoredFormatter(color_fmt, use_color=use_color)


### PR DESCRIPTION
This PR adds two more `TERM` entries as assumed color-capable terminals: `rxvt-unicode-256color`, and `rxvt-256color`

Additionally, I sorted the list and split it to multiple lines for better readability.