### PR TITLE
logger: Use a shorter field width for non-colored output

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -332,8 +332,16 @@ if 'KIVY_NO_CONSOLELOG' not in os.environ:
                 'xterm',
                 'xterm-256color',
                 ))
-        color_fmt = formatter_message(
-            '[%(levelname)-18s] %(message)s', use_color)
+        if not use_color:
+            # No additional control characters will be inserted inside the
+            # levelname field, 7 chars will fit "WARNING"
+            color_fmt = formatter_message(
+                '[%(levelname)-7s] %(message)s', use_color)
+        else:
+            # levelname field width need to take into account the length of the
+            # color control codes (7+4 chars for bold+color, and reset)
+            color_fmt = formatter_message(
+                '[%(levelname)-18s] %(message)s', use_color)
         formatter = ColoredFormatter(color_fmt, use_color=use_color)
         console = ConsoleHandler()
         console.setFormatter(formatter)

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -183,7 +183,7 @@ class FileHandler(logging.Handler):
         msg = self.format(record)
         stream = FileHandler.fd
         fs = "%s\n"
-        stream.write('[%-18s] ' % record.levelname)
+        stream.write('[%-7s] ' % record.levelname)
         if PY2:
             try:
                 if (isinstance(msg, unicode) and


### PR DESCRIPTION
avoids unnecessarily long prefixes when not using color:

    [INFO              ] [Foo] Info message

instead becomes:

    [INFO   ] [Foo] Info message

to test, use `TERM=` set to something unknown:

    % TERM=asdf python examples/demo/showcase/main.py