### PR TITLE
Fix docs build errors

### DIFF
--- a/doc/gallery.py
+++ b/doc/gallery.py
@@ -10,6 +10,7 @@ in the examples/ directory to create rst files in the generation_dir
 
 import os
 import re
+from os.path import sep
 from os.path import join as slash  # just like that name better
 from kivy.logger import Logger
 import textwrap
@@ -52,7 +53,7 @@ def iter_filename_info(dir_name):
                     yield {'error': 'png filename not following screenshot'
                                     ' pattern: {}'.format(filename)}
                 else:
-                    d = m.group(2).replace('__', os.path.sep)
+                    d = m.group(2).replace('__', sep)
                     yield {'dunder': m.group(1),
                            'dir': d,
                            'file': m.group(3),
@@ -134,7 +135,10 @@ def enhance_info_description(info, line_length=50):
             info['files'].append(name)
 
     # add links where the files are referenced
-    text = re.sub(r'([tT]he (?:file|image) )([\w\/]+\.\w+)', r'\1`\2`_', text)
+    folder = '_'.join(info['source'].split(sep)[:-1]) + '_'
+    text = re.sub(r'([tT]he (?:file|image) )([\w\/]+\.\w+)',
+                  r'\1:ref:`\2 <$folder$\2>`', text)
+    text = text.replace('$folder$', folder)
 
     # now break up text into array of paragraphs, each an array of lines.
     lines = text.split('\n')
@@ -257,7 +261,10 @@ def make_detail_page(info):
     for fname in info['files']:
         full_name = slash(info['dir'], fname)
         ext = re.search(r'\.\w+$', fname).group(0)
-        a('\n.. _`' + fname + '`:')
+        a('\n.. _`' + full_name.replace(sep, '_') + '`:')
+        # double separator if building on windows (sphinx skips backslash)
+        if '\\' in full_name:
+            full_name = full_name.replace(sep, sep*2)
 
         if ext in ['.png', '.jpg', '.jpeg']:
             title = 'Image **' + full_name + '**'
@@ -290,7 +297,7 @@ def write_file(name, s):
 
 
 def make_index(infos):
-    ''' return string of the rst for the gallary's index.rst file. '''
+    ''' return string of the rst for the gallery's index.rst file. '''
     start_string = '''
 Gallery of Examples
 ===================

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -65,7 +65,7 @@ release = kivy.__version__
 today_fmt = '%B %d, %Y'
 
 # suppress exclusion warnings
-exclude_patterns = ['guide/layouts.rst', 'api-kivy.lib.osc*']
+exclude_patterns = ['gsoc201*']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/doc/sources/gettingstarted/packaging.rst
+++ b/doc/sources/gettingstarted/packaging.rst
@@ -4,7 +4,6 @@ Packaging
 - :doc:`/guide/packaging-windows`
     - :ref:`packaging-windows-requirements`
     - :ref:`Create-the-spec-file`
-    - :ref:`Build-the-spec`
 - :doc:`/guide/packaging-osx`
     - :ref:`osx_kivy-sdk-packager`
     - :ref:`osx_pyinstaller`

--- a/doc/sources/guide/packaging-android.rst
+++ b/doc/sources/guide/packaging-android.rst
@@ -5,8 +5,8 @@ Create a package for Android
 
 
 You can create a package for android using the `python-for-android
-<https://github.com/kivy/python-for-android>`_ project. This page explains how to
-download and use it directly on your own machine (see
+<https://github.com/kivy/python-for-android>`_ project. This page explains how
+to download and use it directly on your own machine (see
 :ref:`Packaging your application into APK`), use the prebuilt
 :ref:`Kivy Android VM <kivy_android_vm>` image, or
 use the :ref:`buildozer` tool to automate the entire process. You can also see
@@ -28,7 +28,6 @@ information on debugging on the device, are documented at the
 :doc:`main Android page </guide/android>`.
 
 .. note:: Python 3 support on Android is now available experimentally.
-
 
 .. _Buildozer:
 

--- a/doc/sources/guide/packaging-osx.rst
+++ b/doc/sources/guide/packaging-osx.rst
@@ -87,7 +87,8 @@ GStreamer.
 Installing modules
 ~~~~~~~~~~~~~~~~~~
 
-Kivy package on osx uses its own virtual env that is activated when you run your app using `kivy` command.
+Kivy package on osx uses its own virtual env that is activated when you run
+your app using `kivy` command.
 To install any module you need to install the module like so::
 
     $ kivy -m pip install <modulename>
@@ -157,7 +158,8 @@ To make a DMG of your app use the following command::
     osx> ./create-osx-dmg.sh YourApp.app
 
 Note the lack of `/` at the end.
-This should give you a compressed dmg that will further shrink the size of your distributed app.
+This should give you a compressed dmg that will further shrink the size of your
+distributed app.
 
 
 .. _osx_pyinstaller:
@@ -237,24 +239,25 @@ Using PyInstaller and Homebrew
     Package your app on the oldest OS X version you want to support.
 
 Complete guide
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 #. Install `Homebrew <http://brew.sh>`_
 #. Install Python::
 
     $ brew install python
 
    .. note::
-     To use Python 3, ``brew install python3`` and replace ``pip`` with ``pip3``
-     in the guide below.
+     To use Python 3, ``brew install python3`` and replace ``pip`` with
+     ``pip3`` in the guide below.
 
-#. (Re)install your dependencies with ``--build-bottle`` to make sure they can be
-   used on other machines::
+#. (Re)install your dependencies with ``--build-bottle`` to make sure they can
+   be used on other machines::
 
     $ brew reinstall --build-bottle sdl2 sdl2_image sdl2_ttf sdl2_mixer
 
    .. note::
-       If your project depends on GStreamer or other additional libraries (re)install
-       them with ``--build-bottle`` as described `below <additional libraries_>`_.
+       If your project depends on GStreamer or other additional libraries
+       (re)install them with ``--build-bottle`` as described
+       `below <additional libraries_>`_.
 
 #. Install Cython and Kivy::
 
@@ -275,19 +278,20 @@ Complete guide
       /usr/local/share/kivy-examples/demo/touchtracer/main.py
 
    .. note::
-     This will not yet copy additional image or sound files. You would need to adapt the
-     created ``.spec`` file for that.
+     This will not yet copy additional image or sound files. You would need to
+     adapt the created ``.spec`` file for that.
 
 
 Editing the spec file
-^^^^^^^^^^^^^^^^^^^^^
-The specs file is named `touchtracer.spec` and is located in the directory where you ran
-the pyinstaller command.
+~~~~~~~~~~~~~~~~~~~~~
+The specs file is named `touchtracer.spec` and is located in the directory
+where you ran the pyinstaller command.
 
 You need to change the `COLLECT()` call to add the data of touchtracer
 (`touchtracer.kv`, `particle.png`, ...). Change the line to add a Tree()
 object. This Tree will search and add every file found in the touchtracer
-directory to your final package. Your COLLECT section should look something like this::
+directory to your final package. Your COLLECT section should look something
+like this::
 
 
     coll = COLLECT(exe, Tree('/usr/local/share/kivy-examples/demo/touchtracer/'),
@@ -298,11 +302,11 @@ directory to your final package. Your COLLECT section should look something like
                    upx=True,
                    name='touchtracer')
 
-This will add the required hooks so that PyInstaller gets the required Kivy files.
-We are done. Your spec is ready to be executed.
+This will add the required hooks so that PyInstaller gets the required Kivy
+files. We are done. Your spec is ready to be executed.
 
 Build the spec and create a DMG
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Open a console.
 #. Go to the PyInstaller directory, and build the spec::
@@ -319,17 +323,19 @@ Build the spec and create a DMG
 
 
 Additional Libraries
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 GStreamer
-"""""""""
+^^^^^^^^^
 If your project depends on GStreamer::
 
     $ brew reinstall --build-bottle gstreamer gst-plugins-{base,good,bad,ugly}
 
 .. note::
-    If your Project needs Ogg Vorbis support be sure to add the ``--with-libvorbis``
-    option to the command above.
+    If your Project needs Ogg Vorbis support be sure to add the
+    ``--with-libvorbis`` option to the command above.
 
-If you are using Python from Homebrew you currently also need the following step until `this pull request <https://github.com/Homebrew/homebrew/pull/46097>`_ gets merged::
+If you are using Python from Homebrew you will also need the following step
+until `this pull request <https://github.com/Homebrew/homebrew/pull/46097>`_
+gets merged::
 
     $ brew reinstall --with-python --build-bottle https://github.com/cbenhagen/homebrew/raw/patch-3/Library/Formula/gst-python.rb

--- a/doc/sources/guide/packaging-windows.rst
+++ b/doc/sources/guide/packaging-windows.rst
@@ -32,44 +32,50 @@ following examples need to be slightly modified. See :ref:`overwrite-win-hook`.
 Packaging a simple app
 ----------------------
 
-For this example, we'll package the **touchtracer** example project and embed a custom icon.
-The location of the kivy examples is, when using the wheels, installed to ``python\\share\\kivy-examples``
-and when using the github source code installed as ``kivy\\examples``. We'll just refer to the full
-path leading to the examples as ``examples-path``. The touchtracer example is in
+For this example, we'll package the **touchtracer** example project and embed
+a custom icon. The location of the kivy examples is, when using the wheels,
+installed to ``python\\share\\kivy-examples`` and when using the github source
+code installed as ``kivy\\examples``. We'll just refer to the full path leading
+to the examples as ``examples-path``. The touchtracer example is in
 ``examples-path\\demo\\touchtracer`` and the main file is named ``main.py``.
 
-#. Open your command line shell and ensure that python is on the path (i.e. ``python`` works).
-#. Create a folder into which the packaged app will be created. For example create a ``TouchApp``
-   folder and `change to that directory <http://www.computerhope.com/cdhlp.htm>`_ with e.g.
-   ``cd TouchApp``. Then type::
+#. Open your command line shell and ensure that python is on the path (i.e.
+   ``python`` works).
+#. Create a folder into which the packaged app will be created. For example
+   create a ``TouchApp`` folder and `change to that directory
+   <http://www.computerhope.com/cdhlp.htm>`_ with e.g. ``cd TouchApp``.
+   Then type::
 
     python -m PyInstaller --name touchtracer examples-path\demo\touchtracer\main.py
 
-   You can also add an `icon.ico` file to the application folder in order to create an icon
-   for the executable. If you don't have a .ico file available, you can convert your
-   `icon.png` file to ico using the web app `ConvertICO <http://www.convertico.com>`_.
-   Save the `icon.ico` in the touchtracer directory and type::
+   You can also add an `icon.ico` file to the application folder in order to
+   create an icon for the executable. If you don't have a .ico file available,
+   you can convert your `icon.png` file to ico using the web app
+   `ConvertICO <http://www.convertico.com>`_. Save the `icon.ico` in the
+   touchtracer directory and type::
 
     python -m PyInstaller --name touchtracer --icon examples-path\demo\touchtracer\icon.ico examples-path\demo\touchtracer\main.py
 
    For more options, please consult the
    `PyInstaller Manual <http://pythonhosted.org/PyInstaller/>`_.
 
-#. The spec file will be ``touchtracer.spec`` located in ``TouchApp``. Now we need to
-   edit the spec file to add the dependencies hooks to correctly build the exe.
-   Open the spec file with your favorite editor and add these lines at the
-   beginning of the spec (assuming sdl2 is used, the default now)::
+#. The spec file will be ``touchtracer.spec`` located in ``TouchApp``. Now we
+   need to edit the spec file to add the dependencies hooks to correctly build
+   the exe. Open the spec file with your favorite editor and add these lines
+   at the beginning of the spec (assuming sdl2 is used, the default now)::
 
     from kivy.deps import sdl2, glew
 
    Then, find ``COLLECT()`` and add the data for touchtracer
    (`touchtracer.kv`, `particle.png`, ...): Change the line to add a ``Tree()``
    object, e.g. ``Tree('examples-path\\demo\\touchtracer\\')``. This Tree will
-   search and add every file found in the touchtracer directory to your final package.
+   search and add every file found in the touchtracer directory to your final
+   package.
 
    To add the dependencies, before the first keyword argument in COLLECT add a
    Tree object for every path of the dependecies. E.g.
-   ``*[Tree(p) for p in (sdl2.dep_bins + glew.dep_bins)]`` so it'll look something like::
+   ``*[Tree(p) for p in (sdl2.dep_bins + glew.dep_bins)]`` so it'll look
+   something like::
 
     coll = COLLECT(exe, Tree('examples-path\\demo\\touchtracer\\'),
                    a.binaries,
@@ -89,10 +95,11 @@ path leading to the examples as ``examples-path``. The touchtracer example is in
 Packaging a video app with gstreamer
 ------------------------------------
 
-Following we'll slightly modify the example above to package a app that uses gstreamer
-for video. We'll use the ``videoplayer`` example found at ``examples-path\widgets\videoplayer.py``.
-Create a folder somewhere called ``VideoPlayer`` and on the command line change your current
-directory to that folder and do::
+Following we'll slightly modify the example above to package a app that uses
+gstreamer for video. We'll use the ``videoplayer`` example found at
+``examples-path\widgets\videoplayer.py``. Create a folder somewhere called
+``VideoPlayer`` and on the command line change your current directory to that
+folder and do::
 
     python -m PyInstaller --name gstvideo examples-path\widgets\videoplayer.py
 
@@ -101,8 +108,9 @@ gstreamer dependency as well::
 
     from kivy.deps import sdl2, glew, gstreamer
 
-and add the ``Tree()`` to include the video files, e.g. ``Tree('examples-path\\widgets')``
-as well as the gstreamer dependencies so it should look something like::
+and add the ``Tree()`` to include the video files, e.g.
+``Tree('examples-path\\widgets')`` as well as the gstreamer dependencies so it
+should look something like::
 
     coll = COLLECT(exe, Tree('examples-path\\widgets'),
                    a.binaries,
@@ -122,9 +130,9 @@ which when run will play a video.
 
 .. note::
 
-    If you're using Pygame and need PyGame in your packaging app, you'll have to add the
-    following code to your spec file due to kivy issue #1638. After the imports add the
-    following::
+    If you're using Pygame and need PyGame in your packaging app, you'll have
+    to add the following code to your spec file due to kivy issue #1638. After
+    the imports add the following::
 
         def getResource(identifier, *args, **kwargs):
             if identifier == 'pygame_icon.tiff':
@@ -141,33 +149,37 @@ Overwriting the default hook
 ============================
 
 Including/excluding video and audio and reducing app size
--------------------------------------------------------
+---------------------------------------------------------
 
-PyInstaller includes a hook for kivy that by default adds **all** the core modules
-used by kivy, e.g. audio, video, spelling etc (you still need to package
-the gstreamer dlls manually with ``Tree()`` - see the example above) and their
-dependencies. If the hook is not installed or to reduce app size some of these
-modules may be excluded, e.g. if no audio/video is used, with a alternative hook.
+PyInstaller includes a hook for kivy that by default adds **all** the core
+modules used by kivy, e.g. audio, video, spelling etc (you still need to
+package the gstreamer dlls manually with ``Tree()`` - see the example above)
+and their dependencies. If the hook is not installed or to reduce app size some
+of these modules may be excluded, e.g. if no audio/video is used, with
+an alternative hook.
 
 Kivy provides the alternate hook at
-:func:`~kivy.tools.packaging.pyinstaller_hooks.hookspath`. In addition, if and only
-if PyInstaller doesn't have the default hooks
-:func:`~kivy.tools.packaging.pyinstaller_hooks.runtime_hooks` must also be provided.
-When overwriting the hook, the latter one typically is not required to be overwritten.
+:func:`~kivy.tools.packaging.pyinstaller_hooks.hookspath`. In addition, if and
+only if PyInstaller doesn't have the default hooks
+:func:`~kivy.tools.packaging.pyinstaller_hooks.runtime_hooks` must also be
+provided. When overwriting the hook, the latter one typically is not required
+to be overwritten.
 
 The alternate :func:`~kivy.tools.packaging.pyinstaller_hooks.hookspath` hook
-does not include any of the kivy providers. To add them, they have to be added with
+does not include any of the kivy providers. To add them, they have to be added
+with
 :func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_minimal` or
 :func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_all`. See
 their documentation and :mod:`~kivy.tools.packaging.pyinstaller_hooks` for more
-details. But essentially, :func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_all`
-add all the providers like in the default hook while
-:func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_minimal` only adds those
-that are loaded when the app is run. Each method provides a list of hidden kivy imports
-and excluded imports that can be passed on to ``Analysis``.
+details. But essentially,
+:func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_all` add all the
+providers like in the default hook while
+:func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_minimal` only adds
+those that are loaded when the app is run. Each method provides a list of
+hidden kivy imports and excluded imports that can be passed on to ``Analysis``.
 
-One can also generate a alternate hook which literally lists every kivy provider
-module and those not required can be commented out. See
+One can also generate a alternate hook which literally lists every kivy
+provider module and those not required can be commented out. See
 :mod:`~kivy.tools.packaging.pyinstaller_hooks`.
 
 To use the the alternate hooks with the examples above modify as following to
@@ -206,7 +218,7 @@ video in this example) with
 :func:`~kivy.tools.packaging.pyinstaller_hooks.get_deps_minimal`.
 
 Alternate installations
-----------------------
+-----------------------
 
 The previous examples used e.g.
 ``*[Tree(p) for p in (sdl2.dep_bins + glew.dep_bins + gstreamer.dep_bins)],``

--- a/doc/sources/guide/packaging.rst
+++ b/doc/sources/guide/packaging.rst
@@ -13,5 +13,3 @@ Packaging your application
     packaging-osx
     packaging-ios
     packaging-ios-prerequisites
-    packaging-ios-compile
-

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -66,7 +66,7 @@ The garden lib will be only available when you activate this env::
     deactivate
 
 To install binary files
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Just copy the binary to the /Applications/Kivy.app/Contents/Resources/venv/bin/ directory.
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -36,7 +36,7 @@ Manual installation (On Raspbian Jessie)
     
 
 Manual installation (On Raspbian Wheezy)
----------------------------------------
+----------------------------------------
 
 #. Add APT sources for Gstreamer 1.0 in `/etc/apt/sources.list`::
 
@@ -113,8 +113,7 @@ HDMI, use::
 
     KIVY_BCM_DISPMANX_ID=2 python main.py
 
-Check the :doc:`guide/environment` documentation to see all the possible
-value.
+Check :ref:`environment` to see all the possible values.
 
 Using Official RPi touch display
 --------------------------------

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -15,7 +15,7 @@ to an **alternate location** and not to site-packages, please see :ref:`alternat
 
     Python 3.5 is currently not supported on Windows due to issues with MinGW and
     Python 3.5. Support is not expected for some time. See
-    `here <http://bugs.python.org/issue4709>`_ for details. If required,
+    `this issue <http://bugs.python.org/issue4709>`_ for details. If required,
     3.5 MSVC builds should be posssible, but have not been attempted, please enquire
     or let us know if you've compiled with MSVC.
 
@@ -28,7 +28,7 @@ be installed for each Python version that you want to use Kivy.
 Installation
 ------------
 
-Now that python is installed, open the :ref:`Command line` and make sure python
+Now that python is installed, open the :ref:`windows-run-app` and make sure python
 is available by typing ``python --version``. Then, do the following to install.
 
 #. Ensure you have the latest pip and wheel::
@@ -36,7 +36,7 @@ is available by typing ``python --version``. Then, do the following to install.
      python -m pip install --upgrade pip wheel setuptools
 
 #. Install the dependencies (skip gstreamer (~90MB) if not needed, see
-   :ref:`Kivy's dependencies`)::
+   :ref:`kivy-dependencies`)::
 
      python -m pip install docutils pygments pypiwin32 kivy.deps.sdl2 kivy.deps.glew
      python -m pip install kivy.deps.gstreamer --extra-index-url https://kivy.org/downloads/packages/simple/
@@ -82,6 +82,7 @@ these wheels as follows.
 #. Install it with ``python -m pip install wheel-name`` where ``wheel-name``
    is the name of the renamed file.
 
+.. _kivy-dependencies:
 
 Kivy's dependencies
 -------------------
@@ -107,10 +108,13 @@ distributions of a package that has already been compiled and do not require
 additional steps to install.
 
 When hosted on `pypi <https://pypi.python.org/pypi>`_ one installs a wheel
-using ``pip``, e.g. ``python -m pip install kivy``. When downloading and installing
-a wheel directly, ``python -m pip install wheel_file_name`` is used, such as::
+using ``pip``, e.g. ``python -m pip install kivy``. When downloading and
+installing a wheel directly, ``python -m pip install wheel_file_name`` is used,
+such as::
 
     python -m pip install C:\Kivy-1.9.1.dev-cp27-none-win_amd64.whl
+
+.. _windows-run-app:
 
 Command line
 ------------
@@ -118,8 +122,8 @@ Command line
 Know your command line. To execute any of the ``pip``
 or ``wheel`` commands, one needs a command line tool with python on the path.
 The default command line on Windows is
-`CMD <http://www.computerhope.com/issues/chusedos.htm>`_, and the quickest way
-to open it is to press `Win+R` on your keyboard, type ``cmd``
+`Command Prompt <http://www.computerhope.com/issues/chusedos.htm>`_, and the
+quickest way to open it is to press `Win+R` on your keyboard, type ``cmd``
 in the window that opens, and then press enter.
 
 Alternate linux style command shells that we reccomend is
@@ -129,11 +133,11 @@ command line as `well <http://rogerdudler.github.io/git-guide/>`_ as
 installed.
 
 Walking the path! To add your python to the path, simply open your command line
-and then us the ``cd`` command to change the current directory to where python is
-installed, e.g. ``cd C:\Python27``. Alternatively if you only have one python
-version installed, permanently add the python directory to the path for
-`CMD <http://www.computerhope.com/issues/ch000549.htm>`_ for
-`bash <http://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux>`_.
+and then us the ``cd`` command to change the current directory to where python
+is installed, e.g. ``cd C:\Python27``. Alternatively if you only have one
+python version installed, permanently add the python directory to the path for
+`cmd <http://www.computerhope.com/issues/ch000549.htm>`_ or
+`bash <http://stackoverflow.com/q/14637979>`_.
 
 .. _dev-install-win:
 
@@ -222,12 +226,12 @@ and and the kivy or kivy.deps* folders from site-packages.
 Making Python available anywhere
 --------------------------------
 
-There are two methods for launching python on your *.py files.
+There are two methods for launching python on your ``*.py`` files.
 
 Double-click method
 ~~~~~~~~~~~~~~~~~~~
 
-If you only have one Python installed, you can associate all *.py files with
+If you only have one Python installed, you can associate all ``*.py`` files with
 your python, if it isn't already, and then run it by double clicking. Or you can
 only do it once if you want to be able to choose each time:
 
@@ -249,6 +253,7 @@ You can launch a .py file with our Python using the Send-to menu:
    You should get the special Windows directory `SendTo`
 #. Paste the previously copied ``python.exe`` file **as a shortcut**.
 #. Rename it to python <python-version>. E.g. ``python27-x64``
+
 You can now execute your application by right clicking on the .py file ->
 "Send To" -> "python <python-version>".
 

--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -180,7 +180,7 @@ Installing Kivy for Development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now that you've installed all the required dependencies, it's time to
-download and compile a development version of Kivy::
+download and compile a development version of Kivy:
 
 Download Kivy from GitHub::
 

--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -33,8 +33,6 @@ keep this in mind when debugging or running in a
     There are now 2 distinct Gstreamer implementations: one using Gi/Gst working
     for both Python 2+3 with Gstreamer 1.0, and one using PyGST working
     only for Python 2 + Gstreamer 0.10.
-    If you have issue with GStreamer, have a look at
-    :ref:`gstreamer-compatibility`
 
 .. note::
 

--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -9,9 +9,6 @@ Core class for acquiring the camera and converting its input into a
     There is now 2 distinct Gstreamer implementation: one using Gi/Gst
     working for both Python 2+3 with Gstreamer 1.0, and one using PyGST
     working only for Python 2 + Gstreamer 0.10.
-    If you have issue with GStreamer, have a look at
-    :ref:`gstreamer-compatibility`
-
 '''
 
 __all__ = ('CameraBase', 'Camera')

--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -9,8 +9,6 @@ Core class for reading video files and managing the
     There is now 2 distinct Gstreamer implementation: one using Gi/Gst
     working for both Python 2+3 with Gstreamer 1.0, and one using PyGST
     working only for Python 2 + Gstreamer 0.10.
-    If you have issue with GStreamer, have a look at
-    :ref:`gstreamer-compatibility`
 
 .. note::
 

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -667,7 +667,7 @@ class WindowBase(EventDispatcher):
 
     .. versionadded:: 1.9.1
 
-    :attr:`focus` is a read-only :class:`~kivy.properties.AliasProperty and
+    :attr:`focus` is a read-only :class:`~kivy.properties.AliasProperty` and
     defaults to True.
     '''
 

--- a/kivy/input/providers/androidjoystick.py
+++ b/kivy/input/providers/androidjoystick.py
@@ -24,7 +24,8 @@ from kivy.input.provider import MotionEventProvider
 from kivy.input.factory import MotionEventFactory
 from kivy.input.shape import ShapeRect
 from kivy.input.motionevent import MotionEvent
-import pygame.joystick
+if 'KIVY_DOC' not in os.environ:
+    import pygame.joystick
 
 
 class AndroidMotionEvent(MotionEvent):

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -620,6 +620,8 @@ When you are creating a context:
 Template definitions also replace any similarly named definitions in their
 entirety and thus do not support inheritance.
 
+.. _redefining-style:
+
 Redefining a widget's style
 ---------------------------
 
@@ -654,9 +656,9 @@ without any of the instructions inherited from the Label.
 Redefining a widget's property style
 ------------------------------------
 
-Similar to :ref:`Redefining a widget's style`, sometimes we would like to
-inherit from a widget, keep all its KV defined styles, except for the style
-applied to a specific property. For example, we would
+Similar to :ref:`redefining style <redefining-style>`, sometimes we
+would like to inherit from a widget, keep all its KV defined styles, except for
+the style applied to a specific property. For example, we would
 like to inherit from a :class:`~kivy.uix.button.Button`, but we would also
 like to set our own `state_image`, rather then relying on the
 `background_normal` and `background_down` values. We can achieve this by

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -253,6 +253,7 @@ def create_handler(iself, element, key, value, rule, idmap, delayed=False):
                                '{}: {}'.format(e.__class__.__name__, e),
                                cause=tb)
 
+
 class BuilderBase(object):
     '''The Builder is responsible for creating a :class:`Parser` for parsing a
     kv file, merging the results into its internal rules, templates, etc.
@@ -383,6 +384,7 @@ class BuilderBase(object):
 
     def template(self, *args, **ctx):
         '''Create a specialized template using a specific context.
+
         .. versionadded:: 1.0.5
 
         With templates, you can construct custom widgets from a kv lang
@@ -622,9 +624,9 @@ class BuilderBase(object):
                     idmap.update(rctx['ids'])
                     idmap['self'] = widget_set.proxy_ref
                     if not widget_set.fbind(key, custom_callback, crule,
-                                                idmap):
+                                            idmap):
                         raise AttributeError(key)
-                    #hack for on_parent
+                    # hack for on_parent
                     if crule.name == 'on_parent':
                         Factory.Widget.parent.dispatch(widget_set.__self__)
         except Exception as e:
@@ -703,27 +705,27 @@ class BuilderBase(object):
         This effectively clearls all the KV rules associated with this widget.
         For example:
 
-    .. code-block:: python
+        .. code-block:: python
 
-            >>> w = Builder.load_string(\'''
-            ... Widget:
-            ...     height: self.width / 2. if self.disabled else self.width
-            ...     x: self.y + 50
-            ... \''')
-            >>> w.size
-            [100, 100]
-            >>> w.pos
-            [50, 0]
-            >>> w.width = 500
-            >>> w.size
-            [500, 500]
-            >>> Builder.unbind_widget(w.uid)
-            >>> w.width = 222
-            >>> w.y = 500
-            >>> w.size
-            [222, 500]
-            >>> w.pos
-            [50, 500]
+                >>> w = Builder.load_string(\'''
+                ... Widget:
+                ...     height: self.width / 2. if self.disabled else self.width
+                ...     x: self.y + 50
+                ... \''')
+                >>> w.size
+                [100, 100]
+                >>> w.pos
+                [50, 0]
+                >>> w.width = 500
+                >>> w.size
+                [500, 500]
+                >>> Builder.unbind_widget(w.uid)
+                >>> w.width = 222
+                >>> w.y = 500
+                >>> w.size
+                [222, 500]
+                >>> w.pos
+                [50, 500]
 
         .. versionadded:: 1.7.2
         '''

--- a/kivy/lib/ddsfile.py
+++ b/kivy/lib/ddsfile.py
@@ -19,6 +19,8 @@ support on android. We use structs instead.
 DDS Format
 ----------
 
+::
+
     [DDS ][SurfaceDesc][Data]
 
     [SurfaceDesc]:: (everything is uint32)

--- a/kivy/modules/console.py
+++ b/kivy/modules/console.py
@@ -5,9 +5,9 @@ Console
 
 .. versionadded:: 1.9.1
 
-Reboot of the old inspector, designed to be modular and keep concerns separated.
-It also have a addons architecture that allow you to add a button, panel, or
-more in the Console itself.
+Reboot of the old inspector, designed to be modular and keep concerns
+separated. It also have a addons architecture that allow you to add a button,
+panel, or more in the Console itself.
 
 .. warning::
 
@@ -829,13 +829,13 @@ class Console(RelativeLayout):
         """Add a new panel in the Console.
 
         - `cb_activate` is a callable that will be called when the panel is
-        activated by the user.
+          activated by the user.
 
         - `cb_deactivate` is a callable that will be called when the panel is
-        deactivated or when the console will hide.
+          deactivated or when the console will hide.
 
         - `cb_refresh` is an optionnal callable that is called if the user
-        click again on the button for display the panel
+          click again on the button for display the panel
 
         When activated, it's up to the panel to display a content in the
         Console by using :meth:`set_content`.
@@ -972,7 +972,7 @@ class Console(RelativeLayout):
         self.y = -self.height
         self.widget = None
         self.inspect_enabled = False
-        #self.win.remove_widget(self)
+        # self.win.remove_widget(self)
         self._window_node = None
         Logger.info('Console: console deactivated')
 
@@ -1029,8 +1029,8 @@ def create_console(win, ctx, *l):
 
 def start(win, ctx):
     """Create an Console instance attached to the *ctx* and bound to the
-    Windows :meth:`~kivy.core.window.WindowBase.on_keyboard` event for capturing
-    the keyboard shortcut.
+    Window's :meth:`~kivy.core.window.WindowBase.on_keyboard` event for
+    capturing the keyboard shortcut.
 
         :Parameters:
             `win`: A :class:`Window <kivy.core.window.WindowBase>`

--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -713,7 +713,7 @@ class Inspector(FloatLayout):
 
 def create_inspector(win, ctx, *l):
     '''Create an Inspector instance attached to the *ctx* and bound to the
-    Windows :meth:`~kivy.core.window.WindowBase.on_keyboard` event for
+    Window's :meth:`~kivy.core.window.WindowBase.on_keyboard` event for
     capturing the keyboard shortcut.
 
         :Parameters:

--- a/kivy/modules/recorder.py
+++ b/kivy/modules/recorder.py
@@ -14,20 +14,17 @@ class, and bind some keys to record / play sequences:
 Configuration
 -------------
 
+.. |attrs| replace:: :attr:`~kivy.input.recorder.Recorder.record_attrs`
+.. |profile_mask| replace::
+    :attr:`~kivy.input.recorder.Recorder.record_profile_mask`
+
 :Parameters:
-    `attrs`: str, defaults to
-    :attr:`~kivy.input.recorder.Recorder.record_attrs` value.
-
+    `attrs`: str, defaults to |attrs| value.
         Attributes to record from the motion event
-
-    `profile_mask`: str, defaults to
-    :attr:`~kivy.input.recorder.Recorder.record_profile_mask` value.
-
+    `profile_mask`: str, defaults to |profile_mask| value.
         Mask for motion event profile. Used to filter which profile will appear
         in the fake motion event when replayed.
-
     `filename`: str, defaults to 'recorder.kvi'
-
         Name of the file to record / play with
 
 Usage

--- a/kivy/uix/behaviors/emacs.py
+++ b/kivy/uix/behaviors/emacs.py
@@ -7,7 +7,7 @@ The :class:`~kivy.uix.behaviors.emacs.EmacsBehavior`
 `mixin <https://en.wikipedia.org/wiki/Mixin>`_ allows you to add
 `Emacs <https://www.gnu.org/software/emacs/>`_ keyboard shortcuts for basic
 movement and editing to the :class:`~kivy.uix.textinput.TextInput` widget.
-The shortcuts currently available are listed below::
+The shortcuts currently available are listed below:
 
 Emacs shortcuts
 ---------------

--- a/kivy/uix/behaviors/knspace.py
+++ b/kivy/uix/behaviors/knspace.py
@@ -195,7 +195,7 @@ their children also use different namespaces. Consequently, the
 pretty and complex widgets of each instance will have different text.
 
 Further, because both the namespace :class:`~kivy.properties.ObjectProperty`
-references, and :atrr:`KNSpaceBehavior.knspace` have `rebind=True`, the
+references, and :attr:`KNSpaceBehavior.knspace` have `rebind=True`, the
 text of the `MyComplexWidget` label is rebound to match the text of
 `MyPrettyWidget` when either the root's namespace changes or when the
 `root.knspace.pretty` property changes, as expected.

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -4,9 +4,6 @@ EffectWidget
 
 .. versionadded:: 1.9.0
 
-    This code is still experimental, and its API is subject to change in a
-    future version.
-
 The :class:`EffectWidget` is able to apply a variety of fancy
 graphical effects to
 its children. It works by rendering to a series of
@@ -14,6 +11,10 @@ its children. It works by rendering to a series of
 As such, effects can freely do almost anything, from inverting the
 colors of the widget, to anti-aliasing, to emulating the appearance of a
 crt monitor!
+
+.. warning::
+    This code is still experimental, and its API is subject to change in a
+    future version.
 
 The basic usage is as follows::
 

--- a/kivy/uix/recycleview/views.py
+++ b/kivy/uix/recycleview/views.py
@@ -30,6 +30,7 @@ _cache_count = 0
 # maximum number of items in the class cache
 _max_cache_size = 1000
 
+
 def _clean_cache():
     '''Trims _cached_views cache to half the size of `_max_cache_size`.
     '''
@@ -115,8 +116,8 @@ class RecycleDataAdapter(EventDispatcher):
           This occurs when the view is not currently displayed but the data has
           not changed. These views are stored in :attr:`dirty_views`.
         * Finally the view can be dead which occurs when the data changes and
-        the view was not updated or when a view is just created. Such views are
-        typically added to the internal cache.
+          the view was not updated or when a view is just created. Such views
+          are typically added to the internal cache.
 
     Typically what happens is that the layout manager lays out the data
     and then asks for views, using :meth:`set_visible_views,` for some specific


### PR DESCRIPTION
When building docs without `silenced=yes` it throws _a lot_ of errors (~ 30+), so I decided to fix them + some pep8 edge(>79) cutting. This PR reduces errors to 3 basic ones:

<pre>WARNING: while setting up extension autodoc: directive 'autoclass' is already registered, it will be
 overridden

WARNING: while setting up extension preprocess: directive 'automethod' is already registered, it wil
l be overridden

C:\Users\...\doctest\kivy\doc\sources\examples\gen__canvas__repeat_texture__py.rst:34: WA
RNING: duplicate label canvas_mtexture1.png, other instance in C:\Users\...\doctest\kivy\
doc\sources\examples\gen__canvas__multitexture__py.rst</pre>

The last one means that two files use the same file as "anchor" set with ```.. _`<name>` ``` because they use the same file. Excluding the file wouldn't make sense and renaming the anchor would take too much time. Another solution might be duplicating the file and renaming it to `mtexture2` or something like that - or removing any reference from the second file that could trigger this warning.

*The most visible are:*

  - [excluded OSC library](https://kivy.org/docs/api-kivy.lib.html)
  - [note in packaging-android](https://kivy.org/docs/guide/packaging-android.html)
  - [missing headers mostly in osx](https://kivy.org/docs/guide/packaging-osx.html)
  - broken links/`:ref:`/anchors/`:attr:`

*Edits in `gallery.py`:*

To get rid of warnings I made a longer anchors using folder(s) prefix, therefore creating a unique anchor for each file. I think it's better because it works if someone wants to link to that file with `:ref:`

    gen__demo__kivycatalog__main__py.html#demo-kivycatalog-kivycatalog-kv

And a little bonus, I excluded old `gsoc` files so that it wouldn't ping with warnings about not being included in any toctree, because it's basically the latest `gsoc` file with some edits and to see different versions of files you can use github anyway. Hopefully I didn't break anything with `gallery.py` (building works, links too).