### PR TITLE
Make kivy clock thread safe and switch to linked list

### DIFF
--- a/doc/sources/guide/events.rst
+++ b/doc/sources/guide/events.rst
@@ -19,10 +19,10 @@ Introduction to the Event Dispatcher
 ------------------------------------
 
 One of the most important base classes of the framework is the
-:class:`~kivy.event.EventDispatcher` class. This class allows you to register 
+:class:`~kivy.event.EventDispatcher` class. This class allows you to register
 event types, and to dispatch them to interested parties (usually other event
 dispatchers). The :class:`~kivy.uix.widget.Widget`,
-:class:`~kivy.animation.Animation` and :obj:`~kivy.clock.Clock` classes are 
+:class:`~kivy.animation.Animation` and :obj:`~kivy.clock.Clock` classes are
 examples of event dispatchers.
 
 EventDispatcher objects depend on the main loop to generate and
@@ -65,14 +65,18 @@ function named my_callback 30 times per second::
 
     def my_callback(dt):
         print 'My callback is called', dt
-    Clock.schedule_interval(my_callback, 1 / 30.)
+    event = Clock.schedule_interval(my_callback, 1 / 30.)
 
-You have two ways of unscheduling a previously scheduled event. The first would be
-to use :meth:`~kivy.clock.Clock.unschedule`::
+You have multiple ways of unscheduling a previously scheduled event. One, is
+to use :meth:`~kivy.clock.ClockEvent.cancel` or :meth:`~kivy.clock.Clock.unschedule`::
 
-    Clock.unschedule(my_callback)
+    event.cancel()
 
-Or, you can return False in your callback, and your event will be automatically
+or::
+
+    Clock.unschedule(event)
+
+Alternatively, you can return False in your callback, and your event will be automatically
 unscheduled::
 
     count = 0
@@ -133,13 +137,15 @@ Trigger events
 If you want to schedule a function to be called only once for the next frame,
 like a trigger, you might be tempted to achieve that like so::
 
-    Clock.unschedule(my_callback)
+    # before
+    event = Clock.schedule_once(my_callback, 0)
+    # and then later
+    Clock.unschedule(event)
     Clock.schedule_once(my_callback, 0)
 
 This way of programming a trigger is expensive, since you'll always call
-unschedule, whether or not you've even scheduled it. In addition, unschedule
-needs to iterate the weakref list of the Clock in order to find your callback
-and remove it. Use a trigger instead::
+unschedule, even if the event has already completed. In addition, a new event is
+created every time. Use a trigger instead::
 
     trigger = Clock.create_trigger(my_callback)
     # later
@@ -233,12 +239,12 @@ Declaration of a Property
 -------------------------
 
 To declare properties, you must declare them at the class level. The class will then do
-the work to instantiate the real attributes when your object is created. These properties 
+the work to instantiate the real attributes when your object is created. These properties
 are not attributes: they are mechanisms for creating events based on your
 attributes::
 
     class MyWidget(Widget):
-    
+
         text = StringProperty('')
 
 
@@ -265,15 +271,15 @@ For example, consider the following code:
    :linenos:
 
     class CustomBtn(Widget):
-    
+
         pressed = ListProperty([0, 0])
-    
+
         def on_touch_down(self, touch):
             if self.collide_point(*touch.pos):
                 self.pressed = touch.pos
                 return True
             return super(CustomBtn, self).on_touch_down(touch)
-    
+
         def on_pressed(self, instance, pos):
             print ('pressed at {pos}'.format(pos=pos))
 
@@ -294,14 +300,14 @@ At Line 5::
         return super(CustomBtn, self).on_touch_down(touch)
 
 We override the :meth:`on_touch_down` method of the Widget class. Here, we check
-for collision of the `touch` with our widget. 
+for collision of the `touch` with our widget.
 
 If the touch falls inside of our widget, we change the value of `pressed` to touch.pos
 and return True, indicating that we have consumed the touch and don't want it to
 propagate any further.
 
 Finally, if the touch falls outside our widget, we call the original event
-using `super(...)` and return the result. This allows the touch event propagation 
+using `super(...)` and return the result. This allows the touch event propagation
 to continue as it would normally have occured.
 
 Finally on line 11::
@@ -331,7 +337,7 @@ For example, consider the following code:
    :linenos:
 
     class RootWidget(BoxLayout):
-    
+
         def __init__(self, **kwargs):
             super(RootWidget, self).__init__(**kwargs)
             self.add_widget(Button(text='btn 1'))
@@ -339,7 +345,7 @@ For example, consider the following code:
             cb.bind(pressed=self.btn_pressed)
             self.add_widget(cb)
             self.add_widget(Button(text='btn 2'))
-    
+
         def btn_pressed(self, instance, pos):
             print ('pos: printed from root widget: {pos}'.format(pos=.pos))
 
@@ -351,24 +357,24 @@ The reason that both functions are called is simple. Binding doesn't mean
 overriding. Having both of these functions is redundant and you should generally
 only use one of the methods of listening/reacting to property changes.
 
-You should also take note of the parameters that are passed to the 
+You should also take note of the parameters that are passed to the
 `on_<property_name>` event or the function bound to the property.
 
 .. code-block:: python
 
     def btn_pressed(self, instance, pos):
 
-The first parameter is `self`, which is the instance of the class where this 
+The first parameter is `self`, which is the instance of the class where this
 function is defined. You can use an in-line function as follows:
 
 .. code-block:: python
    :linenos:
 
     cb = CustomBtn()
-    
+
     def _local_func(instance, pos):
         print ('pos: printed from root widget: {pos}'.format(pos=pos))
-    
+
     cb.bind(pressed=_local_func)
     self.add_widget(cb)
 

--- a/examples/canvas/lines.py
+++ b/examples/canvas/lines.py
@@ -136,6 +136,7 @@ Builder.load_string('''
 
 
 class LinePlayground(FloatLayout):
+
     alpha_controlline = NumericProperty(1.0)
     alpha = NumericProperty(0.5)
     close = BooleanProperty(False)
@@ -147,6 +148,8 @@ class LinePlayground(FloatLayout):
     cap = OptionProperty('none', options=('round', 'square', 'none'))
     linewidth = NumericProperty(10.0)
     dt = NumericProperty(0)
+
+    _update_points_animation_ev = None
 
     def on_touch_down(self, touch):
         if super(LinePlayground, self).on_touch_down(touch):
@@ -169,9 +172,10 @@ class LinePlayground(FloatLayout):
 
     def animate(self, do_animation):
         if do_animation:
-            Clock.schedule_interval(self.update_points_animation, 0)
-        else:
-            Clock.unschedule(self.update_points_animation)
+            self._update_points_animation_ev = Clock.schedule_interval(
+                self.update_points_animation, 0)
+        elif self._update_points_animation_ev is not None:
+            self._update_points_animation_ev.cancel()
 
     def update_points_animation(self, dt):
         cy = self.height * 0.6

--- a/examples/widgets/label_sizing.py
+++ b/examples/widgets/label_sizing.py
@@ -173,11 +173,9 @@ class LabelTextureSizeExample(App):
         self.add_word()
 
     def add_word(self, dt=None):
-        print dt
         try:
             word = next(self.words)
         except StopIteration:
-            print 'done'
             return
 
         for content_widget in self.text_content_widgets:

--- a/examples/widgets/label_sizing.py
+++ b/examples/widgets/label_sizing.py
@@ -152,6 +152,7 @@ class LabelTextureSizeExample(App):
     max_lines = NumericProperty(0)
 
     def build(self):
+        self._add_word_ev = None
         return Builder.load_string(_kv_code)
 
     def on_start(self):
@@ -162,7 +163,9 @@ class LabelTextureSizeExample(App):
         self.reset_words()
 
     def reset_words(self):
-        Clock.unschedule(self.add_word)
+        if self._add_word_ev is not None:
+            self._add_word_ev.cancel()
+            self._add_word_ev = None
         for content_widget in self.text_content_widgets:
             content_widget.text = _example_title_text
         # initialize words generator
@@ -170,9 +173,11 @@ class LabelTextureSizeExample(App):
         self.add_word()
 
     def add_word(self, dt=None):
+        print dt
         try:
             word = next(self.words)
         except StopIteration:
+            print 'done'
             return
 
         for content_widget in self.text_content_widgets:
@@ -182,7 +187,7 @@ class LabelTextureSizeExample(App):
         if word.endswith(','):
             pause_time += 0.6
 
-        Clock.schedule_once(self.add_word, pause_time)
+        self._add_word_ev = Clock.schedule_once(self.add_word, pause_time)
 
 if __name__ == '__main__':
     LabelTextureSizeExample().run()

--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -1,0 +1,40 @@
+
+cdef class ClockEvent(object):
+
+    cdef int _is_triggered
+    cdef public ClockEvent next
+    cdef public ClockEvent prev
+    cdef public object cid
+    cdef public CyClockBase clock
+    cdef public int loop
+    cdef public object weak_callback
+    cdef public object callback
+    cdef public double timeout
+    cdef public double _last_dt
+    cdef public double _dt
+
+    cpdef get_callback(self)
+    cpdef cancel(self)
+    cpdef release(self)
+    cpdef tick(self, double curtime)
+
+
+cdef class CyClockBase(object):
+
+    cdef public double _last_tick
+    cdef public int max_iteration
+
+    cdef public ClockEvent _root_event
+    cdef public ClockEvent _next_event
+    cdef public ClockEvent _last_event
+    cdef public object _lock
+    cdef public object _lock_acquire
+    cdef public object _lock_release
+
+    cpdef create_trigger(self, callback, timeout=*)
+    cpdef schedule_once(self, callback, timeout=*)
+    cpdef schedule_interval(self, callback, timeout)
+    cpdef unschedule(self, callback, all=*)
+    cpdef _release_references(self)
+    cpdef _process_events(self)
+    cpdef _process_events_before_frame(self)

--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -3,13 +3,23 @@ cdef class ClockEvent(object):
 
     cdef int _is_triggered
     cdef public ClockEvent next
+    '''The next :class:`ClockEvent` in order they were scheduled.
+    '''
     cdef public ClockEvent prev
+    '''The previous :class:`ClockEvent` in order they were scheduled.
+    '''
     cdef public object cid
     cdef public CyClockBase clock
+    '''The :class:`CyClockBase` instance associated with the event.
+    '''
     cdef public int loop
+    '''Whether this event repeats at intervals of :attr:`timeout`.
+    '''
     cdef public object weak_callback
     cdef public object callback
     cdef public double timeout
+    '''The duration after scheduling when the callback should be executed.
+    '''
     cdef public double _last_dt
     cdef public double _dt
 
@@ -23,15 +33,39 @@ cdef class CyClockBase(object):
 
     cdef public double _last_tick
     cdef public int max_iteration
+    '''The maximum number of callback iterations at the end of the frame, before the next
+    frame. If more iterations occur, a warning is issued.
+    '''
 
     cdef public ClockEvent _root_event
+    '''The first event in the chain. Can be None.
+    '''
     cdef public ClockEvent _next_event
+    '''During frame processing when we service the events, this points to the next
+    event that will be processed. After ticking an event, we continue with
+    :attr:`_next_event`.
+
+    If a event that is canceled is the :attr:`_next_event`, :attr:`_next_event`
+    is shifted to point to the after after this, or None if it's at the end of the
+    chain.
+    '''
+    cdef public ClockEvent _cap_event
+    '''The cap event is the last event in the chain for each frame.
+    For a particular frame, events may be added dynamically after this event,
+    and the current frame should not process them.
+
+    Similarly to :attr:`_next_event`,
+    when canceling the :attr:`_cap_event`, :attr:`_cap_event` is shifted to the
+    one previous to it.
+    '''
     cdef public ClockEvent _last_event
+    '''The last event in the chain. New events are added after this. Can be None.
+    '''
     cdef public object _lock
     cdef public object _lock_acquire
     cdef public object _lock_release
 
-    cpdef create_trigger(self, callback, timeout=*)
+    cpdef create_trigger(self, callback, timeout=*, interval=*)
     cpdef schedule_once(self, callback, timeout=*)
     cpdef schedule_interval(self, callback, timeout)
     cpdef unschedule(self, callback, all=*)

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -1,0 +1,341 @@
+
+
+__all__ = ('CyClockBase', 'ClockEvent')
+
+from kivy.weakmethod import WeakMethod
+from kivy.logger import Logger
+from threading import Lock
+
+
+cdef class ClockEvent(object):
+    ''' A class that describes a callback scheduled with kivy's :attr:`Clock`.
+    This class is never created by the user; instead, kivy creates and returns
+    an instance of this class when scheduling a callback.
+
+    .. warning::
+        Most of the methods of this class are internal and can change without
+        notice. The only exception are the :meth:`cancel` and
+        :meth:`__call__` methods.
+    '''
+
+    def __init__(
+            self, CyClockBase clock, int loop, callback, double timeout,
+            double starttime, cid=None, int trigger=False, **kwargs):
+        super(ClockEvent, self).__init__(**kwargs)
+        self._is_triggered = False
+        self.next = None
+        self.prev = None
+        self.cid = None
+        self.clock = clock
+        self.loop = loop
+        self.weak_callback = None
+        self.callback = callback
+        self.timeout = timeout
+        self._last_dt = starttime
+        self._dt = 0.
+
+        if trigger:
+            self._is_triggered = True
+            clock._lock_acquire()
+
+            if clock._root_event is None:
+                clock._last_event = clock._root_event = self
+            else:
+                clock._last_event.next = self
+                self.prev = clock._last_event
+                clock._last_event = self
+            clock._lock_release()
+
+    def __call__(self, *largs):
+        ''' Schedules the callback associated with this instance.
+        If the callback is already scheduled, it will not be scheduled again.
+        '''
+        self.clock._lock_acquire()
+
+        if not self._is_triggered:
+            self._is_triggered = True
+            self._last_dt = self.clock._last_tick
+
+            if self.clock._root_event is None:
+                self.clock._last_event = self.clock._root_event = self
+            else:
+                self.clock._last_event.next = self
+                self.prev = self.clock._last_event
+                self.clock._last_event = self
+            self.clock._lock_release()
+            return True
+        self.clock._lock_release()
+
+    cpdef get_callback(self):
+        cdef object callback = self.callback
+        if callback is not None:
+            return callback
+        callback = self.weak_callback
+        if callback.is_dead():
+            return None
+        return callback()
+
+    @property
+    def is_triggered(self):
+        return self._is_triggered
+
+    cpdef cancel(self):
+        ''' Cancels the callback if it was scheduled to be called.
+        '''
+        self.clock._lock_acquire()
+        if self._is_triggered:
+            self._is_triggered = False
+
+            # update the next event pointer
+            if self.clock._next_event is self:
+                self.clock._next_event = self.next
+
+            if self.prev is None:  # we're first
+                if self.next is None:  # we're also last
+                    self.clock._last_event = self.clock._root_event = None
+                else:  # there are more past us
+                    self.clock._root_event = self.next
+                    self.next.prev = None
+            else:  # there are some behind us
+                if self.next is None:  # we are last
+                    self.clock._last_event = self.prev
+                    self.prev.next = None
+                else:  # we are in middle
+                    self.prev.next = self.next
+                    self.next.prev = self.prev
+            self.prev = self.next = None
+
+        self.clock._lock_release()
+
+    cpdef release(self):
+        self.weak_callback = WeakMethod(self.callback)
+        self.callback = None
+
+    cpdef tick(self, double curtime):
+        cdef object callback, ret
+        # timeout happened ? (check also if we would miss from 5ms) this
+        # 5ms increase the accuracy if the timing of animation for
+        # example.
+        if curtime - self._last_dt < self.timeout - 0.005:
+            return True
+
+        # calculate current timediff for this event
+        self._dt = curtime - self._last_dt
+        self._last_dt = curtime
+
+        # get the callback
+        callback = self.get_callback()
+        if callback is None:
+            self.cancel()
+            return self.loop
+
+        # if it's a trigger, allow to retrigger inside the callback
+        # we have to remove event here, otherwise, if we remove later, the user
+        # might have canceled in the callback and then re-triggered. That'd
+        # result in the removal of the re-trigger
+        if not self.loop:
+            self.cancel()
+
+        # call the callback
+        ret = callback(self._dt)
+
+        # if the user returns False explicitly, remove the event
+        if self.loop and ret is False:
+            self.cancel()
+            return False
+        return self.loop
+
+    def __repr__(self):
+        return '<ClockEvent callback=%r>' % self.get_callback()
+
+
+cdef class CyClockBase(object):
+    '''A clock object with event support.
+    '''
+
+    def __init__(self, **kwargs):
+        super(CyClockBase, self).__init__(**kwargs)
+        self._root_event = None
+        self._last_event = None
+        self._next_event = None
+        self._lock = Lock()
+        self._lock_acquire = self._lock.acquire
+        self._lock_release = self._lock.release
+
+        self.max_iteration = 10
+
+    cpdef create_trigger(self, callback, timeout=0):
+        '''Create a Trigger event. Check module documentation for more
+        information.
+
+        :returns:
+
+            A :class:`ClockEvent` instance. To schedule the callback of this
+            instance, you can call it.
+
+        .. versionadded:: 1.0.5
+        '''
+        cdef ClockEvent ev = ClockEvent(self, False, callback, timeout, 0)
+        ev.release()
+        return ev
+
+    cpdef schedule_once(self, callback, timeout=0):
+        '''Schedule an event in <timeout> seconds. If <timeout> is unspecified
+        or 0, the callback will be called after the next frame is rendered.
+
+        :returns:
+
+            A :class:`ClockEvent` instance. As opposed to
+            :meth:`create_trigger` which only creates the trigger event, this
+            method also schedules it.
+
+        .. versionchanged:: 1.0.5
+            If the timeout is -1, the callback will be called before the next
+            frame (at :meth:`tick_draw`).
+        '''
+        cdef ClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+
+        event = ClockEvent(
+            self, False, callback, timeout, self._last_tick, None, True)
+        return event
+
+    cpdef schedule_interval(self, callback, timeout):
+        '''Schedule an event to be called every <timeout> seconds.
+
+        :returns:
+
+            A :class:`ClockEvent` instance. As opposed to
+            :meth:`create_trigger` which only creates the trigger event, this
+            method also schedules it.
+        '''
+        cdef ClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+
+        event = ClockEvent(
+            self, True, callback, timeout, self._last_tick, None, True)
+        return event
+
+    cpdef unschedule(self, callback, all=True):
+        '''Remove a previously scheduled event.
+
+        :parameters:
+
+            `callback`: :class:`ClockEvent` or a callable.
+                If it's a :class:`ClockEvent` instance, then the callback
+                associated with this event will be canceled if it is
+                scheduled. If it's a callable, then the callable will be
+                unscheduled if it is scheduled.
+            `all`: bool
+                If True and if `callback` is a callable, all instances of this
+                callable will be unscheduled (i.e. if this callable was
+                scheduled multiple times). Defaults to `True`.
+
+        .. versionchanged:: 1.9.0
+            The all parameter was added. Before, it behaved as if `all` was
+            `True`.
+        '''
+        cdef ClockEvent ev, cancel
+        cdef list events
+        if isinstance(callback, ClockEvent):
+            ev = callback
+            ev.cancel()
+        else:
+            if all:
+                events = []
+                self._lock_acquire()
+
+                ev = self._root_event
+                while ev is not None:
+                    if ev.get_callback() == callback:
+                        events.append(ev)
+                    ev = ev.next
+
+                self._lock_release()
+                for ev in events:
+                    ev.cancel()
+            else:
+                cancel = None
+                self._lock_acquire()
+
+                ev = self._root_event
+                while ev is not None:
+                    if ev.get_callback() == callback:
+                        cancel = ev
+                        break
+                    ev = ev.next
+                self._lock_release()
+                if cancel is not None:
+                    cancel.cancel()
+
+    cpdef _release_references(self):
+        # call that function to release all the direct reference to any
+        # callback and replace it with a weakref
+        cdef list events = []
+        cdef ClockEvent ev
+        self._lock_acquire()
+
+        ev = self._root_event
+        while ev is not None:
+            if ev.callback is not None:
+                events.append(ev)
+            ev = ev.next
+
+        self._lock_release()
+        for ev in events:
+            ev.release()
+
+    cpdef _process_events(self):
+        cdef ClockEvent event
+        self._lock_acquire()
+        event = self._root_event
+        while event is not None:
+            self._next_event = event.next
+            self._lock_release()
+
+            try:
+                event.tick(self._last_tick)
+            except:
+                raise
+            else:
+                self._lock_acquire()
+            event = self._next_event
+        self._lock_release()
+
+    cpdef _process_events_before_frame(self):
+        cdef ClockEvent event
+        cdef int count = self.max_iteration
+        cdef int found = True
+
+        while found:
+            count -= 1
+            if count == -1:
+                Logger.critical(
+                    'Clock: Warning, too much iteration done before'
+                    ' the next frame. Check your code, or increase'
+                    ' the Clock.max_iteration attribute')
+                break
+
+            # search event that have timeout = -1
+            found = False
+            self._lock_acquire()
+            event = self._root_event
+            while event is not None:
+                if event.timeout != -1:
+                    event = event.next
+                    continue
+
+                self._next_event = event.next
+                self._lock_release()
+                found = True
+
+                try:
+                    event.tick(self._last_tick)
+                except:
+                    raise
+                else:
+                    self._lock_acquire()
+                event = self._next_event
+            self._lock_release()

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -164,7 +164,7 @@ cdef class CyClockBase(object):
 
         self.max_iteration = 10
 
-    cpdef create_trigger(self, callback, timeout=0):
+    cpdef create_trigger(self, callback, timeout=0, interval=False):
         '''Create a Trigger event. Check module documentation for more
         information.
 
@@ -175,7 +175,7 @@ cdef class CyClockBase(object):
 
         .. versionadded:: 1.0.5
         '''
-        cdef ClockEvent ev = ClockEvent(self, False, callback, timeout, 0)
+        cdef ClockEvent ev = ClockEvent(self, interval, callback, timeout, 0)
         ev.release()
         return ev
 

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -115,6 +115,8 @@ class Animation(EventDispatcher):
 
     '''
 
+    _update_ev = None
+
     _instances = set()
 
     __events__ = ('on_start', 'on_progress', 'on_complete')
@@ -292,14 +294,16 @@ class Animation(EventDispatcher):
     def _clock_install(self):
         if self._clock_installed:
             return
-        Clock.schedule_interval(self._update, self._step)
+        self._update_ev = Clock.schedule_interval(self._update, self._step)
         self._clock_installed = True
 
     def _clock_uninstall(self):
         if self._widgets or not self._clock_installed:
             return
         self._clock_installed = False
-        Clock.unschedule(self._update)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+            self._update_ev = None
 
     def _update(self, dt):
         widgets = self._widgets

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -366,6 +366,7 @@ class ClockEvent(object):
                 else:  # we are in middle
                     prev.next = next
                     next.prev = prev
+            self.prev = self.next = None
 
         clock._lock_release()
 

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -270,7 +270,6 @@ class ClockBase(CyClockBase):
     _dt = 0.0001
     _last_fps_tick = None
     _start_tick = 0
-    _last_tick = 0
     _fps = 0
     _rfps = 0
     _fps_counter = 0

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -35,6 +35,8 @@ class SoundPygame(Sound):
     # TypeError: cannot create weak reference to 'SoundPygame' object
     # We use our clock in play() method.
     # __slots__ = ('_data', '_channel')
+    _check_play_ev = None
+
     @staticmethod
     def extensions():
         if _platform == 'android':
@@ -66,7 +68,7 @@ class SoundPygame(Sound):
         self._channel = self._data.play()
         self.start_time = Clock.time()
         # schedule event to check if the sound is still playing or not
-        Clock.schedule_interval(self._check_play, 0.1)
+        self._check_play_ev = Clock.schedule_interval(self._check_play, 0.1)
         super(SoundPygame, self).play()
 
     def stop(self):
@@ -74,7 +76,9 @@ class SoundPygame(Sound):
             return
         self._data.stop()
         # ensure we don't have anymore the callback
-        Clock.unschedule(self._check_play)
+        if self._check_play_ev is not None:
+            self._check_play_ev.cancel()
+            self._check_play_ev = None
         self._channel = None
         super(SoundPygame, self).stop()
 

--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -126,6 +126,7 @@ class SoundSDL2(Sound):
         return extensions
 
     def __init__(self, **kwargs):
+        self._check_play_ev = None
         self.cc = ChunkContainer()
         mix_init()
         super(SoundSDL2, self).__init__(**kwargs)
@@ -169,7 +170,7 @@ class SoundSDL2(Sound):
                            self.filename, Mix_GetError()))
             return
         # schedule event to check if the sound is still playing or not
-        Clock.schedule_interval(self._check_play, 0.1)
+        self._check_play_ev = Clock.schedule_interval(self._check_play, 0.1)
         super(SoundSDL2, self).play()
 
     def stop(self):
@@ -179,7 +180,9 @@ class SoundSDL2(Sound):
         if Mix_GetChunk(cc.channel) == cc.chunk:
             Mix_HaltChannel(cc.channel)
         cc.channel = -1
-        Clock.unschedule(self._check_play)
+        if self._check_play_ev is not None:
+            self._check_play_ev.cancel()
+            self._check_play_ev = None
         super(SoundSDL2, self).stop()
 
     def load(self):
@@ -243,6 +246,7 @@ class MusicSDL2(Sound):
 
     def __init__(self, **kwargs):
         self.mc = MusicContainer()
+        self._check_play_ev = None
         mix_init()
         super(MusicSDL2, self).__init__(**kwargs)
 
@@ -279,7 +283,7 @@ class MusicSDL2(Sound):
             return
         mc.playing = 1
         # schedule event to check if the sound is still playing or not
-        Clock.schedule_interval(self._check_play, 0.1)
+        self._check_play_ev = Clock.schedule_interval(self._check_play, 0.1)
         super(MusicSDL2, self).play()
 
     def stop(self):
@@ -288,7 +292,9 @@ class MusicSDL2(Sound):
             return
         Mix_HaltMusic()
         mc.playing = 0
-        Clock.unschedule(self._check_play)
+        if self._check_play_ev is not None:
+            self._check_play_ev.cancel()
+            self._check_play_ev = None
         super(MusicSDL2, self).stop()
 
     def load(self):

--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -33,6 +33,8 @@ class CameraAndroid(CameraBase):
     Implementation of CameraBase using Android API
     """
 
+    _update_ev = None
+
     def __init__(self, **kwargs):
         self._android_camera = None
         self._preview_cb = PreviewCallback(self._on_preview_frame)
@@ -124,12 +126,15 @@ class CameraAndroid(CameraBase):
         self._android_camera.setPreviewCallbackWithBuffer(self._preview_cb)
 
         self._android_camera.startPreview()
-        Clock.unschedule(self._update)
-        Clock.schedule_interval(self._update, 1. / self.fps)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+        self._update_ev = Clock.schedule_interval(self._update, 1 / self.fps)
 
     def stop(self):
         super(CameraAndroid, self).stop()
-        Clock.unschedule(self._update)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+            self._update_ev = None
         self._android_camera.stopPreview()
 
         self._android_camera.setPreviewCallbackWithBuffer(None)

--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -36,6 +36,7 @@ class CameraAVFoundation(CameraBase):
 
     def __init__(self, **kwargs):
         self._storage = _AVStorage()
+        self._update_ev = None
         super(CameraAVFoundation, self).__init__(**kwargs)
 
     def init_camera(self):
@@ -72,14 +73,17 @@ class CameraAVFoundation(CameraBase):
     def start(self):
         cdef _AVStorage storage = <_AVStorage>self._storage
         super(CameraAVFoundation, self).start()
-        Clock.unschedule(self._update)
-        Clock.schedule_interval(self._update, 1 / 30.)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+        self._update_ev = Clock.schedule_interval(self._update, 1 / 30.)
         avf_camera_start(storage.camera)
 
     def stop(self):
         cdef _AVStorage storage = <_AVStorage>self._storage
         super(CameraAVFoundation, self).stop()
-        Clock.unschedule(self._update)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+            self._update_ev = None
         avf_camera_stop(storage.camera)
 
 

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -42,6 +42,8 @@ class CameraOpenCV(CameraBase):
     '''Implementation of CameraBase using OpenCV
     '''
 
+    _update_ev = None
+
     def __init__(self, **kwargs):
         self._device = None
         super(CameraOpenCV, self).__init__(**kwargs)
@@ -95,9 +97,12 @@ class CameraOpenCV(CameraBase):
 
     def start(self):
         super(CameraOpenCV, self).start()
-        Clock.unschedule(self._update)
-        Clock.schedule_interval(self._update, self.fps)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+        self._update_ev = Clock.schedule_interval(self._update, self.fps)
 
     def stop(self):
         super(CameraOpenCV, self).stop()
-        Clock.unschedule(self._update)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+            self._update_ev = None

--- a/kivy/core/camera/camera_videocapture.py
+++ b/kivy/core/camera/camera_videocapture.py
@@ -20,6 +20,7 @@ except:
 class CameraVideoCapture(CameraBase):
     '''Implementation of CameraBase using VideoCapture
     '''
+    _update_ev = None
 
     def __init__(self, **kwargs):
         self._device = None
@@ -52,9 +53,12 @@ class CameraVideoCapture(CameraBase):
 
     def start(self):
         super(CameraVideoCapture, self).start()
-        Clock.unschedule(self._update)
-        Clock.schedule_interval(self._update, self.fps)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+        self._update_ev = Clock.schedule_interval(self._update, self.fps)
 
     def stop(self):
         super(CameraVideoCapture, self).stop()
-        Clock.unschedule(self._update)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+            self._update_ev = None

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -477,6 +477,8 @@ class Image(EventDispatcher):
 
     data_uri_re = re.compile(r'^data:image/([^;,]*)(;[^,]*)?,(.*)$')
 
+    _anim_ev = None
+
     def __init__(self, arg, **kwargs):
         # this event should be fired on animation of sequenced img's
         self.register_event_type('on_texture')
@@ -594,9 +596,13 @@ class Image(EventDispatcher):
 
         '''
         # stop animation
-        Clock.unschedule(self._anim)
+        if self._anim_ev is not None:
+            self._anim_ev.cancel()
+            self._anim_ev = None
+
         if allow_anim and self._anim_available and self._anim_delay >= 0:
-            Clock.schedule_interval(self._anim, self.anim_delay)
+            self._anim_ev = Clock.schedule_interval(self._anim,
+                                                    self.anim_delay)
             self._anim()
 
     def _get_anim_delay(self):
@@ -607,9 +613,13 @@ class Image(EventDispatcher):
             return
         self._anim_delay = x
         if self._anim_available:
-            Clock.unschedule(self._anim)
+            if self._anim_ev is not None:
+                self._anim_ev.cancel()
+                self._anim_ev = None
+
             if self._anim_delay >= 0:
-                Clock.schedule_interval(self._anim, self._anim_delay)
+                self._anim_ev = Clock.schedule_interval(self._anim,
+                                                        self._anim_delay)
 
     anim_delay = property(_get_anim_delay, _set_anim_delay)
     '''Delay between each animation frame. A lower value means faster

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -100,6 +100,8 @@ class VideoFFPy(VideoBase):
     }
     """
 
+    _trigger = None
+
     def __init__(self, **kwargs):
         self._ffplayer = None
         self._thread = None
@@ -315,7 +317,8 @@ class VideoFFPy(VideoBase):
         self.unload()
 
     def unload(self):
-        Clock.unschedule(self._redraw)
+        if self._trigger is not None:
+            self._trigger.cancel()
         self._ffplayer_need_quit = True
         if self._thread:
             self._thread.join()

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -685,6 +685,8 @@ class WindowBase(EventDispatcher):
     canvas = ObjectProperty(None)
     title = StringProperty('Kivy')
 
+    trigger_create_window = None
+
     __events__ = (
         'on_draw', 'on_flip', 'on_rotate', 'on_resize', 'on_close',
         'on_minimize', 'on_maximize', 'on_restore', 'on_hide', 'on_show',
@@ -924,7 +926,7 @@ class WindowBase(EventDispatcher):
         '''
         # just to be sure, if the trigger is set, and if this method is
         # manually called, unset the trigger
-        Clock.unschedule(self.create_window)
+        self.trigger_create_window.cancel()
 
         # ensure the window creation will not be called twice
         if platform in ('android', 'ios'):

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -131,6 +131,8 @@ class SDL2MotionEventProvider(MotionEventProvider):
 
 class WindowSDL(WindowBase):
 
+    _do_resize_ev = None
+
     def __init__(self, **kwargs):
         self._pause_loop = False
         self._win = _WindowSDL2Storage()
@@ -481,9 +483,11 @@ class WindowSDL(WindowBase):
             elif action == 'windowresized':
                 self._size = self._win.window_size
                 # don't use trigger here, we want to delay the resize event
-                cb = self._do_resize
-                Clock.unschedule(cb)
-                Clock.schedule_once(cb, .1)
+                ev = self._do_resize_ev
+                if ev is None:
+                    ev = self._do_resize_ev = Clock.schedule_once(cb, .1)
+                else:
+                    ev()
 
             elif action == 'windowresized':
                 self.canvas.ask_update()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -485,7 +485,7 @@ class WindowSDL(WindowBase):
                 # don't use trigger here, we want to delay the resize event
                 ev = self._do_resize_ev
                 if ev is None:
-                    ev = self._do_resize_ev = Clock.schedule_once(cb, .1)
+                    ev = self._do_resize_ev = Clock.schedule_once(self._do_resize, .1)
                 else:
                     ev()
 

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -83,6 +83,7 @@ class LoaderBase(object):
     The _update() function is called every 1 / 25.s or each frame if we have
     less than 25 FPS.
     '''
+    _trigger_update = None
 
     def __init__(self):
         self._loading_image = None
@@ -100,10 +101,8 @@ class LoaderBase(object):
         self._trigger_update = Clock.create_trigger(self._update)
 
     def __del__(self):
-        try:
-            Clock.unschedule(self._update)
-        except Exception:
-            pass
+        if self._trigger_update is not None:
+            self._trigger_update.cancel()
 
     def _set_num_workers(self, num):
         if num < 2:

--- a/kivy/modules/console.py
+++ b/kivy/modules/console.py
@@ -79,10 +79,10 @@ of the Console::
             self.console.add_toolbar_widget(self.lbl, right=True)
 
         def activate(self):
-            Clock.schedule_interval(self.update_fps, 1 / 2.)
+            self.event = Clock.schedule_interval(self.update_fps, 1 / 2.)
 
         def deactivated(self):
-            Clock.unschedule(self.update_fps)
+            self.event.cancel()
 
         def update_fps(self, *args):
             fps = Clock.get_fps()
@@ -377,15 +377,23 @@ class ConsoleAddonSelect(ConsoleAddon):
 
 
 class ConsoleAddonFps(ConsoleAddon):
+
+    _update_ev = None
+
     def init(self):
         self.lbl = ConsoleLabel(text="0 Fps")
         self.console.add_toolbar_widget(self.lbl, right=True)
 
     def activate(self):
-        Clock.schedule_interval(self.update_fps, 1 / 2.)
+        ev = self._update_ev
+        if ev is None:
+            self._update_ev = Clock.schedule_interval(self.update_fps, 1 / 2.)
+        else:
+            ev()
 
     def deactivated(self):
-        Clock.unschedule(self.update_fps)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
 
     def update_fps(self, *args):
         fps = Clock.get_fps()

--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -336,6 +336,8 @@ class Inspector(FloatLayout):
 
     at_bottom = BooleanProperty(True)
 
+    _update_widget_tree_ev = None
+
     def __init__(self, **kwargs):
         self.win = kwargs.pop('win', None)
         super(Inspector, self).__init__(**kwargs)
@@ -475,7 +477,12 @@ class Inspector(FloatLayout):
             else:
                 Animation(y=self.height - 60, t='out_quad', d=.3).start(
                     self.layout)
-            Clock.schedule_interval(self.update_widget_tree, 1)
+            ev = self._update_widget_tree_ev
+            if ev is None:
+                ev = self._update_widget_tree_ev = Clock.schedule_interval(
+                    self.update_widget_tree, 1)
+            else:
+                ev()
             self.update_widget_tree()
 
     def animation_close(self, instance, value):
@@ -487,8 +494,11 @@ class Inspector(FloatLayout):
             for node in list(treeview.iterate_all_nodes()):
                 node.widget_ref = None
                 treeview.remove_node(node)
+
             self._window_node = None
-            Clock.unschedule(self.update_widget_tree)
+            if self._update_widget_tree_ev is not None:
+                self._update_widget_tree_ev.cancel()
+
             widgettree = self.widgettree
             for node in list(widgettree.iterate_all_nodes()):
                 widgettree.remove_node(node)

--- a/kivy/support.py
+++ b/kivy/support.py
@@ -48,6 +48,7 @@ def install_gobject_iteration():
 # -----------------------------------------------------------------------------
 
 g_android_redraw_count = 0
+_redraw_event = None
 
 
 def _android_ask_redraw(*largs):
@@ -95,7 +96,7 @@ def install_android():
         from kivy.base import stopTouchApp
         from kivy.logger import Logger
         from kivy.core.window import Window
-        global g_android_redraw_count
+        global g_android_redraw_count, _redraw_event
 
         # try to get the current running application
         Logger.info('Android: Must go into sleep mode, check the app')
@@ -125,8 +126,12 @@ def install_android():
                 app.dispatch('on_resume')
                 Window.canvas.ask_update()
                 g_android_redraw_count = 25  # 5 frames/seconds for 5 seconds
-                Clock.unschedule(_android_ask_redraw)
-                Clock.schedule_interval(_android_ask_redraw, 1 / 5)
+                if _redraw_event is None:
+                    _redraw_event = Clock.schedule_interval(
+                        _android_ask_redraw, 1 / 5)
+                else:
+                    _redraw_event.cancel()
+                    _redraw_event()
                 Logger.info('Android: App resume completed.')
 
         # app doesn't support pause mode, just stop it.

--- a/kivy/tests/perf_test_textinput.py
+++ b/kivy/tests/perf_test_textinput.py
@@ -76,10 +76,11 @@ class PerfApp(App, FloatLayout):
         self.lt = len_text = len(text_input.text)
         target = len_text - (210 * 9)
         self.tot_time = 0
+        ev = None
 
         def dlt(*l):
             if len(text_input.text) <= target:
-                Clock.unschedule(dlt)
+                ev.cancel()
                 print('Done!')
                 m_len = len(text_input._lines)
                 print('deleted 210 characters 9 times')
@@ -98,8 +99,9 @@ class PerfApp(App, FloatLayout):
             self.lt -= 210
             text_input.scroll_y -= 100
             self.tot_time += l[0]
-            Clock.schedule_once(dlt)
-        Clock.schedule_once(dlt)
+            ev()
+        ev = Clock.create_trigger(dlt)
+        ev()
 
     def stress_insert(self, *largs):
         self.test_done = False
@@ -110,10 +112,11 @@ class PerfApp(App, FloatLayout):
             text_input.selection_to)
         len_text = len(text_input._lines)
         self.tot_time = 0
+        ev = None
 
         def pste(*l):
             if len(text_input._lines) >= (len_text) * 9:
-                Clock.unschedule(pste)
+                ev.cancel()
                 print('Done!')
                 m_len = len(text_input._lines)
                 print('pasted', len_text, 'lines',
@@ -130,18 +133,20 @@ class PerfApp(App, FloatLayout):
                 return
             self.tot_time += l[0]
             text_input._paste()
-            Clock.schedule_once(pste)
-        Clock.schedule_once(pste)
+            ev()
+        ev = Clock.create_trigger(pste)
+        ev()
 
     def stress_selection(self, *largs):
         self.test_done = False
         text_input = self.text_input
         self.tot_time = 0
         old_selection_from = text_input.selection_from - 210
+        ev = None
 
         def pste(*l):
             if text_input.selection_from >= old_selection_from:
-                Clock.unschedule(pste)
+                ev.cancel()
                 print('Done!')
                 import resource
                 print('mem usage after test')
@@ -154,12 +159,14 @@ class PerfApp(App, FloatLayout):
                 return
             text_input.select_text(text_input.selection_from - 1,
                 text_input.selection_to)
-            Clock.schedule_once(pste)
-        Clock.schedule_once(pste)
+            ev()
+        ev = Clock.create_trigger(pste)
+        ev()
 
     def start_test(self, *largs):
         self.but.text = 'test started'
         self.slider.max = len(self.tests)
+        ev = None
 
         def test(*l):
             if self.test_done:
@@ -179,9 +186,9 @@ class PerfApp(App, FloatLayout):
                     print('===================')
                     print('All Tests Completed')
                     print('===================')
-                    Clock.unschedule(test)
+                    ev.cancel()
 
-        Clock.schedule_interval(test, 1)
+        ev = Clock.schedule_interval(test, 1)
 
 
 if __name__ in ('__main__', ):

--- a/kivy/tests/test_clock.py
+++ b/kivy/tests/test_clock.py
@@ -57,6 +57,13 @@ class ClockTestCase(unittest.TestCase):
         Clock.tick()
         self.assertEqual(counter, 0)
 
+    def test_unschedule_event(self):
+        from kivy.clock import Clock
+        ev = Clock.schedule_once(callback)
+        Clock.unschedule(ev)
+        Clock.tick()
+        self.assertEqual(counter, 0)
+
     def test_unschedule_after_tick(self):
         from kivy.clock import Clock
         Clock.schedule_once(callback, 5.)

--- a/kivy/uix/colorpicker.py
+++ b/kivy/uix/colorpicker.py
@@ -409,6 +409,8 @@ class ColorPicker(RelativeLayout):
     defaults to None.
     '''
 
+    _update_clr_ev = _update_hex_ev = None
+
     # now used only internally.
     foreground_color = ListProperty((1, 1, 1, 1))
 
@@ -426,8 +428,10 @@ class ColorPicker(RelativeLayout):
 
     def _trigger_update_clr(self, mode, clr_idx, text):
         self._upd_clr_list = mode, clr_idx, text
-        Clock.unschedule(self._update_clr)
-        Clock.schedule_once(self._update_clr)
+        ev = self._update_clr_ev
+        if ev is None:
+            ev = self._update_clr_ev = Clock.create_trigger(self._update_clr)
+        ev()
 
     def _update_clr(self, dt):
         mode, clr_idx, text = self._upd_clr_list
@@ -447,8 +451,10 @@ class ColorPicker(RelativeLayout):
 
     def _trigger_update_hex(self, text):
         self._upd_hex_list = text
-        Clock.unschedule(self._update_hex)
-        Clock.schedule_once(self._update_hex)
+        ev = self._update_hex_ev
+        if ev is None:
+            ev = self._update_hex_ev = Clock.create_trigger(self._update_hex)
+        ev()
 
     def __init__(self, **kwargs):
         self._updating_clr = False

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -460,6 +460,8 @@ class TabbedPanel(GridLayout):
     :attr:`default_tab_content` is an :class:`~kivy.properties.AliasProperty`.
     '''
 
+    _update_top_ev = _update_tab_ev = _update_tabs_ev = None
+
     def __init__(self, **kwargs):
         # these variables need to be initialized before the kv lang is
         # processed setup the base layout for the tabbed panel
@@ -586,8 +588,11 @@ class TabbedPanel(GridLayout):
         self._default_tab.text = self.default_tab_text
 
     def on_tab_width(self, *l):
-        Clock.unschedule(self._update_tab_width)
-        Clock.schedule_once(self._update_tab_width, 0)
+        ev = self._update_tab_ev
+        if ev is None:
+            ev = self._update_tab_ev = Clock.create_trigger(
+                self._update_tab_width, 0)
+        ev()
 
     def on_tab_height(self, *l):
         self._tab_layout.height = self._tab_strip.height = self.tab_height
@@ -648,8 +653,11 @@ class TabbedPanel(GridLayout):
             self.switch_to(self.default_tab)
 
     def _reposition_tabs(self, *l):
-        Clock.unschedule(self._update_tabs)
-        Clock.schedule_once(self._update_tabs, 0)
+        ev = self._update_tabs_ev
+        if ev is None:
+            ev = self._update_tabs_ev = Clock.create_trigger(
+                self._update_tabs, 0)
+        ev()
 
     def _update_tabs(self, *l):
         self_content = self.content
@@ -802,8 +810,11 @@ class TabbedPanel(GridLayout):
 
     def _update_top(self, *args):
         sctr, top, scrl_v_width, x, y = args
-        Clock.unschedule(partial(self._updt_top, sctr, top, scrl_v_width))
-        Clock.schedule_once(
+        ev = self._update_top_ev
+        if ev is not None:
+            ev.cancel()
+
+        ev = self._update_top_ev = Clock.schedule_once(
             partial(self._updt_top, sctr, top, scrl_v_width), 0)
 
     def _updt_top(self, sctr, top, scrl_v_width, *args):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -449,6 +449,8 @@ class TextInput(FocusBehavior, Widget):
                   'on_quad_touch')
 
     def __init__(self, **kwargs):
+        self._update_graphics_ev = Clock.create_trigger(
+            self._update_graphics, -1)
         self.is_focusable = kwargs.get('is_focusable', True)
         self._cursor = [0, 0]
         self._selection = False
@@ -509,8 +511,6 @@ class TextInput(FocusBehavior, Widget):
         fbind = self.fbind
         refresh_line_options = self._trigger_refresh_line_options
         update_text_options = self._update_text_options
-        self._update_graphics_ev = Clock.create_trigger(
-            self._update_graphics, -1)
 
         fbind('font_size', refresh_line_options)
         fbind('font_name', refresh_line_options)

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -127,6 +127,8 @@ class Video(Image):
     to {}.
     '''
 
+    _video_load_event = None
+
     def __init__(self, **kwargs):
         self._video = None
         super(Video, self).__init__(**kwargs)
@@ -152,8 +154,11 @@ class Video(Image):
         self._video.seek(percent)
 
     def _trigger_video_load(self, *largs):
-        Clock.unschedule(self._do_video_load)
-        Clock.schedule_once(self._do_video_load, -1)
+        ev = self._video_load_event
+        if ev is None:
+            ev = self._video_load_event = Clock.schedule_once(
+                self._do_video_load, -1)
+        ev()
 
     def _do_video_load(self, *largs):
         if CoreVideo is None:

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -480,6 +480,8 @@ class VideoPlayer(GridLayout):
     # internals
     container = ObjectProperty(None)
 
+    _video_load_ev = None
+
     def __init__(self, **kwargs):
         self._video = None
         self._image = None
@@ -493,8 +495,11 @@ class VideoPlayer(GridLayout):
             self._trigger_video_load()
 
     def _trigger_video_load(self, *largs):
-        Clock.unschedule(self._do_video_load)
-        Clock.schedule_once(self._do_video_load, -1)
+        ev = self._video_load_ev
+        if ev is None:
+            ev = self._video_load_ev = Clock.schedule_once(self._do_video_load,
+                                                           -1)
+        ev()
 
     def on_source(self, instance, value):
         # we got a value, try to see if we have an image for it

--- a/kivy/uix/vkeyboard.py
+++ b/kivy/uix/vkeyboard.py
@@ -323,6 +323,9 @@ class VKeyboard(Scatter):
     font_name = StringProperty('data/fonts/DejaVuSans.ttf')
     repeat_touch = ObjectProperty(allownone=True)
 
+    _start_repeat_key_ev = None
+    _repeat_key_ev = None
+
     __events__ = ('on_key_down', 'on_key_up', 'on_textinput')
 
     def __init__(self, **kwargs):
@@ -750,7 +753,9 @@ class VKeyboard(Scatter):
         if special_char is not None:
             # Do not repeat special keys
             if special_char in ('capslock', 'shift', 'layout', 'special'):
-                Clock.unschedule(self._start_repeat_key)
+                if self._start_repeat_key_ev is not None:
+                    self._start_repeat_key_ev.cancel()
+                    self._start_repeat_key_ev = None
                 self.repeat_touch = None
             if special_char == 'capslock':
                 self.have_capslock = not self.have_capslock
@@ -811,7 +816,7 @@ class VKeyboard(Scatter):
         return ret
 
     def _start_repeat_key(self, *kwargs):
-        Clock.schedule_interval(self._repeat_key, 0.05)
+        self._repeat_key_ev = Clock.schedule_interval(self._repeat_key, 0.05)
 
     def _repeat_key(self, *kwargs):
         self.process_key_on(self.repeat_touch)
@@ -826,7 +831,8 @@ class VKeyboard(Scatter):
         x, y = self.to_local(x, y)
         if not self.collide_margin(x, y):
             if self.repeat_touch is None:
-                Clock.schedule_once(self._start_repeat_key, 0.5)
+                self._start_repeat_key_ev = Clock.schedule_once(
+                    self._start_repeat_key, 0.5)
             self.repeat_touch = touch
 
             self.process_key_on(touch)
@@ -840,9 +846,13 @@ class VKeyboard(Scatter):
         if touch.grab_current is self:
             self.process_key_up(touch)
 
-            Clock.unschedule(self._start_repeat_key)
+            if self._start_repeat_key_ev is not None:
+                self._start_repeat_key_ev.cancel()
+                self._start_repeat_key_ev = None
             if touch == self.repeat_touch:
-                Clock.unschedule(self._repeat_key)
+                if self._repeat_key_ev is not None:
+                    self._repeat_key_ev.cancel()
+                    self._repeat_key_ev = None
                 self.repeat_touch = None
 
         return super(VKeyboard, self).on_touch_up(touch)

--- a/setup.py
+++ b/setup.py
@@ -722,6 +722,7 @@ graphics_dependencies = {
 
 sources = {
     '_event.pyx': merge(base_flags, {'depends': ['properties.pxd']}),
+    '_clock.pyx': {},
     'weakproxy.pyx': {},
     'properties.pyx': merge(base_flags, {'depends': ['_event.pxd']}),
     'graphics/buffer.pyx': base_flags,


### PR DESCRIPTION
This makes the Kivy clock fully thread safe and uses a linked list so that the callbacks are deterministic.

Benchmarks using https://github.com/kivy/kivy/wiki/Kivy-clock-experiments
Master:
```
schedule_once: 3.04238663305
trigger:  5.99657834953
unschedule_by_callback: 0.28418420994
unschedule_by_event: 7.20933188983
tick: 7.33034039193
```

PR:
```
schedule_once: 2.14062707372
trigger:  4.78726804852
unschedule_by_callback: 48.8890041079
unschedule_by_event: 6.2745237454
tick: 7.08543473329
```
