### PR TITLE
update emacs mode docs to modern way of enabling newline and indent

### DIFF
--- a/kivy/tools/highlight/kivy-mode.el
+++ b/kivy/tools/highlight/kivy-mode.el
@@ -34,13 +34,13 @@
 ;;
 ;; to your .emacs file.
 ;;
-;; Unlike python-mode, this mode follows the Emacs convention of not
-;; binding the ENTER key to `newline-and-indent'. To get this behavior, add
-;; the key definition to `kivy-mode-hook':
+;; This mode does not enable electric-indent by default. To get this
+;; behavior, either enable electric-indent-mode globally or enable it only
+;; for kivy buffers using `kivy-mode-hook':
 ;;
 ;;    (add-hook 'kivy-mode-hook
 ;;     '(lambda ()
-;;        (define-key kivy-mode-map "\C-m" 'newline-and-indent)))
+;;        (electric-indent-local-mode t)))
 
 
 ;; User definable variables


### PR DESCRIPTION
Binding C-m to newline-and-indent no longer works in emacs. Not sure when the switch to electric-indent-local-mode became available or correct, but it works fine in Debian stable (emacs 24.4) so the change has been around long enough to justify updating the documentation.