### PR TITLE
Fix multiprocessing.freeze_support()

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -331,14 +331,19 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         mp_fork = None
         try:
-            mp_fork = opts['multiprocessing-fork']
+            for opt, arg in opts:
+                if opt == '--multiprocessing-fork':
+                    mp_fork = True
+                    break
         except:
             pass
 
         # set argv to the non-read args
         sys.argv = sys_argv[0:1] + args
         if mp_fork is not None:
-            sys.argv = sys.argv + ['--multiprocessing-fork']
+            # Needs to be first opt for support_freeze to work
+            sys.argv.insert(1, '--multiprocessing-fork')
+
     else:
         opts = []
         args = []


### PR DESCRIPTION
Kivy and `multiprocessing.freeze_support()` wasn't working correctly (on Windows at least) when launching multiple processes from an app packaged with PyInstaller or cx_Freeze.
The  `--multiprocessing-fork` `sys.argv` flag was not being restored in the correct order. It is, surprisingly, hard coded as the first argument in `multiprocessing`'s implementation of this feature.

The patch fixes the check for the `--multiprocessing-fork` argument, as well as restoring it in the correct position in `sys.argv`. Tested and verified on windows 7 with an app frozen with pyinstaller.