### PR TITLE
Make it possible to properly release the pygst camera

### DIFF
--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -102,6 +102,9 @@ class CameraBase(EventDispatcher):
         '''Initialise the camera (internal)'''
         pass
 
+    def release(self):
+        '''Release the camera'''
+
     def start(self):
         '''Start the camera acquire'''
         self.stopped = False
@@ -145,6 +148,5 @@ else:
     providers += (('pygst', 'camera_pygst', 'CameraPyGst'), )
 
 providers += (('opencv', 'camera_opencv', 'CameraOpenCV'), )
-
 
 Camera = core_select_lib('camera', (providers))

--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -42,10 +42,10 @@ class CameraAndroid(CameraBase):
         super(CameraAndroid, self).__init__(**kwargs)
 
     def __del__(self):
-        self._release_camera()
+        self.release()
 
     def init_camera(self):
-        self._release_camera()
+        self.release()
         self._android_camera = Camera.open(self._index)
         params = self._android_camera.getParameters()
         width, height = self._resolution
@@ -90,7 +90,7 @@ class CameraAndroid(CameraBase):
                                         self._camera_texture.bind)
             Rectangle(size=self._resolution)
 
-    def _release_camera(self):
+    def release(self):
         if self._android_camera is None:
             return
 

--- a/kivy/core/camera/camera_pygst.py
+++ b/kivy/core/camera/camera_pygst.py
@@ -47,9 +47,8 @@ class CameraPyGst(CameraBase):
 
     def init_camera(self):
         # TODO: This doesn't work when camera resolution is resized at runtime.
-        # There must be some other way to release the camera?
         if self._pipeline:
-            self._pipeline = None
+            self.release()
 
         video_src = self._video_src
         if video_src == 'v4l2src':
@@ -68,6 +67,13 @@ class CameraPyGst(CameraBase):
 
         if self._camerasink and not self.stopped:
             self.start()
+
+    def release(self):
+        if self._pipeline is None:
+            return
+        self.stop()
+        self._pipeline.set_state(gst.STATE_NULL)
+        self._pipeline = None
 
     def _gst_new_buffer(self, *largs):
         self._format = 'rgb'


### PR DESCRIPTION
Consider the following example. With the default pygst implementation, if you click on "Delete camera" and then "Create camera", it shows a white screen, while it works fine for example on Android.
With this PR, we make it possible to explicitly release the camera; if you uncomment the line `#camera._camera.release()`, you can delete and re-create the camera as many times as you want.

Some notes:
- it is not possible to use a `__del__` in CameraPyGst: unfortunately, there is a reference cycle in `self -> self._camerasink -> self._gst_new_buffer -> self`. This means that when Python garbage collects the object, the `__del__` is not called
- it would be nice if the Camera widget automatically releases the camera when it's destroyed. However, I didn't find any way to automatically execute code on destruction (and the `__del__` does not work for the same reason as above)

``` python
from kivy.app import App
from kivy.lang import Builder
from kivy.factory import Factory

kv = '''
BoxLayout:
    orientation: 'vertical'

    BoxLayout:
        id: mybox

    BoxLayout:
        orientation: 'horizontal'
        size_hint_y: None
        height: '48dp'
        Button:
            text: 'Create camera'
            on_release: app.create()

        Button:
            text: 'Delete camera'
            on_release: app.delete()
'''

class CameraApp(App):
    def build(self):
        self.root = Builder.load_string(kv)
        self.create()
        return self.root

    def create(self):
        self.delete()
        mybox = self.root.ids.mybox
        camera = Factory.Camera(resolution=(640, 480), play=True)
        mybox.add_widget(camera)

    def delete(self):
        mybox = self.root.ids.mybox
        if not mybox.children:
            return
        camera = mybox.children[0]
        camera.play = False
        mybox.remove_widget(camera)
        #camera._camera.release()


if __name__ == '__main__':
    CameraApp().run()
```
