### PR TITLE
Adds various clock options.

### DIFF
--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -29,6 +29,11 @@ cdef class ClockEvent(object):
     cpdef tick(self, double curtime)
 
 
+cdef class FreeClockEvent(ClockEvent):
+
+    cdef public int free
+
+
 cdef class CyClockBase(object):
 
     cdef public double _last_tick
@@ -37,17 +42,12 @@ cdef class CyClockBase(object):
     frame. If more iterations occur, a warning is issued.
     '''
 
-    cdef public double callback_resolution
-    '''If the remaining time until the event timeout is less than :attr:`callback_resolution`,
+    cdef public double clock_resolution
+    '''If the remaining time until the event timeout is less than :attr:`clock_resolution`,
     the clock will execute the callback even if it hasn't exactly timed out.
 
-    If -1, the default, the resolution will be the measured
-    :attr:`events_duration`. Otherwise, the provided value is used.
-    '''
-
-    cdef public double events_duration
-    '''The measured time that it takes to process all the events etc, excepting any
-    sleep or waiting time. It is the average and is updated every 5 seconds.
+    If -1, the default, the resolution will be computed from the :attr:`_max_fps`.
+    Otherwise, the provided value is used.
     '''
 
     cdef public double _max_fps
@@ -80,6 +80,7 @@ cdef class CyClockBase(object):
     cdef public object _lock_acquire
     cdef public object _lock_release
 
+    cpdef get_resolution(self)
     cpdef create_trigger(self, callback, timeout=*, interval=*)
     cpdef schedule_once(self, callback, timeout=*)
     cpdef schedule_interval(self, callback, timeout)
@@ -87,3 +88,14 @@ cdef class CyClockBase(object):
     cpdef _release_references(self)
     cpdef _process_events(self)
     cpdef _process_events_before_frame(self)
+    cpdef get_min_timeout(self)
+    cpdef get_events(self)
+
+
+cdef class CyClockBaseFree(CyClockBase):
+
+    cpdef create_trigger_free(self, callback, timeout=*, interval=*)
+    cpdef schedule_once_free(self, callback, timeout=*)
+    cpdef schedule_interval_free(self, callback, timeout)
+    cpdef _process_free_events(self, double last_tick)
+    cpdef get_min_free_timeout(self)

--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -32,6 +32,8 @@ cdef class ClockEvent(object):
 cdef class FreeClockEvent(ClockEvent):
 
     cdef public int free
+    '''Whether this event was scheduled as a free event.
+    '''
 
 
 cdef class CyClockBase(object):
@@ -46,8 +48,8 @@ cdef class CyClockBase(object):
     '''If the remaining time until the event timeout is less than :attr:`clock_resolution`,
     the clock will execute the callback even if it hasn't exactly timed out.
 
-    If -1, the default, the resolution will be computed from the :attr:`_max_fps`.
-    Otherwise, the provided value is used.
+    If -1, the default, the resolution will be computed from config's ``maxfps``.
+    Otherwise, the provided value is used. Defaults to -1.
     '''
 
     cdef public double _max_fps

--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -37,6 +37,21 @@ cdef class CyClockBase(object):
     frame. If more iterations occur, a warning is issued.
     '''
 
+    cdef public double callback_resolution
+    '''If the remaining time until the event timeout is less than :attr:`callback_resolution`,
+    the clock will execute the callback even if it hasn't exactly timed out.
+
+    If -1, the default, the resolution will be the measured
+    :attr:`events_duration`. Otherwise, the provided value is used.
+    '''
+
+    cdef public double events_duration
+    '''The measured time that it takes to process all the events etc, excepting any
+    sleep or waiting time. It is the average and is updated every 5 seconds.
+    '''
+
+    cdef public double _max_fps
+
     cdef public ClockEvent _root_event
     '''The first event in the chain. Can be None.
     '''

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -1,6 +1,10 @@
 
 
-__all__ = ('CyClockBase', 'ClockEvent')
+__all__ = ('ClockEvent', 'CyClockBase', 'FreeClockEvent', 'CyClockBaseFree')
+
+
+cdef extern from "float.h":
+    double DBL_MAX
 
 from kivy.weakmethod import WeakMethod
 from kivy.logger import Logger
@@ -47,6 +51,7 @@ cdef class ClockEvent(object):
                 clock._last_event.next = self
                 self.prev = clock._last_event
                 clock._last_event = self
+            self.clock.on_schedule(self)
             clock._lock_release()
 
     def __call__(self, *largs):
@@ -65,6 +70,7 @@ cdef class ClockEvent(object):
                 self.clock._last_event.next = self
                 self.prev = self.clock._last_event
                 self.clock._last_event = self
+            self.clock.on_schedule(self)
             self.clock._lock_release()
             return True
         self.clock._lock_release()
@@ -137,16 +143,8 @@ cdef class ClockEvent(object):
         '''(internal method) Processes the event for the kivy thread.
         '''
         cdef object callback, ret
-        cdef double resolution = self.clock.callback_resolution
-        # timeout happened ? (check also if we would miss from 5ms) this
-        # 5ms increase the accuracy if the timing of animation for
-        # example.
-        if resolution < 0:
-            resolution = 3 * self.clock.events_duration
-            if self.clock._max_fps:
-                resolution = max(resolution, 1 / (3. * self.clock._max_fps))
-            resolution = min(resolution, 0.005)
-        if curtime - self._last_dt < self.timeout - resolution:
+        # timeout happened ? if less than resolution process it
+        if curtime - self._last_dt < self.timeout - self.clock.get_resolution():
             return True
 
         # calculate current timediff for this event
@@ -179,13 +177,19 @@ cdef class ClockEvent(object):
         return '<ClockEvent ({}) callback={}>'.format(self.timeout, self.get_callback())
 
 
+cdef class FreeClockEvent(ClockEvent):
+
+    def __init__(self, free, *largs, **kwargs):
+        self.free = free
+        ClockEvent.__init__(self, *largs, **kwargs)
+
+
 cdef class CyClockBase(object):
     '''The base clock object with event support.
     '''
 
     def __cinit__(self, **kwargs):
-        self.callback_resolution = -1
-        self.events_duration = 0
+        self.clock_resolution = -1
         self._max_fps = 60
         self.max_iteration = 10
 
@@ -198,6 +202,21 @@ cdef class CyClockBase(object):
         self._lock = Lock()
         self._lock_acquire = self._lock.acquire
         self._lock_release = self._lock.release
+
+    cpdef get_resolution(self):
+        cdef double resolution = self.clock_resolution
+        # timeout happened ? (check also if we would miss from 5ms) this
+        # 5ms increase the accuracy if the timing of animation for
+        # example.
+        if resolution < 0:
+            if self._max_fps:
+                resolution = 1 / (3. * self._max_fps)
+            else:
+                resolution = 0.0001
+        return resolution
+
+    def on_schedule(self, event):
+        pass
 
     cpdef create_trigger(self, callback, timeout=0, interval=False):
         '''Create a Trigger event. Check module documentation for more
@@ -421,7 +440,22 @@ cdef class CyClockBase(object):
             self._cap_event = None
             self._lock_release()
 
-    def get_events(self):
+    cpdef get_min_timeout(self):
+        cdef ClockEvent ev
+        cdef double val = DBL_MAX
+        self._lock_acquire()
+        ev = self._root_event
+        while ev is not None:
+            if ev.timeout <= 0:
+                val = 0
+                break
+            val = min(val, ev.timeout + ev._last_dt)
+            ev = ev.next
+        self._lock_release()
+
+        return val
+
+    cpdef get_events(self):
         '''Returns the list of :class:`ClockEvent` currently scheduled.
         '''
         cdef list events = []
@@ -434,3 +468,113 @@ cdef class CyClockBase(object):
             ev = ev.next
         self._lock_release()
         return events
+
+
+cdef class CyClockBaseFree(CyClockBase):
+
+    cpdef create_trigger(self, callback, timeout=0, interval=False):
+        cdef FreeClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+        event = FreeClockEvent(False, self, interval, callback, timeout, 0)
+        event.release()
+        return event
+
+    cpdef schedule_once(self, callback, timeout=0):
+        cdef FreeClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+
+        event = FreeClockEvent(
+            False, self, False, callback, timeout, self._last_tick, None, True)
+        return event
+
+    cpdef schedule_interval(self, callback, timeout):
+        cdef FreeClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+
+        event = FreeClockEvent(
+            False, self, True, callback, timeout, self._last_tick, None, True)
+        return event
+
+    cpdef create_trigger_free(self, callback, timeout=0, interval=False):
+        cdef FreeClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+        event = FreeClockEvent(True, self, interval, callback, timeout, 0)
+        event.release()
+        return event
+
+    cpdef schedule_once_free(self, callback, timeout=0):
+        cdef FreeClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+
+        event = FreeClockEvent(
+            True, self, False, callback, timeout, self._last_tick, None, True)
+        return event
+
+    cpdef schedule_interval_free(self, callback, timeout):
+        cdef FreeClockEvent event
+        if not callable(callback):
+            raise ValueError('callback must be a callable, got %s' % callback)
+
+        event = FreeClockEvent(
+            True, self, True, callback, timeout, self._last_tick, None, True)
+        return event
+
+    cpdef _process_free_events(self, double last_tick):
+        cdef FreeClockEvent event
+        cdef int done = False
+
+        self._lock_acquire()
+        if self._root_event is None:
+            self._lock_release()
+            return
+
+        self._cap_event = self._last_event
+        event = self._root_event
+        while not done:
+            self._next_event = event.next
+            done = self._cap_event is event or self._cap_event is None
+            '''We have to worry about this case:
+
+            If in this iteration the cap event is canceled then at end of this
+            iteration _cap_event will have shifted to current event (or to the
+            event before that if current_event is done) which will not be checked
+            again for being the cap event and done will never be True
+            since we are passed the current event. So, when canceling,
+            if _next_event is the canceled event and it's also the _cap_event
+            _cap_event is set to None.
+            '''
+
+            self._lock_release()
+
+            try:
+                event.tick(last_tick)
+            except:
+                raise
+            else:
+                self._lock_acquire()
+            event = self._next_event
+
+        self._cap_event = None
+        self._lock_release()
+
+    cpdef get_min_free_timeout(self):
+        cdef FreeClockEvent ev
+        cdef double val = DBL_MAX
+
+        self._lock_acquire()
+        ev = self._root_event
+        while ev is not None:
+            if ev.free:
+                if ev.timeout <= 0:
+                    val = 0
+                    break
+                val = min(val, ev.timeout + ev._last_dt)
+            ev = ev.next
+        self._lock_release()
+
+        return val

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -108,7 +108,7 @@ cdef class ClockEvent(object):
                 # cap is next, so we have reached the end of the list
                 # because current one being processed is going to be the last event now
                 if self.clock._cap_event is self.clock._next_event:
-                   self.clock._cap_event = None
+                    self.clock._cap_event = None
                 else:
                     self.clock._cap_event = self.prev  # new cap
 
@@ -376,7 +376,7 @@ cdef class CyClockBase(object):
 
         self._cap_event = self._last_event
         event = self._root_event
-        while not done:
+        while not done and event is not None:
             self._next_event = event.next
             done = self._cap_event is event or self._cap_event is None
             '''Usage of _cap_event: We have to worry about this case:
@@ -400,7 +400,7 @@ cdef class CyClockBase(object):
                 self._lock_acquire()
             event = self._next_event
 
-        self._cap_event = None
+        self._next_event = self._cap_event = None
         self._lock_release()
 
     cpdef _process_events_before_frame(self):
@@ -429,7 +429,7 @@ cdef class CyClockBase(object):
 
             self._cap_event = self._last_event
             event = self._root_event
-            while not done:
+            while not done and event is not None:
                 if event.timeout != -1:
                     done = self._cap_event is event or self._cap_event is None
                     event = event.next
@@ -447,7 +447,7 @@ cdef class CyClockBase(object):
                 else:
                     self._lock_acquire()
                 event = self._next_event
-            self._cap_event = None
+            self._next_event = self._cap_event = None
             self._lock_release()
 
     cpdef get_min_timeout(self):
@@ -565,7 +565,7 @@ cdef class CyClockBaseFree(CyClockBase):
 
         self._cap_event = self._last_event
         event = self._root_event
-        while not done:
+        while not done and event is not None:
             if not event.free:
                 done = self._cap_event is event or self._cap_event is None
                 event = event.next
@@ -584,7 +584,7 @@ cdef class CyClockBaseFree(CyClockBase):
                 self._lock_acquire()
             event = self._next_event
 
-        self._cap_event = None
+        self._next_event = self._cap_event = None
         self._lock_release()
 
     cpdef get_min_free_timeout(self):

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -536,18 +536,13 @@ cdef class CyClockBaseFree(CyClockBase):
         self._cap_event = self._last_event
         event = self._root_event
         while not done:
+            if not event.free:
+                done = self._cap_event is event or self._cap_event is None
+                event = event.next
+                continue
+
             self._next_event = event.next
             done = self._cap_event is event or self._cap_event is None
-            '''We have to worry about this case:
-
-            If in this iteration the cap event is canceled then at end of this
-            iteration _cap_event will have shifted to current event (or to the
-            event before that if current_event is done) which will not be checked
-            again for being the cap event and done will never be True
-            since we are passed the current event. So, when canceling,
-            if _next_event is the canceled event and it's also the _cap_event
-            _cap_event is set to None.
-            '''
 
             self._lock_release()
 

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -190,6 +190,8 @@ Available configuration tokens
         :class:`~kivy.uix.behaviors.buttonbehavior.ButtonBehavior` to
         make sure they display their current visual state for the given
         time.
+    `kivy_clock`: one of `default`, `interrupt`, `free_all`, `free_only`
+        The clock type to use with kivy. See :mod:`kivy.clock`.
 
 :input:
 
@@ -259,6 +261,7 @@ Available configuration tokens
 
 .. versionchanged:: 1.9.2
     `min_state_time` has been added to the `graphics` section.
+    `kivy_clock` has been added to the kivy section
 
 .. versionchanged:: 1.9.0
     `borderless` and `window_state` have been added to the graphics section.
@@ -305,7 +308,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 15
+KIVY_CONFIG_VERSION = 16
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -794,6 +797,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 14:
             Config.setdefault('graphics', 'min_state_time', '.035')
+
+        elif version == 15:
+            Config.setdefault('kivy', 'kivy_clock', 'default')
 
         # elif version == 1:
         #    # add here the command for upgrading from configuration 0 to 1


### PR DESCRIPTION
Please read the docs at of clock.py (https://github.com/matham/kivy/blob/4e893a4f40d279d58a376ca4f2fe88b45e2ded37/kivy/clock.py#L221) added by this PR to understand what it does.
A quick summary from there is:

The kivy clock type to use can be set with the ``kivy_clock`` option the
:mod:`~kivy.config`. If ``KIVY_CLOCK`` is present in the environment it
overwrites the config selection. Its possible values are as follows:
* When ``kivy_clock`` is ``default``, the normal clock, :class:`ClockBase`,
  which limits callbacks to the maxfps quantization - is used.
* When ``kivy_clock`` is ``interrupt``, a interruptible clock,
  :class:`ClockBaseInterrupt`, which doesn't limit any callbacks to the
  maxfps - is used. Callbacks will be executed at any time.
* When ``kivy_clock`` is ``free_all``, a interruptible clock,
  :class:`ClockBaseFreeInterruptAll`, which doesn't limit any callbacks to the
  maxfps in the presence of free events, but in their absence it limits events
  to the fps quantization interval - is used.
* When ``kivy_clock`` is ``free_only``, a interruptible clock,
  :class:`ClockBaseFreeInterruptAll`, which treats free and normal events
  independently; normal events are fps limited while free events are not - is
  used.

Also fixes #4417.