### PR TITLE
Moved Slider styling to properties. Introducing value_track* properties.

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -55,8 +55,20 @@
             pos: (self.x + self.padding, self.center_y - self.background_width / 2) if self.orientation == 'horizontal' else (self.center_x - self.background_width / 2, self.y + self.padding)
             size: (self.width - self.padding * 2, self.background_width) if self.orientation == 'horizontal' else (self.background_width, self.height - self.padding * 2)
             source: (self.background_disabled_horizontal if self.orientation == 'horizontal' else self.background_disabled_vertical) if self.disabled else (self.background_horizontal if self.orientation == 'horizontal' else self.background_vertical)
+        Color:
+            rgba: root.value_track_color if self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
+        Line:
+            width: self.value_track_width
+            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos[0], self.center_y - self.value_track_width / 2
+        Color:
+            rgba: root.value_track_color if self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
+        Line:
+            width: self.value_track_width
+            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos[1]
+        Color:
+            rgb: 1, 1, 1
         Rectangle:
-            pos: (self.value_pos[0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2 + 1) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos[1] - self.cursor_height / 2)
+            pos: (self.value_pos[0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos[1] - self.cursor_height / 2)
             size: self.cursor_size
             source: self.cursor_disabled_image if self.disabled else self.cursor_image
 

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -51,14 +51,14 @@
         Color:
             rgb: 1, 1, 1
         BorderImage:
-            border: (0, 18, 0, 18) if self.orientation == 'horizontal' else (18, 0, 18, 0)
-            pos: (self.x + self.padding, self.center_y - sp(18)) if self.orientation == 'horizontal' else (self.center_x - 18, self.y + self.padding)
-            size: (self.width - self.padding * 2, sp(36)) if self.orientation == 'horizontal' else (sp(36), self.height - self.padding * 2)
-            source: 'atlas://data/images/defaulttheme/slider{}_background{}'.format(self.orientation[0], '_disabled' if self.disabled else '')
+            border: self.border_horizontal if self.orientation == 'horizontal' else self.border_vertical
+            pos: (self.x + self.padding, self.center_y - self.background_width / 2) if self.orientation == 'horizontal' else (self.center_x - self.background_width / 2, self.y + self.padding)
+            size: (self.width - self.padding * 2, self.background_width) if self.orientation == 'horizontal' else (self.background_width, self.height - self.padding * 2)
+            source: (self.background_disabled_horizontal if self.orientation == 'horizontal' else self.background_disabled_vertical) if self.disabled else (self.background_horizontal if self.orientation == 'horizontal' else self.background_vertical)
         Rectangle:
-            pos: (self.value_pos[0] - sp(16), self.center_y - sp(17)) if self.orientation == 'horizontal' else (self.center_x - sp(16), self.value_pos[1] - sp(16))
-            size: (sp(32), sp(32))
-            source: 'atlas://data/images/defaulttheme/slider_cursor{}'.format('_disabled' if self.disabled else '')
+            pos: (self.value_pos[0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2 + 1) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos[1] - self.cursor_height / 2)
+            size: self.cursor_size
+            source: self.cursor_disabled_image if self.disabled else self.cursor_image
 
 <ProgressBar>:
     canvas:

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -23,7 +23,7 @@ __all__ = ('Slider', )
 from kivy.uix.widget import Widget
 from kivy.properties import (NumericProperty, AliasProperty, OptionProperty,
                              ReferenceListProperty, BoundedNumericProperty,
-                             StringProperty, ListProperty)
+                             StringProperty, ListProperty, BooleanProperty)
 
 
 class Slider(Widget):
@@ -213,6 +213,34 @@ class Slider(Widget):
 
     :attr:`border_horizontal` is a :class:`~kivy.properties.ListProperty`
     and defaults to [18, 0, 18, 0].
+    """
+
+    value_track = BooleanProperty(False)
+    """Decides if slider should draw the line indicating the
+    space between :attr:`min` and :attr:`value` properties values.
+
+    .. versionadded 1.9.2
+
+    :attr:`value_line` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to False.
+    """
+
+    value_track_color = ListProperty([1, 1, 1, 1])
+    """Color of the :attr:`value_line`.
+
+    .. versionadded 1.9.2
+
+    :attr:`value_line_color` is a :class:`~kivy.properties.ListProperty`
+    and defaults to [1, 1, 1, 1].
+    """
+
+    value_track_width = NumericProperty('3dp')
+    """Width of the track line.
+
+    .. versionadded 1.9.2
+
+    :attr:`value_track_width` is a :class:`~kivy.properties.NumericProperty`
+    and defaults to 3dp.
     """
 
     # The following two methods constrain the slider's value

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -22,7 +22,8 @@ __all__ = ('Slider', )
 
 from kivy.uix.widget import Widget
 from kivy.properties import (NumericProperty, AliasProperty, OptionProperty,
-                             ReferenceListProperty, BoundedNumericProperty)
+                             ReferenceListProperty, BoundedNumericProperty,
+                             StringProperty, ListProperty)
 
 
 class Slider(Widget):
@@ -96,6 +97,36 @@ class Slider(Widget):
 
     :attr:`step` is a :class:`~kivy.properties.NumericProperty` and defaults
     to 1.'''
+
+    background_horizontal = StringProperty(
+        'atlas://data/images/defaulttheme/sliderh_background')
+
+    background_disabled_horizontal = StringProperty(
+        'atlas://data/images/defaulttheme/sliderh_background_disabled')
+
+    background_vertical = StringProperty(
+        'atlas://data/images/defaulttheme/sliderv_background')
+
+    background_disabled_vertical = StringProperty(
+        'atlas://data/images/defaulttheme/sliderv_background_disabled')
+
+    background_width = NumericProperty('36sp')
+
+    cursor_image = StringProperty(
+        'atlas://data/images/defaulttheme/slider_cursor')
+
+    cursor_disabled_image = StringProperty(
+        'atlas://data/images/defaulttheme/slider_cursor_disabled')
+
+    cursor_width = NumericProperty('32sp')
+
+    cursor_height = NumericProperty('32sp')
+
+    cursor_size = ReferenceListProperty(cursor_width, cursor_height)
+
+    border_horizontal = ListProperty([0, 18, 0, 18])
+
+    border_vertical = ListProperty([18, 0, 18, 0])
 
     # The following two methods constrain the slider's value
     # to range(min,max). Otherwise it may happen that self.value < self.min

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -20,7 +20,7 @@ To create a vertical slider::
 To create a slider with a red line tracking the value:
 
     from kivy.uix.slider import Slider
-    s = Slider(value_track=True, value_track_color=[1, 0, 0, 0])
+    s = Slider(value_track=True, value_track_color=[1, 0, 0, 1])
 
 """
 __all__ = ('Slider', )

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -17,6 +17,11 @@ To create a vertical slider::
     from kivy.uix.slider import Slider
     s = Slider(orientation='vertical')
 
+To create a slider with a red line tracking the value:
+
+    from kivy.uix.slider import Slider
+    s = Slider(value_track=True, value_track_color=[1, 0, 0, 0])
+
 """
 __all__ = ('Slider', )
 
@@ -226,7 +231,7 @@ class Slider(Widget):
     """
 
     value_track_color = ListProperty([1, 1, 1, 1])
-    """Color of the :attr:`value_line`.
+    """Color of the :attr:`value_line` in rgba format.
 
     .. versionadded 1.9.2
 

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -100,33 +100,120 @@ class Slider(Widget):
 
     background_horizontal = StringProperty(
         'atlas://data/images/defaulttheme/sliderh_background')
+    """Background of the slider used in the horizontal orientation.
+
+    .. versionadded:: 1.9.2
+
+    :attr:`background_horizontal` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `atlas://data/images/defaulttheme/sliderh_background`.
+    """
 
     background_disabled_horizontal = StringProperty(
         'atlas://data/images/defaulttheme/sliderh_background_disabled')
+    """Background of the disabled slider used in the horizontal orientation.
+
+    .. versionadded:: 1.9.2
+
+    :attr:`background_disabled_horizontal` is a
+    :class:`~kivy.properties.StringProperty` and defaults to
+    `atlas://data/images/defaulttheme/sliderh_background_disabled`.
+    """
 
     background_vertical = StringProperty(
         'atlas://data/images/defaulttheme/sliderv_background')
+    """Background of the slider used in the vertical orientation.
+
+    .. versionadded:: 1.9.2
+
+    :attr:`background_vertical` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `atlas://data/images/defaulttheme/sliderv_background`.
+    """
 
     background_disabled_vertical = StringProperty(
         'atlas://data/images/defaulttheme/sliderv_background_disabled')
+    """Background of the disabled slider used in the vertical orientation.
+
+    .. versionadded:: 1.9.2
+
+    :attr:`background_disabled_vertical` is a
+    :class:`~kivy.properties.StringProperty` and defaults to
+    `atlas://data/images/defaulttheme/sliderv_background_disabled`.
+    """
 
     background_width = NumericProperty('36sp')
+    """Slider's background's width (thickness), used in both horizontal
+    and vertical orientations.
+
+    .. versionadded 1.9.2
+
+    :attr:`background_width` is a
+    :class:`~kivy.properties.NumericProperty` and defaults to 36sp.
+    """
 
     cursor_image = StringProperty(
         'atlas://data/images/defaulttheme/slider_cursor')
+    """Path of the image used to draw the slider cursor.
+
+    .. versionadded 1.9.2
+
+    :attr:`cursor_image` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `atlas://data/images/defaulttheme/slider_cursor`.
+    """
 
     cursor_disabled_image = StringProperty(
         'atlas://data/images/defaulttheme/slider_cursor_disabled')
+    """Path of the image used to draw the disabled slider cursor.
+
+    .. versionadded 1.9.2
+
+    :attr:`cursor_image` is a :class:`~kivy.properties.StringProperty`
+    and defaults to `atlas://data/images/defaulttheme/slider_cursor_disabled`.
+    """
 
     cursor_width = NumericProperty('32sp')
+    """Width of the cursor image.
+
+    .. versionadded 1.9.2
+
+    :attr:`cursor_width` is a :class:`~kivy.properties.NumericProperty`
+    and defaults to 32sp.
+    """
 
     cursor_height = NumericProperty('32sp')
+    """Height of the cursor image.
+
+    .. versionadded 1.9.2
+
+    :attr:`cursor_height` is a :class:`~kivy.properties.NumericProperty`
+    and defaults to 32sp.
+    """
 
     cursor_size = ReferenceListProperty(cursor_width, cursor_height)
+    """Size of the cursor image.
+
+    .. versionadded 1.9.2
+
+    :attr:`cursor_size` is a :class:`~kivy.properties.ReferenceListProperty`
+    of (:attr:`cursor_width`, :attr:`cursor_height`) properties.
+    """
 
     border_horizontal = ListProperty([0, 18, 0, 18])
+    """Border used to draw the slider background in horizontal orientation.
+
+    .. versionadded 1.9.2
+
+    :attr:`border_horizontal` is a :class:`~kivy.properties.ListProperty`
+    and defaults to [0, 18, 0, 18].
+    """
 
     border_vertical = ListProperty([18, 0, 18, 0])
+    """Border used to draw the slider background in vertical orientation.
+
+    .. versionadded 1.9.2
+
+    :attr:`border_horizontal` is a :class:`~kivy.properties.ListProperty`
+    and defaults to [18, 0, 18, 0].
+    """
 
     # The following two methods constrain the slider's value
     # to range(min,max). Otherwise it may happen that self.value < self.min


### PR DESCRIPTION
Removed hardcoded slider kv and moved it's contents into Slider properties. It will allow to style the widget from both Python and kv.

Introducing value_track, value_track_color and value_track_width properties to let the slider to visualize the value as the line starting form 0 up to value_pos.