### PR TITLE
Fix typos

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -843,6 +843,7 @@ cdef class EventDispatcher(ObjectWithUid):
 
 
         ::
+
             >>> mywidget = Widget()
             >>> mywidget.create_property('custom')
             >>> mywidget.custom = True

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -285,7 +285,7 @@ class WindowBase(EventDispatcher):
                 The *unicode* parameter has been deprecated in favor of
                 codepoint, and will be removed completely in future versions.
 
-        `on_key_down`: key, scancode, codepoint
+        `on_key_down`: key, scancode, codepoint, modifier
             Fired when a key pressed.
 
             .. versionchanged:: 1.3.0

--- a/kivy/parser.py
+++ b/kivy/parser.py
@@ -103,7 +103,7 @@ def parse_bool(text):
 
 
 def parse_string(text):
-    '''Parse a string to a string (removing single and double quotes)'''
+    '''Parse a string to a string (removing single and double quotes).'''
     if len(text) >= 2 and text[0] in ('"', "'") and text[-1] in ('"', "'"):
         text = text[1:-1]
     return text.strip()
@@ -150,5 +150,13 @@ def parse_float4(text):
     return value
 
 
-parse_int = int
-parse_float = float
+def parse_int(text):
+    '''An alias of `int()`.
+    '''
+    return int(text)
+
+
+def parse_float(text):
+    '''An alias of `float()`.
+    '''
+    return float(text)


### PR DESCRIPTION
Fixes:
- #4137 (there's missing word)
- code block in event (hiding `::`)
- parser aliases - in docs they are jumping out of casual formatting, because of `parse_int = int`. This wraps it into functions.