### PR TITLE
Fix url in UrlRequest

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -559,7 +559,7 @@ if __name__ == '__main__':
         pprint('Got an error:')
         pprint(error)
 
-    req = UrlRequest('http://en.wikipedia.org/w/api.php?format'
+    req = UrlRequest('https://en.wikipedia.org/w/api.php?format'
         '=json&action=query&titles=Kivy&prop=revisions&rvprop=content',
         on_success, on_error)
     while not req.is_finished:


### PR DESCRIPTION
UrlRequest somehow isn't able to switch to https automatically(issue or not?) and here if the api isn't through https, the request fails. However, there it gets interesting, because the error is empty. Rewriting it to https fixes it and the result is available.