### PR TITLE
Store kivy_home_dir as a unicode string in python 2.

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -36,6 +36,7 @@ from getopt import getopt, GetoptError
 from os import environ, mkdir
 from os.path import dirname, join, basename, exists, expanduser
 import pkgutil
+from kivy.compat import PY2
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
 
@@ -284,6 +285,10 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         elif platform == 'ios':
             user_home_dir = join(expanduser('~'), 'Documents')
         kivy_home_dir = join(user_home_dir, '.kivy')
+
+    if PY2:
+        kivy_home_dir = kivy_home_dir.decode(sys.getfilesystemencoding())
+
     kivy_config_fn = join(kivy_home_dir, 'config.ini')
     kivy_usermodules_dir = join(kivy_home_dir, 'mods')
     kivy_userexts_dir = join(kivy_home_dir, 'extensions')


### PR DESCRIPTION
For Python 3 there is no change. For python 2 and users without
special characters, there is no change (because the string is easily
decoded with ascii codec anyway). The only change is for users that
have special characters in their username.

See https://github.com/kivy/kivy/issues/3912#issuecomment-229679674 for rationale and issue #3912 for reproduction.
Fixes #3912.