### PR TITLE
Update installation-linux.rst

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -316,8 +316,14 @@ Installation
     # Make sure Pip, Virtualenv and Setuptools are updated
     sudo pip install --upgrade pip virtualenv setuptools
 
-    # Create a virtualenv
+    # Then create a virtualenv by either:
+    
+    # 1. using the default interpreter
     virtualenv --no-site-packages kivyinstall
+    
+    # or 2. using a specific interpreter 
+    # (this will use the interpreter in /usr/bin/python2.7)
+    virtualenv --no-site-packages -p /usr/bin/python2.7 kivyinstall
 
     # Enter the virtualenv
     . kivyinstall/bin/activate
@@ -337,7 +343,7 @@ Installation
     # Install stable version of Kivy into the virtualenv
     pip install kivy
     # For the development version of Kivy, use the following command instead
-    # pip install git+https://github.com/kivy/kivy.git@master
+    pip install git+https://github.com/kivy/kivy.git@master
 
 
 Install additional Virtualenv packages


### PR DESCRIPTION
Unless (e.g.) `-p python2.7` is provided, it will use the default interpreter when creating the virtualenv. The default might be unwanted (e.g. use the python3.5 while the user needs specifically 2.7) and go unnoticed for quite a while wasting lots of time for the user.

The second change (irrelevant to the first) is uncommenting a command.