### PR TITLE
Update dropdown.kv

### DIFF
--- a/examples/demo/showcase/data/screens/dropdown.kv
+++ b/examples/demo/showcase/data/screens/dropdown.kv
@@ -18,7 +18,9 @@ ShowcaseScreen:
     DropDown:
 
         id: dropdown
-        on_parent: self.dismiss()
+        first: True
+        on_parent:
+            if self.first: self.dismiss(); self.first = False
         on_select: btn.text = 'Selected value: {}'.format(args[1])
 
         Button:

--- a/examples/demo/showcase/data/screens/dropdown.kv
+++ b/examples/demo/showcase/data/screens/dropdown.kv
@@ -13,14 +13,12 @@ ShowcaseScreen:
         size_hint_y: None
         height: '48dp'
 
-    Widget
+    Widget:
+        on_parent: dropdown.dismiss()
 
     DropDown:
 
         id: dropdown
-        first: True
-        on_parent:
-            if self.first: self.dismiss(); self.first = False
         on_select: btn.text = 'Selected value: {}'.format(args[1])
 
         Button:


### PR DESCRIPTION
If `on_parent` has bound `self.dismiss()` it dismiss basically on every change of `parent` property - such as openning dropdown too :P

I tried to do it `on_id` and change id then, but no win there. There should be something like `on_load` as in web development, though I'm not sure if it wouldn't slow Kivy in a long run. O.o