### PR TITLE
Add on_stop to recorder

### DIFF
--- a/kivy/input/recorder.py
+++ b/kivy/input/recorder.py
@@ -112,6 +112,13 @@ class RecorderMotionEvent(MotionEvent):
 
 class Recorder(EventDispatcher):
     '''Recorder class. Please check module documentation for more information.
+
+    :Events:
+        `on_stop`:
+            Fired when the playing stops.
+
+    .. versionchanged:: 1.9.2
+        Event `on_stop` added.
     '''
 
     window = ObjectProperty(None)
@@ -167,6 +174,8 @@ class Recorder(EventDispatcher):
     # internals
     record_fd = ObjectProperty(None)
     record_time = NumericProperty(0.)
+
+    __events__ = ('on_stop',)
 
     def __init__(self, **kwargs):
         super(Recorder, self).__init__(**kwargs)
@@ -262,10 +271,14 @@ class Recorder(EventDispatcher):
                     (len(self.play_data), self.filename))
         EventLoop.add_input_provider(self)
 
+    def on_stop(self):
+        pass
+
     def update(self, dispatch_fn):
         if not self.play_data:
             Logger.info('Recorder: Playing finished.')
             self.play = False
+            self.dispatch('on_stop')
 
         dt = time() - self.play_time
         while self.play_data:


### PR DESCRIPTION
Adds `on_stop` event to the recorder. `stop` is not a property, so this shouldn't be a problem. I think it should be included, because even if there is a way how to do this now, it's not pretty, because it'd mean rewriting `on_play` i.e. making a class that inherits from `Recorder`, then calling `Recorder.on_play` probably via `super()` in that custom class and then checking for the `play` value.

However, this is dispatched automatically when `self.play = False` in `update()` function, so it's pretty easy to work with. Also, it's placed _after_ `self.play = False`, therefore the event would run when `on_play` is finished.