### PR TITLE
Fix regex for new nightly name

### DIFF
--- a/doc/sources/.static/kivy.js
+++ b/doc/sources/.static/kivy.js
@@ -322,7 +322,7 @@ cs\\/doclist\\/images\\/icon_9_archive_xl128\\.png"\\/><\\/div>\
 https:\\/\\/ssl\\.gstatic\\.com\\/docs\\/doclist\\/images\\/icon_9_\
 archive_list\\.png"\\/><\\/div><div class="flip-entry-title">)';
     var wheel = '(Kivy-\\d\\.\\d\\.\\d)(\\.\\w{4}_$date$_git\\_?\\w\
-{7}-$pyVer$)(-none|_\\d{8}_git_\\w{7}-$pyVer$m)(-$arch$.whl)';
+{7}-$pyVer$)(-none|_\\d{8}_git_\\w{7}-$pyVer$m|-$pyVer$m)(-$arch$.whl)';
     var date = new Date();
     var yesterday = addZeros(date.getDate() - 1, 2);
     var month = addZeros(date.getMonth() + 1, 2);


### PR DESCRIPTION
Change in wheel's name breaks fetching it via javascript on [installation-windows](https://kivy.org/docs/installation/installation-windows.html):

    Kivy-1.9.2.dev0_30062016_git_8d5451f-cp27_30062016_git_8d5451f-none-win32
    ↓
    Kivy-1.9.2.dev0_31072016_git_cfec8f3-cp27-cp27m-win32.whl

I added it only as another "or" to the regex in case the name would be reverted or changed in a way the old part would match the wheel.