### PR TITLE
update the CompoundSelectionBehavior example

### DIFF
--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -53,7 +53,7 @@ to :meth:`select_with_touch` to pass on the touch events::
             """ Use the initialize method to bind to the keyboard to enable
             keyboard interaction e.g. using shift and control for multi-select.
             """
-            super(CompoundSelectionBehavior, self).__init__(**kwargs)
+            super(SelectableGrid, self).__init__(**kwargs)
             keyboard = Window.request_keyboard(None, self)
             keyboard.bind(on_key_down=self.select_with_key_down,
                           on_key_up=self.select_with_key_up)


### PR DESCRIPTION
With the original example code, keyboard select fails, because for some reason self._update_counts is never called. This fixes the problem. (Using the python3 version of super() would also fix the problem, but obviously that's not a good idea because of backwards compatibility.)