### PR TITLE
Osc fixes

### DIFF
--- a/kivy/lib/osc/OSC.py
+++ b/kivy/lib/osc/OSC.py
@@ -271,40 +271,43 @@ def parseArgs(args):
 
 def decodeOSC(data):
     """Converts a typetagged OSC message to a Python list."""
-    table = { ord(b"i") : readInt,
-              ord(b"f") : readFloat,
-              ord(b"s") : readString,
-              ord(b"b") : readBlob,
-              ord(b"d") : readDouble,
-              ord(b"t") : readLong,
-              ord(b"T") : readTrue,
-              ord(b"F") : readFalse,
-              ord(b"I") : readImpulse,
-              ord(b"N") : readNull
-    }
-    decoded = []
-    address,  rest = readString(data)
-    typetags = b""
+    try:
+        table = { ord(b"i") : readInt,
+                  ord(b"f") : readFloat,
+                  ord(b"s") : readString,
+                  ord(b"b") : readBlob,
+                  ord(b"d") : readDouble,
+                  ord(b"t") : readLong,
+                  ord(b"T") : readTrue,
+                  ord(b"F") : readFalse,
+                  ord(b"I") : readImpulse,
+                  ord(b"N") : readNull
+        }
+        decoded = []
+        address,  rest = readString(data)
+        typetags = b""
 
-    if address == "#bundle":
-        time, rest = readLong(rest)
-        #decoded.append(address)
-        #decoded.append(time)
-        while len(rest)>0:
-            length, rest = readInt(rest)
-            decoded.append(decodeOSC(rest[:length]))
-            rest = rest[length:]
+        if address == "#bundle":
+            time, rest = readLong(rest)
+            #decoded.append(address)
+            #decoded.append(time)
+            while len(rest)>0:
+                length, rest = readInt(rest)
+                decoded.append(decodeOSC(rest[:length]))
+                rest = rest[length:]
 
-    elif len(rest) > 0:
-        typetags, rest = readString(rest)
-        decoded.append(address)
-        decoded.append(typetags)
-        if typetags[0] == ord(b","):
-            for tag in typetags[1:]:
-                value, rest = table[tag](rest)
-                decoded.append(value)
-        else:
-            print("Oops, typetag lacks the magic ,")
+        elif len(rest) > 0:
+            typetags, rest = readString(rest)
+            decoded.append(address)
+            decoded.append(typetags)
+            if typetags[0] == ord(b","):
+                for tag in typetags[1:]:
+                    value, rest = table[tag](rest)
+                    decoded.append(value)
+            else:
+                print("Oops, typetag lacks the magic ,")
+    except Exception as e:
+        print("exception: %s" % (e))
 
     return decoded
 

--- a/kivy/lib/osc/oscAPI.py
+++ b/kivy/lib/osc/oscAPI.py
@@ -133,8 +133,8 @@ def sendMsg(oscAddress, dataArray=[], ipAddr='127.0.0.1', port=9000, typehint=No
         defaults to '127.0.0.1', port 9000
     '''
     with oscLock:
-        outSocket.sendto(
-            createBinaryMsg(oscAddress, dataArray, typehint),  (ipAddr, port))
+        msg = createBinaryMsg(oscAddress, dataArray, typehint)
+        outSocket.sendto(msg,  (ipAddr, port))
 
 
 def createBundle():


### PR DESCRIPTION
These are the hacky fixes I had to make to get osc working with python3 - it seems that mostly it didn't understand bytes at all. I also have to pass `typehint='b'` to osc.sendMsg, and make everything bytes explicitly.

This probably shouldn't be merged, but maybe it can help anyone else having python3 problems, and serve as the base for a more robust fix.
