### PR TITLE
Fix input_filter for direct changing

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2893,6 +2893,26 @@ class TextInput(FocusBehavior, Widget):
         return text
 
     def _set_text(self, text):
+        mode = self.input_filter
+        if mode is not None:
+            if text is bytes:
+                int_pat = self._insert_int_patb
+            else:
+                int_pat = self._insert_int_patu
+
+            if mode == 'int':
+                text = re.sub(int_pat, '', text)
+            elif mode == 'float':
+                if '.' not in text:
+                    text = re.sub(int_pat, '', text)
+                else:
+                    text = '.'.join([re.sub(int_pat, '', k) for k
+                                          in text.split('.', 1)])
+            else:
+                text = mode(text, from_undo=False)
+            if not text:
+                return
+
         if isinstance(text, bytes):
             text = text.decode('utf8')
 


### PR DESCRIPTION
I have encountered a problem with `input_filter` which isn't that much obvious, but may be crucial for unittesting the input - I mean explicitly changing `textinput.text` through TextInput's instance. This fixes it, although I'm not 100% sure if it's the right approach.

Example:
```
# -*- coding: utf-8 -*-
import re
from kivy.lang import Builder
from kivy.base import runTouchApp
from kivy.uix.boxlayout import BoxLayout
Builder.load_string('''
<Test>:
    TextInput:
        id: input
        input_filter: 'float' #root.simple_chars
    Button:
        on_release: input.text = '1Ťéşt 1Ťéşt1.2'
''')
class Test(BoxLayout):
    @staticmethod
    def simple_chars(substring, from_undo):
        chars = re.findall(r'([a-zA-Z0-9.])', substring)
        return u''.join(chars)
runTouchApp(Test())
```