### PR TITLE
carousel scrollview children touch_move  fix

### DIFF
--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -523,7 +523,7 @@ class Carousel(StencilView):
             'time': touch.time_start}
         self._change_touch_mode_ev = Clock.schedule_once(
             self._change_touch_mode, self.scroll_timeout / 1000.)
-        self.touc_mode_change = False
+        self.touch_mode_change = False
         return True
 
     def on_touch_move(self, touch):

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -529,11 +529,11 @@ class Carousel(StencilView):
 
     def on_touch_move(self, touch):
         if self.touch_mode_change == False:
-            if self.ignore_perpendicular_swipes and self.direction in ('top','bottom'):
+            if self.ignore_perpendicular_swipes and self.direction in ('top', 'bottom'):
                 if abs(touch.ox - touch.x) > self.scroll_distance:
                     self._change_touch_mode()
                     self.touchModeChange = True
-            elif self.ignore_perpendicular_swipes and self.direction in ('right','left'):
+            elif self.ignore_perpendicular_swipes and self.direction in ('right', 'left'):
                 if abs(touch.oy - touch.y) > self.scroll_distance:
                     self._change_touch_mode()
                     self.touchModeChange = True

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -529,14 +529,16 @@ class Carousel(StencilView):
 
     def on_touch_move(self, touch):
         if self.touch_mode_change == False:
-            if self.ignore_perpendicular_swipes and self.direction in ('top', 'bottom'):
-                if abs(touch.ox - touch.x) > self.scroll_distance:
-                    self._change_touch_mode()
-                    self.touchModeChange = True
-            elif self.ignore_perpendicular_swipes and self.direction in ('right', 'left'):
-                if abs(touch.oy - touch.y) > self.scroll_distance:
-                    self._change_touch_mode()
-                    self.touchModeChange = True
+            if self.ignore_perpendicular_swipes and self.direction in ('top','bottom'):
+                if abs(touch.oy - touch.y) < self.scroll_distance:
+                    if abs(touch.ox - touch.x) > self.scroll_distance:
+                        self._change_touch_mode()
+                        self.touchModeChange = True
+            elif self.ignore_perpendicular_swipes and self.direction in ('right','left'):
+                if abs(touch.ox - touch.x) < self.scroll_distance:
+                    if abs(touch.oy - touch.y) > self.scroll_distance:
+                        self._change_touch_mode()
+                        self.touchModeChange = True
 
         if self._get_uid('cavoid') in touch.ud:
             return

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Carousel
 ========
@@ -241,6 +242,39 @@ class Carousel(StencilView):
     defaults to 'out_quad'.
 
     .. versionadded:: 1.8.0
+    '''
+
+    do_scroll_x = BooleanProperty(True)
+    '''Allow scroll on X axis.
+
+    .. versionadded:: 1.9.2
+    :attr:`do_scroll_x` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to True.
+    '''
+
+    do_scroll_y = BooleanProperty(True)
+    '''Allow scroll on Y axis.
+
+    .. versionadded:: 1.9.2
+    :attr:`do_scroll_y` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to True.
+    '''
+
+    def _get_do_scroll(self):
+        return (self.do_scroll_x, self.do_scroll_y)
+
+    def _set_do_scroll(self, value):
+        if type(value) in (list, tuple):
+            self.do_scroll_x, self.do_scroll_y = value
+        else:
+            self.do_scroll_x = self.do_scroll_y = bool(value)
+    do_scroll = AliasProperty(_get_do_scroll, _set_do_scroll,
+                              bind=('do_scroll_x', 'do_scroll_y'))
+    '''Allow scroll on X or Y axis.
+
+    .. versionadded:: 1.9.2
+    :attr:`do_scroll` is a :class:`~kivy.properties.AliasProperty` of
+    (:attr:`do_scroll_x` + :attr:`do_scroll_y`)
     '''
 
     #### private properties, for internal use only ###
@@ -515,9 +549,19 @@ class Carousel(StencilView):
             'time': touch.time_start}
         self._change_touch_mode_ev = Clock.schedule_once(
             self._change_touch_mode, self.scroll_timeout / 1000.)
+        self.touchModeChange = False
         return True
 
     def on_touch_move(self, touch):
+        if not self.do_scroll_x and not self.touchModeChange:
+            if abs(touch.ox - touch.x) > self.scroll_distance:
+                self._change_touch_mode()
+                self.touchModeChange = True
+        elif not self.do_scroll_y and not self.touchModeChange:
+            if abs(touch.oy - touch.y) > self.scroll_distance:
+                self._change_touch_mode()
+                self.touchModeChange = True
+
         if self._get_uid('cavoid') in touch.ud:
             return
         if self._touch is not touch:

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -266,6 +266,7 @@ class Carousel(StencilView):
             self._position_visible_slides, -1)
         super(Carousel, self).__init__(**kwargs)
         self._skip_slide = None
+        self.touch_mode_change = False
 
     def load_slide(self, slide):
         '''Animate to the slide that is passed as the argument.

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Carousel
 ========
@@ -243,37 +244,12 @@ class Carousel(StencilView):
     .. versionadded:: 1.8.0
     '''
 
-    do_scroll_x = BooleanProperty(True)
-    '''Allow scroll on X axis.
+    ignore_perpendicular_swipes = BooleanProperty(False)
+    '''ignore swipes on axis perpendicular to direction.
 
     .. versionadded:: 1.9.2
-    :attr:`do_scroll_x` is a :class:`~kivy.properties.BooleanProperty` and
-    defaults to True.
-    '''
-
-    do_scroll_y = BooleanProperty(True)
-    '''Allow scroll on Y axis.
-
-    .. versionadded:: 1.9.2
-    :attr:`do_scroll_y` is a :class:`~kivy.properties.BooleanProperty` and
-    defaults to True.
-    '''
-
-    def _get_do_scroll(self):
-        return (self.do_scroll_x, self.do_scroll_y)
-
-    def _set_do_scroll(self, value):
-        if type(value) in (list, tuple):
-            self.do_scroll_x, self.do_scroll_y = value
-        else:
-            self.do_scroll_x = self.do_scroll_y = bool(value)
-    do_scroll = AliasProperty(_get_do_scroll, _set_do_scroll,
-                              bind=('do_scroll_x', 'do_scroll_y'))
-    '''Allow scroll on X or Y axis.
-
-    .. versionadded:: 1.9.2
-    :attr:`do_scroll` is a :class:`~kivy.properties.AliasProperty` of
-    (:attr:`do_scroll_x` + :attr:`do_scroll_y`)
+    :attr:`ignore_perpendicular_swipes` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to False.
     '''
 
     #### private properties, for internal use only ###
@@ -552,14 +528,15 @@ class Carousel(StencilView):
         return True
 
     def on_touch_move(self, touch):
-        if not self.do_scroll_x and not self.touchModeChange:
-            if abs(touch.ox - touch.x) > self.scroll_distance:
-                self._change_touch_mode()
-                self.touchModeChange = True
-        elif not self.do_scroll_y and not self.touchModeChange:
-            if abs(touch.oy - touch.y) > self.scroll_distance:
-                self._change_touch_mode()
-                self.touchModeChange = True
+        if self.touchModeChange == False:
+            if self.ignore_perpendicular_swipes and self.direction in ('top','bottom'):
+                if abs(touch.ox - touch.x) > self.scroll_distance:
+                    self._change_touch_mode()
+                    self.touchModeChange = True
+            elif self.ignore_perpendicular_swipes and self.direction in ('right,left'):
+                if abs(touch.oy - touch.y) > self.scroll_distance:
+                    self._change_touch_mode()
+                    self.touchModeChange = True
 
         if self._get_uid('cavoid') in touch.ud:
             return

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -523,11 +523,11 @@ class Carousel(StencilView):
             'time': touch.time_start}
         self._change_touch_mode_ev = Clock.schedule_once(
             self._change_touch_mode, self.scroll_timeout / 1000.)
-        self.touchModeChange = False
+        self.touc_mode_change = False
         return True
 
     def on_touch_move(self, touch):
-        if self.touchModeChange == False:
+        if self.touch_mode_change == False:
             if self.ignore_perpendicular_swipes and self.direction in ('top','bottom'):
                 if abs(touch.ox - touch.x) > self.scroll_distance:
                     self._change_touch_mode()

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -532,7 +532,7 @@ class Carousel(StencilView):
                 if abs(touch.ox - touch.x) > self.scroll_distance:
                     self._change_touch_mode()
                     self.touchModeChange = True
-            elif self.ignore_perpendicular_swipes and self.direction in ('right,left'):
+            elif self.ignore_perpendicular_swipes and self.direction in ('right','left'):
                 if abs(touch.oy - touch.y) > self.scroll_distance:
                     self._change_touch_mode()
                     self.touchModeChange = True

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 Carousel
 ========


### PR DESCRIPTION
Current carousel has to break scrollview scrolling because it has to try scrolling itself before dispatching scrolling to children.
My solution is to add new "do_scroll" variables (just like scrollview already has) and use those to switch off carousel's own scrolling when x or y "scroll_distance" threshold crossed and "do_scroll_x/y" is False.