### PR TITLE
[WIP] Asyncio support

### DIFF
--- a/examples/asyncio/http_client.py
+++ b/examples/asyncio/http_client.py
@@ -1,0 +1,134 @@
+from kivy.base import KivyEventLoop
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.properties import NumericProperty, BooleanProperty
+from kivy.clock import Clock
+from random import sample
+from string import printable
+from time import sleep
+import asyncio
+import aiohttp
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+KV = '''
+#:import cos math.cos
+#:import sin math.sin
+#:import asyncio asyncio
+
+BoxLayout:
+    orientation: 'vertical'
+    TextInput:
+        text: 'http://www.sphinx-doc.org/en/stable/_sources/rest.txt'
+        multiline: False
+        size_hint_y: None
+        height: self.minimum_height
+        disabled: app.loading
+        on_text_validate:
+            app.load_page(self.text)
+
+    RstDocument:
+        id: viewer
+        text: ''
+        w1: app.time % 100
+        w2: (app.time + 33) % 100
+        w3: (app.time + 66) % 100
+        canvas.after:
+            Color:
+                rgba:
+                    (
+                    1, 1, 1 ,1
+                    ) if app.loading else (
+                    0, 0, 0, 0
+                    )
+
+            Line:
+                width: 4
+                ellipse:
+                    (
+                    self.center_x - (self.w1 or 0) / 2,
+                    self.center_y - (self.w1 or 0) / 2,
+                    self.w1 or 0, self.w1 or 0
+                    ) if app.time else (0, 0, 0, 0)
+            Line:
+                width: 4
+                ellipse:
+                    (
+                    self.center_x - (self.w2 or 0) / 2,
+                    self.center_y - (self.w2 or 0) / 2,
+                    self.w2 or 0, self.w2 or 0
+                    ) if app.time else (0, 0, 0, 0)
+            Line:
+                width: 4
+                ellipse:
+                    (
+                    self.center_x - (self.w3 or 0) / 2,
+                    self.center_y - (self.w3 or 0) / 2,
+                    self.w3 or 0, self.w3 or 0
+                    ) if app.time else (0, 0, 0, 0)
+            Color:
+                rgba: 1, 1, 1, 1
+
+'''  # noqa
+
+
+async def fetch_page(session, url):
+    print("fetch page")
+    with aiohttp.Timeout(10):
+        print("timeout context")
+        async with session.get(url) as response:
+            print("response")
+            if response.status == 200:
+                print("200")
+                return await response.read()
+            else:
+                print("error")
+                return 'error: {}'.format(response.status)
+    print("end timeout context")
+
+
+class DebugTask(asyncio.Task):
+    def _wakeup(self, future):
+        print("woke up", self)
+        super()._wakeup(future)
+        print("after wakeup", self)
+
+
+class MyApp(App):
+    '''XXX
+    '''
+    time = NumericProperty()
+    loading = BooleanProperty(False)
+
+    def build(self):
+        Clock.schedule_interval(self.update_time, 0)
+        return Builder.load_string(KV)
+
+    def update_time(self, deltatime):
+        self.time += deltatime * 10
+
+    def load_page(self, url):
+        self.loading = True
+        print("load page")
+        with aiohttp.ClientSession(loop=ev) as session:
+            print("session")
+            try:
+                content = ev.run_until_complete(
+                    DebugTask(fetch_page(session, url)))
+            except asyncio.TimeoutError:
+                content = "timeout!"
+
+            self.root.ids.viewer.text = content
+            self.loading = False
+        self.loading = False
+
+if __name__ == '__main__':
+    # ev = asyncio.get_event_loop()
+    # with aiohttp.ClientSession(loop=ev) as session:
+    #     print("session")
+    #     print(ev.run_until_complete(
+    #         DebugTask(fetch_page(session, 'http://www.sphinx-doc.org/en/stable/_sources/rest.txt'))
+    #     ))
+    ev = KivyEventLoop(MyApp())
+    ev.set_debug(True)
+    ev.mainloop()

--- a/examples/asyncio/http_client.py
+++ b/examples/asyncio/http_client.py
@@ -35,13 +35,7 @@ BoxLayout:
         w3: (app.time + 66) % 100
         canvas.after:
             Color:
-                rgba:
-                    (
-                    1, 1, 1 ,1
-                    ) if app.loading else (
-                    0, 0, 0, 0
-                    )
-
+                rgba: 1, 1, 1, 1 - (self.w1 if app.loading else 100) / 100
             Line:
                 width: 4
                 ellipse:
@@ -50,6 +44,8 @@ BoxLayout:
                     self.center_y - (self.w1 or 0) / 2,
                     self.w1 or 0, self.w1 or 0
                     ) if app.time else (0, 0, 0, 0)
+            Color:
+                rgba: 1, 1, 1, 1 - (self.w2 if app.loading else 100) / 100
             Line:
                 width: 4
                 ellipse:
@@ -58,6 +54,8 @@ BoxLayout:
                     self.center_y - (self.w2 or 0) / 2,
                     self.w2 or 0, self.w2 or 0
                     ) if app.time else (0, 0, 0, 0)
+            Color:
+                rgba: 1, 1, 1, 1 - (self.w3 if app.loading else 100) / 100
             Line:
                 width: 4
                 ellipse:
@@ -123,12 +121,6 @@ class MyApp(App):
         self.loading = False
 
 if __name__ == '__main__':
-    # ev = asyncio.get_event_loop()
-    # with aiohttp.ClientSession(loop=ev) as session:
-    #     print("session")
-    #     print(ev.run_until_complete(
-    #         DebugTask(fetch_page(session, 'http://www.sphinx-doc.org/en/stable/_sources/rest.txt'))
-    #     ))
     ev = KivyEventLoop(MyApp())
     ev.set_debug(True)
     ev.mainloop()

--- a/examples/asyncio/http_client.py
+++ b/examples/asyncio/http_client.py
@@ -106,13 +106,15 @@ class MyApp(App):
         self.time += deltatime * 10
 
     def load_page(self, url):
+        asyncio.ensure_future(self._load_page(url))
+
+    async def _load_page(self, url):
         self.loading = True
         print("load page")
         with aiohttp.ClientSession(loop=ev) as session:
             print("session")
             try:
-                content = ev.run_until_complete(
-                    DebugTask(fetch_page(session, url)))
+                content = await fetch_page(session, url)
             except asyncio.TimeoutError:
                 content = "timeout!"
 

--- a/examples/asyncio/http_client.py
+++ b/examples/asyncio/http_client.py
@@ -72,24 +72,14 @@ BoxLayout:
 
 async def fetch_page(session, url):
     print("fetch page")
-    with aiohttp.Timeout(10):
-        print("timeout context")
-        async with session.get(url) as response:
-            print("response")
-            if response.status == 200:
-                print("200")
-                return await response.read()
-            else:
-                print("error")
-                return 'error: {}'.format(response.status)
-    print("end timeout context")
-
-
-class DebugTask(asyncio.Task):
-    def _wakeup(self, future):
-        print("woke up", self)
-        super()._wakeup(future)
-        print("after wakeup", self)
+    resonse = await session.get(url)
+    print("response")
+    if response.status == 200:
+        print("200")
+        return await response.read()
+    else:
+        print("error")
+        return 'error: {}'.format(response.status)
 
 
 class MyApp(App):

--- a/examples/kivy_asyncio.py
+++ b/examples/kivy_asyncio.py
@@ -38,7 +38,6 @@ BoxLayout:
 def generate_text():
     '''XXX
     '''
-    print("called")
     sleep(1)
     return ''.join(sample(printable, 10))
 

--- a/examples/kivy_asyncio.py
+++ b/examples/kivy_asyncio.py
@@ -1,0 +1,68 @@
+from kivy.base import KivyEventLoop
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.properties import NumericProperty
+from kivy.clock import Clock
+from random import sample
+from string import printable
+from time import sleep
+import asyncio
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+KV = '''
+#:import cos math.cos
+#:import sin math.sin
+#:import asyncio asyncio
+
+BoxLayout:
+    Label:
+        id: label
+        text: 'test'
+        canvas.before:
+            Line:
+                width: 5
+                ellipse:
+                    (
+                    self.center_x - cos(app.time) * 100 - 30,
+                    self.center_y - sin(app.time) * 100 - 30,
+                    30, 30
+                    )
+
+    Button:
+        text: 'push me'
+        on_press:
+            app.do_slow_stuff()
+'''
+
+
+def generate_text():
+    print("called")
+    return ''.join(sample(printable, 10))
+
+
+class MyApp(App):
+    time = NumericProperty()
+
+    def build(self):
+        Clock.schedule_interval(self.update_time, 0)
+        return Builder.load_string(KV)
+
+    def do_slow_stuff(self):
+        ev.run_in_executor(None, self._do_slow_stuff)
+
+    def _do_slow_stuff(self):
+        label = self.root.ids.label
+        label.text = ''
+        for i in range(10):
+            sleep(.1)
+            label.text += generate_text()
+
+    def update_time(self, dt):
+        self.time += dt
+
+
+if __name__ == '__main__':
+    ev = KivyEventLoop(MyApp())
+    ev.set_debug(True)
+    ev.mainloop()

--- a/examples/kivy_asyncio.py
+++ b/examples/kivy_asyncio.py
@@ -13,7 +13,6 @@ logging.basicConfig(level=logging.DEBUG)
 KV = '''
 #:import cos math.cos
 #:import sin math.sin
-#:import asyncio asyncio
 
 BoxLayout:
     Label:
@@ -37,29 +36,34 @@ BoxLayout:
 
 
 def generate_text():
+    '''XXX
+    '''
     print("called")
+    sleep(1)
     return ''.join(sample(printable, 10))
 
 
 class MyApp(App):
+    '''XXX
+    '''
     time = NumericProperty()
 
     def build(self):
         Clock.schedule_interval(self.update_time, 0)
         return Builder.load_string(KV)
 
+    def _do_slow_stuff(self, *args):
+        lbl = self.root.ids.label
+        lbl.text = ''
+        for _ in range(10):
+            lbl.text += ev.run_until_complete(
+                ev.run_in_executor(None, generate_text))
+
     def do_slow_stuff(self):
-        ev.run_in_executor(None, self._do_slow_stuff)
+        self._do_slow_stuff()
 
-    def _do_slow_stuff(self):
-        label = self.root.ids.label
-        label.text = ''
-        for i in range(10):
-            sleep(.1)
-            label.text += generate_text()
-
-    def update_time(self, dt):
-        self.time += dt
+    def update_time(self, deltatime):
+        self.time += deltatime
 
 
 if __name__ == '__main__':

--- a/examples/kivy_asyncio.py
+++ b/examples/kivy_asyncio.py
@@ -51,15 +51,14 @@ class MyApp(App):
         Clock.schedule_interval(self.update_time, 0)
         return Builder.load_string(KV)
 
-    def _do_slow_stuff(self, *args):
+    async def _do_slow_stuff(self, *args):
         lbl = self.root.ids.label
         lbl.text = ''
         for _ in range(10):
-            lbl.text += ev.run_until_complete(
-                ev.run_in_executor(None, generate_text))
+            lbl.text += await ev.run_in_executor(None, generate_text)
 
     def do_slow_stuff(self):
-        self._do_slow_stuff()
+        asyncio.ensure_future(self._do_slow_stuff())
 
     def update_time(self, deltatime):
         self.time += deltatime

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -826,7 +826,7 @@ class App(EventDispatcher):
 
         self.dispatch('on_start')
         runTouchApp()
-        self.stop()
+        # self.stop()
 
     def stop(self, *largs):
         '''Stop the application.

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -30,6 +30,8 @@ from kivy.clock import Clock
 from kivy.event import EventDispatcher
 from kivy.lang import Builder
 from kivy.context import register_context
+from asyncio import set_event_loop
+from kivy.guievents import GuiEventLoop
 
 # private vars
 EventLoop = None
@@ -497,3 +499,47 @@ def stopTouchApp():
         return
     Logger.info('Base: Leaving application in progress...')
     EventLoop.close()
+
+
+class KivyEventLoop(GuiEventLoop):
+    _default_executor = None
+
+    def __init__(self, app):
+        super().__init__()
+        self.app = app
+
+    def mainloop(self):
+        set_event_loop(self)
+        try:
+            self.run_forever()
+        finally:
+            set_event_loop(None)
+
+    def run(self):
+        self.app.run()
+
+    def run_forever(self):
+        self.run()
+
+    def run_once(self, timeout=None):
+        EventLoop.tick()
+
+    def stop(self):
+        super().stop()
+        self.app.stop()
+
+    def call_later(self, delay, callback, *args):
+        res = Clock.schedule_once(
+            lambda *args: callback(*args),
+            delay * 1000)
+
+        return _CancelJob(self, res)
+
+
+class _CancelJob(object):
+    def __init__(self, event_loop, after_id):
+        self.event_loop = event_loop
+        self.after_id = after_id
+
+    def cancel(self):
+        Clock.unschedule(self.after_id)

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -501,7 +501,7 @@ def stopTouchApp():
     if EventLoop.status != 'started':
         return
     Logger.info('Base: Leaving application in progress...')
-    EventLoop.close()
+    # EventLoop.close()
 
 
 
@@ -537,7 +537,8 @@ if not PY2:
         def run(self):
             while not EventLoop.quit:
                 self.run_once()
-            # stopTouchApp()
+
+            self.close()
 
         def run_forever(self):
             self.run()

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -526,7 +526,10 @@ if not PY2:
             self.run()
 
         def run_once(self, timeout=None):
-            EventLoop.idle()
+            if EventLoop.window and hasattr(EventLoop.window, '_mainloop'):
+                EventLoop.window._mainloop()
+            else:
+                EventLoop.idle()
 
         def stop(self):
             super().stop()
@@ -536,7 +539,6 @@ if not PY2:
             res = Clock.schedule_once(
                 lambda *_: callback(*args),
                 delay * 1000)
-            print("{} scheduled".format(res))
 
             return _CancelJob(self, res)
 

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -526,7 +526,7 @@ if not PY2:
             self.run()
 
         def run_once(self, timeout=None):
-            EventLoop.tick()
+            EventLoop.idle()
 
         def stop(self):
             super().stop()
@@ -534,8 +534,9 @@ if not PY2:
 
         def call_later(self, delay, callback, *args):
             res = Clock.schedule_once(
-                lambda *args: callback(*args),
+                lambda *_: callback(*args),
                 delay * 1000)
+            print("{} scheduled".format(res))
 
             return _CancelJob(self, res)
 

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -1,0 +1,247 @@
+from asyncio.events import AbstractEventLoop
+from asyncio.base_events import BaseEventLoop
+from asyncio import events
+import asyncio
+import concurrent
+import threading
+from asyncio import futures
+
+_MAX_WORKERS = 10
+
+
+class GuiEventLoop(BaseEventLoop):
+    # Methods returning Futures for interacting with threads.
+    def __init__(self):
+        super().__init__()
+        self._start_io_event_loop()
+
+    def _start_io_event_loop(self):
+        """Starts the I/O event loop which we defer to for doing I/O
+        running on another thread
+        """
+        self._event_loop_started = threading.Lock()
+        self._event_loop_started.acquire()
+        threading.Thread(None, self._io_event_loop_thread, daemon=True).start()
+        self._event_loop_started.acquire()
+
+    def _io_event_loop_thread(self):
+        """Worker thread for running the I/O event loop"""
+        io_event_loop = asyncio.get_event_loop_policy().new_event_loop()
+        asyncio.set_event_loop(io_event_loop)
+        assert isinstance(io_event_loop, AbstractEventLoop)
+        self._io_event_loop = io_event_loop
+        self._event_loop_started.release()
+        self._io_event_loop.run_forever()
+
+    def stop(self):
+        self._io_event_loop.stop()
+
+    def wrap_future(self, future):
+        """XXX"""
+        if isinstance(future, futures.Future):
+            return future  # Don't wrap our own type of Future.
+        new_future = futures.Future()
+        future.add_done_callback(
+            lambda future:
+                self.call_soon_threadsafe(new_future._copy_state, future))
+        return new_future
+
+    def run_until_complete(self, future, timeout=None):  # NEW!
+        """Run the event loop until a Future is done.
+
+        Return the Future's result, or raise its exception.
+
+        If timeout is not None, run it for at most that long;
+        if the Future is still not done, raise TimeoutError
+        (but don't cancel the Future).
+        """
+        assert isinstance(future, Future)
+
+        signal = threading.Condition()
+        if timeout is None:
+            while not future.done():
+                self.run_once()
+        else:
+            raise Exception('Not implemented: timeouts until complete')
+
+        return future.result()
+
+    def call_repeatedly(self, interval, callback, *args):  # NEW!
+        return _CancelJobRepeatedly(self, interval, callback, args)
+
+    def call_soon(self, callback, *args):
+        return self.call_later(0, callback, *args)
+
+    def call_soon_threadsafe(self, callback, *args):
+        return self.call_soon(callback, *args)
+
+    def run_in_executor(self, executor, callback, *args):
+        if isinstance(callback, asyncio.Handle):
+            assert not args
+            assert not isinstance(callback, asyncio.TimerHandle)
+            if callback.cancelled:
+                f = futures.Future()
+                f.set_result(None)
+                return f
+            callback, args = callback.callback, callback.args
+        if executor is None:
+            executor = self._default_executor
+            if executor is None:
+                executor = concurrent.futures.ThreadPoolExecutor(_MAX_WORKERS)
+                self._default_executor = executor
+        return self.wrap_future(executor.submit(callback, *args))
+
+    def _io_helper(self, target, args, kwargs):
+        lock = threading.Lock()
+        lock.acquire()
+        res = None
+
+        def helper_target():
+            # nonlocal res
+            res = target(*args, **kwargs)
+            lock.release()
+
+        handler = self._io_event_loop.call_soon_threadsafe(helper_target)
+        lock.acquire()
+        return res
+
+    # Network I/O methods returning Futures.
+    def getaddrinfo(
+        self, host, port, *, family=0, type=0, proto=0, flags=0
+    ):
+        return self._io_helper(
+            self._io_event_loop.getaddrinfo,
+            (host, port),
+            {
+                'family': family,
+                'type': type,
+                'proto': proto,
+                'flags': flags
+            }
+        )
+
+    def getnameinfo(self, sockaddr, flags=0):
+        return self._io_helper(
+            self._io_event_loop.getnameinfo,
+            (sockaddr, flags),
+            {}
+        )
+
+    def create_connection(self, protocol_factory, host=None, port=None, *,
+                          family=0, proto=0, flags=0, sock=None):
+        return self._io_helper(
+            self._io_event_loop.create_connection,
+            (protocol_factory, host, port),
+            {
+                'family': family,
+                'proto': proto,
+                'flags': flags,
+                'sock': sock
+            }
+        )
+
+    def start_serving(self, protocol_factory, host=None, port=None, *,
+                      family=0, proto=0, flags=0, sock=None):
+        return self._io_helper(
+            self._io_event_loop.start_serving,
+            (protocol_factory, host, port),
+            {
+                'family': family,
+                'proto': proto,
+                'flags': flags,
+                'sock': sock
+            }
+        )
+
+    # Ready-based callback registration methods.
+    # The add_*() methods return a Handler.
+    # The remove_*() methods return True if something was removed,
+    # False if there was nothing to delete.
+
+    def _handler_helper(self, target, *args):
+        lock = threading.Lock()
+        lock.acquire()
+        handler = None
+
+        def helper_target():
+            nonlocal handler
+            handler = target(*args)
+            lock.release()
+
+        self._io_event_loop.call_soon_threadsafe(helper_target)
+        lock.acquire()
+        return handler
+
+    def add_reader(self, fd, callback, *args):
+        return _ready_helper(
+            self._io_event_loop.add_reader, fd, callback, *args)
+
+    def remove_reader(self, fd):
+        return _ready_helper(self._io_event_loop.remove_reader, fd)
+
+    def add_writer(self, fd, callback, *args):
+        return _ready_helper(
+            self._io_event_loop.add_writer, fd, callback, *args)
+
+    def remove_writer(self, fd):
+        return _ready_helper(self._io_event_loop.remove_writer, fd)
+
+    # Completion based I/O methods returning Futures.
+
+    def sock_recv(self, sock, nbytes):
+        return self._io_helper(
+            self._io_event_loop.sock_recv,
+            (sock, nbytes),
+            {}
+        )
+
+    def sock_sendall(self, sock, data):
+        return self._io_helper(
+            self._io_event_loop.sock_sendall,
+            (sock, data),
+            {}
+        )
+
+    def sock_connect(self, sock, address):
+        return self._io_helper(
+            self._io_event_loop.sock_connect,
+            (sock, address),
+            {}
+        )
+        # return self.run_in_executor(None, sock.connect, address)
+
+    def sock_accept(self, sock):
+        return self._io_helper(
+            self._io_event_loop.sock_accept,
+            (sock, ),
+            {}
+        )
+
+    # Signal handling.
+
+    def add_signal_handler(self, sig, callback, *args):
+        return self._handler_helper(
+            self.add_signal_handler, sig, callback, *args)
+
+    def remove_signal_handler(self, sig):
+        return self._handler_helper(self.remove_signal_handler, sig)
+
+
+class _CancelJobRepeatedly(object):
+    """Object that allows cancelling of a call_repeatedly"""
+    def __init__(self, event_loop, delay, callback, args):
+        self.event_loop = event_loop
+        self.delay = delay
+        self.callback = callback
+        self.args = args
+        self.post()
+
+    def invoke(self):
+        self.callback(*self.args)
+        self.post()
+
+    def post(self):
+        self.canceler = self.event_loop.call_later(self.delay, self.invoke)
+
+    def cancel(self):
+        self.canceler.cancel()

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -1,6 +1,6 @@
 from asyncio.events import AbstractEventLoop
 from asyncio.base_events import BaseEventLoop
-from asyncio import events
+from asyncio import events, SelectorEventLoop
 import asyncio
 import concurrent
 import threading
@@ -9,32 +9,12 @@ from asyncio import futures
 _MAX_WORKERS = 10
 
 
-class GuiEventLoop(BaseEventLoop):
+class GuiEventLoop(SelectorEventLoop):
     # Methods returning Futures for interacting with threads.
-    def __init__(self):
-        super().__init__()
-        self._start_io_event_loop()
-
-    def _start_io_event_loop(self):
-        """Starts the I/O event loop which we defer to for doing I/O
-        running on another thread
-        """
-        self._event_loop_started = threading.Lock()
-        self._event_loop_started.acquire()
-        threading.Thread(None, self._io_event_loop_thread, daemon=True).start()
-        self._event_loop_started.acquire()
-
-    def _io_event_loop_thread(self):
-        """Worker thread for running the I/O event loop"""
-        io_event_loop = asyncio.get_event_loop_policy().new_event_loop()
-        asyncio.set_event_loop(io_event_loop)
-        assert isinstance(io_event_loop, AbstractEventLoop)
-        self._io_event_loop = io_event_loop
-        self._event_loop_started.release()
-        self._io_event_loop.run_forever()
 
     def stop(self):
-        self._io_event_loop.stop()
+        # self._io_event_loop.stop()
+        pass
 
     def wrap_future(self, future):
         """XXX"""
@@ -56,9 +36,10 @@ class GuiEventLoop(BaseEventLoop):
         if the Future is still not done, raise TimeoutError
         (but don't cancel the Future).
         """
+        print("run_until_complete called")
         assert isinstance(future, futures.Future)
 
-        signal = threading.Condition()
+        # signal = threading.Condition()
         if timeout is None:
             while not future.done():
                 self.run_once()
@@ -91,123 +72,6 @@ class GuiEventLoop(BaseEventLoop):
                 executor = concurrent.futures.ThreadPoolExecutor(_MAX_WORKERS)
                 self._default_executor = executor
         return self.wrap_future(executor.submit(callback, *args))
-
-    def _io_helper(self, target, args, kwargs):
-        lock = threading.Lock()
-        lock.acquire()
-        res = None
-
-        def helper_target():
-            nonlocal res
-            res = target(*args, **kwargs)
-            lock.release()
-
-        handler = self._io_event_loop.call_soon_threadsafe(helper_target)
-        lock.acquire()
-        return res
-
-    # Network I/O methods returning Futures.
-    def getaddrinfo(*args, **kwargs):
-        return self._io_helper(
-            self._io_event_loop.getaddrinfo, args, kwargs)
-
-    def getnameinfo(self, sockaddr, flags=0):
-        return self._io_helper(
-            self._io_event_loop.getnameinfo,
-            (sockaddr, flags),
-            {}
-        )
-
-    def create_connection(self, *args, **kwargs):
-        return self._io_helper(
-            self._io_event_loop.create_connection,
-            args, kwargs)
-
-    def start_serving(self, protocol_factory, host=None, port=None, *,
-                      family=0, proto=0, flags=0, sock=None):
-        return self._io_helper(
-            self._io_event_loop.start_serving,
-            (protocol_factory, host, port),
-            {
-                'family': family,
-                'proto': proto,
-                'flags': flags,
-                'sock': sock
-            }
-        )
-
-    # Ready-based callback registration methods.
-    # The add_*() methods return a Handler.
-    # The remove_*() methods return True if something was removed,
-    # False if there was nothing to delete.
-
-    def _handler_helper(self, target, *args):
-        lock = threading.Lock()
-        lock.acquire()
-        handler = None
-
-        def helper_target():
-            nonlocal handler
-            handler = target(*args)
-            lock.release()
-
-        self._io_event_loop.call_soon_threadsafe(helper_target)
-        lock.acquire()
-        return handler
-
-    def add_reader(self, *args):
-        return _ready_helper(
-            self._io_event_loop.add_reader, *args)
-
-    def remove_reader(self, *args):
-        return _ready_helper(self._io_event_loop.remove_reader, *args)
-
-    def add_writer(self, *args):
-        return _ready_helper(
-            self._io_event_loop.add_writer, *args)
-
-    def remove_writer(self, fd):
-        return _ready_helper(self._io_event_loop.remove_writer, fd)
-
-    # Completion based I/O methods returning Futures.
-
-    def sock_recv(self, sock, nbytes):
-        return self._io_helper(
-            self._io_event_loop.sock_recv,
-            (sock, nbytes),
-            {}
-        )
-
-    def sock_sendall(self, sock, data):
-        return self._io_helper(
-            self._io_event_loop.sock_sendall,
-            (sock, data),
-            {}
-        )
-
-    def sock_connect(self, sock, address):
-        return self._io_helper(
-            self._io_event_loop.sock_connect,
-            (sock, address),
-            {}
-        )
-        # return self.run_in_executor(None, sock.connect, address)
-
-    def sock_accept(self, sock):
-        return self._io_helper(
-            self._io_event_loop.sock_accept,
-            (sock, ),
-            {}
-        )
-
-    # Signal handling.
-
-    def add_signal_handler(self, sig, callback, *args):
-        return self._handler_helper(
-            self.add_signal_handler, sig, callback, *args)
-
-    def remove_signal_handler(self, sig):
-        return self._handler_helper(self.remove_signal_handler, sig)
 
 
 class _CancelJobRepeatedly(object):

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -118,18 +118,10 @@ class GuiEventLoop(BaseEventLoop):
             {}
         )
 
-    def create_connection(self, protocol_factory, host=None, port=None, *,
-                          family=0, proto=0, flags=0, sock=None):
+    def create_connection(self, *args, **kwargs):
         return self._io_helper(
             self._io_event_loop.create_connection,
-            (protocol_factory, host, port),
-            {
-                'family': family,
-                'proto': proto,
-                'flags': flags,
-                'sock': sock
-            }
-        )
+            args, kwargs)
 
     def start_serving(self, protocol_factory, host=None, port=None, *,
                       family=0, proto=0, flags=0, sock=None):
@@ -163,16 +155,16 @@ class GuiEventLoop(BaseEventLoop):
         lock.acquire()
         return handler
 
-    def add_reader(self, fd, callback, *args):
+    def add_reader(self, *args):
         return _ready_helper(
-            self._io_event_loop.add_reader, fd, callback, *args)
+            self._io_event_loop.add_reader, *args)
 
-    def remove_reader(self, fd):
-        return _ready_helper(self._io_event_loop.remove_reader, fd)
+    def remove_reader(self, *args):
+        return _ready_helper(self._io_event_loop.remove_reader, *args)
 
-    def add_writer(self, fd, callback, *args):
+    def add_writer(self, *args):
         return _ready_helper(
-            self._io_event_loop.add_writer, fd, callback, *args)
+            self._io_event_loop.add_writer, *args)
 
     def remove_writer(self, fd):
         return _ready_helper(self._io_event_loop.remove_writer, fd)

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -98,7 +98,7 @@ class GuiEventLoop(BaseEventLoop):
         res = None
 
         def helper_target():
-            # nonlocal res
+            nonlocal res
             res = target(*args, **kwargs)
             lock.release()
 
@@ -107,19 +107,9 @@ class GuiEventLoop(BaseEventLoop):
         return res
 
     # Network I/O methods returning Futures.
-    def getaddrinfo(
-        self, host, port, *, family=0, type=0, proto=0, flags=0
-    ):
+    def getaddrinfo(*args, **kwargs):
         return self._io_helper(
-            self._io_event_loop.getaddrinfo,
-            (host, port),
-            {
-                'family': family,
-                'type': type,
-                'proto': proto,
-                'flags': flags
-            }
-        )
+            self._io_event_loop.getaddrinfo, args, kwargs)
 
     def getnameinfo(self, sockaddr, flags=0):
         return self._io_helper(

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -1,94 +1,10 @@
-from asyncio.events import AbstractEventLoop
-from asyncio.base_events import BaseEventLoop
-from asyncio import events, SelectorEventLoop
-import asyncio
-import concurrent
-import threading
-from asyncio import futures
-
-_MAX_WORKERS = 10
+from asyncio import SelectorEventLoop
 
 
 class GuiEventLoop(SelectorEventLoop):
-    # Methods returning Futures for interacting with threads.
-
-    def stop(self):
-        # self._io_event_loop.stop()
-        pass
-
-    # def wrap_future(self, future):
-    #     """XXX"""
-    #     if isinstance(future, futures.Future):
-    #         return future  # Don't wrap our own type of Future.
-    #     new_future = futures.Future()
-    #     future.add_done_callback(
-    #         lambda future:
-    #             self.call_soon_threadsafe(
-    #                 futures._copy_future_state, future, new_future))
-    #     return new_future
-
-    # def run_until_complete(self, future, timeout=None):  # NEW!
-    #     """Run the event loop until a Future is done.
-
-    #     Return the Future's result, or raise its exception.
-
-    #     If timeout is not None, run it for at most that long;
-    #     if the Future is still not done, raise TimeoutError
-    #     (but don't cancel the Future).
-    #     """
-    #     print("run_until_complete called")
-    #     assert isinstance(future, futures.Future)
-
-    #     # signal = threading.Condition()
-    #     if timeout is None:
-    #         while not future.done():
-    #             self.run_once()
-    #     else:
-    #         raise Exception('Not implemented: timeouts until complete')
-
-    #     return future.result()
-
-    def call_repeatedly(self, interval, callback, *args):  # NEW!
-        return _CancelJobRepeatedly(self, interval, callback, args)
 
     def call_soon(self, callback, *args):
         return self.call_later(0, callback, *args)
 
     def call_soon_threadsafe(self, callback, *args):
         return self.call_soon(callback, *args)
-
-    # def run_in_executor(self, executor, callback, *args):
-    #     if isinstance(callback, asyncio.Handle):
-    #         assert not args
-    #         assert not isinstance(callback, asyncio.TimerHandle)
-    #         if callback.cancelled:
-    #             f = futures.Future()
-    #             f.set_result(None)
-    #             return f
-    #         callback, args = callback.callback, callback.args
-    #     if executor is None:
-    #         executor = self._default_executor
-    #         if executor is None:
-    #             executor = concurrent.futures.ThreadPoolExecutor(_MAX_WORKERS)
-    #             self._default_executor = executor
-    #     return self.wrap_future(executor.submit(callback, *args))
-
-
-class _CancelJobRepeatedly(object):
-    """Object that allows cancelling of a call_repeatedly"""
-    def __init__(self, event_loop, delay, callback, args):
-        self.event_loop = event_loop
-        self.delay = delay
-        self.callback = callback
-        self.args = args
-        self.post()
-
-    def invoke(self):
-        self.callback(*self.args)
-        self.post()
-
-    def post(self):
-        self.canceler = self.event_loop.call_later(self.delay, self.invoke)
-
-    def cancel(self):
-        self.canceler.cancel()

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -43,7 +43,8 @@ class GuiEventLoop(BaseEventLoop):
         new_future = futures.Future()
         future.add_done_callback(
             lambda future:
-                self.call_soon_threadsafe(_copy_state, new_future, future))
+                self.call_soon_threadsafe(
+                    futures._copy_future_state, future, new_future))
         return new_future
 
     def run_until_complete(self, future, timeout=None):  # NEW!
@@ -245,25 +246,3 @@ class _CancelJobRepeatedly(object):
 
     def cancel(self):
         self.canceler.cancel()
-
-
-def _copy_state(one, other):
-    """Internal helper to copy state from another Future.
-    The other Future may be a concurrent.futures.Future.
-    """
-    assert other.done()
-    if one.cancelled():
-        return
-
-    assert not one.done()
-    if other.cancelled():
-        one.cancel()
-
-    else:
-        exception = other.exception()
-        if exception is not None:
-            one.set_exception(exception)
-
-        else:
-            result = other.result()
-            one.set_result(result)

--- a/kivy/guievents.py
+++ b/kivy/guievents.py
@@ -16,37 +16,37 @@ class GuiEventLoop(SelectorEventLoop):
         # self._io_event_loop.stop()
         pass
 
-    def wrap_future(self, future):
-        """XXX"""
-        if isinstance(future, futures.Future):
-            return future  # Don't wrap our own type of Future.
-        new_future = futures.Future()
-        future.add_done_callback(
-            lambda future:
-                self.call_soon_threadsafe(
-                    futures._copy_future_state, future, new_future))
-        return new_future
+    # def wrap_future(self, future):
+    #     """XXX"""
+    #     if isinstance(future, futures.Future):
+    #         return future  # Don't wrap our own type of Future.
+    #     new_future = futures.Future()
+    #     future.add_done_callback(
+    #         lambda future:
+    #             self.call_soon_threadsafe(
+    #                 futures._copy_future_state, future, new_future))
+    #     return new_future
 
-    def run_until_complete(self, future, timeout=None):  # NEW!
-        """Run the event loop until a Future is done.
+    # def run_until_complete(self, future, timeout=None):  # NEW!
+    #     """Run the event loop until a Future is done.
 
-        Return the Future's result, or raise its exception.
+    #     Return the Future's result, or raise its exception.
 
-        If timeout is not None, run it for at most that long;
-        if the Future is still not done, raise TimeoutError
-        (but don't cancel the Future).
-        """
-        print("run_until_complete called")
-        assert isinstance(future, futures.Future)
+    #     If timeout is not None, run it for at most that long;
+    #     if the Future is still not done, raise TimeoutError
+    #     (but don't cancel the Future).
+    #     """
+    #     print("run_until_complete called")
+    #     assert isinstance(future, futures.Future)
 
-        # signal = threading.Condition()
-        if timeout is None:
-            while not future.done():
-                self.run_once()
-        else:
-            raise Exception('Not implemented: timeouts until complete')
+    #     # signal = threading.Condition()
+    #     if timeout is None:
+    #         while not future.done():
+    #             self.run_once()
+    #     else:
+    #         raise Exception('Not implemented: timeouts until complete')
 
-        return future.result()
+    #     return future.result()
 
     def call_repeatedly(self, interval, callback, *args):  # NEW!
         return _CancelJobRepeatedly(self, interval, callback, args)
@@ -57,21 +57,21 @@ class GuiEventLoop(SelectorEventLoop):
     def call_soon_threadsafe(self, callback, *args):
         return self.call_soon(callback, *args)
 
-    def run_in_executor(self, executor, callback, *args):
-        if isinstance(callback, asyncio.Handle):
-            assert not args
-            assert not isinstance(callback, asyncio.TimerHandle)
-            if callback.cancelled:
-                f = futures.Future()
-                f.set_result(None)
-                return f
-            callback, args = callback.callback, callback.args
-        if executor is None:
-            executor = self._default_executor
-            if executor is None:
-                executor = concurrent.futures.ThreadPoolExecutor(_MAX_WORKERS)
-                self._default_executor = executor
-        return self.wrap_future(executor.submit(callback, *args))
+    # def run_in_executor(self, executor, callback, *args):
+    #     if isinstance(callback, asyncio.Handle):
+    #         assert not args
+    #         assert not isinstance(callback, asyncio.TimerHandle)
+    #         if callback.cancelled:
+    #             f = futures.Future()
+    #             f.set_result(None)
+    #             return f
+    #         callback, args = callback.callback, callback.args
+    #     if executor is None:
+    #         executor = self._default_executor
+    #         if executor is None:
+    #             executor = concurrent.futures.ThreadPoolExecutor(_MAX_WORKERS)
+    #             self._default_executor = executor
+    #     return self.wrap_future(executor.submit(callback, *args))
 
 
 class _CancelJobRepeatedly(object):

--- a/test_unix_events.py
+++ b/test_unix_events.py
@@ -1,0 +1,1572 @@
+"""Tests for unix_events.py."""
+import q
+
+import collections
+import errno
+import io
+import os
+import signal
+import socket
+import stat
+import sys
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+if sys.platform == 'win32':
+    raise unittest.SkipTest('UNIX only')
+
+
+import asyncio
+from asyncio import log
+from asyncio import test_utils
+from asyncio import unix_events
+
+from kivy.base import KivyEventLoop
+# from kivy.guievents import GuiEventLoop as KivyEventLoop
+
+MOCK_ANY = mock.ANY
+
+
+def close_pipe_transport(transport):
+    # Don't call transport.close() because the event loop and the selector
+    # are mocked
+    if transport._pipe is None:
+        return
+    transport._pipe.close()
+    transport._pipe = None
+
+
+@unittest.skipUnless(signal, 'Signals are not supported')
+class KivyEventLoopSignalTests(test_utils.TestCase):
+
+    def setUp(self):
+        self.loop = KivyEventLoop()
+        self.loop.set_debug(True)
+        q("event loop:", self.loop, id(self.loop))
+        self.set_event_loop(self.loop)
+
+    def test_check_signal(self):
+        self.assertRaises(
+            TypeError, self.loop._check_signal, '1')
+        self.assertRaises(
+            ValueError, self.loop._check_signal, signal.NSIG + 1)
+
+    def test_handle_signal_no_handler(self):
+        self.loop._handle_signal(signal.NSIG + 1)
+
+    def test_handle_signal_cancelled_handler(self):
+        h = asyncio.Handle(mock.Mock(), (),
+                           loop=mock.Mock())
+        h.cancel()
+        self.loop._signal_handlers[signal.NSIG + 1] = h
+        self.loop.remove_signal_handler = mock.Mock()
+        self.loop._handle_signal(signal.NSIG + 1)
+        self.loop.remove_signal_handler.assert_called_with(signal.NSIG + 1)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_add_signal_handler_setup_error(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+        m_signal.set_wakeup_fd.side_effect = ValueError
+
+        self.assertRaises(
+            RuntimeError,
+            self.loop.add_signal_handler,
+            signal.SIGINT, lambda: True)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_add_signal_handler_coroutine_error(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+
+        @asyncio.coroutine
+        def simple_coroutine():
+            yield from []
+
+        # callback must not be a coroutine function
+        coro_func = simple_coroutine
+        coro_obj = coro_func()
+        # import pudb; pudb.set_trace()
+        # self.addCleanup(coro_obj.close)
+        for func in (coro_func, coro_obj):
+            self.assertRaisesRegex(
+                TypeError, 'coroutines cannot be used with add_signal_handler',
+                self.loop.add_signal_handler,
+                signal.SIGINT, func)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_add_signal_handler(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+
+        cb = lambda: True
+        self.loop.add_signal_handler(signal.SIGHUP, cb)
+        h = self.loop._signal_handlers.get(signal.SIGHUP)
+        self.assertIsInstance(h, asyncio.Handle)
+        self.assertEqual(h._callback, cb)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_add_signal_handler_install_error(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+
+        def set_wakeup_fd(fd):
+            if fd == -1:
+                raise ValueError()
+        m_signal.set_wakeup_fd = set_wakeup_fd
+
+        class Err(OSError):
+            errno = errno.EFAULT
+        m_signal.signal.side_effect = Err
+
+        self.assertRaises(
+            Err,
+            self.loop.add_signal_handler,
+            signal.SIGINT, lambda: True)
+
+    @mock.patch('asyncio.unix_events.signal')
+    @mock.patch('asyncio.base_events.logger')
+    def test_add_signal_handler_install_error2(self, m_logging, m_signal):
+        m_signal.NSIG = signal.NSIG
+
+        class Err(OSError):
+            errno = errno.EINVAL
+        m_signal.signal.side_effect = Err
+
+        self.loop._signal_handlers[signal.SIGHUP] = lambda: True
+        self.assertRaises(
+            RuntimeError,
+            self.loop.add_signal_handler,
+            signal.SIGINT, lambda: True)
+        self.assertFalse(m_logging.info.called)
+        self.assertEqual(1, m_signal.set_wakeup_fd.call_count)
+
+    @mock.patch('asyncio.unix_events.signal')
+    @mock.patch('asyncio.base_events.logger')
+    def test_add_signal_handler_install_error3(self, m_logging, m_signal):
+        class Err(OSError):
+            errno = errno.EINVAL
+        m_signal.signal.side_effect = Err
+        m_signal.NSIG = signal.NSIG
+
+        self.assertRaises(
+            RuntimeError,
+            self.loop.add_signal_handler,
+            signal.SIGINT, lambda: True)
+        self.assertFalse(m_logging.info.called)
+        self.assertEqual(2, m_signal.set_wakeup_fd.call_count)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_remove_signal_handler(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+
+        self.loop.add_signal_handler(signal.SIGHUP, lambda: True)
+
+        self.assertTrue(
+            self.loop.remove_signal_handler(signal.SIGHUP))
+        self.assertTrue(m_signal.set_wakeup_fd.called)
+        self.assertTrue(m_signal.signal.called)
+        self.assertEqual(
+            (signal.SIGHUP, m_signal.SIG_DFL), m_signal.signal.call_args[0])
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_remove_signal_handler_2(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+        m_signal.SIGINT = signal.SIGINT
+
+        self.loop.add_signal_handler(signal.SIGINT, lambda: True)
+        self.loop._signal_handlers[signal.SIGHUP] = object()
+        m_signal.set_wakeup_fd.reset_mock()
+
+        self.assertTrue(
+            self.loop.remove_signal_handler(signal.SIGINT))
+        self.assertFalse(m_signal.set_wakeup_fd.called)
+        self.assertTrue(m_signal.signal.called)
+        self.assertEqual(
+            (signal.SIGINT, m_signal.default_int_handler),
+            m_signal.signal.call_args[0])
+
+    @mock.patch('asyncio.unix_events.signal')
+    @mock.patch('asyncio.base_events.logger')
+    def test_remove_signal_handler_cleanup_error(self, m_logging, m_signal):
+        m_signal.NSIG = signal.NSIG
+        self.loop.add_signal_handler(signal.SIGHUP, lambda: True)
+
+        m_signal.set_wakeup_fd.side_effect = ValueError
+
+        self.loop.remove_signal_handler(signal.SIGHUP)
+        self.assertTrue(m_logging.info)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_remove_signal_handler_error(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+        self.loop.add_signal_handler(signal.SIGHUP, lambda: True)
+
+        m_signal.signal.side_effect = OSError
+
+        self.assertRaises(
+            OSError, self.loop.remove_signal_handler, signal.SIGHUP)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_remove_signal_handler_error2(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+        self.loop.add_signal_handler(signal.SIGHUP, lambda: True)
+
+        class Err(OSError):
+            errno = errno.EINVAL
+        m_signal.signal.side_effect = Err
+
+        self.assertRaises(
+            RuntimeError, self.loop.remove_signal_handler, signal.SIGHUP)
+
+    @mock.patch('asyncio.unix_events.signal')
+    def test_close(self, m_signal):
+        m_signal.NSIG = signal.NSIG
+
+        self.loop.add_signal_handler(signal.SIGHUP, lambda: True)
+        self.loop.add_signal_handler(signal.SIGCHLD, lambda: True)
+
+        self.assertEqual(len(self.loop._signal_handlers), 2)
+
+        m_signal.set_wakeup_fd.reset_mock()
+
+        self.loop.close()
+
+        self.assertEqual(len(self.loop._signal_handlers), 0)
+        m_signal.set_wakeup_fd.assert_called_once_with(-1)
+
+
+@unittest.skipUnless(hasattr(socket, 'AF_UNIX'),
+                     'UNIX Sockets are not supported')
+class KivyEventLoopUnixSocketTests(test_utils.TestCase):
+
+    def setUp(self):
+        self.loop = KivyEventLoop()
+        self.loop.set_debug(True)
+        q("event loop:", self.loop, id(self.loop))
+        self.set_event_loop(self.loop)
+
+    def test_create_unix_server_existing_path_sock(self):
+        with test_utils.unix_socket_path() as path:
+            sock = socket.socket(socket.AF_UNIX)
+            sock.bind(path)
+            with sock:
+                coro = self.loop.create_unix_server(lambda: None, path)
+                with self.assertRaisesRegex(OSError,
+                                            'Address.*is already in use'):
+                    self.loop.run_until_complete(coro)
+
+    def test_create_unix_server_existing_path_nonsock(self):
+        with tempfile.NamedTemporaryFile() as file:
+            coro = self.loop.create_unix_server(lambda: None, file.name)
+            with self.assertRaisesRegex(OSError,
+                                        'Address.*is already in use'):
+                self.loop.run_until_complete(coro)
+
+    def test_create_unix_server_ssl_bool(self):
+        coro = self.loop.create_unix_server(lambda: None, path='spam',
+                                            ssl=True)
+        with self.assertRaisesRegex(TypeError,
+                                    'ssl argument must be an SSLContext'):
+            self.loop.run_until_complete(coro)
+
+    def test_create_unix_server_nopath_nosock(self):
+        coro = self.loop.create_unix_server(lambda: None, path=None)
+        with self.assertRaisesRegex(ValueError,
+                                    'path was not specified, and no sock'):
+            self.loop.run_until_complete(coro)
+
+    def test_create_unix_server_path_inetsock(self):
+        sock = socket.socket()
+        with sock:
+            coro = self.loop.create_unix_server(lambda: None, path=None,
+                                                sock=sock)
+            with self.assertRaisesRegex(ValueError,
+                                        'A UNIX Domain Socket was expected'):
+                self.loop.run_until_complete(coro)
+
+    @mock.patch('asyncio.unix_events.socket')
+    def test_create_unix_server_bind_error(self, m_socket):
+        # Ensure that the socket is closed on any bind error
+        sock = mock.Mock()
+        m_socket.socket.return_value = sock
+
+        sock.bind.side_effect = OSError
+        coro = self.loop.create_unix_server(lambda: None, path="/test")
+        with self.assertRaises(OSError):
+            self.loop.run_until_complete(coro)
+        self.assertTrue(sock.close.called)
+
+        sock.bind.side_effect = MemoryError
+        coro = self.loop.create_unix_server(lambda: None, path="/test")
+        with self.assertRaises(MemoryError):
+            self.loop.run_until_complete(coro)
+        self.assertTrue(sock.close.called)
+
+    def test_create_unix_connection_path_sock(self):
+        coro = self.loop.create_unix_connection(
+            lambda: None, os.devnull, sock=object())
+        with self.assertRaisesRegex(ValueError, 'path and sock can not be'):
+            self.loop.run_until_complete(coro)
+
+    def test_create_unix_connection_nopath_nosock(self):
+        coro = self.loop.create_unix_connection(
+            lambda: None, None)
+        with self.assertRaisesRegex(ValueError,
+                                    'no path and sock were specified'):
+            self.loop.run_until_complete(coro)
+
+    def test_create_unix_connection_nossl_serverhost(self):
+        coro = self.loop.create_unix_connection(
+            lambda: None, os.devnull, server_hostname='spam')
+        with self.assertRaisesRegex(ValueError,
+                                    'server_hostname is only meaningful'):
+            self.loop.run_until_complete(coro)
+
+    def test_create_unix_connection_ssl_noserverhost(self):
+        coro = self.loop.create_unix_connection(
+            lambda: None, os.devnull, ssl=True)
+
+        with self.assertRaisesRegex(
+            ValueError, 'you have to pass server_hostname when using ssl'):
+
+            self.loop.run_until_complete(coro)
+
+
+class UnixReadPipeTransportTests(test_utils.TestCase):
+
+    def setUp(self):
+        self.loop = self.new_test_loop()
+        self.protocol = test_utils.make_test_protocol(asyncio.Protocol)
+        self.pipe = mock.Mock(spec_set=io.RawIOBase)
+        self.pipe.fileno.return_value = 5
+
+        blocking_patcher = mock.patch('asyncio.unix_events._set_nonblocking')
+        blocking_patcher.start()
+        self.addCleanup(blocking_patcher.stop)
+
+        fstat_patcher = mock.patch('os.fstat')
+        m_fstat = fstat_patcher.start()
+        st = mock.Mock()
+        st.st_mode = stat.S_IFIFO
+        m_fstat.return_value = st
+        self.addCleanup(fstat_patcher.stop)
+
+    def read_pipe_transport(self, waiter=None):
+        transport = unix_events._UnixReadPipeTransport(self.loop, self.pipe,
+                                                       self.protocol,
+                                                       waiter=waiter)
+        self.addCleanup(close_pipe_transport, transport)
+        return transport
+
+    def test_ctor(self):
+        waiter = asyncio.Future(loop=self.loop)
+        tr = self.read_pipe_transport(waiter=waiter)
+        self.loop.run_until_complete(waiter)
+
+        self.protocol.connection_made.assert_called_with(tr)
+        self.loop.assert_reader(5, tr._read_ready)
+        self.assertIsNone(waiter.result())
+
+    @mock.patch('os.read')
+    def test__read_ready(self, m_read):
+        tr = self.read_pipe_transport()
+        m_read.return_value = b'data'
+        tr._read_ready()
+
+        m_read.assert_called_with(5, tr.max_size)
+        self.protocol.data_received.assert_called_with(b'data')
+
+    @mock.patch('os.read')
+    def test__read_ready_eof(self, m_read):
+        tr = self.read_pipe_transport()
+        m_read.return_value = b''
+        tr._read_ready()
+
+        m_read.assert_called_with(5, tr.max_size)
+        self.assertFalse(self.loop.readers)
+        test_utils.run_briefly(self.loop)
+        self.protocol.eof_received.assert_called_with()
+        self.protocol.connection_lost.assert_called_with(None)
+
+    @mock.patch('os.read')
+    def test__read_ready_blocked(self, m_read):
+        tr = self.read_pipe_transport()
+        m_read.side_effect = BlockingIOError
+        tr._read_ready()
+
+        m_read.assert_called_with(5, tr.max_size)
+        test_utils.run_briefly(self.loop)
+        self.assertFalse(self.protocol.data_received.called)
+
+    @mock.patch('asyncio.log.logger.error')
+    @mock.patch('os.read')
+    def test__read_ready_error(self, m_read, m_logexc):
+        tr = self.read_pipe_transport()
+        err = OSError()
+        m_read.side_effect = err
+        tr._close = mock.Mock()
+        tr._read_ready()
+
+        m_read.assert_called_with(5, tr.max_size)
+        tr._close.assert_called_with(err)
+        m_logexc.assert_called_with(
+            test_utils.MockPattern(
+                'Fatal read error on pipe transport'
+                '\nprotocol:.*\ntransport:.*'),
+            exc_info=(OSError, MOCK_ANY, MOCK_ANY))
+
+    @mock.patch('os.read')
+    def test_pause_reading(self, m_read):
+        tr = self.read_pipe_transport()
+        m = mock.Mock()
+        self.loop.add_reader(5, m)
+        tr.pause_reading()
+        self.assertFalse(self.loop.readers)
+
+    @mock.patch('os.read')
+    def test_resume_reading(self, m_read):
+        tr = self.read_pipe_transport()
+        tr.resume_reading()
+        self.loop.assert_reader(5, tr._read_ready)
+
+    @mock.patch('os.read')
+    def test_close(self, m_read):
+        tr = self.read_pipe_transport()
+        tr._close = mock.Mock()
+        tr.close()
+        tr._close.assert_called_with(None)
+
+    @mock.patch('os.read')
+    def test_close_already_closing(self, m_read):
+        tr = self.read_pipe_transport()
+        tr._closing = True
+        tr._close = mock.Mock()
+        tr.close()
+        self.assertFalse(tr._close.called)
+
+    @mock.patch('os.read')
+    def test__close(self, m_read):
+        tr = self.read_pipe_transport()
+        err = object()
+        tr._close(err)
+        self.assertTrue(tr.is_closing())
+        self.assertFalse(self.loop.readers)
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(err)
+
+    def test__call_connection_lost(self):
+        tr = self.read_pipe_transport()
+        self.assertIsNotNone(tr._protocol)
+        self.assertIsNotNone(tr._loop)
+
+        err = None
+        tr._call_connection_lost(err)
+        self.protocol.connection_lost.assert_called_with(err)
+        self.pipe.close.assert_called_with()
+
+        self.assertIsNone(tr._protocol)
+        self.assertIsNone(tr._loop)
+
+    def test__call_connection_lost_with_err(self):
+        tr = self.read_pipe_transport()
+        self.assertIsNotNone(tr._protocol)
+        self.assertIsNotNone(tr._loop)
+
+        err = OSError()
+        tr._call_connection_lost(err)
+        self.protocol.connection_lost.assert_called_with(err)
+        self.pipe.close.assert_called_with()
+
+        self.assertIsNone(tr._protocol)
+        self.assertIsNone(tr._loop)
+
+
+class UnixWritePipeTransportTests(test_utils.TestCase):
+
+    def setUp(self):
+        self.loop = self.new_test_loop()
+        self.protocol = test_utils.make_test_protocol(asyncio.BaseProtocol)
+        self.pipe = mock.Mock(spec_set=io.RawIOBase)
+        self.pipe.fileno.return_value = 5
+
+        blocking_patcher = mock.patch('asyncio.unix_events._set_nonblocking')
+        blocking_patcher.start()
+        self.addCleanup(blocking_patcher.stop)
+
+        fstat_patcher = mock.patch('os.fstat')
+        m_fstat = fstat_patcher.start()
+        st = mock.Mock()
+        st.st_mode = stat.S_IFSOCK
+        m_fstat.return_value = st
+        self.addCleanup(fstat_patcher.stop)
+
+    def write_pipe_transport(self, waiter=None):
+        transport = unix_events._UnixWritePipeTransport(self.loop, self.pipe,
+                                                        self.protocol,
+                                                        waiter=waiter)
+        self.addCleanup(close_pipe_transport, transport)
+        return transport
+
+    def test_ctor(self):
+        waiter = asyncio.Future(loop=self.loop)
+        tr = self.write_pipe_transport(waiter=waiter)
+        self.loop.run_until_complete(waiter)
+
+        self.protocol.connection_made.assert_called_with(tr)
+        self.loop.assert_reader(5, tr._read_ready)
+        self.assertEqual(None, waiter.result())
+
+    def test_can_write_eof(self):
+        tr = self.write_pipe_transport()
+        self.assertTrue(tr.can_write_eof())
+
+    @mock.patch('os.write')
+    def test_write(self, m_write):
+        tr = self.write_pipe_transport()
+        m_write.return_value = 4
+        tr.write(b'data')
+        m_write.assert_called_with(5, b'data')
+        self.assertFalse(self.loop.writers)
+        self.assertEqual([], tr._buffer)
+
+    @mock.patch('os.write')
+    def test_write_no_data(self, m_write):
+        tr = self.write_pipe_transport()
+        tr.write(b'')
+        self.assertFalse(m_write.called)
+        self.assertFalse(self.loop.writers)
+        self.assertEqual([], tr._buffer)
+
+    @mock.patch('os.write')
+    def test_write_partial(self, m_write):
+        tr = self.write_pipe_transport()
+        m_write.return_value = 2
+        tr.write(b'data')
+        m_write.assert_called_with(5, b'data')
+        self.loop.assert_writer(5, tr._write_ready)
+        self.assertEqual([b'ta'], tr._buffer)
+
+    @mock.patch('os.write')
+    def test_write_buffer(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._buffer = [b'previous']
+        tr.write(b'data')
+        self.assertFalse(m_write.called)
+        self.loop.assert_writer(5, tr._write_ready)
+        self.assertEqual([b'previous', b'data'], tr._buffer)
+
+    @mock.patch('os.write')
+    def test_write_again(self, m_write):
+        tr = self.write_pipe_transport()
+        m_write.side_effect = BlockingIOError()
+        tr.write(b'data')
+        m_write.assert_called_with(5, b'data')
+        self.loop.assert_writer(5, tr._write_ready)
+        self.assertEqual([b'data'], tr._buffer)
+
+    @mock.patch('asyncio.unix_events.logger')
+    @mock.patch('os.write')
+    def test_write_err(self, m_write, m_log):
+        tr = self.write_pipe_transport()
+        err = OSError()
+        m_write.side_effect = err
+        tr._fatal_error = mock.Mock()
+        tr.write(b'data')
+        m_write.assert_called_with(5, b'data')
+        self.assertFalse(self.loop.writers)
+        self.assertEqual([], tr._buffer)
+        tr._fatal_error.assert_called_with(
+                            err,
+                            'Fatal write error on pipe transport')
+        self.assertEqual(1, tr._conn_lost)
+
+        tr.write(b'data')
+        self.assertEqual(2, tr._conn_lost)
+        tr.write(b'data')
+        tr.write(b'data')
+        tr.write(b'data')
+        tr.write(b'data')
+        # This is a bit overspecified. :-(
+        m_log.warning.assert_called_with(
+            'pipe closed by peer or os.write(pipe, data) raised exception.')
+        tr.close()
+
+    @mock.patch('os.write')
+    def test_write_close(self, m_write):
+        tr = self.write_pipe_transport()
+        tr._read_ready()  # pipe was closed by peer
+
+        tr.write(b'data')
+        self.assertEqual(tr._conn_lost, 1)
+        tr.write(b'data')
+        self.assertEqual(tr._conn_lost, 2)
+
+    def test__read_ready(self):
+        tr = self.write_pipe_transport()
+        tr._read_ready()
+        self.assertFalse(self.loop.readers)
+        self.assertFalse(self.loop.writers)
+        self.assertTrue(tr.is_closing())
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(None)
+
+    @mock.patch('os.write')
+    def test__write_ready(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._buffer = [b'da', b'ta']
+        m_write.return_value = 4
+        tr._write_ready()
+        m_write.assert_called_with(5, b'data')
+        self.assertFalse(self.loop.writers)
+        self.assertEqual([], tr._buffer)
+
+    @mock.patch('os.write')
+    def test__write_ready_partial(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._buffer = [b'da', b'ta']
+        m_write.return_value = 3
+        tr._write_ready()
+        m_write.assert_called_with(5, b'data')
+        self.loop.assert_writer(5, tr._write_ready)
+        self.assertEqual([b'a'], tr._buffer)
+
+    @mock.patch('os.write')
+    def test__write_ready_again(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._buffer = [b'da', b'ta']
+        m_write.side_effect = BlockingIOError()
+        tr._write_ready()
+        m_write.assert_called_with(5, b'data')
+        self.loop.assert_writer(5, tr._write_ready)
+        self.assertEqual([b'data'], tr._buffer)
+
+    @mock.patch('os.write')
+    def test__write_ready_empty(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._buffer = [b'da', b'ta']
+        m_write.return_value = 0
+        tr._write_ready()
+        m_write.assert_called_with(5, b'data')
+        self.loop.assert_writer(5, tr._write_ready)
+        self.assertEqual([b'data'], tr._buffer)
+
+    @mock.patch('asyncio.log.logger.error')
+    @mock.patch('os.write')
+    def test__write_ready_err(self, m_write, m_logexc):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._buffer = [b'da', b'ta']
+        m_write.side_effect = err = OSError()
+        tr._write_ready()
+        m_write.assert_called_with(5, b'data')
+        self.assertFalse(self.loop.writers)
+        self.assertFalse(self.loop.readers)
+        self.assertEqual([], tr._buffer)
+        self.assertTrue(tr.is_closing())
+        m_logexc.assert_called_with(
+            test_utils.MockPattern(
+                'Fatal write error on pipe transport'
+                '\nprotocol:.*\ntransport:.*'),
+            exc_info=(OSError, MOCK_ANY, MOCK_ANY))
+        self.assertEqual(1, tr._conn_lost)
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(err)
+
+    @mock.patch('os.write')
+    def test__write_ready_closing(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        tr._closing = True
+        tr._buffer = [b'da', b'ta']
+        m_write.return_value = 4
+        tr._write_ready()
+        m_write.assert_called_with(5, b'data')
+        self.assertFalse(self.loop.writers)
+        self.assertFalse(self.loop.readers)
+        self.assertEqual([], tr._buffer)
+        self.protocol.connection_lost.assert_called_with(None)
+        self.pipe.close.assert_called_with()
+
+    @mock.patch('os.write')
+    def test_abort(self, m_write):
+        tr = self.write_pipe_transport()
+        self.loop.add_writer(5, tr._write_ready)
+        self.loop.add_reader(5, tr._read_ready)
+        tr._buffer = [b'da', b'ta']
+        tr.abort()
+        self.assertFalse(m_write.called)
+        self.assertFalse(self.loop.readers)
+        self.assertFalse(self.loop.writers)
+        self.assertEqual([], tr._buffer)
+        self.assertTrue(tr.is_closing())
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(None)
+
+    def test__call_connection_lost(self):
+        tr = self.write_pipe_transport()
+        self.assertIsNotNone(tr._protocol)
+        self.assertIsNotNone(tr._loop)
+
+        err = None
+        tr._call_connection_lost(err)
+        self.protocol.connection_lost.assert_called_with(err)
+        self.pipe.close.assert_called_with()
+
+        self.assertIsNone(tr._protocol)
+        self.assertIsNone(tr._loop)
+
+    def test__call_connection_lost_with_err(self):
+        tr = self.write_pipe_transport()
+        self.assertIsNotNone(tr._protocol)
+        self.assertIsNotNone(tr._loop)
+
+        err = OSError()
+        tr._call_connection_lost(err)
+        self.protocol.connection_lost.assert_called_with(err)
+        self.pipe.close.assert_called_with()
+
+        self.assertIsNone(tr._protocol)
+        self.assertIsNone(tr._loop)
+
+    def test_close(self):
+        tr = self.write_pipe_transport()
+        tr.write_eof = mock.Mock()
+        tr.close()
+        tr.write_eof.assert_called_with()
+
+        # closing the transport twice must not fail
+        tr.close()
+
+    def test_close_closing(self):
+        tr = self.write_pipe_transport()
+        tr.write_eof = mock.Mock()
+        tr._closing = True
+        tr.close()
+        self.assertFalse(tr.write_eof.called)
+
+    def test_write_eof(self):
+        tr = self.write_pipe_transport()
+        tr.write_eof()
+        self.assertTrue(tr.is_closing())
+        self.assertFalse(self.loop.readers)
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(None)
+
+    def test_write_eof_pending(self):
+        tr = self.write_pipe_transport()
+        tr._buffer = [b'data']
+        tr.write_eof()
+        self.assertTrue(tr.is_closing())
+        self.assertFalse(self.protocol.connection_lost.called)
+
+
+class AbstractChildWatcherTests(unittest.TestCase):
+
+    def test_not_implemented(self):
+        f = mock.Mock()
+        watcher = asyncio.AbstractChildWatcher()
+        self.assertRaises(
+            NotImplementedError, watcher.add_child_handler, f, f)
+        self.assertRaises(
+            NotImplementedError, watcher.remove_child_handler, f)
+        self.assertRaises(
+            NotImplementedError, watcher.attach_loop, f)
+        self.assertRaises(
+            NotImplementedError, watcher.close)
+        self.assertRaises(
+            NotImplementedError, watcher.__enter__)
+        self.assertRaises(
+            NotImplementedError, watcher.__exit__, f, f, f)
+
+
+class BaseChildWatcherTests(unittest.TestCase):
+
+    def test_not_implemented(self):
+        f = mock.Mock()
+        watcher = unix_events.BaseChildWatcher()
+        self.assertRaises(
+            NotImplementedError, watcher._do_waitpid, f)
+
+
+WaitPidMocks = collections.namedtuple("WaitPidMocks",
+                                      ("waitpid",
+                                       "WIFEXITED",
+                                       "WIFSIGNALED",
+                                       "WEXITSTATUS",
+                                       "WTERMSIG",
+                                       ))
+
+
+class ChildWatcherTestsMixin:
+
+    ignore_warnings = mock.patch.object(log.logger, "warning")
+
+    def setUp(self):
+        self.loop = self.new_test_loop()
+        self.running = False
+        self.zombies = {}
+
+        with mock.patch.object(
+                self.loop, "add_signal_handler") as self.m_add_signal_handler:
+            self.watcher = self.create_watcher()
+            self.watcher.attach_loop(self.loop)
+
+    def waitpid(self, pid, flags):
+        if isinstance(self.watcher, asyncio.SafeChildWatcher) or pid != -1:
+            self.assertGreater(pid, 0)
+        try:
+            if pid < 0:
+                return self.zombies.popitem()
+            else:
+                return pid, self.zombies.pop(pid)
+        except KeyError:
+            pass
+        if self.running:
+            return 0, 0
+        else:
+            raise ChildProcessError()
+
+    def add_zombie(self, pid, returncode):
+        self.zombies[pid] = returncode + 32768
+
+    def WIFEXITED(self, status):
+        return status >= 32768
+
+    def WIFSIGNALED(self, status):
+        return 32700 < status < 32768
+
+    def WEXITSTATUS(self, status):
+        self.assertTrue(self.WIFEXITED(status))
+        return status - 32768
+
+    def WTERMSIG(self, status):
+        self.assertTrue(self.WIFSIGNALED(status))
+        return 32768 - status
+
+    def test_create_watcher(self):
+        self.m_add_signal_handler.assert_called_once_with(
+            signal.SIGCHLD, self.watcher._sig_chld)
+
+    def waitpid_mocks(func):
+        def wrapped_func(self):
+            def patch(target, wrapper):
+                return mock.patch(target, wraps=wrapper,
+                                  new_callable=mock.Mock)
+
+            with patch('os.WTERMSIG', self.WTERMSIG) as m_WTERMSIG, \
+                 patch('os.WEXITSTATUS', self.WEXITSTATUS) as m_WEXITSTATUS, \
+                 patch('os.WIFSIGNALED', self.WIFSIGNALED) as m_WIFSIGNALED, \
+                 patch('os.WIFEXITED', self.WIFEXITED) as m_WIFEXITED, \
+                 patch('os.waitpid', self.waitpid) as m_waitpid:
+                func(self, WaitPidMocks(m_waitpid,
+                                        m_WIFEXITED, m_WIFSIGNALED,
+                                        m_WEXITSTATUS, m_WTERMSIG,
+                                        ))
+        return wrapped_func
+
+    @waitpid_mocks
+    def test_sigchld(self, m):
+        # register a child
+        callback = mock.Mock()
+
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(42, callback, 9, 10, 14)
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child is running
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child terminates (returncode 12)
+        self.running = False
+        self.add_zombie(42, 12)
+        self.watcher._sig_chld()
+
+        self.assertTrue(m.WIFEXITED.called)
+        self.assertTrue(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+        callback.assert_called_once_with(42, 12, 9, 10, 14)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WEXITSTATUS.reset_mock()
+        callback.reset_mock()
+
+        # ensure that the child is effectively reaped
+        self.add_zombie(42, 13)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WEXITSTATUS.reset_mock()
+
+        # sigchld called again
+        self.zombies.clear()
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+    @waitpid_mocks
+    def test_sigchld_two_children(self, m):
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
+
+        # register child 1
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(43, callback1, 7, 8)
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # register child 2
+        with self.watcher:
+            self.watcher.add_child_handler(44, callback2, 147, 18)
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # children are running
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child 1 terminates (signal 3)
+        self.add_zombie(43, -3)
+        self.watcher._sig_chld()
+
+        callback1.assert_called_once_with(43, -3, 7, 8)
+        self.assertFalse(callback2.called)
+        self.assertTrue(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertTrue(m.WTERMSIG.called)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WTERMSIG.reset_mock()
+        callback1.reset_mock()
+
+        # child 2 still running
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child 2 terminates (code 108)
+        self.add_zombie(44, 108)
+        self.running = False
+        self.watcher._sig_chld()
+
+        callback2.assert_called_once_with(44, 108, 147, 18)
+        self.assertFalse(callback1.called)
+        self.assertTrue(m.WIFEXITED.called)
+        self.assertTrue(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WEXITSTATUS.reset_mock()
+        callback2.reset_mock()
+
+        # ensure that the children are effectively reaped
+        self.add_zombie(43, 14)
+        self.add_zombie(44, 15)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WEXITSTATUS.reset_mock()
+
+        # sigchld called again
+        self.zombies.clear()
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+    @waitpid_mocks
+    def test_sigchld_two_children_terminating_together(self, m):
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
+
+        # register child 1
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(45, callback1, 17, 8)
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # register child 2
+        with self.watcher:
+            self.watcher.add_child_handler(46, callback2, 1147, 18)
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # children are running
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child 1 terminates (code 78)
+        # child 2 terminates (signal 5)
+        self.add_zombie(45, 78)
+        self.add_zombie(46, -5)
+        self.running = False
+        self.watcher._sig_chld()
+
+        callback1.assert_called_once_with(45, 78, 17, 8)
+        callback2.assert_called_once_with(46, -5, 1147, 18)
+        self.assertTrue(m.WIFSIGNALED.called)
+        self.assertTrue(m.WIFEXITED.called)
+        self.assertTrue(m.WEXITSTATUS.called)
+        self.assertTrue(m.WTERMSIG.called)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WTERMSIG.reset_mock()
+        m.WEXITSTATUS.reset_mock()
+        callback1.reset_mock()
+        callback2.reset_mock()
+
+        # ensure that the children are effectively reaped
+        self.add_zombie(45, 14)
+        self.add_zombie(46, 15)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+    @waitpid_mocks
+    def test_sigchld_race_condition(self, m):
+        # register a child
+        callback = mock.Mock()
+
+        with self.watcher:
+            # child terminates before being registered
+            self.add_zombie(50, 4)
+            self.watcher._sig_chld()
+
+            self.watcher.add_child_handler(50, callback, 1, 12)
+
+        callback.assert_called_once_with(50, 4, 1, 12)
+        callback.reset_mock()
+
+        # ensure that the child is effectively reaped
+        self.add_zombie(50, -1)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback.called)
+
+    @waitpid_mocks
+    def test_sigchld_replace_handler(self, m):
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
+
+        # register a child
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(51, callback1, 19)
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # register the same child again
+        with self.watcher:
+            self.watcher.add_child_handler(51, callback2, 21)
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child terminates (signal 8)
+        self.running = False
+        self.add_zombie(51, -8)
+        self.watcher._sig_chld()
+
+        callback2.assert_called_once_with(51, -8, 21)
+        self.assertFalse(callback1.called)
+        self.assertTrue(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertTrue(m.WTERMSIG.called)
+
+        m.WIFSIGNALED.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WTERMSIG.reset_mock()
+        callback2.reset_mock()
+
+        # ensure that the child is effectively reaped
+        self.add_zombie(51, 13)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+    @waitpid_mocks
+    def test_sigchld_remove_handler(self, m):
+        callback = mock.Mock()
+
+        # register a child
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(52, callback, 1984)
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # unregister the child
+        self.watcher.remove_child_handler(52)
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child terminates (code 99)
+        self.running = False
+        self.add_zombie(52, 99)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback.called)
+
+    @waitpid_mocks
+    def test_sigchld_unknown_status(self, m):
+        callback = mock.Mock()
+
+        # register a child
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(53, callback, -19)
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # terminate with unknown status
+        self.zombies[53] = 1178
+        self.running = False
+        self.watcher._sig_chld()
+
+        callback.assert_called_once_with(53, 1178, -19)
+        self.assertTrue(m.WIFEXITED.called)
+        self.assertTrue(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        callback.reset_mock()
+        m.WIFEXITED.reset_mock()
+        m.WIFSIGNALED.reset_mock()
+
+        # ensure that the child is effectively reaped
+        self.add_zombie(53, 101)
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback.called)
+
+    @waitpid_mocks
+    def test_remove_child_handler(self, m):
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
+        callback3 = mock.Mock()
+
+        # register children
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(54, callback1, 1)
+            self.watcher.add_child_handler(55, callback2, 2)
+            self.watcher.add_child_handler(56, callback3, 3)
+
+        # remove child handler 1
+        self.assertTrue(self.watcher.remove_child_handler(54))
+
+        # remove child handler 2 multiple times
+        self.assertTrue(self.watcher.remove_child_handler(55))
+        self.assertFalse(self.watcher.remove_child_handler(55))
+        self.assertFalse(self.watcher.remove_child_handler(55))
+
+        # all children terminate
+        self.add_zombie(54, 0)
+        self.add_zombie(55, 1)
+        self.add_zombie(56, 2)
+        self.running = False
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        callback3.assert_called_once_with(56, 2, 3)
+
+    @waitpid_mocks
+    def test_sigchld_unhandled_exception(self, m):
+        callback = mock.Mock()
+
+        # register a child
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(57, callback)
+
+        # raise an exception
+        m.waitpid.side_effect = ValueError
+
+        with mock.patch.object(log.logger,
+                               'error') as m_error:
+
+            self.assertEqual(self.watcher._sig_chld(), None)
+            self.assertTrue(m_error.called)
+
+    @waitpid_mocks
+    def test_sigchld_child_reaped_elsewhere(self, m):
+        # register a child
+        callback = mock.Mock()
+
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(58, callback)
+
+        self.assertFalse(callback.called)
+        self.assertFalse(m.WIFEXITED.called)
+        self.assertFalse(m.WIFSIGNALED.called)
+        self.assertFalse(m.WEXITSTATUS.called)
+        self.assertFalse(m.WTERMSIG.called)
+
+        # child terminates
+        self.running = False
+        self.add_zombie(58, 4)
+
+        # waitpid is called elsewhere
+        os.waitpid(58, os.WNOHANG)
+
+        m.waitpid.reset_mock()
+
+        # sigchld
+        with self.ignore_warnings:
+            self.watcher._sig_chld()
+
+        if isinstance(self.watcher, asyncio.FastChildWatcher):
+            # here the FastChildWatche enters a deadlock
+            # (there is no way to prevent it)
+            self.assertFalse(callback.called)
+        else:
+            callback.assert_called_once_with(58, 255)
+
+    @waitpid_mocks
+    def test_sigchld_unknown_pid_during_registration(self, m):
+        # register two children
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
+
+        with self.ignore_warnings, self.watcher:
+            self.running = True
+            # child 1 terminates
+            self.add_zombie(591, 7)
+            # an unknown child terminates
+            self.add_zombie(593, 17)
+
+            self.watcher._sig_chld()
+
+            self.watcher.add_child_handler(591, callback1)
+            self.watcher.add_child_handler(592, callback2)
+
+        callback1.assert_called_once_with(591, 7)
+        self.assertFalse(callback2.called)
+
+    @waitpid_mocks
+    def test_set_loop(self, m):
+        # register a child
+        callback = mock.Mock()
+
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(60, callback)
+
+        # attach a new loop
+        old_loop = self.loop
+        self.loop = self.new_test_loop()
+        patch = mock.patch.object
+
+        with patch(old_loop, "remove_signal_handler") as m_old_remove, \
+             patch(self.loop, "add_signal_handler") as m_new_add:
+
+            self.watcher.attach_loop(self.loop)
+
+            m_old_remove.assert_called_once_with(
+                signal.SIGCHLD)
+            m_new_add.assert_called_once_with(
+                signal.SIGCHLD, self.watcher._sig_chld)
+
+        # child terminates
+        self.running = False
+        self.add_zombie(60, 9)
+        self.watcher._sig_chld()
+
+        callback.assert_called_once_with(60, 9)
+
+    @waitpid_mocks
+    def test_set_loop_race_condition(self, m):
+        # register 3 children
+        callback1 = mock.Mock()
+        callback2 = mock.Mock()
+        callback3 = mock.Mock()
+
+        with self.watcher:
+            self.running = True
+            self.watcher.add_child_handler(61, callback1)
+            self.watcher.add_child_handler(62, callback2)
+            self.watcher.add_child_handler(622, callback3)
+
+        # detach the loop
+        old_loop = self.loop
+        self.loop = None
+
+        with mock.patch.object(
+                old_loop, "remove_signal_handler") as m_remove_signal_handler:
+
+            self.watcher.attach_loop(None)
+
+            m_remove_signal_handler.assert_called_once_with(
+                signal.SIGCHLD)
+
+        # child 1 & 2 terminate
+        self.add_zombie(61, 11)
+        self.add_zombie(62, -5)
+
+        # SIGCHLD was not caught
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        self.assertFalse(callback3.called)
+
+        # attach a new loop
+        self.loop = self.new_test_loop()
+
+        with mock.patch.object(
+                self.loop, "add_signal_handler") as m_add_signal_handler:
+
+            self.watcher.attach_loop(self.loop)
+
+            m_add_signal_handler.assert_called_once_with(
+                signal.SIGCHLD, self.watcher._sig_chld)
+            callback1.assert_called_once_with(61, 11)  # race condition!
+            callback2.assert_called_once_with(62, -5)  # race condition!
+            self.assertFalse(callback3.called)
+
+        callback1.reset_mock()
+        callback2.reset_mock()
+
+        # child 3 terminates
+        self.running = False
+        self.add_zombie(622, 19)
+        self.watcher._sig_chld()
+
+        self.assertFalse(callback1.called)
+        self.assertFalse(callback2.called)
+        callback3.assert_called_once_with(622, 19)
+
+    @waitpid_mocks
+    def test_close(self, m):
+        # register two children
+        callback1 = mock.Mock()
+
+        with self.watcher:
+            self.running = True
+            # child 1 terminates
+            self.add_zombie(63, 9)
+            # other child terminates
+            self.add_zombie(65, 18)
+            self.watcher._sig_chld()
+
+            self.watcher.add_child_handler(63, callback1)
+            self.watcher.add_child_handler(64, callback1)
+
+            self.assertEqual(len(self.watcher._callbacks), 1)
+            if isinstance(self.watcher, asyncio.FastChildWatcher):
+                self.assertEqual(len(self.watcher._zombies), 1)
+
+            with mock.patch.object(
+                    self.loop,
+                    "remove_signal_handler") as m_remove_signal_handler:
+
+                self.watcher.close()
+
+                m_remove_signal_handler.assert_called_once_with(
+                    signal.SIGCHLD)
+                self.assertFalse(self.watcher._callbacks)
+                if isinstance(self.watcher, asyncio.FastChildWatcher):
+                    self.assertFalse(self.watcher._zombies)
+
+
+class SafeChildWatcherTests (ChildWatcherTestsMixin, test_utils.TestCase):
+    def create_watcher(self):
+        return asyncio.SafeChildWatcher()
+
+
+class FastChildWatcherTests (ChildWatcherTestsMixin, test_utils.TestCase):
+    def create_watcher(self):
+        return asyncio.FastChildWatcher()
+
+
+class PolicyTests(unittest.TestCase):
+
+    def create_policy(self):
+        return asyncio.DefaultEventLoopPolicy()
+
+    def test_get_child_watcher(self):
+        policy = self.create_policy()
+        self.assertIsNone(policy._watcher)
+
+        watcher = policy.get_child_watcher()
+        self.assertIsInstance(watcher, asyncio.SafeChildWatcher)
+
+        self.assertIs(policy._watcher, watcher)
+
+        self.assertIs(watcher, policy.get_child_watcher())
+        self.assertIsNone(watcher._loop)
+
+    def test_get_child_watcher_after_set(self):
+        policy = self.create_policy()
+        watcher = asyncio.FastChildWatcher()
+
+        policy.set_child_watcher(watcher)
+        self.assertIs(policy._watcher, watcher)
+        self.assertIs(watcher, policy.get_child_watcher())
+
+    def test_get_child_watcher_with_mainloop_existing(self):
+        policy = self.create_policy()
+        loop = policy.get_event_loop()
+
+        self.assertIsNone(policy._watcher)
+        watcher = policy.get_child_watcher()
+
+        self.assertIsInstance(watcher, asyncio.SafeChildWatcher)
+        self.assertIs(watcher._loop, loop)
+
+        loop.close()
+
+    def test_get_child_watcher_thread(self):
+
+        def f():
+            policy.set_event_loop(policy.new_event_loop())
+
+            self.assertIsInstance(policy.get_event_loop(),
+                                  asyncio.AbstractEventLoop)
+            watcher = policy.get_child_watcher()
+
+            self.assertIsInstance(watcher, asyncio.SafeChildWatcher)
+            self.assertIsNone(watcher._loop)
+
+            policy.get_event_loop().close()
+
+        policy = self.create_policy()
+
+        th = threading.Thread(target=f)
+        th.start()
+        th.join()
+
+    def test_child_watcher_replace_mainloop_existing(self):
+        policy = self.create_policy()
+        loop = policy.get_event_loop()
+
+        watcher = policy.get_child_watcher()
+
+        self.assertIs(watcher._loop, loop)
+
+        new_loop = policy.new_event_loop()
+        policy.set_event_loop(new_loop)
+
+        self.assertIs(watcher._loop, new_loop)
+
+        policy.set_event_loop(None)
+
+        self.assertIs(watcher._loop, None)
+
+        loop.close()
+        new_loop.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This changeset allows to make use of asyncio Tasks and coroutines in kivy programs, and contains a little example doing so.
(see examples/kivy_asyncio.py)

Right now it's slightly hacky and only tested with WindowSDL.

The issue is that currently, and since the first kivy commit, the mainloop is (or at least can be) actually driven by the Window instead of the EventLoop, so calling EventLoop.idle() is actually not enough to have a fully functional app, so `KivyEventLoop` (asyncio event loop implementation for kivy) directly calls EventLoop.window._mainloop(), instead, it would be better if EventLoop.idle() called its Window step function (be it called _mainloop or whatever).

I didn't check, but since Window runs its `mainloop()` function, and KivyEventLoop also calls `_mainloop()`, the workload is probably doubled to create a frame.

for this reason, it could be interesting to revamp the system to make Window the worker for EventLoop, not the opposite.

Testable, but probably not mergeable in this state.

tested with python3.5.2 on linux, but should work with any python version with asyncio.
