### PR TITLE
uix:TextInput convert hint_text to unicode only if string isn't already unicode

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2156,7 +2156,10 @@ class TextInput(FocusBehavior, Widget):
         # Tokenize a text string from some delimiters
         if text is None:
             return
-        delimiters = u' ,\'".;:\n\r\t'
+        try:
+            delimiters = u' ,\'".;:\n\r\t'
+        except UnicodeDecodeError:
+            delimiters = ' ,\'".;:\n\r\t'
         oldindex = 0
         for index, char in enumerate(text):
             if char not in delimiters:


### PR DESCRIPTION
Testing with the following code:

```py
#-*- coding: utf-8 -*-
from kivy.app import App
from kivy.lang import Builder

root = Builder.load_string('''
TextInput:
    hint_text: 'привіт світ'
    text: ''
''')

class TestApp(App):
    def build(self):
        return root


if __name__ == '__main__':
    TestApp().run()
```