### PR TITLE
Removed long , annoying tracebacks

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -260,7 +260,8 @@ class Image(Widget):
                                                  keep_data=self.keep_data,
                                                  nocache=self.nocache)
             except Exception as e:
-                Logger.exception(e)
+                Logger.error('Image: Error reading file {filename}'.
+                                    format(filename=self.source))
                 self._coreimage = ci = None
 
             if ci:

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -260,7 +260,7 @@ class Image(Widget):
                                                  keep_data=self.keep_data,
                                                  nocache=self.nocache)
             except Exception as e:
-                Logger.error('Image: Error reading file {filename}'.
+                Logger.error('Image: Error loading texture {filename}'.
                                     format(filename=self.source))
                 self._coreimage = ci = None
 


### PR DESCRIPTION
i get long tracebacks when loading video files with kivy
removed traceback, replaced with Image: Error loading texture {filename}'..

currently http://i.prntscr.com/19310636b6f348f292d2563144a29478.png

after http://i.prntscr.com/abfcbf20f638458190ddf6ad58a31b34.png

