### PR TITLE
Fix "no isatty() method" errors

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -299,6 +299,9 @@ class LogFile(object):
 
     def flush(self):
         return
+    
+    def isatty(self):
+        return False
 
 
 def logger_config_update(section, key, value):


### PR DESCRIPTION
Since Kivy overwrites stdout and stderr with LogFiles, any import which tries to test for TTY consoles (for colored text, basically) throws an error. This fixes that problem.

Here's an example: https://github.com/staticshock/colored-traceback.py/issues/2

I personally get the error when trying to import astropy.