### PR TITLE
Fix Spinner

### DIFF
--- a/kivy/uix/spinner.py
+++ b/kivy/uix/spinner.py
@@ -191,7 +191,8 @@ class Spinner(Button):
                 self.text = ''
 
     def _toggle_dropdown(self, *largs):
-        self.is_open = not self.is_open
+        if self.values:
+            self.is_open = not self.is_open
 
     def _close_dropdown(self, *largs):
         self.is_open = False


### PR DESCRIPTION
Fixes opening for empty values. This can be annoying/weird if you have multiple buttons or spinners and a user would click on an empty Spinner. When such an action is performed, it won't allow another touch because there's a DropDown attached and if it's empty, it's invisible, therefore it behaves like a "block" for the next touch, which may seem for a user weird and buggy. This fix just forbids the opening and let's the empty Spinner behave like a casual Button.