### PR TITLE
Separate image and button in Switch

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -472,6 +472,9 @@
             source: 'atlas://data/images/defaulttheme/switch-background{}'.format('_disabled' if self.disabled else '')
             size: sp(83), sp(32)
             pos: int(self.center_x - sp(41)), int(self.center_y - sp(16))
+    canvas.after:
+        Color:
+            rgb: 1, 1, 1
         Rectangle:
             source: 'atlas://data/images/defaulttheme/switch-button{}'.format('_disabled' if self.disabled else '')
             size: sp(43), sp(32)


### PR DESCRIPTION
Puts the Button in the right place. If they are on "the same" canvas, it's hard to customize the widget, however when they are separated, widget becomes highly customizable even if it's in a state that requires image(s) as the background.

Example:

```
from kivy.lang import Builder
from kivy.base import runTouchApp
from kivy.uix.boxlayout import BoxLayout
Builder.load_string('''
<Custom@Switch>:
    canvas:
        Color:
            rgb: 0.2, 0.709, 0.898, 1
        Rectangle:
            size: [sp(41.5), sp(20)]
            pos: [self.center_x - sp(41.5), self.center_y - sp(10)]
        Color:
            rgb: 0.4, 0.4, 0.4, 1
        Rectangle:
            size: [sp(41.5), sp(20)]
            pos: [self.center_x, self.center_y - sp(10)]
    Label:
        text: '[b]OFF[/b]'
        markup: True
        font_size: 13
        pos: [root.center_x - sp(70), root.center_y - sp(50)]
    Label:
        color: 0.75, 0.75, 0.75, 1
        text: '[b]ON[/b]'
        markup: True
        font_size: 13
        pos: [root.center_x - sp(30), root.center_y - sp(50)]

<Test>:
    Widget:
        canvas:
            Color:
                rgb: 0.2, 0.709, 0.898, 1
            Rectangle:
                size: 800, 800
                pos: [0,0]
    Custom:
    Switch:
    Widget:
        # change pos to [0,0] to see
        canvas:
            Color:
                rgb: 0.2, 0.709, 0.898, 1
            Rectangle:
                size: 800, 800
                pos: [500,0]
            
''')
class Test(BoxLayout): pass
runTouchApp(Test())
```

First widget demonstrates that separating doesn't cripple `canvas`, nor `canvas.after`, because it's added as a child sooner. The second one demonstrates the same for `canvas.before`.

As some of my PRs were closed because of theming-like content(ref https://github.com/kivy/kivy/pull/4296#issuecomment-231480546), I'm kind of worried, however, as I don't see any sane reason why this should be bad(correct me if I'm wrong), I think it may be a good change, because it introduces new possibilities e.g. to cover the text on the widget.