### PR TITLE
Fix scrolling in TabbedPanel

### DIFF
--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -487,8 +487,8 @@ class TabbedPanel(GridLayout):
         self._setup_default_tab()
         self.switch_to(self.default_tab)
 
-    def switch_to(self, header, do_scroll=True):
-        '''Switch to a specific panel header.
+    def switch_to(self, header, do_scroll=False):
+        '''Switch to a specific panel header. If used with `do_scroll=True`, it scrolls to the header's tab too.
         '''
         header_content = header.content
         self._current_tab.state = 'normal'

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -487,7 +487,7 @@ class TabbedPanel(GridLayout):
         self._setup_default_tab()
         self.switch_to(self.default_tab)
 
-    def switch_to(self, header):
+    def switch_to(self, header, do_scroll=True):
         '''Switch to a specific panel header.
         '''
         header_content = header.content
@@ -502,6 +502,10 @@ class TabbedPanel(GridLayout):
         if parent:
             parent.remove_widget(header_content)
         self.add_widget(header_content)
+
+        if do_scroll:
+            tabs = self._tab_strip
+            tabs.parent.scroll_to(header)
 
     def clear_tabs(self, *l):
         self_tabs = self._tab_strip

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -488,7 +488,8 @@ class TabbedPanel(GridLayout):
         self.switch_to(self.default_tab)
 
     def switch_to(self, header, do_scroll=False):
-        '''Switch to a specific panel header. If used with `do_scroll=True`, it scrolls to the header's tab too.
+        '''Switch to a specific panel header. If used with
+        `do_scroll=True`, it scrolls to the header's tab too.
         '''
         header_content = header.content
         self._current_tab.state = 'normal'


### PR DESCRIPTION
`switch_to(tab, do_scroll=False)` is the behavior until this patch. This introduces `do_scroll` keyword, which if set to True(by default), scrolls the tab list to the header of the tab TabbedPanel switches to.