### PR TITLE
Add TreeView.deselect_node()

### DIFF
--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -345,7 +345,16 @@ class TreeView(Widget):
 
     def select_node(self, node):
         '''Select a node in the tree.
+
+        .. versionchanged:: 1.9.2
+
+        If ``None`` is used as a value for `node` and there's
+        already a selected node, it will unselect it.
         '''
+        if not node:
+            if self._selected_node:
+                self._selected_node.is_selected = False
+            return
         if node.no_selection:
             return
         if self._selected_node:

--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -345,22 +345,21 @@ class TreeView(Widget):
 
     def select_node(self, node):
         '''Select a node in the tree.
-
-        .. versionchanged:: 1.9.2
-
-        If ``None`` is used as a value for `node` and there's
-        already a selected node, it will unselect it.
         '''
-        if not node:
-            if self._selected_node:
-                self._selected_node.is_selected = False
-            return
         if node.no_selection:
             return
         if self._selected_node:
             self._selected_node.is_selected = False
         node.is_selected = True
         self._selected_node = node
+
+    def deselect_node(self, *args):
+        '''Deselect any selected node.
+
+        .. versionadded:: 1.9.2
+        '''
+        if self._selected_node:
+            self._selected_node.is_selected = False
 
     def toggle_node(self, node):
         '''Toggle the state of the node (open/collapsed).


### PR DESCRIPTION
This solves the issue #3572 but I'm not quite sure if it's a good idea. On the other hand, it could be tweeked a little bit more to `node=None` by default and that way it could prevent crashing an app.