### PR TITLE
Draw animation every frame by default, use step=0 instead of 1 / 60.0

### DIFF
--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -127,7 +127,7 @@ class Animation(EventDispatcher):
         self._clock_installed = False
         self._duration = kw.pop('d', kw.pop('duration', 1.))
         self._transition = kw.pop('t', kw.pop('transition', 'linear'))
-        self._step = kw.pop('s', kw.pop('step', 1. / 60.))
+        self._step = kw.pop('s', kw.pop('step', 0))
         if isinstance(self._transition, string_types):
             self._transition = getattr(AnimationTransition, self._transition)
         self._animated_properties = kw

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -102,6 +102,9 @@ class Animation(EventDispatcher):
         `step` or `s`: float
             Step in milliseconds of the animation. Defaults to 0, which means
             animation is updated every frame.
+            
+            To draw the animation less often, set the step value to float.
+            For example, if you want to animate at 30 FPS, use s=1/30. 
 
     :Events:
         `on_start`: widget

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -100,7 +100,8 @@ class Animation(EventDispatcher):
             Transition function for animate properties. It can be the name of a
             method from :class:`AnimationTransition`.
         `step` or `s`: float
-            Step in milliseconds of the animation. Defaults to 1 / 60.
+            Step in milliseconds of the animation. Defaults to 0, which means
+            animation is updated every frame.
 
     :Events:
         `on_start`: widget


### PR DESCRIPTION
Animation should be as smooth as possible by default. Drawing animation on every frame will be the best default to provide rich, smooth user experience. As discussed with @tshirtman, Config.graphics.maxfps should limit that if set, and the user would have the option to degrade performance by using other kwarg parameter value.