### PR TITLE
Fix docs for RTD

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -39,8 +39,8 @@ else
 	_TESTS = _TEST
 endif
 
-AUTOBUILD_STAMP_BASE = autobuild.py-done-with-
-AUTOBUILD_STAMP      = "$(AUTOBUILD_STAMP_BASE)$(PYTHON)"
+# Created in autobuild.py
+AUTOBUILD_STAMP = "autobuild.py-done"
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck gettext
 
@@ -71,28 +71,19 @@ ifdef ComSpec
 	-rmdir /s /q build
 else
 	-rm -rf build/*
-	-rm $(AUTOBUILD_STAMP_BASE)*
+	-rm $(AUTOBUILD_STAMP)*
 endif
 
 fasthtml: html
 
 html:
 	$(MKDIR) build$(P)html build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP) || type NUL > $(AUTOBUILD_STAMP)
-endif
-	$(PYTHON) gallery.py
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS$(_TESTS)) build/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
 gettext:
 	$(MKDIR) build$(P)html build$(P)doctrees_gettext
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b gettext $(ALLSPHINXOPTSGT$(_TESTS)) build/gettext
 	@echo
 	@echo "Build finished. The Gettext pages are in build/gettext."
@@ -100,10 +91,6 @@ endif
 
 pickle:
 	$(MKDIR) build$(P)pickle build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS$(_TESTS)) build/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files or run"
@@ -114,10 +101,6 @@ web: pickle
 
 htmlhelp:
 	$(MKDIR) build$(P)htmlhelp build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS$(_TESTS)) build/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
@@ -125,10 +108,6 @@ endif
 
 latex:
 	$(MKDIR) build$(P)latex build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS$(_TESTS)) build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in build/latex."
@@ -156,30 +135,18 @@ ps: latex
 
 man:
 	$(MKDIR) build$(P)man build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS$(_TESTS)) build/man
 	@echo
 	@echo "Build finished. The manual pages are in build/man."
 
 changes:
 	$(MKDIR) build$(P)changes build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS$(_TESTS)) build/changes
 	@echo
 	@echo "The overview file is in build/changes."
 
 linkcheck:
 	$(MKDIR) build$(P)linkcheck build$(P)doctrees
-ifeq ("$(wildcard $(AUTOBUILD_STAMP))","")
-	$(PYTHON) autobuild.py silenced=$(ENDUSER_BUILD)
-	touch $(AUTOBUILD_STAMP)
-endif
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS$(_TESTS)) build/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \

--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -66,21 +66,23 @@ from kivy.factory import Factory
 from kivy.lib import osc, ddsfile, mtdev
 
 # check for silenced build
-BE_QUIET = False
-for arg in sys.argv:
-    if "silenced=" in arg:
-        if arg.split("=")[1] == "yes":
-            BE_QUIET = True
+BE_QUIET = True
+if os.environ.get('BE_QUIET') == 'False':
+    BE_QUIET = False
 
 # force loading of all classes from factory
 for x in list(Factory.classes.keys())[:]:
     getattr(Factory, x)
 
-
 # Directory of doc
 base_dir = os.path.dirname(__file__)
 dest_dir = os.path.join(base_dir, 'sources')
 examples_framework_dir = os.path.join(base_dir, '..', 'examples', 'framework')
+
+# Check touch file
+base = 'autobuild.py-done'
+with open(os.path.join(base_dir, base), 'w') as f:
+    f.write('')
 
 
 def writefile(filename, data):

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -3,26 +3,31 @@
 # Kivy documentation build configuration file, created by
 # sphinx-quickstart on Wed Jan 21 22:37:12 2009.
 #
-# This file is execfile()d with the current directory set to its containing dir.
+# This file is execfile()d with the current directory set to its containing
+# dir.
 #
 # The contents of this file are pickled, so don't put values in the namespace
-# that aren't pickleable (module imports are okay, they're removed automatically).
+# that aren't pickleable (module imports are okay, they're removed
+# automatically).
 #
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
-import sys, os
+import os
+import sys
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 sys.path.insert(0, os.path.abspath('sphinxext'))
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(base_dir))
 
 # General configuration
 # ---------------------
 
-# Add any Sphinx extension module names here, as strings. They can be extensions
-# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'autodoc', 'sphinx.ext.todo', 'preprocess', 'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode', 'sphinx.ext.mathjax']
@@ -36,7 +41,10 @@ import sphinx.ext.autodoc
 sphinx.ext.autodoc.ClassDocumenter.priority = 10
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['.templates']
+if os.environ.get('READTHEDOCS') == 'True':
+    templates_path = ['_templates']
+else:
+    templates_path = ['.templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -57,29 +65,33 @@ print(kivy.__file__)
 
 version = kivy.__version__
 release = kivy.__version__
+base = 'autobuild.py-done'
+if not os.path.exists(os.path.join(os.path.dirname(base_dir), base)):
+    import autobuild
+import gallery
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
 today_fmt = '%B %d, %Y'
 
 # suppress exclusion warnings
 exclude_patterns = ['gsoc201*']
 
-# The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+# The reST default role (used for this markup: `text`) to use for all documents
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'kivy_pygments_theme.KivyStyle'
@@ -93,12 +105,18 @@ pygments_style = 'kivy_pygments_theme.KivyStyle'
 # given in html_static_path.
 html_style = 'fresh.css'
 
+# Check for theme (remove 'if' when switched to RTD)
+if os.environ.get('READTHEDOCS') == 'True':
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
@@ -107,7 +125,7 @@ html_logo = '.static/logo-kivy.png'
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -120,34 +138,34 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_use_modindex = True
+# html_use_modindex = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-#html_copy_source = True
+# html_copy_source = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = ''
+# html_file_suffix = ''
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Kivydoc'
@@ -157,13 +175,13 @@ htmlhelp_basename = 'Kivydoc'
 # ------------------------
 
 # The paper size ('letter' or 'a4').
-#latex_paper_size = 'letter'
+# latex_paper_size = 'letter'
 
 # The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# latex_font_size = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, document class [howto/manual]).
+# (source start file, target name, title, author, document class [manual]).
 latex_documents = [
   ('index', 'Kivy.tex', 'Kivy Documentation',
    'The Kivy Developers', 'manual'),
@@ -171,7 +189,7 @@ latex_documents = [
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 latex_elements = {
     'fontpkg':      r'\usepackage{mathpazo}',
@@ -180,20 +198,20 @@ latex_elements = {
     'preamble':     r'\usepackage{kivystyle}'
 }
 latex_additional_files = ['kivystyle.sty',
-    '../../kivy/data/logo/kivy-icon-512.png']
+                          '../../kivy/data/logo/kivy-icon-512.png']
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
 latex_use_parts = True
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+# latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_use_modindex = True
+# latex_use_modindex = True
 
 from kivy import setupconfig
 


### PR DESCRIPTION
* Removed old `AUTOBUILD_STAMP`, autobuild.py now works as import in conf.py(RTD ignores such commands in Makefile). Check for the touch file still present, but filename changed to `autobuild.py-done` as it sounds simpler and I haven't found other checks for the specific filename + getting exact python from env shouldn't be necessary.

* `autobuild.py` has as default behavior set `BE_QUIET=True` as this it when the docs are built by default with make locally.

* touch `autobuild.py-done` is done within python, which removes my ugly fix for Win ^^

* Some pep8 fixes of `conf.py`

* `templates_path = ['.templates']` is required for local build of docs from kivy.org, however the underscore version is requirer on RTD

* Implemented check for RTD and if, choose their theme - leaves local build's behavior alone.