### PR TITLE
Use consistent Lang headers for logs in kivy.lang module

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -67,12 +67,12 @@ def custom_callback(__kvlang__, idmap, *largs, **kwargs):
 def call_fn(args, instance, v):
     element, key, value, rule, idmap = args
     if __debug__:
-        trace('Builder: call_fn %s, key=%s, value=%r, %r' % (
+        trace('Lang: call_fn %s, key=%s, value=%r, %r' % (
             element, key, value, rule.value))
     rule.count += 1
     e_value = eval(value, idmap)
     if __debug__:
-        trace('Builder: call_fn => value=%r' % (e_value, ))
+        trace('Lang: call_fn => value=%r' % (e_value, ))
     setattr(element, key, e_value)
 
 
@@ -284,7 +284,7 @@ class BuilderBase(object):
         '''
         filename = resource_find(filename) or filename
         if __debug__:
-            trace('Builder: load file %s' % filename)
+            trace('Lang: load file %s' % filename)
         with open(filename, 'r') as fd:
             kwargs['filename'] = filename
             data = fd.read()
@@ -426,7 +426,7 @@ class BuilderBase(object):
         '''
         rules = self.match_rule_name(rule_name)
         if __debug__:
-            trace('Builder: Found %d rules for %s' % (len(rules), rule_name))
+            trace('Lang: Found %d rules for %s' % (len(rules), rule_name))
         if not rules:
             return
         for rule in rules:
@@ -442,7 +442,7 @@ class BuilderBase(object):
         '''
         rules = self.match(widget)
         if __debug__:
-            trace('Builder: Found %d rules for %s' % (len(rules), widget))
+            trace('Lang: Found %d rules for %s' % (len(rules), widget))
         if not rules:
             return
         for rule in rules:

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -423,7 +423,7 @@ class Parser(object):
                     force_load = True
 
                 if ref[-3:] != '.kv':
-                    Logger.warn('WARNING: {0} does not have a valid Kivy'
+                    Logger.warn('Parser: {0} does not have a valid Kivy'
                                 'Language extension (.kv)'.format(ref))
                     break
                 if ref in __KV_INCLUDES__:
@@ -431,16 +431,16 @@ class Parser(object):
                         raise ParserException(self, ln,
                             'Invalid or unknown file: {0}'.format(ref))
                     if not force_load:
-                        Logger.warn('WARNING: {0} has already been included!'
+                        Logger.warn('Parser: {0} has already been included!'
                                     .format(ref))
                         continue
                     else:
-                        Logger.debug('Reloading {0} because include was forced.'
+                        Logger.debug('Parser: Reloading {0} because include was forced.'
                                     .format(ref))
                         kivy.lang.builder.Builder.unload_file(ref)
                         kivy.lang.builder.Builder.load_file(ref)
                         continue
-                Logger.debug('Including file: {0}'.format(0))
+                Logger.debug('Parser: Including file: {0}'.format(0))
                 __KV_INCLUDES__.append(ref)
                 kivy.lang.builder.Builder.load_file(ref)
             elif cmd[:7] == 'import ':

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -423,7 +423,7 @@ class Parser(object):
                     force_load = True
 
                 if ref[-3:] != '.kv':
-                    Logger.warn('Parser: {0} does not have a valid Kivy'
+                    Logger.warn('Lang: {0} does not have a valid Kivy'
                                 'Language extension (.kv)'.format(ref))
                     break
                 if ref in __KV_INCLUDES__:
@@ -431,16 +431,16 @@ class Parser(object):
                         raise ParserException(self, ln,
                             'Invalid or unknown file: {0}'.format(ref))
                     if not force_load:
-                        Logger.warn('Parser: {0} has already been included!'
+                        Logger.warn('Lang: {0} has already been included!'
                                     .format(ref))
                         continue
                     else:
-                        Logger.debug('Parser: Reloading {0} because include was forced.'
+                        Logger.debug('Lang: Reloading {0} because include was forced.'
                                     .format(ref))
                         kivy.lang.builder.Builder.unload_file(ref)
                         kivy.lang.builder.Builder.load_file(ref)
                         continue
-                Logger.debug('Parser: Including file: {0}'.format(0))
+                Logger.debug('Lang: Including file: {0}'.format(0))
                 __KV_INCLUDES__.append(ref)
                 kivy.lang.builder.Builder.load_file(ref)
             elif cmd[:7] == 'import ':


### PR DESCRIPTION
…" title coming from nowhere

Logger.warning itself is a warning, no need to repeat it twice. User wants to know which part of Kivy raises such warning.

My first idea was to use "Lang" instead of "Parser" header, but for that we should use it everywhere in lang package. Ill be glad to hear what you think about it.