### PR TITLE
Update cython min version to 0.23 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if PY3:  # fix error with py3's LooseVersion comparisons
     LooseVersion.__eq__ = ver_equal
 
 
-MIN_CYTHON_STRING = '0.20'
+MIN_CYTHON_STRING = '0.23'
 MIN_CYTHON_VERSION = LooseVersion(MIN_CYTHON_STRING)
 MAX_CYTHON_STRING = '0.23'
 MAX_CYTHON_VERSION = LooseVersion(MAX_CYTHON_STRING)


### PR DESCRIPTION
Latest master doesn't compile with '0.22'

This will help prevent bugs like #4581

I hope it isn't a problem that both min and max versions are '0.23'