### PR TITLE
Remove tab limit

### DIFF
--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -470,7 +470,7 @@ class TabbedPanel(GridLayout):
         self.rows = 1
         self._tab_strip = TabbedPanelStrip(
             tabbed_panel=self,
-            rows=1, cols=99, size_hint=(None, None),
+            rows=1, size_hint=(None, None),
             height=self.tab_height, width=self.tab_width)
 
         self._partial_update_scrollview = None


### PR DESCRIPTION
When the limit is exceeded, obviously the app will crash while trying to add the 100th tab. This removes the limit. It doesn't seem to be important having both rows and cols set (if there's no wrapping of tabs to e.g. two lines or something), mainly because `rows=1` is enough to let the layout work.