### PR TITLE
Made on_pause default to True

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -868,7 +868,7 @@ class App(EventDispatcher):
 
         .. versionadded:: 1.1.0
         '''
-        return False
+        return True
 
     def on_resume(self):
         '''Event handler called when your application is resuming from


### PR DESCRIPTION
Not sure if there's a reason not to do this. I think it's a better default on Android almost all the time.

It might affect desktop behavior with the fancy sdl2 pausing we have there now (at least on OS X, as I remember), but I haven't seen anyone have problems with that so I'd guess it isn't a big issue.
