### PR TITLE
Add package licensing guide

### DIFF
--- a/doc/sources/guide-index.rst
+++ b/doc/sources/guide-index.rst
@@ -19,3 +19,4 @@ Programming Guide
     guide/bestpractices
     guide/advancedgraphics
     guide/packaging
+    guide/licensing

--- a/doc/sources/guide/licensing.rst
+++ b/doc/sources/guide/licensing.rst
@@ -38,7 +38,8 @@ code.
 
 You'll probably need to check image and audio libraries manually (mostly
 begin with ``lib``). The ``LICENSE*`` files that belong to them should be
-included by PyInstaller.
+included by PyInstaller, but are not by python-for-android and you need
+to find them.
 
 Windows (PyInstaller)
 ---------------------
@@ -47,7 +48,7 @@ Windows (PyInstaller)
 .. _win32: https://pypi.python.org/pypi/pypiwin32
 
 To access Windows API, Kivy uses |win32|_ package. This package is released
-under [PSF license](https://opensource.org/licenses/Python-2.0).
+under `PSF license <https://opensource.org/licenses/Python-2.0>`_.
 
 VS redistributables
 ~~~~~~~~~~~~~~~~~~~
@@ -93,11 +94,44 @@ Missing.
 Android
 -------
 
-Missing.
+As APK is just an archive of files, you can extract files from it and (as in
+Windows part) check all the files.
 
-(pygame license, etc)
+``APK/assets/private.mp3/private.mp3/`` contains all the included files. Most
+of them are related to Kivy, Python or your source, but those that aren't need
+checking.
+
+Known packages:
+
+* `pygame <https://bitbucket.org/pygame/pygame/src/a9c9f5bf17445dfc8f7a85b9c5222dbcb3ece3bb/LGPL>`_
+  (if old_toolchain is used)
+* `sqlite3 <https://github.com/ghaering/pysqlite/blob/master/LICENSE>`_
+* `six <https://bitbucket.org/gutworth/six/src/ca4580a5a648fc75abc568907e81abc80b05d58c/LICENSE>`_
+
+There are included libraries either Kivy directly or through Pygame/SDL2 uses,
+those are located in ``APK/lib/armeabi/``. Most of them are related to
+dependencies or are produced from python-for-android and are part of its source
+(and licensing).
+
+* libapplication.so
 
 RPi
 ---
 
 Missing.
+
+Avoiding binaries
+-----------------
+
+.. |cons| replace:: consequences
+.. _cons: http://programmers.stackexchange.com/a/234295
+
+There is a way how to avoid this licensing process with avoiding creating
+a distribution with third-party stuff completely. With Python you can create
+a module, which is only your code with ``__main__.py`` + ``setup.py`` that only
+lists required deps. This way you can still distribute your app - your *code* -
+and don't need to care about other licenses. The combination of your code and
+the dependencies is then a "usage", not a "distribution". The responsibility of
+satisfying licenses then targets your user, who needs to assemble the
+environment to even run the application. If you care about your users, slow
+down a little and read more about |cons|_.

--- a/doc/sources/guide/licensing.rst
+++ b/doc/sources/guide/licensing.rst
@@ -26,10 +26,12 @@ only pasting a copyright notice to your app and not pretending you wrote the
 code.
 
 .. |mixer| replace:: SDL_mixer has them
-.. _mixer: http://hg.libsdl.org/SDL_mixer/file/efa81a285f22/VisualC/external/lib/x86
+.. _mixer: http://hg.libsdl.org/SDL_mixer/file/default/VisualC/external/lib/x86
+.. |dcutil| replace:: docutils
+.. _dcutil: https://sf.net/p/docutils/code/HEAD/tree/trunk/docutils/COPYING.txt
 
-* `docutils <https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/COPYING.txt>`_
-* `pygments <https://bitbucket.org/birkenfeld/pygments-main/src/a042025b350cd9c9461f7385d9ba0f13cdb01bb9/LICENSE>`_
+* |dcutil|_
+* `pygments <https://bitbucket.org/birkenfeld/pygments-main/src/tip/LICENSE>`_
 * `sdl2 <https://www.libsdl.org/license.php>`_
 * `glew <http://glew.sourceforge.net/glew.txt>`_
 * `gstreamer <https://github.com/GStreamer/gstreamer/blob/master/COPYING>`_
@@ -95,16 +97,6 @@ package), there's a |badsit|_. It's up to you to decide whether you satisfy
 conditions of other licenses and for example including copyright attribution
 into your app or not.
 
-Mac
----
-
-Missing.
-
-iOS
----
-
-Missing.
-
 Android
 -------
 
@@ -117,10 +109,10 @@ checking.
 
 Known packages:
 
-* `pygame <https://bitbucket.org/pygame/pygame/src/a9c9f5bf17445dfc8f7a85b9c5222dbcb3ece3bb/LGPL>`_
+* `pygame <https://bitbucket.org/pygame/pygame/src/tip/LGPL>`_
   (if old_toolchain is used)
 * `sqlite3 <https://github.com/ghaering/pysqlite/blob/master/LICENSE>`_
-* `six <https://bitbucket.org/gutworth/six/src/ca4580a5a648fc75abc568907e81abc80b05d58c/LICENSE>`_
+* `six <https://bitbucket.org/gutworth/six/src/tip/LICENSE>`_
 
 There are included libraries either Kivy directly or through Pygame/SDL2 uses,
 those are located in ``APK/lib/armeabi/``. Most of them are related to
@@ -128,6 +120,16 @@ dependencies or are produced from python-for-android and are part of its source
 (and licensing).
 
 * libapplication.so
+
+Mac
+---
+
+Missing.
+
+iOS
+---
+
+Missing.
 
 .. _avoid:
 

--- a/doc/sources/guide/licensing.rst
+++ b/doc/sources/guide/licensing.rst
@@ -1,0 +1,103 @@
+Package licensing
+=================
+
+.. warning:: This is not a lawyer consulted guide! Kivy organisation, authors
+   or contributors to this guide take no responsibility for any lack of
+   information, misleading information presented here or any actions based on
+   this guide. The guide is merely informative and is meant to protect
+   inexperienced users.
+
+Your code alone may not require including licensing info and copyright notices
+of other used software, but binaries are something else. When a binary (.exe,
+.app, .apk, ...) is created it includes Kivy, its dependencies and other
+packages that your application uses. Some of them are licensed in a way they
+require including a copyright notice somewhere in your app (or more). Before
+distributing any of the binaries, please **check all the created files** that
+don't belong to your source (.dll, .pyd, .so, ...) and include approperiate
+copyright notices if required by the license the files belong to. This way you
+should satisfy licensing requirements of the Kivy deps.
+
+Dependencies
+------------
+
+All of the dependencies will jump out at least partially on each platform Kivy
+supports, therefore you need to comply to their licenses, which mostly requires
+only pasting a copyright notice to your app and not pretending you wrote the
+code.
+
+.. |mixer| replace:: SDL_mixer has them
+.. _mixer: http://hg.libsdl.org/SDL_mixer/file/efa81a285f22/VisualC/external/lib/x86
+
+* `docutils <https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/COPYING.txt>`_
+* `pygments <https://bitbucket.org/birkenfeld/pygments-main/src/a042025b350cd9c9461f7385d9ba0f13cdb01bb9/LICENSE>`_
+* `sdl2 <https://www.libsdl.org/license.php>`_
+* `glew <http://glew.sourceforge.net/glew.txt>`_
+* `gstreamer <https://github.com/GStreamer/gstreamer/blob/master/COPYING>`_
+  (if used)
+* image & audio libraries(e.g. |mixer|_)
+
+You'll probably need to check image and audio libraries manually (mostly
+begin with ``lib``). The ``LICENSE*`` files that belong to them should be
+included by PyInstaller.
+
+Windows (PyInstaller)
+---------------------
+
+.. |win32| replace:: pypiwin32
+.. _win32: https://pypi.python.org/pypi/pypiwin32
+
+To access Windows API, Kivy uses |win32|_ package. This package is released
+under [PSF license](https://opensource.org/licenses/Python-2.0).
+
+VS redistributables
+~~~~~~~~~~~~~~~~~~~
+
+.. |py2crt| replace:: Py2 CRT license
+.. _py2crt: https://hg.python.org/sandbox/2.7/file/tip/Tools/msi/crtlicense.txt
+.. |py3crt| replace:: Py3 CRT license
+.. _py3crt: https://hg.python.org/cpython/file/tip/Tools/msi/exe/crtlicense.txt
+.. |redist| replace:: List of redistributables
+.. _redist: https://msdn.microsoft.com/en-us/library/8kche8ah(v=vs.90).aspx
+
+Python compiled with Visual Studio (official) has some files from Microsoft
+and you are required to protect them if you distribute them. You can do that
+by including names of the files and a reworded version of |py2crt|_ or
+|py3crt|_ depending which interpreter you use, so that it targets the end-user
+of your application.
+
+* |redist|_
+
+Other libraries
+~~~~~~~~~~~~~~~
+
+* `zlib <https://github.com/madler/zlib/blob/master/README>`_
+
+.. note:: Please add other libs that you *don't use directly* and are present
+   after packaging with e.g. PyInstaller on Windows.
+
+Linux
+-----
+
+Missing.
+
+Mac
+---
+
+Missing.
+
+iOS
+---
+
+Missing.
+
+Android
+-------
+
+Missing.
+
+(pygame license, etc)
+
+RPi
+---
+
+Missing.

--- a/doc/sources/guide/licensing.rst
+++ b/doc/sources/guide/licensing.rst
@@ -36,10 +36,9 @@ code.
   (if used)
 * image & audio libraries(e.g. |mixer|_)
 
-You'll probably need to check image and audio libraries manually (mostly
-begin with ``lib``). The ``LICENSE*`` files that belong to them should be
-included by PyInstaller, but are not by python-for-android and you need
-to find them.
+You'll probably need to check image and audio libraries manually (mostly begin
+with ``lib``). The ``LICENSE*`` files that belong to them should be included by
+PyInstaller, but are not by python-for-android and you need to find them.
 
 Windows (PyInstaller)
 ---------------------
@@ -79,7 +78,22 @@ Other libraries
 Linux
 -----
 
-Missing.
+.. |badsit| replace:: situation bad for your user
+.. _badsit: avoid_
+
+Linux has many distributions which means there's no correct guide for all of
+the distributions. Under this part belongs RPi too. However, it can be
+simplified into two ways of how to create a package (also with PyInstaller):
+with or without including binaries.
+
+If the binaries are included, you should check every file (e.g. `.so`) that's
+not your source and find a license it belongs to. According to that license
+you'll probably need to put an attribution into your application or even more.
+
+If the binaries are excluded (which allows packaging your app as e.g. `.deb`
+package), there's a |badsit|_. It's up to you to decide whether you satisfy
+conditions of other licenses and for example including copyright attribution
+into your app or not.
 
 Mac
 ---
@@ -115,10 +129,7 @@ dependencies or are produced from python-for-android and are part of its source
 
 * libapplication.so
 
-RPi
----
-
-Missing.
+.. _avoid:
 
 Avoiding binaries
 -----------------
@@ -129,10 +140,12 @@ Avoiding binaries
 There might be a way how to avoid this licensing process with avoiding creating
 a distribution with third-party stuff completely. With Python you can create
 a module, which is only your code with ``__main__.py`` + ``setup.py`` that only
-lists required deps. This way you can still distribute your app - your *code* -
-and you might not need to care about other licenses. The combination of your
-code and the dependencies could be specified as a "usage" rather than
-a "distribution". The responsibility of satisfying licenses, however, most
-likely transfers to your user, who needs to assemble the environment to even
-run the module. If you care about your users, you might want to slow down
-a little and read more about |cons|_.
+lists required deps.
+
+This way you can still distribute your app - your *code* - and you might not
+need to care about other licenses. The combination of your code and the
+dependencies could be specified as a "usage" rather than a "distribution". The
+responsibility of satisfying licenses, however, most likely transfers to your
+user, who needs to assemble the environment to even run the module. If you care
+about your users, you might want to slow down a little and read more about
+|cons|_.

--- a/doc/sources/guide/licensing.rst
+++ b/doc/sources/guide/licensing.rst
@@ -15,7 +15,7 @@ require including a copyright notice somewhere in your app (or more). Before
 distributing any of the binaries, please **check all the created files** that
 don't belong to your source (.dll, .pyd, .so, ...) and include approperiate
 copyright notices if required by the license the files belong to. This way you
-should satisfy licensing requirements of the Kivy deps.
+may satisfy licensing requirements of the Kivy deps.
 
 Dependencies
 ------------
@@ -47,8 +47,8 @@ Windows (PyInstaller)
 .. |win32| replace:: pypiwin32
 .. _win32: https://pypi.python.org/pypi/pypiwin32
 
-To access Windows API, Kivy uses |win32|_ package. This package is released
-under `PSF license <https://opensource.org/licenses/Python-2.0>`_.
+To access some Windows API features, Kivy uses |win32|_ package. This package
+is released under `PSF license <https://opensource.org/licenses/Python-2.0>`_.
 
 VS redistributables
 ~~~~~~~~~~~~~~~~~~~
@@ -60,11 +60,11 @@ VS redistributables
 .. |redist| replace:: List of redistributables
 .. _redist: https://msdn.microsoft.com/en-us/library/8kche8ah(v=vs.90).aspx
 
-Python compiled with Visual Studio (official) has some files from Microsoft
-and you are required to protect them if you distribute them. You can do that
-by including names of the files and a reworded version of |py2crt|_ or
-|py3crt|_ depending which interpreter you use, so that it targets the end-user
-of your application.
+Python compiled with Visual Studio (official) has some files from Microsoft and
+you are allowed to redistribute them under specific conditions listed in the
+CRTlicense. Including the names of the files and a reworded version of
+|py2crt|_ or |py3crt|_ depending which interpreter you use, so that it targets
+the end-user of your application may satisfy such requirements.
 
 * |redist|_
 
@@ -126,12 +126,13 @@ Avoiding binaries
 .. |cons| replace:: consequences
 .. _cons: http://programmers.stackexchange.com/a/234295
 
-There is a way how to avoid this licensing process with avoiding creating
+There might be a way how to avoid this licensing process with avoiding creating
 a distribution with third-party stuff completely. With Python you can create
 a module, which is only your code with ``__main__.py`` + ``setup.py`` that only
 lists required deps. This way you can still distribute your app - your *code* -
-and don't need to care about other licenses. The combination of your code and
-the dependencies is then a "usage", not a "distribution". The responsibility of
-satisfying licenses then targets your user, who needs to assemble the
-environment to even run the application. If you care about your users, slow
-down a little and read more about |cons|_.
+and you might not need to care about other licenses. The combination of your
+code and the dependencies could be specified as a "usage" rather than
+a "distribution". The responsibility of satisfying licenses, however, most
+likely transfers to your user, who needs to assemble the environment to even
+run the module. If you care about your users, you might want to slow down
+a little and read more about |cons|_.


### PR DESCRIPTION
I found out there's a damn lot of things you can miss or misread while licensing a binary package. I made this guide as a request for other info mainly related to binaries created on/for Mac/iOS (don't have an access to those machines), so that this guide could be completed. As I mentioned in the warning, the guide has only an informative character, kind of check-list of what to do before releasing into public.

Licensing may not seem important to users who make small apps or basically only learn how to code with Kivy, however if used in a serious production _and_ if licensed badly or with some stuff missing, it may shine a bad light at Kivy as a whole.

Basically I'd need some diff of source <-> binary i.e. what does a packager include to a user's source for each missing platform, so that I could find a license and paste it there. If you find the files and licenses, make a commit (devs) or a comment (who can't / don't want to).