### PR TITLE
Update setup.py for SDL2 on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -603,7 +603,7 @@ def determine_sdl2():
 
     sdl2_path = environ.get('KIVY_SDL2_PATH', None)
 
-    if sdl2_flags and not sdl2_path and platform == 'darwin':
+    if sdl2_flags and not sdl2_path and platform == 'darwin' or platform == 'linux':
         return sdl2_flags
 
     # no pkgconfig info, or we want to use a specific sdl2 path, so perform

--- a/setup.py
+++ b/setup.py
@@ -603,7 +603,7 @@ def determine_sdl2():
 
     sdl2_path = environ.get('KIVY_SDL2_PATH', None)
 
-    if sdl2_flags and not sdl2_path and (platform == 'darwin' or platform == 'linux'):
+    if sdl2_flags and not sdl2_path and platform == 'darwin':
         return sdl2_flags
 
     # no pkgconfig info, or we want to use a specific sdl2 path, so perform

--- a/setup.py
+++ b/setup.py
@@ -626,6 +626,9 @@ def determine_sdl2():
         ['-L' + p for p in sdl2_paths] if sdl2_paths else
         ['-L/usr/local/lib/'])
 
+    if sdl2_flags:
+        flags = merge(flags, sdl2_flags)
+
     # ensure headers for all the SDL2 and sub libraries are available
     libs_to_check = ['SDL', 'SDL_mixer', 'SDL_ttf', 'SDL_image']
     can_compile = True

--- a/setup.py
+++ b/setup.py
@@ -603,7 +603,7 @@ def determine_sdl2():
 
     sdl2_path = environ.get('KIVY_SDL2_PATH', None)
 
-    if sdl2_flags and not sdl2_path and platform == 'darwin' or platform == 'linux':
+    if sdl2_flags and not sdl2_path and (platform == 'darwin' or platform == 'linux'):
         return sdl2_flags
 
     # no pkgconfig info, or we want to use a specific sdl2 path, so perform


### PR DESCRIPTION
issue:
Platform:  Centos 7 x86
When I activate environment variable USE_SDL2=1 on centos 7, the compilation flags for SDL2 is thrown away somewhere before compiling the source code. Before doing this, I ensure that the SDL2 suites are correctly installed and can be resolved correctly.
Solution:
merge sdl2_flags with the flags such that compiling check will not fail when sdl2_flags is correct
