### PR TITLE
Kv Lang: fix profiling tool HTML output generation

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -865,7 +865,10 @@ if 'KIVY_PROFILE_LANG' in environ:
             '</style>']
         files = set([x[1].ctx.filename for x in Builder.rules])
         for fn in files:
-            lines = open(fn).readlines()
+            try:
+                lines = open(fn).readlines()
+            except:
+                continue
             html += ['<h2>', fn, '</h2>', '<table>']
             count = 0
             for index, line in enumerate(lines):

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -866,8 +866,9 @@ if 'KIVY_PROFILE_LANG' in environ:
         files = set([x[1].ctx.filename for x in Builder.rules])
         for fn in files:
             try:
-                lines = open(fn).readlines()
-            except:
+                with open(fn) as f:
+                    lines = f.readlines()
+            except IOError:
                 continue
             html += ['<h2>', fn, '</h2>', '<table>']
             count = 0


### PR DESCRIPTION
Fixes `TypeError: coercing to Unicode: need string or buffer, NoneType found` error during HTML output generation. Skips one loop iteration if the file cant be opened.

Works like a charm for me and I believe it's better way of handling file than None check. Tool can encounter various problems while handling files and try/except is the most reliable solution in my opinion.