### PR TITLE
Adds size_hint_min/max to widgets.

### DIFF
--- a/examples/widgets/recycleview/basic_data.py
+++ b/examples/widgets/recycleview/basic_data.py
@@ -15,8 +15,6 @@ kv = """
             size: self.size
             pos: self.pos
     value: ''
-    size_hint_y: None
-    height: dp(100)
     Label:
         text: root.value
 

--- a/examples/widgets/recycleview/basic_data.py
+++ b/examples/widgets/recycleview/basic_data.py
@@ -15,6 +15,8 @@ kv = """
             size: self.size
             pos: self.pos
     value: ''
+    size_hint_y: None
+    height: dp(100)
     Label:
         text: root.value
 

--- a/kivy/compat.py
+++ b/kivy/compat.py
@@ -7,14 +7,19 @@ to aid in writing Python 2/3 compatibile code.
 '''
 
 __all__ = ('PY2', 'clock', 'string_types', 'queue', 'iterkeys',
-           'itervalues', 'iteritems')
+           'itervalues', 'iteritems', 'isclose')
 
 import sys
 import time
+from math import isinf, fabs
 try:
     import queue
 except ImportError:
     import Queue as queue
+try:
+    from math import isclose
+except ImportError:
+    isclose = None
 
 PY2 = sys.version_info[0] == 2
 '''True if this version of python is 2.x.'''
@@ -65,3 +70,31 @@ if PY2:
         clock = time.time
 else:
     clock = time.perf_counter
+
+
+def _isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
+    '''Measures whether two floats are "close" to each other. Identical to
+    https://docs.python.org/3.6/library/math.html#math.isclose, for older
+    versions of python.
+    '''
+
+    if a == b:  # short-circuit exact equality
+        return True
+
+    if rel_tol < 0.0 or abs_tol < 0.0:
+        raise ValueError('error tolerances must be non-negative')
+
+    # use cmath so it will work with complex ot float
+    if isinf(abs(a)) or isinf(abs(b)):
+        # This includes the case of two infinities of opposite sign, or
+        # one infinity and one finite number. Two infinities of opposite sign
+        # would otherwise have an infinite relative tolerance.
+        return False
+    diff = fabs(b - a)
+
+    return (((diff <= fabs(rel_tol * b)) or
+             (diff <= fabs(rel_tol * a))) or
+            (diff <= abs_tol))
+
+if isclose is None:
+    isclose = _isclose

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -982,6 +982,8 @@ class WindowBase(EventDispatcher):
         widget.bind(
             pos_hint=self._update_childsize,
             size_hint=self._update_childsize,
+            size_hint_max=self._update_childsize,
+            size_hint_min=self._update_childsize,
             size=self._update_childsize,
             pos=self._update_childsize)
 
@@ -1001,6 +1003,8 @@ class WindowBase(EventDispatcher):
         widget.unbind(
             pos_hint=self._update_childsize,
             size_hint=self._update_childsize,
+            size_hint_max=self._update_childsize,
+            size_hint_min=self._update_childsize,
             size=self._update_childsize,
             pos=self._update_childsize)
 
@@ -1173,12 +1177,40 @@ class WindowBase(EventDispatcher):
             childs = self.children
         for w in childs:
             shw, shh = w.size_hint
-            if shw and shh:
-                w.size = shw * width, shh * height
-            elif shw:
-                w.width = shw * width
-            elif shh:
-                w.height = shh * height
+            shw_min, shh_min = w.size_hint_min
+            shw_max, shh_max = w.size_hint_max
+
+            if shw is not None and shh is not None:
+                c_w = shw * width
+                c_h = shh * height
+
+                if shw_min is not None and c_w < shw_min:
+                    c_w = shw_min
+                elif shw_max is not None and c_w > shw_max:
+                    c_w = shw_max
+
+                if shh_min is not None and c_h < shh_min:
+                    c_h = shh_min
+                elif shh_max is not None and c_h > shh_max:
+                    c_h = shh_max
+                w.size = c_w, c_h
+            elif shw is not None:
+                c_w = shw * width
+
+                if shw_min is not None and c_w < shw_min:
+                    c_w = shw_min
+                elif shw_max is not None and c_w > shw_max:
+                    c_w = shw_max
+                w.width = c_w
+            elif shh is not None:
+                c_h = shh * height
+
+                if shh_min is not None and c_h < shh_min:
+                    c_h = shh_min
+                elif shh_max is not None and c_h > shh_max:
+                    c_h = shh_max
+                w.height = c_h
+
             for key, value in w.pos_hint.items():
                 if key == 'x':
                     w.x = value * width

--- a/kivy/uix/anchorlayout.py
+++ b/kivy/uix/anchorlayout.py
@@ -87,12 +87,23 @@ class AnchorLayout(Layout):
         for c in self.children:
             x, y = _x, _y
             cw, ch = c.size
-            size_hint_h, size_hint_v = c.size_hint
+            shw, shh = c.size_hint
+            shw_min, shh_min = c.size_hint_min
+            shw_max, shh_max = c.size_hint_max
 
-            if size_hint_h is not None:
-                cw = size_hint_h * (width - pad_left - pad_right)
-            if size_hint_v is not None:
-                ch = size_hint_v * (height - pad_top - pad_bottom)
+            if shw is not None:
+                cw = shw * (width - pad_left - pad_right)
+                if shw_min is not None and cw < shw_min:
+                    cw = shw_min
+                elif shw_max is not None and cw > shw_max:
+                    cw = shw_max
+
+            if shh is not None:
+                ch = shh * (height - pad_top - pad_bottom)
+                if shh_min is not None and ch < shh_min:
+                    ch = shh_min
+                elif shh_max is not None and ch > shh_max:
+                    ch = shh_max
 
             if anchor_x == 'left':
                 x = x + pad_left

--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -154,9 +154,10 @@ class BoxLayout(Layout):
         has_bound = False
         hint = [None] * len_children
         # min size from all the None hint, and from those with sh_min
-        minimum_size_bounded = minimum_size_none = 0
+        minimum_size_bounded = 0
         if orientation == 'horizontal':
             minimum_size_y = 0
+            minimum_size_none = padding_x + spacing * (len_children - 1)
 
             for i, ((w, h), (shw, shh), _, (shw_min, shh_min),
                     (shw_max, _)) in enumerate(sizes):
@@ -176,11 +177,11 @@ class BoxLayout(Layout):
                 elif shh_min:
                     minimum_size_y = max(minimum_size_y, shh_min)
 
-            minimum_size_x = minimum_size_bounded + minimum_size_none + \
-                padding_x + spacing * (len_children - 1)
+            minimum_size_x = minimum_size_bounded + minimum_size_none
             minimum_size_y += padding_y
         else:
             minimum_size_x = 0
+            minimum_size_none = padding_y + spacing * (len_children - 1)
 
             for i, ((w, h), (shw, shh), _, (shw_min, shh_min),
                     (_, shh_max)) in enumerate(sizes):
@@ -200,8 +201,8 @@ class BoxLayout(Layout):
                 elif shw_min:
                     minimum_size_x = max(minimum_size_x, shw_min)
 
-            minimum_size_y = minimum_size_bounded + minimum_size_none + \
-                padding_y + spacing * (len_children - 1)
+
+            minimum_size_y = minimum_size_bounded + minimum_size_none
             minimum_size_x += padding_x
 
         self.minimum_size = minimum_size_x, minimum_size_y

--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -150,52 +150,109 @@ class BoxLayout(Layout):
         padding_y = padding_top + padding_bottom
 
         # calculate maximum space used by size_hint
-        stretch_weight_x = 0.
-        stretch_weight_y = 0.
+        stretch_sum = 0.
+        has_bound = False
+        hint = [None] * len_children
+        # min size from all the None hint, and from those with sh_min
+        minimum_size_bounded = minimum_size_none = 0
         if orientation == 'horizontal':
-            minimum_size_x = padding_x + spacing * (len_children - 1)
             minimum_size_y = 0
-            for (w, h), (shw, shh), _ in sizes:
+
+            for i, ((w, h), (shw, shh), _, (shw_min, shh_min),
+                    (shw_max, _)) in enumerate(sizes):
                 if shw is None:
-                    minimum_size_x += w
+                    minimum_size_none += w
                 else:
-                    stretch_weight_x += shw
+                    hint[i] = shw
+                    if shw_min:
+                        has_bound = True
+                        minimum_size_bounded += shw_min
+                    elif shw_max is not None:
+                        has_bound = True
+                    stretch_sum += shw
+
                 if shh is None:
                     minimum_size_y = max(minimum_size_y, h)
+                elif shh_min:
+                    minimum_size_y = max(minimum_size_y, shh_min)
+
+            minimum_size_x = minimum_size_bounded + minimum_size_none + \
+                padding_x + spacing * (len_children - 1)
             minimum_size_y += padding_y
         else:
             minimum_size_x = 0
-            minimum_size_y = padding_y + spacing * (len_children - 1)
-            for (w, h), (shw, shh), _ in sizes:
+
+            for i, ((w, h), (shw, shh), _, (shw_min, shh_min),
+                    (_, shh_max)) in enumerate(sizes):
+                if shh is None:
+                    minimum_size_none += h
+                else:
+                    hint[i] = shh
+                    if shh_min:
+                        has_bound = True
+                        minimum_size_bounded += shh_min
+                    elif shh_max is not None:
+                        has_bound = True
+                    stretch_sum += shh
+
                 if shw is None:
                     minimum_size_x = max(minimum_size_x, w)
-                if shh is None:
-                    minimum_size_y += h
-                else:
-                    stretch_weight_y += shh
+                elif shw_min:
+                    minimum_size_x = max(minimum_size_x, shw_min)
+
+            minimum_size_y = minimum_size_bounded + minimum_size_none + \
+                padding_y + spacing * (len_children - 1)
             minimum_size_x += padding_x
 
         self.minimum_size = minimum_size_x, minimum_size_y
-        selfw = self.width
-        selfh = self.height
+        # do not move the w/h get above, it's likely to change on above line
         selfx = self.x
         selfy = self.y
 
         if orientation == 'horizontal':
-            x = padding_left
-            stretch_space = max(0.0, selfw - minimum_size_x)
-            for i, ((w, h), (shw, shh), pos_hint) in enumerate(
-                    reversed(sizes)):
-                cx = selfx + x
+            stretch_space = max(0.0, self.width - minimum_size_none)
+            dim = 0
+        else:
+            stretch_space = max(0.0, self.height - minimum_size_none)
+            dim = 1
+
+        if has_bound:
+            # make sure the size_hint_min/max are not violated
+            if stretch_space < 1e-9:
+                # there's no space, so just set to min size or zero
+                stretch_sum = stretch_space = 1.
+
+                for i, val in enumerate(sizes):
+                    sh = val[1][dim]
+                    if sh is None:
+                        continue
+
+                    sh_min = val[3][dim]
+                    if sh_min is not None:
+                        hint[i] = sh_min
+                    else:
+                        hint[i] = 0.  # everything else is zero
+            else:
+                # hint gets updated in place
+                self.layout_hint_with_bounds(
+                    stretch_sum, stretch_space, minimum_size_bounded,
+                    (val[3][dim] for val in sizes),
+                    (elem[4][dim] for elem in sizes), hint)
+
+        if orientation == 'horizontal':
+            x = padding_left + selfx
+            size_y = self.height - padding_y
+            for i, (sh, ((w, h), (_, shh), pos_hint, _, _)) in enumerate(
+                    zip(reversed(hint), reversed(sizes))):
                 cy = selfy + padding_bottom
 
-                if shw:
-                    w = stretch_space * shw / stretch_weight_x
+                if sh:
+                    w = max(0., stretch_space * sh / stretch_sum)
                 if shh:
-                    h = max(0, shh * (selfh - padding_y))
+                    h = max(0, shh * size_y)
 
                 for key, value in pos_hint.items():
-                    posy = value * (selfh - padding_y)
+                    posy = value * size_y
                     if key == 'y':
                         cy += posy
                     elif key == 'top':
@@ -203,24 +260,23 @@ class BoxLayout(Layout):
                     elif key == 'center_y':
                         cy += posy - (h / 2.)
 
-                yield len_children - i - 1, cx, cy, w, h
+                yield len_children - i - 1, x, cy, w, h
                 x += w + spacing
 
-        if orientation == 'vertical':
-            y = padding_bottom
-            stretch_space = max(0.0, selfh - minimum_size_y)
-            for i, ((w, h), (shw, shh), pos_hint) in enumerate(sizes):
-
+        else:
+            y = padding_bottom + selfy
+            size_x = self.width - padding_x
+            for i, (sh, ((w, h), (shw, _), pos_hint, _, _)) in enumerate(
+                    zip(hint, sizes)):
                 cx = selfx + padding_left
-                cy = selfy + y
 
-                if shh:
-                    h = stretch_space * shh / stretch_weight_y
+                if sh:
+                    h = max(0., stretch_space * sh / stretch_sum)
                 if shw:
-                    w = max(0, shw * (selfw - padding_x))
+                    w = max(0, shw * size_x)
 
                 for key, value in pos_hint.items():
-                    posx = value * (selfw - padding_x)
+                    posx = value * size_x
                     if key == 'x':
                         cx += posx
                     elif key == 'right':
@@ -228,7 +284,7 @@ class BoxLayout(Layout):
                     elif key == 'center_x':
                         cx += posx - (w / 2.)
 
-                yield i, cx, cy, w, h
+                yield i, cx, y, w, h
                 y += h + spacing
 
     def do_layout(self, *largs):
@@ -239,7 +295,8 @@ class BoxLayout(Layout):
             return
 
         for i, x, y, w, h in self._iterate_layout(
-                [(c.size, c.size_hint, c.pos_hint) for c in children]):
+                [(c.size, c.size_hint, c.pos_hint, c.size_hint_min,
+                  c.size_hint_max) for c in children]):
             c = children[i]
             c.pos = x, y
             shw, shh = c.size_hint

--- a/kivy/uix/floatlayout.py
+++ b/kivy/uix/floatlayout.py
@@ -78,12 +78,40 @@ class FloatLayout(Layout):
         for c in self.children:
             # size
             shw, shh = c.size_hint
+            shw_min, shh_min = c.size_hint_min
+            shw_max, shh_max = c.size_hint_max
+
             if shw is not None and shh is not None:
-                c.size = w * shw, h * shh
+                c_w = shw * w
+                c_h = shh * h
+
+                if shw_min is not None and c_w < shw_min:
+                    c_w = shw_min
+                elif shw_max is not None and c_w > shw_max:
+                    c_w = shw_max
+
+                if shh_min is not None and c_h < shh_min:
+                    c_h = shh_min
+                elif shh_max is not None and c_h > shh_max:
+                    c_h = shh_max
+                c.size = c_w, c_h
             elif shw is not None:
-                c.width = w * shw
+                c_w = shw * w
+
+                if shw_min is not None and c_w < shw_min:
+                    c_w = shw_min
+                elif shw_max is not None and c_w > shw_max:
+                    c_w = shw_max
+                c.width = c_w
             elif shh is not None:
-                c.height = h * shh
+                c_h = shh * h
+
+                if shh_min is not None and c_h < shh_min:
+                    c_h = shh_min
+                elif shh_max is not None and c_h > shh_max:
+                    c_h = shh_max
+                c.height = c_h
+
             # pos
             for key, value in c.pos_hint.items():
                 if key == 'x':

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -372,6 +372,7 @@ class GridLayout(Layout):
         cols, rows = self._cols, self._rows
 
         width = l + r + spacing_x * (len(cols) - 1)
+        self._cols_min_size_none = sum(cols) + width
         # we need to subtract for the sh_max/min the already guaranteed size
         # due to having a None in the col. So sh_min gets smaller by that size
         # since it's already covered. Similarly for sh_max, because if we
@@ -380,7 +381,6 @@ class GridLayout(Layout):
         if self._has_hint_bound_x:
             cols_sh_min = self._cols_sh_min
             cols_sh_max = self._cols_sh_max
-            self._cols_min_size_none = sum(cols) + width
 
             for i, (c, sh_min, sh_max) in enumerate(
                     zip(cols, cols_sh_min, cols_sh_max)):
@@ -393,13 +393,13 @@ class GridLayout(Layout):
                 if sh_max is not None:
                     cols_sh_max[i] = max(0., sh_max - c)
         else:
-            width += sum(cols)
+            width = self._cols_min_size_none
 
         height = t + b + spacing_y * (len(rows) - 1)
+        self._rows_min_size_none = sum(rows) + height
         if self._has_hint_bound_y:
             rows_sh_min = self._rows_sh_min
             rows_sh_max = self._rows_sh_max
-            self._rows_min_size_none = sum(rows) + height
 
             for i, (r, sh_min, sh_max) in enumerate(
                     zip(rows, rows_sh_min, rows_sh_max)):
@@ -412,7 +412,7 @@ class GridLayout(Layout):
                 if sh_max is not None:
                     rows_sh_max[i] = max(0., sh_max - r)
         else:
-            height += sum(rows)
+            height = self._rows_min_size_none
 
         # finally, set the minimum size
         self.minimum_size = (width, height)

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -103,6 +103,12 @@ def nmax(*args):
     return max(args)
 
 
+def nmin(*args):
+    # merge into one list
+    args = [x for x in args if x is not None]
+    return min(args)
+
+
 class GridLayoutException(Exception):
     '''Exception for errors if the grid layout manipulation fails.
     '''
@@ -297,27 +303,40 @@ class GridLayout(Layout):
         current_cols = max(1, current_cols)
         current_rows = max(1, current_rows)
 
+        self._has_hint_bound_x = False
+        self._has_hint_bound_y = False
+        self._cols_min_size_none = 0.  # min size from all the None hint
+        self._rows_min_size_none = 0.  # min size from all the None hint
         self._cols = cols = [self.col_default_width] * current_cols
-        self._cols_sh = cols_sh = [None] * current_cols
+        self._cols_sh = [None] * current_cols
+        self._cols_sh_min = [None] * current_cols
+        self._cols_sh_max = [None] * current_cols
         self._rows = rows = [self.row_default_height] * current_rows
-        self._rows_sh = rows_sh = [None] * current_rows
+        self._rows_sh = [None] * current_rows
+        self._rows_sh_min = [None] * current_rows
+        self._rows_sh_max = [None] * current_rows
 
         # update minimum size from the dicts
         # FIXME index might be outside the bounds ?
         for index, value in self.cols_minimum.items():
-            cols[index] = value
+            cols[index] = max(value, cols[index])
         for index, value in self.rows_minimum.items():
-            rows[index] = value
+            rows[index] = max(value, rows[index])
         return True
 
     def _fill_rows_cols_sizes(self):
         cols, rows = self._cols, self._rows
         cols_sh, rows_sh = self._cols_sh, self._rows_sh
+        cols_sh_min, rows_sh_min = self._cols_sh_min, self._rows_sh_min
+        cols_sh_max, rows_sh_max = self._cols_sh_max, self._rows_sh_max
 
         # calculate minimum size for each columns and rows
         n_cols = len(cols)
+        has_bound_y = has_bound_x = False
         for i, child in enumerate(reversed(self.children)):
             (shw, shh), (w, h) = child.size_hint, child.size
+            shw_min, shh_min = child.size_hint_min
+            shw_max, shh_max = child.size_hint_max
             row, col = divmod(i, n_cols)
 
             # compute minimum size / maximum stretch needed
@@ -325,11 +344,25 @@ class GridLayout(Layout):
                 cols[col] = nmax(cols[col], w)
             else:
                 cols_sh[col] = nmax(cols_sh[col], shw)
+                if shw_min is not None:
+                    has_bound_x = True
+                    cols_sh_min[col] = nmax(cols_sh_min[col], shw_min)
+                if shw_max is not None:
+                    has_bound_x = True
+                    cols_sh_max[col] = nmin(cols_sh_max[col], shw_max)
 
             if shh is None:
                 rows[row] = nmax(rows[row], h)
             else:
                 rows_sh[row] = nmax(rows_sh[row], shh)
+                if shh_min is not None:
+                    has_bound_y = True
+                    rows_sh_min[col] = nmax(rows_sh_min[col], shh_min)
+                if shh_max is not None:
+                    has_bound_y = True
+                    rows_sh_max[col] = nmin(rows_sh_max[col], shh_max)
+        self._has_hint_bound_x = has_bound_x
+        self._has_hint_bound_y = has_bound_y
 
     def _update_minimum_size(self):
         # calculate minimum width/height needed, starting from padding +
@@ -337,11 +370,49 @@ class GridLayout(Layout):
         l, t, r, b = self.padding
         spacing_x, spacing_y = self.spacing
         cols, rows = self._cols, self._rows
+
         width = l + r + spacing_x * (len(cols) - 1)
+        # we need to subtract for the sh_max/min the already guaranteed size
+        # due to having a None in the col. So sh_min gets smaller by that size
+        # since it's already covered. Similarly for sh_max, because if we
+        # already exceeded the max, the subtracted max will be zero, so
+        # it won't get larger
+        if self._has_hint_bound_x:
+            cols_sh_min = self._cols_sh_min
+            cols_sh_max = self._cols_sh_max
+            self._cols_min_size_none = sum(cols) + width
+
+            for i, (c, sh_min, sh_max) in enumerate(
+                    zip(cols, cols_sh_min, cols_sh_max)):
+                if sh_min is not None:
+                    width += max(c, sh_min)
+                    cols_sh_min[i] = max(0., sh_min - c)
+                else:
+                    width += c
+
+                if sh_max is not None:
+                    cols_sh_max[i] = max(0., sh_max - c)
+        else:
+            width += sum(cols)
+
         height = t + b + spacing_y * (len(rows) - 1)
-        # then add the cell size
-        width += sum(cols)
-        height += sum(rows)
+        if self._has_hint_bound_y:
+            rows_sh_min = self._rows_sh_min
+            rows_sh_max = self._rows_sh_max
+            self._rows_min_size_none = sum(rows) + height
+
+            for i, (r, sh_min, sh_max) in enumerate(
+                    zip(rows, rows_sh_min, rows_sh_max)):
+                if sh_min is not None:
+                    height += max(r, sh_min)
+                    rows_sh_min[i] = max(0., sh_min - r)
+                else:
+                    height += r
+
+                if sh_max is not None:
+                    rows_sh_max[i] = max(0., sh_max - r)
+        else:
+            height += sum(rows)
 
         # finally, set the minimum size
         self.minimum_size = (width, height)
@@ -359,14 +430,24 @@ class GridLayout(Layout):
         else:
             cols = self._cols
             cols_sh = self._cols_sh
-            cols_weigth = sum([x for x in cols_sh if x])
-            stretch_w = max(0, selfw - self.minimum_width)
-            for index, col_stretch in enumerate(cols_sh):
-                # if the col don't have stretch information, nothing to do
-                if not col_stretch:
-                    continue
-                # add to the min width whatever remains from size_hint
-                cols[index] += stretch_w * col_stretch / cols_weigth
+            cols_sh_min = self._cols_sh_min
+            cols_weight = float(sum((x for x in cols_sh if x is not None)))
+            stretch_w = max(0., selfw - self._cols_min_size_none)
+
+            if stretch_w > 1e-9:
+                if self._has_hint_bound_x:
+                    # fix the hints to be within bounds
+                    self.layout_hint_with_bounds(
+                        cols_weight, stretch_w,
+                        sum((c for c in cols_sh_min if c is not None)),
+                        cols_sh_min, self._cols_sh_max, cols_sh)
+
+                for index, col_stretch in enumerate(cols_sh):
+                    # if the col don't have stretch information, nothing to do
+                    if not col_stretch:
+                        continue
+                    # add to the min width whatever remains from size_hint
+                    cols[index] += stretch_w * col_stretch / cols_weight
 
         # same algo for rows
         if self.row_force_default:
@@ -377,15 +458,24 @@ class GridLayout(Layout):
         else:
             rows = self._rows
             rows_sh = self._rows_sh
-            rows_weigth = sum([x for x in rows_sh if x])
-            stretch_h = max(0, selfh - self.minimum_height)
-            for index in range(len(rows)):
-                # if the row don't have stretch information, nothing to do
-                row_stretch = rows_sh[index]
-                if not row_stretch:
-                    continue
-                # add to the min height whatever remains from size_hint
-                rows[index] += stretch_h * row_stretch / rows_weigth
+            rows_sh_min = self._rows_sh_min
+            rows_weight = float(sum((x for x in rows_sh if x is not None)))
+            stretch_h = max(0., selfh - self._rows_min_size_none)
+
+            if stretch_h > 1e-9:
+                if self._has_hint_bound_y:
+                    # fix the hints to be within bounds
+                    self.layout_hint_with_bounds(
+                        rows_weight, stretch_h,
+                        sum((r for r in rows_sh_min if r is not None)),
+                        rows_sh_min, self._rows_sh_max, rows_sh)
+
+                for index, row_stretch in enumerate(rows_sh):
+                    # if the row don't have stretch information, nothing to do
+                    if not row_stretch:
+                        continue
+                    # add to the min height whatever remains from size_hint
+                    rows[index] += stretch_h * row_stretch / rows_weight
 
     def _iterate_layout(self, count):
         selfx = self.x
@@ -421,6 +511,27 @@ class GridLayout(Layout):
             c = children[i]
             c.pos = x, y
             shw, shh = c.size_hint
+            shw_min, shh_min = c.size_hint_min
+            shw_max, shh_max = c.size_hint_max
+
+            if shw_min is not None:
+                if shw_max is not None:
+                    w = max(min(w, shw_max), shw_min)
+                else:
+                    w = max(w, shw_min)
+            else:
+                if shw_max is not None:
+                    w = min(w, shw_max)
+
+            if shh_min is not None:
+                if shh_max is not None:
+                    h = max(min(h, shh_max), shh_min)
+                else:
+                    h = max(h, shh_min)
+            else:
+                if shh_max is not None:
+                    h = min(h, shh_max)
+
             if shw is None:
                 if shh is not None:
                     c.height = h

--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -57,6 +57,7 @@ __all__ = ('Layout', )
 
 from kivy.clock import Clock
 from kivy.uix.widget import Widget
+from kivy.compat import isclose
 
 
 class Layout(Widget):
@@ -91,10 +92,229 @@ class Layout(Widget):
         fbind = widget.fbind
         fbind('size', self._trigger_layout)
         fbind('size_hint', self._trigger_layout)
+        fbind('size_hint_max', self._trigger_layout)
+        fbind('size_hint_min', self._trigger_layout)
         return super(Layout, self).add_widget(widget, index)
 
     def remove_widget(self, widget):
         funbind = widget.funbind
         funbind('size', self._trigger_layout)
         funbind('size_hint', self._trigger_layout)
+        funbind('size_hint_max', self._trigger_layout)
+        funbind('size_hint_min', self._trigger_layout)
         return super(Layout, self).remove_widget(widget)
+
+    def layout_hint_with_bounds(
+            self, sh_sum, available_space, min_bounded_size, sh_min_vals,
+            sh_max_vals, hint):
+        '''(internal) Computes the appropriate (size) hint for all the
+        widgets given (potential) min or max bounds on the widgets' size.
+        The ``hint`` list is updated with appropriate sizes.
+
+        It walks through the hints and for any widgets whose hint will result
+        in violating min or max constraints, it fixes the hint. Any remaining
+        or missing space after all the widgets are fixed get distributed
+        to the widgets making them smaller or larger according to their
+        size hint.
+
+        This algorithms knows nothing about the widgets other than what is
+        passed through the input params, so it's fairly generic for laying
+        things out according to constraints using size hints.
+
+        :Parameters:
+
+            `sh_sum`: float
+                The sum of the size hints (basically ``sum(size_hint)``).
+            `available_space`: float
+                The amount of pixels available for all the widgets
+                whose size hint is not None. Cannot be zero.
+            `min_bounded_size`: float
+                The minimum amount of space required according to the
+                `size_hint_min` of the widgets (basically
+                ``sum(size_hint_min)``).
+            `sh_min_vals`: list or iterable
+                Items in the iterable are the size_hint_min for each widget.
+                Can be None. The length should be the same as ``hint``
+            `sh_max_vals`: list or iterable
+                Items in the iterable are the size_hint_max for each widget.
+                Can be None. The length should be the same as ``hint``
+            `hint`: list
+                A list whose size is the same as the length of ``sh_min_vals``
+                and ``sh_min_vals`` whose each element is the corresponding
+                size hint value of that element. This list is updated in place
+                with correct size hints that ensure the constraints are not
+                violated.
+
+        :returns:
+            Nothing. ``hint`` is updated in place.
+        '''
+        if not sh_sum:
+            return
+        # TODO: test when children have size_hint, max/min of zero
+
+        # all divs are float denominator ;)
+        stretch_ratio = sh_sum / float(available_space)
+        if available_space <= min_bounded_size or \
+                isclose(available_space, min_bounded_size):
+            # too small, just set to min
+            for i, (sh, sh_min) in enumerate(zip(hint, sh_min_vals)):
+                if sh is None:
+                    continue
+
+                if sh_min is not None:
+                    hint[i] = sh_min * stretch_ratio  # set to min size
+                else:
+                    hint[i] = 0.  # everything else is zero
+            return
+
+        # these dicts take i (widget child) as key
+        not_mined_contrib = {}  # all who's sh > min_sh or had no min_sh
+        not_maxed_contrib = {}  # all who's sh < max_sh or had no max_sh
+        sh_mins_avail = {}  # the sh amt removable until we hit sh_min
+        sh_maxs_avail = {}  # the sh amt addable until we hit sh_max
+        oversize_amt = undersize_amt = 0
+        hint_orig = hint[:]
+
+        # first,  for all the items, set them to be withing their max/min
+        # size_hint bound, also find how much their size_hint can be reduced
+        # or increased
+        for i, (sh, sh_min, sh_max) in enumerate(
+                zip(hint, sh_min_vals, sh_max_vals)):
+            if sh is None:
+                continue
+
+            diff = 0
+
+            if sh_min is not None:
+                sh_min *= stretch_ratio
+                diff = sh_min - sh  # how much we are under the min
+
+                if diff > 0:
+                    hint[i] = sh_min
+                    undersize_amt += diff
+                else:
+                    not_mined_contrib[i] = None
+
+                sh_mins_avail[i] = hint[i] - sh_min
+            else:
+                not_mined_contrib[i] = None
+                sh_mins_avail[i] = hint[i]
+
+            if sh_max is not None:
+                sh_max *= stretch_ratio
+                diff = sh - sh_max
+
+                if diff > 0:
+                    hint[i] = sh_max  # how much we are over the max
+                    oversize_amt += diff
+                else:
+                    not_maxed_contrib[i] = None
+
+                sh_maxs_avail[i] = sh_max - hint[i]
+            else:
+                not_maxed_contrib[i] = None
+                sh_maxs_avail[i] = sh_sum - hint[i]
+
+            if i in not_mined_contrib:
+                not_mined_contrib[i] = max(0., diff)  # how much got removed
+            if i in not_maxed_contrib:
+                not_maxed_contrib[i] = max(0., diff)  # how much got added
+
+        # if margin is zero, the amount of the widgets that were made smaller
+        # magically equals the amount of the widgets that were made larger
+        # so we're all good
+        margin = oversize_amt - undersize_amt
+        if isclose(oversize_amt, undersize_amt):
+            return
+
+        # we need to redistribute the margin among all widgets
+        # if margin is positive, then we have extra space because the widgets
+        # that were larger and were reduced contributed more, so increase
+        # the size hint for those that are allowed to be larger by the
+        # most allowed, proportionately to their size (or inverse size hint).
+        # similarly for the opposite case
+        if margin > 1e-15:
+            contrib_amt = not_maxed_contrib
+            sh_available = sh_maxs_avail
+            mult = 1.
+            contrib_proportion = hint_orig
+        elif margin < -1e-15:
+            margin *= -1.
+            contrib_amt = not_mined_contrib
+            sh_available = sh_mins_avail
+            mult = -1.
+
+            # when reducing the size of widgets proportionately, those with
+            # larger sh get reduced less, and those with smaller, more.
+            mn = min((h for h in hint_orig if h))
+            mx = max((h for h in hint_orig if h is not None))
+            hint_top = (2. * mn if mn else 1.) if mn == mx else mn + mx
+            contrib_proportion = [None if h is None else hint_top - h for
+                          h in hint_orig]
+
+        # contrib_amt is all the widgets that are not their max/min and
+        # can afford to be made bigger/smaller
+        # We only use the contrib_amt indices from now on
+        contrib_prop_sum = float(
+            sum((contrib_proportion[i] for i in contrib_amt)))
+
+        if contrib_prop_sum < 1e-9:
+            assert mult == 1.  # should only happen when all sh are zero
+            return
+
+        contrib_height = {
+            i: val / (contrib_proportion[i] / contrib_prop_sum) for
+            i, val in contrib_amt.items()}
+        items = sorted(
+            (i for i in contrib_amt),
+            key=lambda x: contrib_height[x])
+
+        j = items[0]
+        sum_i_contributed = contrib_amt[j]
+        last_height = contrib_height[j]
+        sh_available_i = {j: sh_available[j]}
+        contrib_prop_sum_i = contrib_proportion[j]
+
+        n = len(items)  # check when n <= 1
+        j = items[1]
+        i = 1
+        curr_height = contrib_height[j]
+        done = False
+        while not done and i < n:
+            while i < n and last_height == curr_height:
+                j = items[i]
+                sum_i_contributed += contrib_amt[j]
+                contrib_prop_sum_i += contrib_proportion[j]
+                sh_available_i[j] = sh_available[j]
+                curr_height = contrib_height[j]
+                i += 1
+            last_height = curr_height
+
+            while not done:
+                margin_height = ((margin + sum_i_contributed) /
+                                 (contrib_prop_sum_i / contrib_prop_sum))
+                if margin_height - curr_height > 1e-9 and i < n:
+                    break
+
+                done = True
+                for k, available_sh in list(sh_available_i.items()):
+                    if margin_height - available_sh / (
+                            contrib_proportion[k] / contrib_prop_sum) > 1e-9:
+                        del sh_available_i[k]
+                        sum_i_contributed -= contrib_amt[k]
+                        contrib_prop_sum_i -= contrib_proportion[k]
+                        margin -= available_sh
+                        hint[k] += mult * available_sh
+                        done = False
+
+                if not sh_available_i:  # all were under the margin
+                    break
+
+        if sh_available_i:
+            assert contrib_prop_sum_i and margin
+            margin_height = ((margin + sum_i_contributed) /
+                             (contrib_prop_sum_i / contrib_prop_sum))
+            for i in sh_available_i:
+                hint[i] += mult * (
+                    margin_height * contrib_proportion[i] / contrib_prop_sum -
+                    contrib_amt[i])

--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -276,9 +276,11 @@ class Layout(Widget):
         contrib_prop_sum_i = contrib_proportion[j]
 
         n = len(items)  # check when n <= 1
-        j = items[1]
         i = 1
-        curr_height = contrib_height[j]
+        if 1 < n:
+            j = items[1]
+            curr_height = contrib_height[j]
+
         done = False
         while not done and i < n:
             while i < n and last_height == curr_height:

--- a/kivy/uix/pagelayout.py
+++ b/kivy/uix/pagelayout.py
@@ -9,8 +9,10 @@ The :class:`PageLayout` class is used to create a simple multi-page
 layout, in a way that allows easy flipping from one page to another using
 borders.
 
-:class:`PageLayout` does not currently honor
-:attr:`~kivy.uix.widget.Widget.size_hint` or
+:class:`PageLayout` does not currently honor the
+:attr:`~kivy.uix.widget.Widget.size_hint`,
+:attr:`~kivy.uix.widget.Widget.size_hint_min`,
+:attr:`~kivy.uix.widget.Widget.size_hint_max`, or
 :attr:`~kivy.uix.widget.Widget.pos_hint` properties.
 
 .. versionadded:: 1.8.0

--- a/kivy/uix/recycleboxlayout.py
+++ b/kivy/uix/recycleboxlayout.py
@@ -106,7 +106,8 @@ class RecycleBoxLayout(RecycleLayout, BoxLayout):
         view_opts = self.view_opts
         n = len(view_opts)
         for i, x, y, w, h in self._iterate_layout(
-                [(opt['size'], opt['size_hint'], opt['pos_hint']) for
+                [(opt['size'], opt['size_hint'], opt['pos_hint'],
+                  (None, None), (None, None)) for
                  opt in reversed(view_opts)]):
             opt = view_opts[n - i - 1]
             shw, shh = opt['size_hint']

--- a/kivy/uix/recycleboxlayout.py
+++ b/kivy/uix/recycleboxlayout.py
@@ -44,9 +44,14 @@ class RecycleBoxLayout(RecycleLayout, BoxLayout):
         remove_view = self.remove_view
 
         for (index, widget, (w, h), (wn, hn), (shw, shh), (shnw, shnh),
-             ph, phn) in changed:
-            if horizontal and (shw != shnw or w != wn) or (shh != shnh or
-                                                           h != hn):
+             (shw_min, shh_min), (shwn_min, shhn_min), (shw_max, shh_max),
+             (shwn_max, shhn_max), ph, phn) in changed:
+            if (horizontal and
+                (shw != shnw or w != wn or shw_min != shwn_min or
+                 shw_max != shwn_max) or
+                not horizontal and
+                (shh != shnh or h != hn or shh_min != shhn_min or
+                 shh_max != shhn_max)):
                 return True
 
             remove_view(widget, index)
@@ -107,7 +112,7 @@ class RecycleBoxLayout(RecycleLayout, BoxLayout):
         n = len(view_opts)
         for i, x, y, w, h in self._iterate_layout(
                 [(opt['size'], opt['size_hint'], opt['pos_hint'],
-                  (None, None), (None, None)) for
+                  opt['size_hint_min'], opt['size_hint_max']) for
                  opt in reversed(view_opts)]):
             opt = view_opts[n - i - 1]
             shw, shh = opt['size_hint']

--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -15,16 +15,10 @@ The RecycleGridLayout is designed to provide a
 """
 
 from kivy.uix.recyclelayout import RecycleLayout
-from kivy.uix.gridlayout import GridLayout
+from kivy.uix.gridlayout import GridLayout, nmax, nmin
 from collections import defaultdict
 
 __all__ = ('RecycleGridLayout', )
-
-
-def nmax(*args):
-    # merge into one list
-    args = [x for x in args if x is not None]
-    return max(args)
 
 
 class RecycleGridLayout(RecycleLayout, GridLayout):
@@ -35,8 +29,6 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
     def __init__(self, **kwargs):
         super(RecycleGridLayout, self).__init__(**kwargs)
         self.funbind('children', self._trigger_layout)
-        self._has_hint_bound_x = False
-        self._has_hint_bound_y = False
 
     def on_children(self, instance, value):
         pass
@@ -44,14 +36,20 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
     def _fill_rows_cols_sizes(self):
         cols, rows = self._cols, self._rows
         cols_sh, rows_sh = self._cols_sh, self._rows_sh
+        cols_sh_min, rows_sh_min = self._cols_sh_min, self._rows_sh_min
+        cols_sh_max, rows_sh_max = self._cols_sh_max, self._rows_sh_max
         self._cols_count = cols_count = [defaultdict(int) for _ in cols]
         self._rows_count = rows_count = [defaultdict(int) for _ in rows]
 
         # calculate minimum size for each columns and rows
         n_cols = len(cols)
+        has_bound_y = has_bound_x = False
         for i, opt in enumerate(self.view_opts):
             (shw, shh), (w, h) = opt['size_hint'], opt['size']
+            shw_min, shh_min = opt['size_hint_min']
+            shw_max, shh_max = opt['size_hint_max']
             row, col = divmod(i, n_cols)
+
             if shw is None:
                 cols_count[col][w] += 1
             if shh is None:
@@ -62,11 +60,25 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
                 cols[col] = nmax(cols[col], w)
             else:
                 cols_sh[col] = nmax(cols_sh[col], shw)
+                if shw_min is not None:
+                    has_bound_x = True
+                    cols_sh_min[col] = nmax(cols_sh_min[col], shw_min)
+                if shw_max is not None:
+                    has_bound_x = True
+                    cols_sh_max[col] = nmin(cols_sh_max[col], shw_max)
 
             if shh is None:
                 rows[row] = nmax(rows[row], h)
             else:
                 rows_sh[row] = nmax(rows_sh[row], shh)
+                if shh_min is not None:
+                    has_bound_y = True
+                    rows_sh_min[col] = nmax(rows_sh_min[col], shh_min)
+                if shh_max is not None:
+                    has_bound_y = True
+                    rows_sh_max[col] = nmin(rows_sh_max[col], shh_max)
+        self._has_hint_bound_x = has_bound_x
+        self._has_hint_bound_y = has_bound_y
 
     def _update_rows_cols_sizes(self, changed):
         cols_count, rows_count = self._cols_count, self._rows_count
@@ -75,13 +87,16 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
         n_cols = len(cols_count)
 
         # this can be further improved to reduce re-comp, but whatever...
-        for index, widget, (w, h), (wn, hn), sh, shn, _, _ in changed:
-            if sh != shn:
+        for index, widget, (w, h), (wn, hn), sh, shn, sh_min, shn_min, \
+                sh_max, shn_max, _, _ in changed:
+            if sh != shn or sh_min != shn_min or sh_max != shn_max:
                 return True
-            elif (sh[0] is not None and w != wn or
-                  sh[1] is not None and h != hn):
+            elif (sh[0] is not None and w != wn and
+                  (h == hn or sh[1] is not None) or
+                  sh[1] is not None and h != hn and
+                  (w == wn or sh[0] is not None)):
                 remove_view(widget, index)
-            else:
+            else:  # size hint is None, so check if it can be resized inplace
                 row, col = divmod(index, n_cols)
 
                 if w != wn:

--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -35,6 +35,8 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
     def __init__(self, **kwargs):
         super(RecycleGridLayout, self).__init__(**kwargs)
         self.funbind('children', self._trigger_layout)
+        self._has_hint_bound_x = False
+        self._has_hint_bound_y = False
 
     def on_children(self, instance, value):
         pass

--- a/kivy/uix/recyclelayout.py
+++ b/kivy/uix/recyclelayout.py
@@ -25,6 +25,10 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
     key_size = StringProperty(None, allownone=True)
     default_size_hint = ObjectProperty((None, None))
     key_size_hint = StringProperty(None, allownone=True)
+    default_size_hint_min = ObjectProperty((None, None))
+    key_size_hint_min = StringProperty(None, allownone=True)
+    default_size_hint_max = ObjectProperty((None, None))
+    key_size_hint_max = StringProperty(None, allownone=True)
     default_pos_hint = ObjectProperty({})
     key_pos_hint = StringProperty(None, allownone=True)
     initial_size = ObjectProperty((100, 100))
@@ -50,6 +54,10 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             fbind('key_size', rv.refresh_from_data)
             fbind('default_size_hint', rv.refresh_from_data)
             fbind('key_size_hint', rv.refresh_from_data)
+            fbind('default_size_hint_min', rv.refresh_from_data)
+            fbind('key_size_hint_min', rv.refresh_from_data)
+            fbind('default_size_hint_max', rv.refresh_from_data)
+            fbind('key_size_hint_max', rv.refresh_from_data)
             fbind('default_pos_hint', rv.refresh_from_data)
             fbind('key_pos_hint', rv.refresh_from_data)
 
@@ -61,6 +69,10 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             funbind('key_size', rv.refresh_from_data)
             funbind('default_size_hint', rv.refresh_from_data)
             funbind('key_size_hint', rv.refresh_from_data)
+            funbind('default_size_hint_min', rv.refresh_from_data)
+            funbind('key_size_hint_min', rv.refresh_from_data)
+            funbind('default_size_hint_max', rv.refresh_from_data)
+            funbind('key_size_hint_max', rv.refresh_from_data)
             funbind('default_pos_hint', rv.refresh_from_data)
             funbind('key_pos_hint', rv.refresh_from_data)
         super(RecycleLayout, self).detach_recycleview()
@@ -77,6 +89,8 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             opt = self.view_opts[idx]
             if (instance.size == opt['size'] and
                 instance.size_hint == opt['size_hint'] and
+                instance.size_hint_min == opt['size_hint_min'] and
+                instance.size_hint_max == opt['size_hint_max'] and
                 instance.pos_hint == opt['pos_hint']):
                 return
             self._size_needs_update = True
@@ -118,6 +132,10 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
         ph_def = self.default_pos_hint
         sh_key = self.key_size_hint
         sh_def = self.default_size_hint
+        sh_min_key = self.key_size_hint_min
+        sh_min_def = self.default_size_hint_min
+        sh_max_key = self.key_size_hint_max
+        sh_max_def = self.default_size_hint_max
         s_key = self.key_size
         s_def = self.default_size
         viewcls_def = self.viewclass
@@ -137,6 +155,18 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             sh = [item.get('size_hint_x', sh[0]),
                   item.get('size_hint_y', sh[1])]
 
+            sh_min = sh_min_def if sh_min_key is None else item.get(sh_min_key,
+                                                                    sh_min_def)
+            sh_min = item.get('size_hint_min', sh_min)
+            sh_min = [item.get('size_hint_min_x', sh_min[0]),
+                      item.get('size_hint_min_y', sh_min[1])]
+
+            sh_max = sh_max_def if sh_max_key is None else item.get(sh_max_key,
+                                                                    sh_max_def)
+            sh_max = item.get('size_hint_max', sh_max)
+            sh_max = [item.get('size_hint_max_x', sh_max[0]),
+                      item.get('size_hint_max_y', sh_max[1])]
+
             s = s_def if s_key is None else item.get(s_key, s_def)
             s = item.get('size', s)
             w, h = s = item.get('width', s[0]), item.get('height', s[1])
@@ -151,7 +181,8 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
 
             opts[i] = {
                 'size': [(iw if w is None else w), (ih if h is None else h)],
-                'size_hint': sh, 'pos': None, 'pos_hint': ph,
+                'size_hint': sh, 'size_hint_min': sh_min,
+                'size_hint_max': sh_max, 'pos': None, 'pos_hint': ph,
                 'viewclass': viewcls, 'width_none': w is None,
                 'height_none': h is None}
 
@@ -165,11 +196,17 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             s = opt['size']
             w, h = sn = widget.size
             sh = opt['size_hint']
-            shnw, shnh = shn = widget.size_hint
+            shn = widget.size_hint
+            sh_min = opt['size_hint_min']
+            shn_min = widget.size_hint_min
+            sh_max = opt['size_hint_max']
+            shn_max = widget.size_hint_max
             ph = opt['pos_hint']
             phn = widget.pos_hint
-            if s != sn or sh != shn or ph != phn:
-                changed.append((index, widget, s, sn, sh, shn, ph, phn))
+            if s != sn or sh != shn or ph != phn or sh_min != shn_min or \
+                    sh_max != shn_max:
+                changed.append((index, widget, s, sn, sh, shn, sh_min, shn_min,
+                                sh_max, shn_max, ph, phn))
                 if shnw is None:
                     if shnh is None:
                         opt['size'] = sn
@@ -178,6 +215,8 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
                 elif shnh is None:
                     opt['size'] = [s[0], h]
                 opt['size_hint'] = shn
+                opt['size_hint_min'] = shn_min
+                opt['size_hint_max'] = shn_max
                 opt['pos_hint'] = phn
 
         if [f for f in flags if not f]:  # need to redo everything
@@ -205,10 +244,10 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
         for index, widget in new:
             # make sure widget is added first so that any sizing updates
             # will be recorded
-            opt = view_opts[index]
-            refresh_view_layout(
-                index, opt['pos'], opt['pos_hint'], opt['size'],
-                opt['size_hint'], widget, viewport)
+            opt = view_opts[index].copy()
+            del opt['width_none']
+            del opt['height_none']
+            refresh_view_layout(index, opt, widget, viewport)
 
         # then add all the visible widgets, which binds size/size_hint
         add = self.add_widget
@@ -224,6 +263,8 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             opt = view_opts[index]
             if (changed or widget.size == opt['size'] and
                 widget.size_hint == opt['size_hint'] and
+                widget.size_hint_min == opt['size_hint_min'] and
+                widget.size_hint_max == opt['size_hint_max'] and
                 widget.pos_hint == opt['pos_hint']):
                 continue
             changed = True
@@ -234,17 +275,21 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             self._size_needs_update = True
             self.recycleview.refresh_from_layout(view_size=True)
 
-    def refresh_view_layout(self, index, pos, pos_hint, size, size_hint, view,
-                            viewport):
-        opt = self.view_opts[index]
-        w, h = size
-        shw, shh = size_hint
-        if shw is None and opt['width_none']:
+    def refresh_view_layout(self, index, layout, view, viewport):
+        opt = self.view_opts[index].copy()
+        width_none = opt.pop('width_none')
+        height_none = opt.pop('height_none')
+        opt.update(layout)
+
+        w, h = opt['size']
+        shw, shh = opt['size_hint']
+        if shw is None and width_none:
             w = None
-        if shh is None and opt['height_none']:
+        if shh is None and height_none:
             h = None
+        opt['size'] = w, h
         super(RecycleLayout, self).refresh_view_layout(
-            index, pos, pos_hint, (w, h), size_hint, view, viewport)
+            index, opt, view, viewport)
 
     def remove_views(self):
         super(RecycleLayout, self).remove_views()

--- a/kivy/uix/recyclelayout.py
+++ b/kivy/uix/recyclelayout.py
@@ -196,7 +196,7 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
             s = opt['size']
             w, h = sn = widget.size
             sh = opt['size_hint']
-            shn = widget.size_hint
+            shnw, shnh = shn = widget.size_hint
             sh_min = opt['size_hint_min']
             shn_min = widget.size_hint_min
             sh_max = opt['size_hint_max']

--- a/kivy/uix/recycleview/layout.py
+++ b/kivy/uix/recycleview/layout.py
@@ -142,10 +142,9 @@ apply_selection` method will be called everything the view needs to refresh
         if _view_base_cache[viewclass]:
             view.apply_selection(self.recycleview, index, is_selected)
 
-    def refresh_view_layout(self, index, pos, pos_hint, size, size_hint, view,
-                            viewport):
+    def refresh_view_layout(self, index, layout, view, viewport):
         super(LayoutSelectionBehavior, self).refresh_view_layout(
-            index, pos, pos_hint, size, size_hint, view, viewport)
+            index, layout, view, viewport)
         self.apply_selection(index, view, index in self.selected_nodes)
 
 
@@ -207,13 +206,12 @@ class RecycleLayoutManagerBehavior(object):
         '''
         pass
 
-    def refresh_view_layout(self, index, pos, pos_hint, size, size_hint, view,
-                            viewport):
+    def refresh_view_layout(self, index, layout, view, viewport):
         '''`See :meth:`~kivy.uix.recycleview.views.RecycleDataAdapter.\
 refresh_view_layout`.
         '''
         self.recycleview.view_adapter.refresh_view_layout(
-            index, pos, pos_hint, size, size_hint, view, viewport)
+            index, layout, view, viewport)
 
     def get_view_index_at(self, pos):
         """Return the view `index` on which position, `pos`, falls.

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -1127,6 +1127,86 @@ class Widget(WidgetBase):
     containing a dict.
     '''
 
+    size_hint_min_x = NumericProperty(None, allownone=True)
+    '''When not None, the X-direction minimum size (in pixels,
+    like :attr:`width`) when :attr:`size_hint_x` is also not None.
+
+    When :attr:`size_hint_x` is not None, it is the minimum width that the
+    widget will be set due to the :attr:`size_hint_x`. I.e. when a smaller size
+    would be set, :attr:`size_hint_min_x` is the value used instead for the
+    widget width. When None, or when :attr:`size_hint_x` is None,
+    :attr:`size_hint_min_x` doesn't do anything.
+
+    Only the :class:`~kivy.uix.layout.Layout` and
+    :class:`~kivy.core.window.Window` classes make use of the hint.
+
+    :attr:`size_hint_min_x` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to None.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    size_hint_min_y = NumericProperty(None, allownone=True)
+    '''When not None, the Y-direction minimum size (in pixels,
+    like :attr:`height`) when :attr:`size_hint_y` is also not None.
+
+    When :attr:`size_hint_y` is not None, it is the minimum height that the
+    widget will be set due to the :attr:`size_hint_y`. I.e. when a smaller size
+    would be set, :attr:`size_hint_min_y` is the value used instead for the
+    widget height. When None, or when :attr:`size_hint_y` is None,
+    :attr:`size_hint_min_y` doesn't do anything.
+
+    Only the :class:`~kivy.uix.layout.Layout` and
+    :class:`~kivy.core.window.Window` classes make use of the hint.
+
+    :attr:`size_hint_min_y` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to None.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    size_hint_min = ReferenceListProperty(size_hint_min_x, size_hint_min_y)
+    '''Minimum size when using :attr:`size_hint`.
+
+    :attr:`size_hint_min` is a :class:`~kivy.properties.ReferenceListProperty`
+    of (:attr:`size_hint_min_x`, :attr:`size_hint_min_y`) properties.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    size_hint_max_x = NumericProperty(None, allownone=True)
+    '''When not None, the X-direction maximum size (in pixels,
+    like :attr:`width`) when :attr:`size_hint_x` is also not None.
+
+    Similar to :attr:`size_hint_min_x`, except that it sets the maximum width.
+
+    :attr:`size_hint_max_x` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to None.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    size_hint_max_y = NumericProperty(None, allownone=True)
+    '''When not None, the Y-direction maximum size (in pixels,
+    like :attr:`height`) when :attr:`size_hint_y` is also not None.
+
+    Similar to :attr:`size_hint_min_y`, except that it sets the maximum height.
+
+    :attr:`size_hint_max_y` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to None.
+
+    .. versionadded:: 1.9.2
+    '''
+
+    size_hint_max = ReferenceListProperty(size_hint_max_x, size_hint_max_y)
+    '''Maximum size when using :attr:`size_hint`.
+
+    :attr:`size_hint_max` is a :class:`~kivy.properties.ReferenceListProperty`
+    of (:attr:`size_hint_max_x`, :attr:`size_hint_max_y`) properties.
+
+    .. versionadded:: 1.9.2
+    '''
+
     ids = DictProperty({})
     '''This is a dictionary of ids defined in your kv language. This will only
     be populated if you use ids in your kv language code.


### PR DESCRIPTION
The addition is explained in Widget, partially quoted below:

```py
size_hint_min_x = NumericProperty(None, allownone=True)
    '''When not None, the X-direction minimum size (in pixels,
    like :attr:`width`) when :attr:`size_hint_x` is also not None.

    When :attr:`size_hint_x` is not None, it is the minimum width that the
    widget will be set due to the :attr:`size_hint_x`. I.e. when a smaller size
    would be set, :attr:`size_hint_min_x` is the value used instead for the
    widget width. When None, or when :attr:`size_hint_x` is None,
    :attr:`size_hint_min_x` doesn't do anything.
    '''

    size_hint_min_y = NumericProperty(None, allownone=True)
    '''When not None, the Y-direction minimum size (in pixels,
    like :attr:`height`) when :attr:`size_hint_y` is also not None.

    When :attr:`size_hint_y` is not None, it is the minimum height that the
    widget will be set due to the :attr:`size_hint_y`. I.e. when a smaller size
    would be set, :attr:`size_hint_min_y` is the value used instead for the
    widget height. When None, or when :attr:`size_hint_y` is None,
    :attr:`size_hint_min_y` doesn't do anything.
    '''

    size_hint_min = ReferenceListProperty(size_hint_min_x, size_hint_min_y)

    size_hint_max_x = NumericProperty(None, allownone=True)
    '''When not None, the X-direction maximum size (in pixels,
    like :attr:`width`) when :attr:`size_hint_x` is also not None.

    Similar to :attr:`size_hint_min_x`, except that it sets the maximum width.
    '''

    size_hint_max_y = NumericProperty(None, allownone=True)
    '''When not None, the Y-direction maximum size (in pixels,
    like :attr:`height`) when :attr:`size_hint_y` is also not None.

    Similar to :attr:`size_hint_min_y`, except that it sets the maximum height.
    '''

    size_hint_max = ReferenceListProperty(size_hint_max_x, size_hint_max_y)
```


All layouts including RecycleView layouts support it. 
In terms of reduced perf, if size_hint_min/max is not used the layout incurs minimum cost (except maybe for StackLayout since the code there generally isn't as optimized as it could probably be), except of course due to the addition of these new properties to the widgets.

Example code:
```py
from kivy.lang import Builder
from kivy.app import runTouchApp

runTouchApp(Builder.load_string('''
BoxLayout:
    orientation: 'vertical'
    GridLayout:
        rows: 1
        Button:
            text: '1'
            width: 100
            size_hint_x: None
        Button:
            text: '2'
            size_hint_min_x: 300
        Button:
            text: '3'
        Button:
            text: '4'
            size_hint_max_x: 25
    BoxLayout:
        Button:
            text: '1'
            width: 100
            size_hint_x: None
        Button:
            text: '2'
            size_hint_min_x: 300
        Button:
            text: '3'
        Button:
            text: '4'
            size_hint_max_x: 25
'''))
```