### PR TITLE
test_wordbreak fails on retina mac

### DIFF
--- a/kivy/tests/test_uix_textinput.py
+++ b/kivy/tests/test_uix_textinput.py
@@ -22,7 +22,7 @@ class TextInputTest(unittest.TestCase):
     def test_wordbreak(self):
         self.test_txt = "Firstlongline\n\nSecondveryverylongline"
 
-        ti = TextInput(width=30, size_hint_x=None)
+        ti = TextInput(width='30dp', size_hint_x=None)
         ti.bind(text=self.on_text)
         ti.text = self.test_txt
 


### PR DESCRIPTION
This test fails on macos/retina display: returning (0,11) instead of the expected (0,6).
Having a look at the output on my retina mac confirms that `width=30` means there is only room for 2 characters.