### PR TITLE
Ellipsis Style for markup label

### DIFF
--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -752,7 +752,14 @@ class MarkupLabel(MarkupLabelBase):
         s = self.get_extents(last_text)
         if len(last_text):
             line1.append(LayoutWord(last_word.options, s[0], s[1], last_text))
-        elps.options = last_word.options
+
+        elps_opts = old_opts
+        if 'ellipsis_options' in old_opts:
+            user_opts = old_opts['ellipsis_options']
+            for k in user_opts:
+                elps_opts[k] = user_opts[k]
+
+        elps.options = elps_opts
         line1.append(elps)
 
         # now add back the right half

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -627,6 +627,12 @@ class MarkupLabel(MarkupLabelBase):
             return lw + 2 * xpad, lh + 2 * ypad, [LayoutLine(0, 0,
             lw, lh, 1, 0, line)]
 
+        elps_opts = copy(old_opts)
+        if 'ellipsis_options' in old_opts:
+            elps_opts.update(old_opts['ellipsis_options'])
+
+        # Set new opts for ellipsis
+        self.options = elps_opts
         # find the size of ellipsis that'll fit
         elps_s = textwidth('...')
         if elps_s[0] > uw:  # even ellipsis didn't fit...
@@ -640,8 +646,10 @@ class MarkupLabel(MarkupLabelBase):
                 return (s[0] + 2 * xpad, s[1] * line_height + 2 * ypad,
                     [LayoutLine(0, 0, s[0], s[1], 1, 0, [LayoutWord(old_opts,
                     s[0], s[1], '.')])])
-        elps = LayoutWord(old_opts, elps_s[0], elps_s[1], '...')
+        elps = LayoutWord(elps_opts, elps_s[0], elps_s[1], '...')
         uw -= elps_s[0]
+        # Restore old opts
+        self.options = old_opts
 
         # now find the first left and right words that fit
         w1, e1, l1, clipped1 = n_restricted(line, uw, c)
@@ -752,14 +760,6 @@ class MarkupLabel(MarkupLabelBase):
         s = self.get_extents(last_text)
         if len(last_text):
             line1.append(LayoutWord(last_word.options, s[0], s[1], last_text))
-
-        elps_opts = old_opts
-        if 'ellipsis_options' in old_opts:
-            user_opts = old_opts['ellipsis_options']
-            for k in user_opts:
-                elps_opts[k] = user_opts[k]
-
-        elps.options = elps_opts
         line1.append(elps)
 
         # now add back the right half

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -267,8 +267,9 @@ class Label(Widget):
                         'outline_width', 'disabled_outline_color',
                         'outline_color', 'text_size', 'shorten', 'mipmap',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
-                        'split_str', 'unicode_errors', 'markup',
-                        'font_hinting', 'font_kerning', 'font_blended')
+                        'split_str', 'ellipsis_options', 'unicode_errors',
+                        'markup', 'font_hinting', 'font_kerning',
+                        'font_blended')
 
     def __init__(self, **kwargs):
         self._trigger_texture = Clock.create_trigger(self.texture_update, -1)
@@ -746,6 +747,8 @@ class Label(Widget):
     :attr:`split_str` is a :class:`~kivy.properties.StringProperty` and
     defaults to `''` (the empty string).
     '''
+
+    ellipsis_options = DictProperty({})
 
     unicode_errors = OptionProperty(
         'replace', options=('strict', 'replace', 'ignore'))

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -749,6 +749,26 @@ class Label(Widget):
     '''
 
     ellipsis_options = DictProperty({})
+    '''Font options for the ellipsis string('...') used to split the text.
+
+    Accepts a dict as option name with the value. Only applied when
+    :attr:`markup` is true and text is shortened. All font options which work
+    for :class:`Label` will work for :attr:`ellipsis_options`. Defaults for
+    the options not specified are taken from the surronding text.
+
+    .. code-block:: kv
+
+        Label:
+            text: 'Some very long line which will be cut'
+            markup: True
+            shorten: True
+            ellipsis_options: {'color':(1,0.5,0.5,1),'underline':True}
+
+    .. versionadded:: 2.0.0
+
+    :attr:`ellipsis_options` is a :class:`~kivy.properties.DictProperty` and
+    defaults to `{}` (the empty dict).
+    '''
 
     unicode_errors = OptionProperty(
         'replace', options=('strict', 'replace', 'ignore'))


### PR DESCRIPTION
Fixes #4580 

Keeping a different font size breaks baseline alignment of ellipsis. I don't know if that is supposed to happen (as an outcome of bad UI config). If it is a required feature I'll look into it.

Example app

```
from kivy.app import App
from kivy.lang import Builder

kv = """
Label:
    text_size: 200, None
    text: 'Some very long line which will be cut'
    markup: True
    shorten: True
    ellipsis_options: {'color':(1,0.5,0.5,1),'underline':True}
"""


class TestApp(App):
    def build(self):
        return Builder.load_string(kv)

if __name__ == '__main__':
    TestApp().run()
```