### PR TITLE
Fix property numeric

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -579,7 +579,10 @@ cdef class NumericProperty(Property):
                 self.name, x))
 
     cdef float parse_str(self, EventDispatcher obj, value):
-        return self.parse_list(obj, value[:-2], value[-2:])
+        if value[-2:] in NUMERIC_FORMATS:
+            return self.parse_list(obj, value[:-2], value[-2:])
+        else:
+            return float(value)
 
     cdef float parse_list(self, EventDispatcher obj, value, ext):
         cdef PropertyStorage ps = obj.__storage[self._name]

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -410,6 +410,17 @@ class PropertiesTestCase(unittest.TestCase):
         self.assertEqual(a.get(wid), 9504.0 * density)
         self.assertEqual(a.get_format(wid), 'in')
 
+    def test_numeric_string_without_units(self):
+        from kivy.properties import NumericProperty
+
+        a = NumericProperty()
+        a.link(wid, 'a')
+        a.link_deps(wid, 'a')
+        self.assertEqual(a.get(wid), 0)
+
+        a.set(wid, '2')
+        self.assertEqual(a.get(wid), 2)
+
     def test_property_rebind(self):
         from kivy.uix.label import Label
         from kivy.uix.togglebutton import ToggleButton


### PR DESCRIPTION
NumericProperty won't convert something that looks like a number unless it has units attached to it.

I found this trying to populate a `padding` value from a `Settings` pane.
Since such an item can be a bare string, or any of a 1, 2, or 4 item list, I was reading it in as a string, and then converting things to NumericProperties.

Here's how you can see the issue.

```python
from kivy.event import EventDispatcher
class TestProperty(EventDispatcher):
    pass

wid = TestProperty()

from kivy.properties import NumericProperty

a = NumericProperty()
a.link(wid, 'a')
a.link_deps(wid, 'a')
print(a.get(wid))
a.set(wid, '1px')
print(a.get(wid))
a.set(wid, '2')
print(a.get(wid))
```

After the fix, something like '2' will be handled just like '2px'

