### PR TITLE
AnchorLayout is badly broken

### DIFF
--- a/kivy/uix/anchorlayout.py
+++ b/kivy/uix/anchorlayout.py
@@ -82,33 +82,30 @@ class AnchorLayout(Layout):
         height = self.height
         anchor_x = self.anchor_x
         anchor_y = self.anchor_y
-        padding = self.padding
-
-        left, top, right, bottom = range(4)
-        horizontal, vertical = range(2)
+        pad_left, pad_top, pad_right, pad_bottom = self.padding
 
         for c in self.children:
             x, y = _x, _y
             cw, ch = c.size
-            if c.size_hint[horizontal] is not None:
-                cw = c.size_hint[horizontal] * (width - padding[left] - padding[right])
-            if c.size_hint[vertical] is not None:
-                ch = c.size_hint[vertical] * (height - padding[top] - padding[bottom])
+            size_hint_h, size_hint_v = c.size_hint
+
+            if size_hint_h is not None:
+                cw = size_hint_h * (width - pad_left - pad_right)
+            if size_hint_v is not None:
+                ch = size_hint_v * (height - pad_top - pad_bottom)
 
             if anchor_x == 'left':
-                x = x + padding[left]
-            if anchor_x == 'right':
-                x = x + width - (cw + padding[right])
-            if self.anchor_x == 'center':
-                x = x + (width - padding[right] + padding[left] - cw) / 2
+                x = x + pad_left
+            elif anchor_x == 'right':
+                x = x + width - (cw + pad_right)
+            else:
+                x = x + (width - pad_right + pad_left - cw) / 2
             if anchor_y == 'bottom':
-                y = y + padding[bottom]
-            if anchor_y == 'top':
-                y = y + height - (ch + padding[top])
-            if anchor_y == 'center':
-                y = y + (height - padding[top] + padding[bottom] - ch) / 2
+                y = y + pad_bottom
+            elif anchor_y == 'top':
+                y = y + height - (ch + pad_top)
+            else:
+                y = y + (height - pad_top + pad_bottom - ch) / 2
 
-            c.x = x
-            c.y = y
-            c.width = cw
-            c.height = ch
+            c.pos = x, y
+            c.size = cw, ch

--- a/kivy/uix/anchorlayout.py
+++ b/kivy/uix/anchorlayout.py
@@ -84,28 +84,31 @@ class AnchorLayout(Layout):
         anchor_y = self.anchor_y
         padding = self.padding
 
+        left, top, right, bottom = range(4)
+        horizontal, vertical = range(2)
+
         for c in self.children:
             x, y = _x, _y
-            w, h = c.size
-            if c.size_hint[0] is not None:
-                w = c.size_hint[0] * width - (padding[0] + padding[2])
-            if c.size_hint[1] is not None:
-                h = c.size_hint[1] * height - (padding[1] + padding[3])
+            cw, ch = c.size
+            if c.size_hint[horizontal] is not None:
+                cw = c.size_hint[horizontal] * (width - padding[left] - padding[right])
+            if c.size_hint[vertical] is not None:
+                ch = c.size_hint[vertical] * (height - padding[top] - padding[bottom])
 
             if anchor_x == 'left':
-                x = x + padding[0]
+                x = x + padding[left]
             if anchor_x == 'right':
-                x = x + width - (w + padding[2])
+                x = x + width - (cw + padding[right])
             if self.anchor_x == 'center':
-                x = x + (width / 2) - (w / 2)
+                x = x + (width - padding[right] + padding[left] - cw) / 2
             if anchor_y == 'bottom':
-                y = y + padding[1]
+                y = y + padding[bottom]
             if anchor_y == 'top':
-                y = y + height - (h + padding[3])
+                y = y + height - (ch + padding[top])
             if anchor_y == 'center':
-                y = y + (height / 2) - (h / 2)
+                y = y + (height - padding[top] + padding[bottom] - ch) / 2
 
             c.x = x
             c.y = y
-            c.width = w
-            c.height = h
+            c.width = cw
+            c.height = ch


### PR DESCRIPTION
An asymmetric padding list will show the problem. If you use a constant pad value, you likely wouldn't have noticed.

In short:
* Top/bottom padding indices were mixed up
* `size_hint` calculation is wrong
* `center` calculations ignore padding entirely (placing all children in the middle of the screen regardless of padding)

These are all easy to see by running the code at: https://gist.github.com/llfkj/08c2ccede6cf271d4238405d9ba5e2d6

The linked example should create a button that is half the size of the padded area, and attempts to place it within the rectangle. Short version: it doesn't. The white rectangle is the area inside the padding.

