### PR TITLE
Fix #4331

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1187,6 +1187,7 @@ class TextInput(FocusBehavior, Widget):
         self._selection = False
         self._selection_finished = True
         self._selection_touch = None
+        self.selection_text = u''
         self._trigger_update_graphics()
 
     def delete_selection(self, from_undo=False):


### PR DESCRIPTION
`selection_text` is a property that stores the value of selected text. Although everything else was cleared, this one remained the same, therefore issues like 4331 happened.