### PR TITLE
stopTouchApp(): don't simply return, try stop in the next frame

### DIFF
--- a/kivy/base.py
+++ b/kivy/base.py
@@ -491,9 +491,8 @@ def runTouchApp(widget=None, slave=False):
 
 def stopTouchApp():
     '''Stop the current application by leaving the main loop'''
-    if EventLoop is None:
-        return
-    if EventLoop.status != 'started':
+    if EventLoop is None or EventLoop.status != 'started':
+        Clock.schedule_once(lambda dt: stopTouchApp(), 0)
         return
     Logger.info('Base: Leaving application in progress...')
     EventLoop.close()


### PR DESCRIPTION
If someone wants to close the app, its the app which is responsible of successful finishing the eventloop.

There are use cases, as described in #4634 when user wants to close the app on startup, for example in build() or on_start(). Current solution breaks such possibility: when eventloop is not available, the request to close will be forgotten. That together with #4636 fixes #4634 completely.
