### PR TITLE
Added softinput_mode handling for SDL2

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -516,6 +516,8 @@ class WindowBase(EventDispatcher):
     :attr:`softinput_mode` is an :class:`~kivy.properties.OptionProperty` and
     defaults to `None`.
 
+    .. note:: The `resize` option does not currently work with SDL2 on Android.
+
     .. versionadded:: 1.9.0
 
     .. versionchanged:: 1.9.1

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -567,6 +567,9 @@ class WindowBase(EventDispatcher):
     '''Returns the height of the softkeyboard/IME on mobile platforms.
     Will return 0 if not on mobile platform or if IME is not active.
 
+    .. note:: This property returns 0 with SDL2 on Android, but setting
+              Window.softinput_mode does works.
+
     .. versionadded:: 1.9.0
 
     :attr:`keyboard_height` is a read-only

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -274,9 +274,7 @@ cdef class _WindowSDL2Storage:
 
     def hide_keyboard(self):
         if SDL_IsTextInputActive():
-
             SDL_StopTextInput()
-
 
     def is_keyboard_shown(self):
         return SDL_IsTextInputActive()

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -231,7 +231,6 @@ cdef class _WindowSDL2Storage:
         cdef SDL_Rect *rect = <SDL_Rect *>PyMem_Malloc(sizeof(SDL_Rect))
         if not rect:
             raise MemoryError('Memory error in rect allocation')
-        cdef int targetbottom, targetleft, targetwidth, targetheight
         try:
             if platform == 'android':
                 # This could probably be safely done on every platform

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -5,7 +5,9 @@ from libc.string cimport memcpy
 from os import environ
 from kivy.config import Config
 from kivy.logger import Logger
+from kivy import platform
 
+from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 
 cdef int _event_filter(void *userdata, SDL_Event *event) with gil:
     return (<_WindowSDL2Storage>userdata).cb_event_filter(event)
@@ -223,13 +225,58 @@ cdef class _WindowSDL2Storage:
         SDL_DestroyWindow(self.win)
         SDL_Quit()
 
-    def show_keyboard(self):
-        if not SDL_IsTextInputActive():
+    def show_keyboard(self, system_keyboard, softinput_mode):
+        if SDL_IsTextInputActive():
+            return
+        cdef SDL_Rect *rect = <SDL_Rect *>PyMem_Malloc(sizeof(SDL_Rect))
+        if not rect:
+            raise MemoryError('Memory error in rect allocation')
+        cdef int targetbottom, targetleft, targetwidth, targetheight
+        try:
+            if platform == 'android':
+                # This could probably be safely done on every platform
+                # (and should behave correctly with e.g. the windows
+                # software keyboard), but this hasn't been tested
+
+                wx, wy = self.window_size
+
+                # Note Android's coordinate system has y=0 at the top
+                # of the screen
+
+                if softinput_mode == 'below_target':
+                    target = system_keyboard.target
+                    rect.y = max(0, wy - target.to_window(0, target.top)[1]) if target else 0
+                    rect.x = max(0, target.to_window(target.x, 0)[0]) if target else 0
+                    rect.w = max(0, target.width) if target else 0
+                    rect.h = max(0, target.height) if target else 0
+                    SDL_SetTextInputRect(rect)
+                elif softinput_mode == 'pan':
+                    # tell Android the TextInput is at the screen
+                    # bottom, so that it always pans
+                    rect.y = wy - 5
+                    rect.x = 0
+                    rect.w = wx
+                    rect.h = 5
+                    SDL_SetTextInputRect(rect)
+                else:
+                    # Supporting 'resize' needs to call the Android
+                    # API to set ADJUST_RESIZE mode, and change the
+                    # java bootstrap to a different root Layout.
+                    rect.y = 0
+                    rect.x = 0
+                    rect.w = 10
+                    rect.h = 1
+                    SDL_SetTextInputRect(rect)
+
             SDL_StartTextInput()
+        finally:
+            PyMem_Free(<void *>rect)
 
     def hide_keyboard(self):
         if SDL_IsTextInputActive():
+
             SDL_StopTextInput()
+
 
     def is_keyboard_shown(self):
         return SDL_IsTextInputActive()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -682,7 +682,7 @@ class WindowSDL(WindowBase):
     def request_keyboard(self, callback, target, input_type='text'):
         self._sdl_keyboard = super(WindowSDL, self).\
             request_keyboard(callback, target, input_type)
-        self._win.show_keyboard()
+        self._win.show_keyboard(self._system_keyboard, self.softinput_mode)
         Clock.schedule_interval(self._check_keyboard_shown, 1 / 5.)
         return self._sdl_keyboard
 


### PR DESCRIPTION
This works by using the SDL2 built in keyboard height handling. below_target and pan mode work easily, but resize doesn't do anything.

To get the keyboard handling you also need an up to date p4a version (pending me merging the small change necessary).

To add `resize` it would be necessary to modify PythonActivity's windowSoftInputMode to adjustResize, and also to change the java widget structure to something other than an AbsoluteLayout. Without doing that, I think the resize of the root widget works but the opengl canvas isn't itself resized, just shifted.

@akshayaurora I know you weren't enamoured with using SDL2 because of the limitations (e.g. still need more work to actually get the keyboard height within a kivy app), but I think it has the major advantages that it's very simple and easy, and faster than the old method (the shift is instant), without really any downsides.

I limited this code to set the text region on Android only because that's where it's tested. I think the same thing would work on iOS with SDL2, and I think SDL2 can also do something in relation to the software keyboard on Windows.