### PR TITLE
Added proper handling for back button on Android

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1399,8 +1399,24 @@ class WindowBase(EventDispatcher):
         if WindowBase.on_keyboard.exit_on_escape:
             if key == 27 or all([is_osx, key in [113, 119], modifier == 1024]):
                 if not self.dispatch('on_request_close', source='keyboard'):
-                    stopTouchApp()
-                    self.close()
+                    if platform == 'android':
+                        # back button on Android should not be treated
+                        # the same as desktop's ESC
+                        from jnius import autoclass, JavaException
+                        try:
+                            activity = autoclass('org.kivy.android.PythonActivity')
+                        except JavaException:
+                            activity = None
+                        if not activity:
+                            try:
+                                activity = autoclass('org.renpy.android.PythonActivity')
+                            except JavaErception:
+                                activity = None
+                        if activity is not None:
+                            activity.moveTaskToBack(True)
+                    else:
+                        stopTouchApp()
+                        self.close()
                     return True
 
     if Config:


### PR DESCRIPTION
With this PR, the back button will exit to the homescreen without stopping Kivy, just like the home button.

I think this is correct behaviour because, although SDL2 maps the back button to the esc keycode, it doesn't have the same implications as on the desktop. That said, I just threw this together from the code in my own app and have made the PR to raise discussion, the best solution may not be the same as this.

Something definitely needs changing, as right now kivy halts without informing Android, so it appears to have crashed and will raise an error popup when the user navigates back to the app.

Edit: I also haven't tested this exact code, even if you really love it then that needs doing before merging.
