### PR TITLE
Compile Kivy with MSVC

### DIFF
--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -212,7 +212,49 @@ with git rather than a wheel there are some additional steps:
 MSVC
 ~~~~
 
-...
+.. warning::
+   The branch is still in progress and some things might not work when compiled
+   with msvc.
+
+.. |msvc| replace:: compiler
+.. _msvc: http://landinghub.visualstudio.com/visual-cpp-build-tools
+.. |py3deps| replace:: py3.5 deps
+.. _py3deps: https://drive.google.com/drive/folders/0B1_HB9J8mZepdUl0bEZubXZiSUE
+.. |gl-back| replace:: feature-gl-backend
+.. _gl-back: https://github.com/kivy/kivy/pull/4385
+
+Environment
+^^^^^^^^^^^
+
+1. Get the |msvc|_ (~5GB total size)
+2. Open ``cmd.exe`` in `<python.exe dir>` (`shift` + right click)
+3. Upgrade pip and setuptools*
+4. Get sdl2 and glew |py3deps|_
+   and install them
+5. ``"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"``
+6. Set environment variables::
+
+    set MSSdk=1
+    set USE_SDL2=1
+    REM ^^^^^^^^^^ and USE_GSTREAMER if used
+    set DISTUTILS_USE_SDK=1
+    set LIB=%cd%\libs;%LIB%
+    set INCLUDE=%cd%\include;%INCLUDE%
+
+7. ``git clone -b feature-gl-backend https://github.com/kivy/kivy``
+
+.. note:: Use branch |gl-back|_ until properly merged into `master`
+
+\*The setuptools Python package version must be at least 24.0. according to
+Python's `wiki <https://wiki.python.org/moin/WindowsCompilers>`_
+
+Compile Kivy
+^^^^^^^^^^^^
+
+1. ``python -m pip install kivy\`` (the local path, not "kivy" as stable from
+   pypi)
+
+Kivy then will be installed into `site-packages` and you can delete the clone.
 
 .. _alternate-win:
 

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -209,6 +209,11 @@ with git rather than a wheel there are some additional steps:
    can be a url such as ``https://github.com/kivy/kivy/archive/master.zip`` for
    kivy master, or the full path to a local copy of a kivy zip.
 
+MSVC
+~~~~
+
+...
+
 .. _alternate-win:
 
 Installing Kivy to an alternate location

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -212,10 +212,6 @@ with git rather than a wheel there are some additional steps:
 MSVC
 ~~~~
 
-.. warning::
-   The branch is still in progress and some things might not work when compiled
-   with msvc.
-
 .. |msvc| replace:: compiler
 .. _msvc: http://landinghub.visualstudio.com/visual-cpp-build-tools
 .. |py3deps| replace:: py3.5 deps
@@ -223,14 +219,18 @@ MSVC
 .. |gl-back| replace:: feature-gl-backend
 .. _gl-back: https://github.com/kivy/kivy/pull/4385
 
+.. warning::
+   The branch |gl-back|_ is still in progress and some things might not work
+   when compiled with MSVC. Using it until properly merged into `master` is
+   more than experimental.
+
 Environment
 ^^^^^^^^^^^
 
 1. Get the |msvc|_ (~5GB total size)
 2. Open ``cmd.exe`` in `<python.exe dir>` (`shift` + right click)
 3. Upgrade pip and setuptools*
-4. Get sdl2 and glew |py3deps|_
-   and install them
+4. Get sdl2 and glew |py3deps|_ and install them.
 5. ``"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"``
 6. Set environment variables::
 
@@ -243,8 +243,6 @@ Environment
 
 7. ``git clone -b feature-gl-backend https://github.com/kivy/kivy``
 
-.. note:: Use branch |gl-back|_ until properly merged into `master`
-
 \*The setuptools Python package version must be at least 24.0. according to
 Python's `wiki <https://wiki.python.org/moin/WindowsCompilers>`_
 
@@ -253,8 +251,16 @@ Compile Kivy
 
 1. ``python -m pip install kivy\`` (the local path, not "kivy" as stable from
    pypi)
+2. Set correct paths for binaries (located in ``share\sdl2`` and
+   ``share\glew``) and run. ::
 
-Kivy then will be installed into `site-packages` and you can delete the clone.
+    set PATH=%PATH%;%cd%\share\sdl2;%cd%\share\glew
+
+Kivy was successfully installed into `site-packages` and you can delete
+the clone. There's a tricky part about SDL2 now, because for 3.5 weren't
+created binaries yet, therefore you'll need to download `kivy.deps.sdl2`
+wheel for Python 3.4 and rename parts of sdl2 wheels from `cp34` to `cp35`
+so that is could be installed.
 
 .. _alternate-win:
 

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -254,7 +254,7 @@ Compile Kivy
 2. Set correct paths for binaries (located in ``share\sdl2`` and
    ``share\glew``) and run. ::
 
-    set PATH=%PATH%;%cd%\share\sdl2;%cd%\share\glew
+    set PATH=%PATH%;%cd%\share\sdl2\bin;%cd%\share\glew\bin
 
 Kivy was successfully installed into `site-packages` and you can delete
 the clone. There's a tricky part about SDL2 now, because for 3.5 weren't


### PR DESCRIPTION
As a lot of you know, there's a problem with MinGW/Python for 3.5 and higher versions which if you use multiple frameworks/packages and want to stay up-to-date ends up with having multiple Python installations. That's not nice.

There are experimental wheels for stable version, but that has a lot of differences, therefore the newest version is sometimes more desired than relying on stable, so I kind of hope we can hammer some instructions together for compiling Kivy in MSVC which could result in making wheels with MSVC soon-ish after that.

I tried it for Win8.1 x64 for Python 3.5, 32bit, so it might be a little bit different with the SDK versions, but the rest should be the same:
## Environment
1. Get the [compiler](http://landinghub.visualstudio.com/visual-cpp-build-tools) (~5GB total size)
2. Open `cmd.exe` in `<python.exe dir>` (`shift` + right click)
3. Upgrade pip and setuptools*, [get deps](https://drive.google.com/drive/folders/0B1_HB9J8mZepdUl0bEZubXZiSUE) and install them
4. Run `"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"`
5. Set environment:
   
   ```
   set MSSdk=1
   set USE_SDL2=1
   REM ^^^^^^ and USE_GSTREAMER if used
   set DISTUTILS_USE_SDK=1 
   set LIB=%cd%\libs;%LIB%
   set INCLUDE=%cd%\include;%INCLUDE%
   ```
6. `git clone https://github.com/kivy/kivy`

*`The setuptools Python package version must be at least 24.0.` according to Python's [wiki](https://wiki.python.org/moin/WindowsCompilers)
## Compile Kivy
1. `python -m pip install kivy\` (the local path, not "kivy" as stable from pypi)
2. Still some magic missing

Returns a [link error](http://pastebin.com/7rqXjEG5) for now, but I don't have a clue what/how to link the missing thing.
