### PR TITLE
reactivate free calls in smoothline

### DIFF
--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -1481,8 +1481,8 @@ cdef class SmoothLine(Line):
 
         self.batch.set_data(vertices, <int>vcount, indices, <int>icount)
 
-        #free(vertices)
-        #free(indices)
+        free(vertices)
+        free(indices)
 
 
     property overdraw_width:


### PR DESCRIPTION
fixes #4683

not sure why the free calls were commented, it doesn't seem to cause any crash to me to enable them again, and it should fix a memory leak in SmoothLine updates.