### PR TITLE
Cache improvements

### DIFF
--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -103,7 +103,6 @@ class Cache(object):
             return
         timeout = timeout or cat['timeout']
 
-        # FIXME: activate purge when limit is hit
         limit = cat['limit']
         if limit is not None and len(Cache._objects[category]) >= limit:
             Cache._purge_oldest(category)

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -312,7 +312,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 16
+KIVY_CONFIG_VERSION = 17
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -804,6 +804,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 15:
             Config.setdefault('kivy', 'kivy_clock', 'default')
+
+        elif version == 16:
+            Config.setdefault('graphics', 'texture_max_cache', '0')
 
         # elif version == 1:
         #    # add here the command for upgrading from configuration 0 to 1

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -28,6 +28,7 @@ from kivy.cache import Cache
 from kivy.resources import resource_find
 from kivy.core.image import Image
 from kivy.logger import Logger
+from kivy.config import Config
 
 from os.path import join
 from kivy import kivy_shader_dir
@@ -40,7 +41,13 @@ cdef object get_default_texture():
     return DEFAULT_TEXTURE
 
 # register Image cache
-Cache.register('kv.texture', limit=1000, timeout=60)
+texture_max_cache = Config.getint('graphics', 'texture_max_cache')
+if texture_max_cache:
+    kw = {'max_size': texture_max_cache, 'compute_size': lambda x: x.memory_size}
+else:
+    kw = {}
+
+Cache.register('kv.texture', limit=1000, timeout=60, **kw)
 Cache.register('kv.shader', limit=1000, timeout=3600)
 
 # ensure that our resources are cleaned

--- a/kivy/graphics/texture.pxd
+++ b/kivy/graphics/texture.pxd
@@ -27,6 +27,7 @@ cdef class Texture:
     cdef list observers
     cdef object _proxyimage
     cdef object _callback
+    cdef int _memory_size
 
     cdef void update_tex_coords(self)
     cdef void set_min_filter(self, x)

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -972,6 +972,7 @@ cdef class Texture:
         cdef char *cpdst
         cdef int i
         cdef int require_subimage = 0
+        self._memory_size = bytes_per_pixels * self._width * self._height
 
         # if the hardware doesn't support native unpack, use alternative method.
         if need_unpack and not gl_has_capability(GLCAP_UNPACK_SUBIMAGE):
@@ -1013,9 +1014,10 @@ cdef class Texture:
             else:
                 glTexImage2D(target, _mipmap_level, iglfmt, w, h, 0, glfmt,
                     glbufferfmt, cdata)
-                
+
             if _mipmap_generation:
                 glGenerateMipmap(target)
+                self._memory_size *= 2
 
             if need_unpack:
                 glPixelStorei(GL_UNPACK_ROW_LENGTH, 0)
@@ -1171,6 +1173,12 @@ cdef class Texture:
         '''
         def __get__(self):
             return self._height
+
+    property memory_size:
+        '''Return the (gpu) memory size of the texture (readonly).
+        '''
+        def __get__(self):
+            return self._memory_size
 
     property tex_coords:
         '''Return the list of tex_coords (opengl).

--- a/kivy/tests/test_cache.py
+++ b/kivy/tests/test_cache.py
@@ -1,0 +1,40 @@
+'''
+Cache tests
+===========
+'''
+
+import unittest
+
+
+def get_size(x):
+    return x
+
+
+class CacheTestCase(unittest.TestCase):
+
+    def setUp(self):
+        from kivy.cache import Cache
+        Cache.register('test_simple')
+        Cache.register('test_limit', limit=10)
+        Cache.register('test_max_size', max_size=10, compute_size=get_size)
+
+    def test_set_get(self):
+        from kivy.cache import Cache
+        a = 1
+        Cache.append('test_simple', '1', a)
+        assert Cache.get('test_simple', '1') == a
+
+    def test_limit(self):
+        from kivy.cache import Cache
+        from kivy.clock import Clock
+
+        for i in range(10):
+            Cache.append('test_limit', str(i), i)
+
+        for i in range(10):
+            Clock.tick()
+            v = Cache.get('test_limit', str(i))
+            assert v == i
+
+        Cache.append('test_limit', '11', 11)
+        assert Cache.get('test_limit', '0') is None

--- a/kivy/tests/test_cache.py
+++ b/kivy/tests/test_cache.py
@@ -38,3 +38,19 @@ class CacheTestCase(unittest.TestCase):
 
         Cache.append('test_limit', '11', 11)
         assert Cache.get('test_limit', '0') is None
+
+    def test_max_size(self):
+        from kivy.cache import Cache
+        from kivy.clock import Clock
+
+        for i in range(10):
+            Cache.append('test_max_size', str(i), i)
+            Clock.tick()
+
+        for i in range(10):
+            Clock.tick()
+            if Cache.get('test_max_size', str(i)) is None:
+                break
+        else:
+            print(Cache._categories['test_max_size'])
+            assert False


### PR DESCRIPTION
This didn't get a lot of testing (only ran touchtracer/showcase/kivycatalog), so more are welcome, in short.

- Added a few tests cases for Cache
- Found out the `limit` argument wasn't used at all, so only the timeout would prevent the cache from growing indefinitly (if applied)
- Fixed that and the purge logic that was disabled because of being broken
- removed a few try/except/pass that didn't seem necessary (so extra tests are very welcome)
- added another limitation system, allowing one to define a function to compute the size of each element, and call the same purge logic as for the limit argument, when the total size of a cache outgrow its defined limit, this does add some overhead both in computation and memory footprint, put is entirely optional and shouldn't add much overhead when not used (which is the default).
- converted print statements to Logger.debug/trace and added a few more
edit:
- The PR now tries to use the feature with texture cache, adding a setting in kivy to configure a max size, sadly, while the feature seems to work at removing textures from the cache, it doesn't seem to make the gpu release the textures, so it's not really useful at the moment.