### PR TITLE
Fixed space input under SDL2 for some Android keyboards

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2400,7 +2400,8 @@ class TextInput(FocusBehavior, Widget):
             else:
                 if EventLoop.window.__class__.__module__ == \
                     'kivy.core.window.window_sdl2':
-                    return
+                    if not (text == ' ' and platform == 'android'):
+                        return
                 if self._selection:
                     self.delete_selection()
                 self.insert_text(text)


### PR DESCRIPTION
Not for merging without further discussion - this seems to work without causing more problems, but I'm PRing mainly to report the issue and a possible fix.

The problem is that on android we listen only for textinput events, which is how text is supposed to be passed by sdl2. Some keyboards (e.g. LG G4 default) pass only textinput events. Others (e.g. Motorola E default) pass both a textinput event and keydown/keyup events for each key, which is why the current behaviour is to ignore the latter. However, in some cases the space character is passed only as keydown/keyup, not as textinput, so it is also ignored.

This PR would just recognise the space character. I don't know how reliable it is - it could cause another problem on any device that passes both keydown/keyup and textinput events for space characters.