### PR TITLE
Fix auto_dismiss

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -264,7 +264,6 @@ class ActionDropDown(DropDown):
         if super(ActionDropDown, self).on_touch_down(touch):
             if self.auto_dismiss:
                 self.dismiss()
-            return True
 
 
 class ActionGroup(ActionItem, Spinner):


### PR DESCRIPTION
return causes ignoring auto_dismiss if passed in e.g. kv via <ActionDropdown>:, however the on_touch_down is still necessary to dismiss it properly, which has a side effect of dismissing when an item's on_release or similar are triggered.