### PR TITLE
Catch permission errors

### DIFF
--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -222,7 +222,16 @@ else:
             # open mtdev device
             _fn = input_fn
             _slot = 0
-            _device = Device(_fn)
+            try:
+                _device = Device(_fn)
+            except OSError as e:
+                if e.errno == 13:  # Permission denied
+                    Logger.warn(
+                        'MTD: Unable to open device "{0}". Please ensure you'
+                        ' have the appropriate permissions.'.format(_fn))
+                    return
+                else:
+                    raise
             _changes = set()
 
             # prepare some vars to get limit of some component


### PR DESCRIPTION
These error are over dramatic and cause a lot of alarms amongst new
users. This pull request logs a warning instead of throwing an error.

references #4413, #4682

See also:

http://stackoverflow.com/questions/34477313/my-permission-is-denied-
using-kivy

http://stackoverflow.com/questions/26164723/kivy-and-buildozer-
permission-denied