### PR TITLE
Add multiline comment support

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -508,12 +508,18 @@ class Parser(object):
            Comments need to be on a single line and not at the end of a line.
            i.e. a comment line's first non-whitespace character must be a #.
         '''
+        mult_com = False
         # extract directives
         for ln, line in lines[:]:
             stripped = line.strip()
             if stripped[:2] == '#:':
                 self.directives.append((ln, stripped[2:]))
-            if stripped[:1] == '#':
+            if mult_com or "'''#" in stripped or '"""#' in stripped:
+                mult_com = True
+                lines.remove((ln, line))
+                if "#'''" in stripped or '#"""' in stripped:
+                    mult_com = False
+            elif stripped[:1] == '#':
                 lines.remove((ln, line))
             if not stripped:
                 lines.remove((ln, line))

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -514,11 +514,22 @@ class Parser(object):
             stripped = line.strip()
             if stripped[:2] == '#:':
                 self.directives.append((ln, stripped[2:]))
-            if mult_com or "'''#" in stripped or '"""#' in stripped:
-                mult_com = True
+            if mult_com or '###' in stripped:
                 lines.remove((ln, line))
-                if "#'''" in stripped or '#"""' in stripped:
+                begin = stripped.find('###') + 1
+                end = stripped.find('###', begin + 2) + 1
+
+                if begin and mult_com:
+                    # end of multiline com found
                     mult_com = False
+                    continue
+
+                if end:
+                    # end of multiline com in single line
+                    mult_com = False
+                    continue
+                mult_com = True
+
             elif stripped[:1] == '#':
                 lines.remove((ln, line))
             if not stripped:


### PR DESCRIPTION
Implement `'''` or `"""` alone to symbolize a multiline comment won't do as there will surely appear a person who will use multiline strings in kv like in python (`''' text on multiple lines'''`), so I added a `#` symbol to be even more obvious. Using `''# #''` might be a bad idea too.

Now it basically has a higher priority than a casual comment and to fetch this multiline comment the whole line (`stripped` variable) is checked for an occurrence of the comment start and then it starts removing _everything_ unless the comment ending (`#'''`or `#"""`) is present. Python breaks too with such a mistake, so I don't see a problem with it in kv.

Note that multiline comments **_won't work_** in `Builder.load_string(''' <kv> ''')` unless you choose the other variant of the quotes e.g. `Builder.load_string(''' '''# comment #''' ''')` will obviously break.

Test string:
```
'''#
Multiline
comment
#'''
    '''#
    Multiline
    comment
    #'''
'''#Multiline
comment#'''
#:import dp kivy.metrics.dp
'''#
Multiline
comment
#'''
    '''#
    Multiline
    comment
    #'''
'''#Multiline
comment#'''
<Test>:
    '''#
    Multiline
    comment
    #'''
        '''#
        Multiline
        comment
        #'''
    '''#Multiline
    comment#'''
    canvas:
        '''#
        Multiline
        comment
        #'''
            '''#
            Multiline
            comment
            #'''
        '''#Multiline
        comment#'''
        Color:
            '''#
            Multiline
            comment
            #'''
                '''#
                Multiline
                comment
                #'''
            '''#Multiline
            comment#'''
            rgb: 1, 0, 0
            '''#
            Multiline
            comment
            #'''
                '''#
                Multiline
                comment
                #'''
            '''#Multiline
            comment#'''
        Rectangle:
            '''#
            Multiline
            comment
            #'''
                '''#
                Multiline
                comment
                #'''
            '''#Multiline
            comment#'''
            size: self.size
            '''#
            Multiline
            comment
            #'''
                '''#
                Multiline
                comment
                #'''
            '''#Multiline
            comment#'''
            pos: self.pos
            '''#
            Multiline
            comment
            #'''
                '''#
                Multiline
                comment
                #'''
            '''#Multiline
            comment#'''
    Button:
        '''#
        Multiline
        comment
        #'''
            '''#
            Multiline
            comment
            #'''
        '''#Multiline
        comment#'''
        '''# Yes, this will work too #'''
```

Closes #4650 