### PR TITLE
Hide Image if no app_icon in ActionPrevious

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -659,7 +659,7 @@
                     width:
                         (self.temp_width if self.temp_height <= self.height else \
                         self.temp_width * (self.height / self.temp_height)) \
-                        if self.texture else dp(8)
+                        if self.texture and root.app_icon else 0
                     mipmap: root.mipmap
                 Widget:
                     size_hint_x: None


### PR DESCRIPTION
As the title says. Basically, the current behavior isn't intuitive enough e.g. you set `app_icon = ''` and you get blank/white image (not transparent). A user expects such thing to work without playing with `width` or `height` directly and this resulted in some questions on SO.

Now if set `app_icon =''` the `width` of the `Image` that would have the icon is basically set to zero. This doesn't affect the previous arrow, so if you choose to have `with_previous: True`, the arrow will be placed there normally.