### PR TITLE
Add cursor_width to TextInput

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -187,7 +187,7 @@
             rgba: (self.cursor_color if self.focus and not self.cursor_blink else (0, 0, 0, 0))
         Rectangle:
             pos: [int(x) for x in self.cursor_pos]
-            size: 1, -self.line_height
+            size: root.cursor_width, -self.line_height
         Color:
             rgba: self.disabled_foreground_color if self.disabled else (self.hint_text_color if not self.text else self.foreground_color)
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2615,6 +2615,15 @@ class TextInput(FocusBehavior, Widget):
     defaults to [1, 0, 0, 1].
     '''
 
+    cursor_width = NumericProperty('1sp')
+    '''Current width of the cursor.
+
+    .. versionadded:: 1.9.2
+
+    :attr:`cursor_width` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to '1sp'.
+    '''
+
     line_height = NumericProperty(1)
     '''Height of a line. This property is automatically computed from the
     :attr:`font_name`, :attr:`font_size`. Changing the line_height will have


### PR DESCRIPTION
A new fancy property! It should be a nice feature if someone would like to use the ancient-like cursor from DOS/emacs/... However I'm not sure if the cursor should be centered at the pos, or left-aligned (as it is now) - meaning:

    word<cursor>   (default)
    wo<cursor>rd   (better?)

or even cursor _above_ the letter e.g. like if inserting/overwriting in console. That would however need a little bit of tweaking.

Test with:

    from kivy.lang import Builder
    from kivy.base import runTouchApp
    from kivy.uix.boxlayout import BoxLayout
    Builder.load_string('''
    <Test>:
        TextInput:
            cursor_width: 20
    ''')
    class Test(BoxLayout): pass
    runTouchApp(Test())
