### PR TITLE
Update texture.pyx

### DIFF
--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -584,8 +584,11 @@ def texture_create_from_data(im, mipmap=False):
         allocate = 0
 
     # if imagedata have more than one image, activate mipmap
-    if im.have_mipmap:
-        mipmap = True
+    try:
+        if im.have_mipmap:
+            mipmap = True
+    except Exception:
+        pass
 
     IF not USE_OPENGL_ES2:
         if gl_get_version_major() < 3:


### PR DESCRIPTION
texture_create_from_data  defaults to  mipmap=False
so if we try, and fail to find  im.have_mipmap
then we pass, and continue with default value.

solves this issue:

flip = Texture .create_from_data(self .image, mipmap = False) .flip_horizontal()
   File "kivy/graphics/texture.pyx", line 585, in kivy.graphics.texture.texture_create_from_data (kivy/graphics/texture.c:7399)
 AttributeError: 'Sprite' object has no attribute 'have_mipmap'