### PR TITLE
Add more usable error for new-line chars

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -178,7 +178,8 @@ class ParserRuleProperty(object):
         if mode == 'eval':
             # if we don't detect any string/key in it, we can eval and give the
             # result
-            if re.search(lang_key, tmp) is None and value in ["'", '"']:
+            quotes = ["'", '"', "'''", '"""']
+            if re.search(lang_key, tmp) is None and value in quotes:
                 try:
                     self.co_value = eval(value)
                 except SyntaxError as e:
@@ -316,7 +317,7 @@ class ParserRule(object):
                 sc_previous = self.ctx.sourcecode[self.line - 1]
                 sc_current = self.ctx.sourcecode[self.line]
 
-                for quote in ["'", '"', "''", '""']:
+                for quote in ["'", '"', "'''", '"""']:
                     if sc_previous.count(quote) == sc_current.count(quote):
                         raise ParserException(
                             self.ctx, self.line,
@@ -575,12 +576,10 @@ class Parser(object):
                 err_msg = ('Invalid indentation, '
                            'must be a multiple of '
                            '%s spaces' % spaces)
-                print repr(lines), '___', repr(line)
                 sc_current = line
                 sc_previous = lines[lines.index(line) - 1]
-                print sc_current, sc_previous
 
-                for quote in ["'", '"', "''", '""']:
+                for quote in ["'", '"', "'''", '"""']:
                     if sc_previous.count(quote) == sc_current.count(quote):
                         raise ParserException(
                             self, ln,


### PR DESCRIPTION
I think I've seen it in docs already, but this seems to be a better approach to just explicitly tell a user what to do rather than expecting that the user will dig throught the whole documentation or google for that. Although the error is quite readable for people who work with the python often, it's completly unusable for beginners who encounter kv-lang for the first time and at the same time are python beginners.

I made pep8 fixes too. Please help me test L448, because I'm not sure how to trigger it. ^^