### PR TITLE
Fix#4672 : Select_all,Copy, Paste options reachable on android when textinput is upper/top widget

### DIFF
--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -80,6 +80,9 @@ class BubbleButton(Button):
     Rather use this BubbleButton widget that is already defined and provides a
     suitable background for you.
     '''
+    def __init__(self, **kwargs):
+        super(BubbleButton, self).__init__(**kwargs)
+        self.always_release = BooleanProperty(False)
     pass
 
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -146,6 +146,8 @@ __all__ = ('TextInput', )
 
 import re
 import sys
+import string
+from functools import partial
 from os import environ
 from weakref import ref
 
@@ -154,6 +156,8 @@ from kivy.base import EventLoop
 from kivy.cache import Cache
 from kivy.clock import Clock
 from kivy.config import Config
+from kivy.compat import PY2
+from kivy.logger import Logger
 from kivy.metrics import inch
 from kivy.utils import boundary, platform
 from kivy.uix.behaviors import FocusBehavior
@@ -170,7 +174,7 @@ from kivy.uix.image import Image
 
 from kivy.properties import StringProperty, NumericProperty, \
     BooleanProperty, AliasProperty, \
-    ListProperty, ObjectProperty, VariableListProperty
+    ListProperty, ObjectProperty, VariableListProperty, OptionProperty
 
 Cache_register = Cache.register
 Cache_append = Cache.append
@@ -179,9 +183,7 @@ Cache_remove = Cache.remove
 Cache_register('textinput.label', timeout=60.)
 Cache_register('textinput.width', timeout=60.)
 
-FL_IS_LINEBREAK = 0x01
-FL_IS_WORDBREAK = 0x02
-FL_IS_NEWLINE = FL_IS_LINEBREAK | FL_IS_WORDBREAK
+FL_IS_NEWLINE = 0x01
 
 # late binding
 Clipboard = None
@@ -280,12 +282,11 @@ class TextInputCutCopyPaste(Bubble):
 
     matrix = ObjectProperty(None)
 
-    _check_parent_ev = None
-
     def __init__(self, **kwargs):
+        self.always_release = BooleanProperty(True)
         self.mode = 'normal'
         super(TextInputCutCopyPaste, self).__init__(**kwargs)
-        self._check_parent_ev = Clock.schedule_interval(self._check_parent, .5)
+        Clock.schedule_interval(self._check_parent, .5)
         self.matrix = self.textinput.get_window_matrix()
 
         with self.canvas.before:
@@ -332,7 +333,7 @@ class TextInputCutCopyPaste(Bubble):
                 break
             parent = parent.parent
         if parent is None:
-            self._check_parent_ev.cancel()
+            Clock.unschedule(self._check_parent)
             if self.textinput:
                 self.textinput._hide_cut_copy_paste()
 
@@ -375,7 +376,6 @@ class TextInputCutCopyPaste(Bubble):
                       self.on_parent(self, self.parent))
             anim.start(self.but_selectall)
             return
-
         self.hide()
 
     def hide(self):
@@ -426,9 +426,6 @@ class TextInput(FocusBehavior, Widget):
         (use Clock.schedule) the call to the functions for selecting
         text (select_all, select_text).
 
-    .. versionchanged:: 1.9.2
-        `background_disabled_active` has been removed.
-
     .. versionchanged:: 1.9.0
 
         :class:`TextInput` now inherits from
@@ -449,9 +446,8 @@ class TextInput(FocusBehavior, Widget):
                   'on_quad_touch')
 
     def __init__(self, **kwargs):
-        self._update_graphics_ev = Clock.create_trigger(
-            self._update_graphics, -1)
         self.is_focusable = kwargs.get('is_focusable', True)
+        self._cursor_blink_time = Clock.get_time()
         self._cursor = [0, 0]
         self._selection = False
         self._selection_finished = True
@@ -481,11 +477,6 @@ class TextInput(FocusBehavior, Widget):
         self._ctrl_r = False
         self._alt_l = False
         self._alt_r = False
-        self._refresh_text_from_property_ev = None
-        self._long_touch_ev = None
-        self._do_blink_cursor_ev = Clock.create_trigger(
-            self._do_blink_cursor, .5, interval=True)
-        self._refresh_line_options_ev = None
         self.interesting_keys = {
             8: 'backspace',
             13: 'enter',
@@ -518,11 +509,6 @@ class TextInput(FocusBehavior, Widget):
         def handle_readonly(instance, value):
             if value and (not _is_desktop or not self.allow_copy):
                 self.is_focusable = False
-            if (not (value or self.disabled) or _is_desktop and
-                self._keyboard_mode == 'system'):
-                self._editable = True
-            else:
-                self._editable = False
 
         fbind('padding', update_text_options)
         fbind('tab_width', update_text_options)
@@ -530,7 +516,6 @@ class TextInput(FocusBehavior, Widget):
         fbind('font_name', update_text_options)
         fbind('size', update_text_options)
         fbind('password', update_text_options)
-        fbind('password_mask', update_text_options)
 
         fbind('pos', self._trigger_update_graphics)
         fbind('readonly', handle_readonly)
@@ -541,8 +526,6 @@ class TextInput(FocusBehavior, Widget):
             self._position_handles)
         self._trigger_show_handles = Clock.create_trigger(
             self._show_handles, .05)
-        self._trigger_cursor_reset = Clock.create_trigger(
-            self._reset_cursor_blink)
         self._trigger_update_cutbuffer = Clock.create_trigger(
             self._update_cutbuffer)
         refresh_line_options()
@@ -575,9 +558,9 @@ class TextInput(FocusBehavior, Widget):
                 if row >= len(l):
                     continue
                 index += len(l[row])
-                if lf[row] & FL_IS_LINEBREAK:
+                if lf[row] & FL_IS_NEWLINE:
                     index += 1
-            if lf[cr] & FL_IS_LINEBREAK:
+            if lf[cr] & FL_IS_NEWLINE:
                 index += 1
             return index
         except IndexError:
@@ -607,7 +590,7 @@ class TextInput(FocusBehavior, Widget):
         i = 0
         for row in range(len(l)):
             ni = i + len(l[row])
-            if lf[row] & FL_IS_LINEBREAK:
+            if lf[row] & FL_IS_NEWLINE:
                 ni += 1
                 i += 1
             if ni >= index:
@@ -707,7 +690,7 @@ class TextInput(FocusBehavior, Widget):
         wrap = (self._get_text_width(
             new_text,
             self.tab_width,
-            self._label_cached) > (self.width - self.padding[0] - self.padding[2]))
+            self._label_cached) > self.width)
         if len_str > 1 or substring == u'\n' or wrap:
             # Avoid refreshing text on every keystroke.
             # Allows for faster typing of text when the amount of text in
@@ -1092,8 +1075,6 @@ class TextInput(FocusBehavior, Widget):
         .. versionchanged:: 1.9.1
 
         '''
-        if not self._lines:
-            return
         pgmove_speed = int(self.height /
             (self.line_height + self.line_spacing) - 1)
         col, row = self.cursor
@@ -1166,15 +1147,17 @@ class TextInput(FocusBehavior, Widget):
         scrl_y = scrl_y / dy if scrl_y > 0 else 0
         cy = (self.top - padding_top + scrl_y * dy) - y
         cy = int(boundary(round(cy / dy - 0.5), 0, len(l) - 1))
+        dcx = 0
         _get_text_width = self._get_text_width
         _tab_width = self.tab_width
         _label_cached = self._label_cached
-        for i in range(0, len(l[cy])):
-            if _get_text_width(l[cy][:i], _tab_width, _label_cached) + \
-                  _get_text_width(l[cy][i], _tab_width, _label_cached) * 0.6 + \
-                  padding_left > cx + scrl_x:
-                cx = i
+        for i in range(1, len(l[cy]) + 1):
+            if _get_text_width(l[cy][:i],
+                               _tab_width,
+                               _label_cached) + padding_left >= cx + scrl_x:
                 break
+            dcx = i
+        cx = dcx
         return cx, cy
 
     #
@@ -1187,7 +1170,6 @@ class TextInput(FocusBehavior, Widget):
         self._selection = False
         self._selection_finished = True
         self._selection_touch = None
-        self.selection_text = u''
         self._trigger_update_graphics()
 
     def delete_selection(self, from_undo=False):
@@ -1219,7 +1201,7 @@ class TextInput(FocusBehavior, Widget):
                                              lineflags, len_lines)
         self.scroll_x = scrl_x
         self.scroll_y = scrl_y
-        # handle undo and redo for delete selection
+        # handle undo and redo for delete selecttion
         self._set_unredo_delsel(a, b, v[a:b], from_undo)
         self.cancel_selection()
 
@@ -1244,8 +1226,8 @@ class TextInput(FocusBehavior, Widget):
         self._selection_finished = finished
         _selection_text = self._get_text(encode=False)[a:b]
         self.selection_text = ("" if not self.allow_copy else
-                               ((self.password_mask * (b - a)) if
-                                self.password else _selection_text))
+                               (('*' * (b - a)) if self.password else
+                                _selection_text))
         if not finished:
             self._selection = True
         else:
@@ -1262,7 +1244,6 @@ class TextInput(FocusBehavior, Widget):
     # Touch control
     #
     def long_touch(self, dt):
-        self._long_touch_ev = None
         if self._selection_to == self._selection_from:
             pos = self.to_local(*self._long_touch_pos, relative=True)
             self._show_cut_copy_paste(
@@ -1313,9 +1294,6 @@ class TextInput(FocusBehavior, Widget):
         if super(TextInput, self).on_touch_down(touch):
             return True
 
-        if self.focus:
-            self._trigger_cursor_reset()
-
         # Check for scroll wheel
         if 'button' in touch.profile and touch.button.startswith('scroll'):
             scroll_type = touch.button[6:]
@@ -1352,7 +1330,7 @@ class TextInput(FocusBehavior, Widget):
         self._hide_cut_copy_paste(EventLoop.window)
         # schedule long touch for paste
         self._long_touch_pos = touch.pos
-        self._long_touch_ev = Clock.schedule_once(self.long_touch, .5)
+        Clock.schedule_once(self.long_touch, .5)
 
         self.cursor = self.get_cursor_from_xy(*touch_pos)
         if not self._selection_touch:
@@ -1388,9 +1366,7 @@ class TextInput(FocusBehavior, Widget):
         self._touch_count -= 1
 
         # schedule long touch for paste
-        if self._long_touch_ev is not None:
-            self._long_touch_ev.cancel()
-            self._long_touch_ev = None
+        Clock.unschedule(self.long_touch)
 
         if not self.focus:
             return False
@@ -1401,7 +1377,8 @@ class TextInput(FocusBehavior, Widget):
             # show Bubble
             win = EventLoop.window
             if self._selection_to != self._selection_from:
-                self._show_cut_copy_paste(touch.pos, win)
+                touch_rel_pos = (touch.pos[0] - self.x, touch.pos[1] - self.y)
+                self._show_cut_copy_paste(touch_rel_pos, win)
             elif self.use_handles:
                 self._hide_handles()
                 handle_middle = self._handle_middle
@@ -1594,7 +1571,7 @@ class TextInput(FocusBehavior, Widget):
 
         if (bubble_pos[0] - bubble_hw) < 0:
             # bubble beyond left of window
-            if bubble_pos[1] > (win_size[1] - bubble_size[1]):
+            if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
                 bubble_pos = (bubble_hw, (t_pos[1]) - (lh + ls + inch(.25)))
                 bubble.arrow_pos = 'top_left'
@@ -1603,7 +1580,7 @@ class TextInput(FocusBehavior, Widget):
                 bubble.arrow_pos = 'bottom_left'
         elif (bubble_pos[0] + bubble_hw) > win_size[0]:
             # bubble beyond right of window
-            if bubble_pos[1] > (win_size[1] - bubble_size[1]):
+            if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
                 bubble_pos = (win_size[0] - bubble_hw,
                              (t_pos[1]) - (lh + ls + inch(.25)))
@@ -1612,7 +1589,7 @@ class TextInput(FocusBehavior, Widget):
                 bubble_pos = (win_size[0] - bubble_hw, bubble_pos[1])
                 bubble.arrow_pos = 'bottom_right'
         else:
-            if bubble_pos[1] > (win_size[1] - bubble_size[1]):
+            if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
                 bubble_pos = (bubble_pos[0],
                              (t_pos[1]) - (lh + ls + inch(.25)))
@@ -1650,6 +1627,7 @@ class TextInput(FocusBehavior, Widget):
             _textinput_list.remove(wr)
 
     def _on_textinput_focused(self, instance, value, *largs):
+        self.focus = value
 
         win = EventLoop.window
         self.cancel_selection()
@@ -1658,12 +1636,12 @@ class TextInput(FocusBehavior, Widget):
         if value:
             if (not (self.readonly or self.disabled) or _is_desktop and
                 self._keyboard_mode == 'system'):
-                self._trigger_cursor_reset()
+                Clock.schedule_interval(self._do_blink_cursor, 1 / 2.)
                 self._editable = True
             else:
                 self._editable = False
         else:
-            self._do_blink_cursor_ev.cancel()
+            Clock.unschedule(self._do_blink_cursor)
             self._hide_handles(win)
 
     def _ensure_clipboard(self):
@@ -1732,25 +1710,20 @@ class TextInput(FocusBehavior, Widget):
         if not self.password:
             width = _label_cached.get_extents(text)[0]
         else:
-            width = _label_cached.get_extents(
-                self.password_mask * len(text))[0]
+            width = _label_cached.get_extents('*' * len(text))[0]
         Cache_append('textinput.width', cid, width)
         return width
 
     def _do_blink_cursor(self, dt):
-        # Callback for blinking the cursor.
-        self.cursor_blink = not self.cursor_blink
-
-    def _reset_cursor_blink(self, *args):
-        self._do_blink_cursor_ev.cancel()
-        self.cursor_blink = 0
-        self._do_blink_cursor_ev()
+        # Callback called by the timer to blink the cursor, according to the
+        # last activity in the widget
+        b = (Clock.get_time() - self._cursor_blink_time)
+        self.cursor_blink = int(b * 2) % 2
 
     def on_cursor(self, instance, value):
-        # When the cursor is moved, reset cursor blinking to keep it showing,
-        # and update all the graphics.
-        if self.focus:
-            self._trigger_cursor_reset()
+        # When the cursor is moved, reset the activity timer, and update all
+        # the graphics.
+        self._cursor_blink_time = Clock.get_time()
         self._trigger_update_graphics()
 
     def _delete_line(self, idx):
@@ -1767,12 +1740,8 @@ class TextInput(FocusBehavior, Widget):
         self._lines[line_num] = text
 
     def _trigger_refresh_line_options(self, *largs):
-        if self._refresh_line_options_ev is not None:
-            self._refresh_line_options_ev.cancel()
-        else:
-            self._refresh_line_options_ev = Clock.create_trigger(
-                self._refresh_line_options, 0)
-        self._refresh_line_options_ev()
+        Clock.unschedule(self._refresh_line_options)
+        Clock.schedule_once(self._refresh_line_options, 0)
 
     def _refresh_line_options(self, *largs):
         self._line_options = None
@@ -1784,10 +1753,9 @@ class TextInput(FocusBehavior, Widget):
     def _trigger_refresh_text(self, *largs):
         if len(largs) and largs[0] == self:
             largs = ()
-        if self._refresh_text_from_property_ev is not None:
-            self._refresh_text_from_property_ev.cancel()
-        self._refresh_text_from_property_ev = Clock.schedule_once(
-            lambda dt: self._refresh_text_from_property(*largs))
+        Clock.unschedule(lambda dt: self._refresh_text_from_property(*largs))
+        Clock.schedule_once(lambda dt:
+                            self._refresh_text_from_property(*largs))
 
     def _update_text_options(self, *largs):
         Cache_remove('textinput.width')
@@ -1890,8 +1858,8 @@ class TextInput(FocusBehavior, Widget):
             self._lines = _lins
 
     def _trigger_update_graphics(self, *largs):
-        self._update_graphics_ev.cancel()
-        self._update_graphics_ev()
+        Clock.unschedule(self._update_graphics)
+        Clock.schedule_once(self._update_graphics, -1)
 
     def _update_graphics(self, *largs):
         # Update all the graphics according to the current internal values.
@@ -1915,8 +1883,8 @@ class TextInput(FocusBehavior, Widget):
         sy = self.scroll_y
 
         # draw labels
-        if not self._lines or (
-                not self._lines[0] and len(self._lines) == 1):
+        if not self.focus and (not self._lines or (
+                not self._lines[0] and len(self._lines) == 1)):
             rects = self._hint_text_rects
             labels = self._hint_text_labels
             lines = self._hint_text_lines
@@ -2111,7 +2079,7 @@ class TextInput(FocusBehavior, Widget):
         # Create a label from a text, using line options
         ntext = text.replace(u'\n', u'').replace(u'\t', u' ' * self.tab_width)
         if self.password and not hint:  # Don't replace hint_text with *
-            ntext = self.password_mask * len(ntext)
+            ntext = u'*' * len(ntext)
         kw = self._get_line_options()
         cid = '%s\0%s' % (ntext, str(kw))
         texture = Cache_get('textinput.label', cid)
@@ -2179,7 +2147,7 @@ class TextInput(FocusBehavior, Widget):
         # depend of the options, split the text on line, or word
         if not self.multiline:
             lines = text.split(u'\n')
-            lines_flags = [0] + [FL_IS_LINEBREAK] * (len(lines) - 1)
+            lines_flags = [0] + [FL_IS_NEWLINE] * (len(lines) - 1)
             return lines, lines_flags
 
         # no autosize, do wordwrap.
@@ -2208,33 +2176,11 @@ class TextInput(FocusBehavior, Widget):
                 line = []
                 x = 0
             if is_newline:
-                flags |= FL_IS_LINEBREAK
-            elif width >= 1 and w > width:
-                while w > width:
-                    split_width = split_pos = 0
-                    # split the word
-                    for c in word:
-                        cw = self._get_text_width(
-                            c, self.tab_width, self._label_cached
-                        )
-                        if split_width + cw > width:
-                            break
-                        split_width += cw
-                        split_pos += 1
-                    if split_width == split_pos == 0:
-                        # can't fit the word in, give up
-                        break
-                    lines_append(word[:split_pos])
-                    lines_flags_append(flags)
-                    flags = FL_IS_WORDBREAK
-                    word = word[split_pos:]
-                    w -= split_width
-                x = w
-                line.append(word)
+                flags |= FL_IS_NEWLINE
             else:
                 x += w
                 line.append(word)
-        if line or flags & FL_IS_LINEBREAK:
+        if line or flags & FL_IS_NEWLINE:
             lines_append(_join(line))
             lines_flags_append(flags)
 
@@ -2307,7 +2253,7 @@ class TextInput(FocusBehavior, Widget):
             self._alt_r = False
 
     def keyboard_on_key_down(self, window, keycode, text, modifiers):
-        # Keycodes on OS X:
+        # Keycodes on OSX:
         ctrl, cmd = 64, 1024
         key, key_str = keycode
         win = EventLoop.window
@@ -2435,7 +2381,7 @@ class TextInput(FocusBehavior, Widget):
             self.delete_selection()
         self.insert_text(text, False)
 
-    def on__hint_text(self, instance, value):
+    def on_hint_text(self, instance, value):
         self._refresh_hint_text()
 
     def _refresh_hint_text(self):
@@ -2485,8 +2431,7 @@ class TextInput(FocusBehavior, Widget):
     '''
 
     password = BooleanProperty(False)
-    '''If True, the widget will display its characters as the character
-    set in :attr:`password_mask`.
+    '''If True, the widget will display its characters as the character '*'.
 
     .. versionadded:: 1.2.0
 
@@ -2494,23 +2439,14 @@ class TextInput(FocusBehavior, Widget):
     defaults to False.
     '''
 
-    password_mask = StringProperty('*')
-    '''Sets the character used to mask the text when :attr:`password` is True.
-
-    .. versionadded:: 1.9.2
-
-    :attr:`password_mask` is a :class:`~kivy.properties.StringProperty` and
-    defaults to `'*'`.
-    '''
-
     keyboard_suggestions = BooleanProperty(True)
     '''If True provides auto suggestions on top of keyboard.
     This will only work if :attr:`input_type` is set to `text`.
 
-    .. versionadded:: 1.8.0
+     .. versionadded:: 1.8.0
 
-    :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
-    defaults to True.
+     :attr:`keyboard_suggestions` is a
+     :class:`~kivy.properties.BooleanProperty` defaults to True.
     '''
 
     cursor_blink = BooleanProperty(False)
@@ -2546,7 +2482,7 @@ class TextInput(FocusBehavior, Widget):
         sx = self.scroll_x
         offset = self.cursor_offset()
 
-        # if offset is outside the current bounds, readjust
+        # if offset is outside the current bounds, reajust
         if offset > viewport_width + sx:
             self.scroll_x = offset - viewport_width
         if offset < sx:
@@ -2759,6 +2695,17 @@ class TextInput(FocusBehavior, Widget):
     defaults to 'atlas://data/images/defaulttheme/textinput_active'.
     '''
 
+    background_disabled_active = StringProperty(
+        'atlas://data/images/defaulttheme/textinput_disabled_active')
+    '''Background image of the TextInput when it's in focus and disabled.
+
+    .. versionadded:: 1.8.0
+
+    :attr:`background_disabled_active` is a
+    :class:`~kivy.properties.StringProperty` and
+    defaults to 'atlas://data/images/defaulttheme/textinput_disabled_active'.
+    '''
+
     background_color = ListProperty([1, 1, 1, 1])
     '''Current color of the background, in (r, g, b, a) format.
 
@@ -2806,15 +2753,15 @@ class TextInput(FocusBehavior, Widget):
     '''
 
     suggestion_text = StringProperty('')
-    '''Shows a suggestion text at the end of the current line.
-    The feature is useful for text autocompletion, and it does not implement
-    validation (accepting the suggested text on enter etc.).
-    This can also be used by the IME to setup the current word being edited.
+    '''Shows a suggestion text/word from currentcursor position onwards,
+    that can be used as a possible completion. Usefull for suggesting completion
+    text. This can also be used by the IME to setup the current word being
+    edited
 
     .. versionadded:: 1.9.0
 
-    :attr:`suggestion_text` is a :class:`~kivy.properties.StringProperty` and
-    defaults to `''`.
+    :attr:`suggestion_text` is a :class:`~kivy.properties.StringProperty`
+    defaults to `''`
     '''
 
     def on_suggestion_text(self, instance, value):
@@ -2888,7 +2835,7 @@ class TextInput(FocusBehavior, Widget):
         if len(lf) < len_l:
             lf.append(1)
 
-        text = u''.join([(u'\n' if (lf[i] & FL_IS_LINEBREAK) else u'') + l[i]
+        text = u''.join([(u'\n' if (lf[i] & FL_IS_NEWLINE) else u'') + l[i]
                         for i in range(len_l)])
 
         if encode and not isinstance(text, bytes):
@@ -2948,29 +2895,17 @@ class TextInput(FocusBehavior, Widget):
     '''Font size of the text in pixels.
 
     :attr:`font_size` is a :class:`~kivy.properties.NumericProperty` and
-    defaults to 15\ :attr:`~kivy.metrics.sp`.
+    defaults to 10.
     '''
-    _hint_text = StringProperty('')
 
-    def _set_hint_text(self, value):
-        if isinstance(value, bytes):
-            value = value.decode('utf8')
-        self._hint_text = value
+    hint_text = StringProperty('')
+    '''Hint text of the widget.
 
-    def _get_hint_text(self):
-        return self._hint_text
-
-    hint_text = AliasProperty(
-        _get_hint_text, _set_hint_text, bind=('_hint_text', ))
-    '''Hint text of the widget, shown if text is ''.
+    Shown if text is '' and focus is False.
 
     .. versionadded:: 1.6.0
 
-    .. versionchanged:: 1.9.2
-        The property is now an AliasProperty and byte values are decoded to
-        strings. The hint text will stay visible when the widget is focused.
-
-    :attr:`hint_text` a :class:`~kivy.properties.AliasProperty` and defaults
+    :attr:`hint_text` a :class:`~kivy.properties.StringProperty` and defaults
     to ''.
     '''
 
@@ -3053,7 +2988,7 @@ class TextInput(FocusBehavior, Widget):
     defaults to `None`. Can be one of `None`, `'int'` (string), or `'float'`
     (string), or a callable. If it is `'int'`, it will only accept numbers.
     If it is `'float'` it will also accept a single period. Finally, if it is
-    a callable it will be called with two parameters; the string to be added
+    a callable it will be called with two parameter; the string to be added
     and a bool indicating whether the string is a result of undo (True). The
     callable should return a new substring that will be used instead.
     '''


### PR DESCRIPTION
The pos argument of _show_cut_copy_paste function in textinput.py file has to be relative , so changed that to relative(to the widget) by subtracting self.y (position of textinput widget w.r.t the window). Also in function on_touch_up in textinput.py the call to _show_cut_copy_paste has been made using absolute position, so  introduced a variable touch_rel_pos to pass the relative touch position to _show_cut_copy_paste.
To make the textinput bubble respond on touching , added a always_release=True in the TextInputCutCopyPaste Class.