### PR TITLE
Fix#4672 : Select_all,Copy, Paste options reachable on android when textinput is upper/top widget

### DIFF
--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -80,7 +80,7 @@ class BubbleButton(Button):
     Rather use this BubbleButton widget that is already defined and provides a
     suitable background for you.
     '''
-    pass
+    always_release = BooleanProperty(True)
 
 
 class BubbleContent(GridLayout):
@@ -372,3 +372,4 @@ class Bubble(GridLayout):
     def _update_arrow(self, *dt):
         if self.arrow_pos in ('left_mid', 'right_mid'):
             self._sctr.center_y = self._arrow_layout.center_y
+

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -372,4 +372,3 @@ class Bubble(GridLayout):
     def _update_arrow(self, *dt):
         if self.arrow_pos in ('left_mid', 'right_mid'):
             self._sctr.center_y = self._arrow_layout.center_y
-

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -80,7 +80,7 @@ class BubbleButton(Button):
     Rather use this BubbleButton widget that is already defined and provides a
     suitable background for you.
     '''
-    always_release = BooleanProperty(True)
+    pass
 
 
 class BubbleContent(GridLayout):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -485,7 +485,7 @@ class TextInput(FocusBehavior, Widget):
         self._refresh_text_from_property_ev = None
         self._long_touch_ev = None
         self._do_blink_cursor_ev = Clock.create_trigger(
-            self._do_blink_cursor, .5, interval=True)
+            self._do_blink_cursor, .5)
         self._refresh_line_options_ev = None
         self.interesting_keys = {
             8: 'backspace',
@@ -1596,7 +1596,7 @@ class TextInput(FocusBehavior, Widget):
         win_size = win.size
         bubble_pos = (t_pos[0], t_pos[1] + inch(.25))
 
-        if (bubble_pos[0] - bubble_hw) < 0:
+        if (bubble_pos[0] - bubble_hw + self.x) < 0:
             # bubble beyond left of window
             if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
@@ -1605,15 +1605,15 @@ class TextInput(FocusBehavior, Widget):
             else:
                 bubble_pos = (bubble_hw, bubble_pos[1])
                 bubble.arrow_pos = 'bottom_left'
-        elif (bubble_pos[0] + bubble_hw) > win_size[0]:
+        elif (bubble_pos[0] + bubble_hw + self.x) > win_size[0]:
             # bubble beyond right of window
             if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
-                bubble_pos = (win_size[0] - bubble_hw,
+                bubble_pos = (win_size[0] - bubble_hw - self.x,
                              (t_pos[1]) - (lh + ls + inch(.25)))
                 bubble.arrow_pos = 'top_right'
             else:
-                bubble_pos = (win_size[0] - bubble_hw, bubble_pos[1])
+                bubble_pos = (win_size[0] - bubble_hw - self.x, bubble_pos[1])
                 bubble.arrow_pos = 'bottom_right'
         else:
             if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -283,6 +283,7 @@ class TextInputCutCopyPaste(Bubble):
     _check_parent_ev = None
 
     def __init__(self, **kwargs):
+        self.always_release = BooleanProperty(True)
         self.mode = 'normal'
         super(TextInputCutCopyPaste, self).__init__(**kwargs)
         self._check_parent_ev = Clock.schedule_interval(self._check_parent, .5)
@@ -1403,7 +1404,8 @@ class TextInput(FocusBehavior, Widget):
             # show Bubble
             win = EventLoop.window
             if self._selection_to != self._selection_from:
-                self._show_cut_copy_paste(touch.pos, win)
+                touch_rel_pos = (touch.pos[0] - self.x, touch.pos[1] - self.y)
+                self._show_cut_copy_paste(touch_rel_pos, win)
             elif self.use_handles:
                 self._hide_handles()
                 handle_middle = self._handle_middle
@@ -1596,7 +1598,7 @@ class TextInput(FocusBehavior, Widget):
 
         if (bubble_pos[0] - bubble_hw) < 0:
             # bubble beyond left of window
-            if bubble_pos[1] > (win_size[1] - bubble_size[1]):
+            if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
                 bubble_pos = (bubble_hw, (t_pos[1]) - (lh + ls + inch(.25)))
                 bubble.arrow_pos = 'top_left'
@@ -1605,7 +1607,7 @@ class TextInput(FocusBehavior, Widget):
                 bubble.arrow_pos = 'bottom_left'
         elif (bubble_pos[0] + bubble_hw) > win_size[0]:
             # bubble beyond right of window
-            if bubble_pos[1] > (win_size[1] - bubble_size[1]):
+            if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
                 bubble_pos = (win_size[0] - bubble_hw,
                              (t_pos[1]) - (lh + ls + inch(.25)))
@@ -1614,7 +1616,7 @@ class TextInput(FocusBehavior, Widget):
                 bubble_pos = (win_size[0] - bubble_hw, bubble_pos[1])
                 bubble.arrow_pos = 'bottom_right'
         else:
-            if bubble_pos[1] > (win_size[1] - bubble_size[1]):
+            if (bubble_pos[1] + self.y) > (win_size[1] - bubble_size[1]):
                 # bubble above window height
                 bubble_pos = (bubble_pos[0],
                              (t_pos[1]) - (lh + ls + inch(.25)))

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -454,7 +454,7 @@ class TextInput(FocusBehavior, Widget):
                   'on_quad_touch')
 
     def __init__(self, **kwargs):
-        self.always_release_bubble = kwargs.get('always_release_bubble', False)
+        self.always_release_bubble = kwargs.get('always_release_bubble', True)
         self._update_graphics_ev = Clock.create_trigger(
             self._update_graphics, -1)
         self.is_focusable = kwargs.get('is_focusable', True)

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -283,7 +283,6 @@ class TextInputCutCopyPaste(Bubble):
     _check_parent_ev = None
 
     def __init__(self, **kwargs):
-        self.always_release = BooleanProperty(True)
         self.mode = 'normal'
         super(TextInputCutCopyPaste, self).__init__(**kwargs)
         self._check_parent_ev = Clock.schedule_interval(self._check_parent, .5)
@@ -485,7 +484,7 @@ class TextInput(FocusBehavior, Widget):
         self._refresh_text_from_property_ev = None
         self._long_touch_ev = None
         self._do_blink_cursor_ev = Clock.create_trigger(
-            self._do_blink_cursor, .5)
+            self._do_blink_cursor, .5, interval=True)
         self._refresh_line_options_ev = None
         self.interesting_keys = {
             8: 'backspace',


### PR DESCRIPTION
The pos argument of _show_cut_copy_paste function in textinput.py file has to be relative , so changed that to relative(to the widget) by subtracting self.y (position of textinput widget w.r.t the window). Also in function on_touch_up in textinput.py the call to _show_cut_copy_paste has been made using absolute position, so introduced a variable touch_rel_pos to pass the relative touch position to _show_cut_copy_paste.
To make the textinput bubble respond on touching , added a always_release=True in the TextInputCutCopyPaste Class.