### PR TITLE
Recycle view fixes.

### DIFF
--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -73,10 +73,10 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
                 rows_sh[row] = nmax(rows_sh[row], shh)
                 if shh_min is not None:
                     has_bound_y = True
-                    rows_sh_min[col] = nmax(rows_sh_min[col], shh_min)
+                    rows_sh_min[row] = nmax(rows_sh_min[row], shh_min)
                 if shh_max is not None:
                     has_bound_y = True
-                    rows_sh_max[col] = nmin(rows_sh_max[col], shh_max)
+                    rows_sh_max[row] = nmin(rows_sh_max[row], shh_max)
         self._has_hint_bound_x = has_bound_x
         self._has_hint_bound_y = has_bound_y
 

--- a/kivy/uix/recyclelayout.py
+++ b/kivy/uix/recyclelayout.py
@@ -194,15 +194,15 @@ class RecycleLayout(RecycleLayoutManagerBehavior, Layout):
         for widget, index in self.view_indices.items():
             opt = opts[index]
             s = opt['size']
-            w, h = sn = widget.size
+            w, h = sn = list(widget.size)
             sh = opt['size_hint']
-            shnw, shnh = shn = widget.size_hint
+            shnw, shnh = shn = list(widget.size_hint)
             sh_min = opt['size_hint_min']
-            shn_min = widget.size_hint_min
+            shn_min = list(widget.size_hint_min)
             sh_max = opt['size_hint_max']
-            shn_max = widget.size_hint_max
+            shn_max = list(widget.size_hint_max)
             ph = opt['pos_hint']
-            phn = widget.pos_hint
+            phn = dict(widget.pos_hint)
             if s != sn or sh != shn or ph != phn or sh_min != shn_min or \
                     sh_max != shn_max:
                 changed.append((index, widget, s, sn, sh, shn, sh_min, shn_min,


### PR DESCRIPTION
Fixes the example below.

```py
from random import sample, choice
from string import ascii_lowercase

from kivy.app import runTouchApp
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout


kv = """

<Row@BoxLayout>:
    size_hint_min: label.texture_size
    canvas.before:
        Color:
            rgba: 0.5, 0.5, 0.5, 1
        Rectangle:
            size: self.size
            pos: self.pos
    value: ''
    Label:
        id: label
        text: root.value
        padding: 10, 10

RecycleView:
    id: rv
    scroll_type: ['bars', 'content']
    scroll_wheel_distance: dp(114)
    bar_width: dp(10)
    key_viewclass: 'widget'
    on_data_model:
        import pudb; pudb.set_trace()

    RecycleGridLayout:
        default_size: dp(100), dp(56)
        default_size_hint: 1, 1
        # size_hint: None, None
        # height: self.minimum_height
        # width: self.minimum_width
        cols: 5
        spacing: dp(2)
"""


root = Builder.load_string(kv)
root.data = [{
    'value': ''.join(sample(ascii_lowercase, 6)),
    'widget': 'Row'} for x in range(50)]
runTouchApp(root)
```