### PR TITLE
Fix#4752:Line end drawn correctly on canvas when cap='round'

### DIFF
--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -285,11 +285,15 @@ cdef class Line(VertexInstruction):
         self._bxmax = -999999999
         self._bymax = -999999999
 
+        cap = self._cap
+        if cap == LINE_CAP_SQUARE:
+            p = p[2:]
+            count -= 1
+
         if count < 2:
             self.batch.clear_data()
             return
 
-        cap = self._cap
         if self._close and count > 2:
             p = p + p[0:4]
             count += 2

--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -314,8 +314,8 @@ cdef class Line(VertexInstruction):
             indices_count += 12
             vertices_count += 4
         elif cap == LINE_CAP_ROUND:
-            indices_count += (self._cap_precision * 3) * 2
-            vertices_count += (self._cap_precision) * 2
+            indices_count += 2 * (self._cap_precision + 1) * 3 * 2
+            vertices_count += 2 * (self._cap_precision + 1) * 2
 
         vertices = <vertex_t *>malloc(vertices_count * sizeof(vertex_t))
         if vertices == NULL:
@@ -592,7 +592,7 @@ cdef class Line(VertexInstruction):
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
             iv += 1
-            for i in xrange(0, self._cap_precision - 1):
+            for i in xrange(0, 2 * self._cap_precision + 1):
                 vertices[iv].x = cx + cos(a1 + step * i) * w
                 vertices[iv].y = cy + sin(a1 + step * i) * w
                 vertices[iv].s0 = 1
@@ -624,7 +624,7 @@ cdef class Line(VertexInstruction):
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
             iv += 1
-            for i in xrange(0, self._cap_precision - 1):
+            for i in xrange(0, 2 * self._cap_precision + 1):
                 vertices[iv].x = cx + cos(a1 + step * i) * w
                 vertices[iv].y = cy + sin(a1 + step * i) * w
                 vertices[iv].s0 = 0


### PR DESCRIPTION
For making the cap at both ends round , instead of taking the vertices  from ~(0-173) degrees at the two ends , I have sampled the vertices from complete (0-360) degrees and that's why the vertices_count and indices_count has been increased . Moreover range of for loop has been increased to cover the complete rounded circle at both ends.This works only for round cap.For square cap , the sangle(starting angle) =0 always hence the starting cap vertices point  [https://github.com/kivy/kivy/blob/master/kivy/graphics/vertex_instructions_line.pxi#L564-L569](url)  are coming the same whatever the line direction be.