### PR TITLE
Obvious typo in the collide_point check

### DIFF
--- a/kivy/uix/gesturesurface.py
+++ b/kivy/uix/gesturesurface.py
@@ -362,7 +362,7 @@ class GestureSurface(FloatLayout):
         bounding box of another gesture - if so, they should be merged.'''
         if touch.grab_current is not self:
             return
-        if not self.collide_point(touch.y, touch.y):
+        if not self.collide_point(touch.x, touch.y):
             return
 
         # Retrieve the GestureContainer object that handles this touch, and


### PR DESCRIPTION
My first attempt to use multigesture in my own code failed, but the bug looks to be a typo in the collision check for `on_touch_move`