### PR TITLE
Made sure Selector gets on_touch_down only once

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -250,8 +250,7 @@ class Selector(ButtonBehavior, Image):
             lambda x, y: matrix.transform_point(x, y, 0)[:2])
 
     def on_touch_down(self, touch):
-        win = EventLoop.window
-        if self.parent is not win:
+        if self.parent is not EventLoop.window:
             return
 
         try:

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -227,7 +227,6 @@ class Selector(ButtonBehavior, Image):
 
     def __init__(self, **kwargs):
         super(Selector, self).__init__(**kwargs)
-        self.window.bind(on_touch_down=self.on_window_touch_down)
         self.matrix = self.target.get_window_matrix()
 
         with self.canvas.before:
@@ -250,7 +249,8 @@ class Selector(ButtonBehavior, Image):
         touch.apply_transform_2d(
             lambda x, y: matrix.transform_point(x, y, 0)[:2])
 
-    def on_window_touch_down(self, win, touch):
+    def on_touch_down(self, touch):
+        win = EventLoop.window
         if self.parent is not win:
             return
 


### PR DESCRIPTION
Currently Selector works by binding manually to window.on_touch_down. It then translates the touch appropriately before checking for collision and handling its Selector functionality.

However, because the Selector is added to the Window, it still gets the normal on_touch_down call, which is handled according to its real position. That means if the user happens to tap where the Selector widget actually is (before its translation is applied), the touch will collide and the Selector can be manipulated!

This is hard to come across accidentally because it normally isn't important, but is a big problem if e.g. the user tries to press a Button outside the TextInput that happens to be below the real Selector position.

Edit: @akshayaurora Does this look right to you? I think this fix should be otherwise harmless.