### PR TITLE
Fix a silly multistroke crash

### DIFF
--- a/kivy/multistroke.py
+++ b/kivy/multistroke.py
@@ -1351,7 +1351,7 @@ def scale_dim(points, size, oneDratio):
     bbox_x, bbox_y, bbox_w, bbox_h = bounding_box(points)
 
     if bbox_h == 0 or bbox_w == 0:
-        raise MultistrokeError('scale_dim() called with invalid points')
+        raise MultistrokeError('scale_dim() called with invalid points: h:{}, w:{}'.format(bbox_h, bbox_w))
 
     # 1D or 2D gesture test
     uniformly = min(bbox_w / bbox_h, bbox_h / bbox_w) <= oneDratio
@@ -1448,7 +1448,7 @@ def bounding_box(points):
         if py > maxy:
             maxy = py
 
-    return (minx, miny, maxx - minx, maxy - miny)
+    return (minx, miny, maxx - minx + 1, maxy - miny + 1)
 
 
 def path_length(points):


### PR DESCRIPTION
The multistroke engine will crash if you draw a perfectly horizontal (or presumably vertical) line.

This just looks like a fencepost error.

This fix ensures the computed bounding box is at least 1 coordinate high (or wide). 
While here, improve the error message so it is clear why it is crashing.