### PR TITLE
Fix #4730 :ActionGroup behaviour becomes normal.First click works perfectly.

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -33,6 +33,7 @@ dropdown. ::
         # When adding widgets, we need to specify the height manually
         # (disabling the size_hint_y) so the dropdown can calculate
         # the area it needs.
+
         btn = Button(text='Value %d' % index, size_hint_y=None, height=44)
 
         # for each button, attach a callback that will call the select() method
@@ -223,7 +224,8 @@ class DropDown(ScrollView):
             return True
 
     def on_container(self, instance, value):
-        pass
+        if value is not None:
+            self.container.bind(minimum_size=self._reposition)
 
     def open(self, widget):
         '''Open the dropdown list and attach it to a specific widget.


### PR DESCRIPTION
#4730 The problem occurs when one doesn't specifies max_height of the dropdown then in these lines https://github.com/kivy/kivy/blob/master/kivy/uix/dropdown.py#L340-L343 , the max_height = None and hence for the first click self.container.minimum_height = 0 => self.height = 0  due to which first click on the ActionDropDown doesn't shows dropdown list.