### PR TITLE
added support for opencv 2 and 3

### DIFF
--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -43,7 +43,8 @@ except ImportError:
     # opencv 2 case (and also opencv 3, because it still uses cv2 module name)
     try:
         import cv2
-        # here missing this OSX specific highgui thing. I'm not on OSX so don't know if it is still valid in opencv >= 2
+        # here missing this OSX specific highgui thing.
+        # I'm not on OSX so don't know if it is still valid in opencv >= 2
     except ImportError:
         raise
 
@@ -54,7 +55,8 @@ class CameraOpenCV(CameraBase):
     '''
 
     def __init__(self, **kwargs):
-        # we will need it, because constants have different access paths between ver. 2 and 3
+        # we will need it, because constants have
+        # different access paths between ver. 2 and 3
         try:
             self.opencvMajorVersion = int(cv.__version__[0])
         except NameError:
@@ -91,9 +93,9 @@ class CameraOpenCV(CameraBase):
             # and get frame to check if it's ok
             frame = hg.cvQueryFrame(self._device)
             # Just set the resolution to the frame we just got, but don't use
-            # self.resolution for that as that would cause an infinite recursion
-            # with self.init_camera (but slowly as we'd have to always get a
-            # frame).
+            # self.resolution for that as that would cause an infinite
+            # recursion with self.init_camera (but slowly as we'd have to
+            # always get a frame).
             self._resolution = (int(frame.width), int(frame.height))
             # get fps
             self.fps = cv.GetCaptureProperty(self._device, cv.CV_CAP_PROP_FPS)
@@ -109,7 +111,8 @@ class CameraOpenCV(CameraBase):
             # and get frame to check if it's ok
             ret, frame = self._device.read()
 
-            # source: http://stackoverflow.com/questions/32468371/video-capture-propid-parameters-in-opencv
+            # source:
+            # http://stackoverflow.com/questions/32468371/video-capture-propid-parameters-in-opencv # noqa
             self._resolution = (int(frame.shape[1]), int(frame.shape[0]))
             # get fps
             self.fps = self._device.get(PROPERTY_FPS)

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -16,15 +16,17 @@ from kivy.core.camera import CameraBase
 try:
     # opencv 1 case
     import opencv as cv
+
     try:
         import opencv.highgui as hg
-    except ImportError: 
+    except ImportError:
         class Hg(object):
             '''
-            On OSX, not only are the import names different, but the API also
-            differs. There is no module called 'highgui' but the names are directly
-            available in the 'cv' module. Some of them even have a different
-            names.
+            On OSX, not only are the import names different,
+            but the API also differs.
+            There is no module called 'highgui' but the names are
+            directly available in the 'cv' module.
+            Some of them even have a different names.
 
             Therefore we use this proxy object.
             '''
@@ -45,28 +47,31 @@ except ImportError:
     except ImportError:
         raise
 
+
 class CameraOpenCV(CameraBase):
-    '''Implementation of CameraBase using OpenCV
+    '''
+    Implementation of CameraBase using OpenCV
     '''
 
     def __init__(self, **kwargs):
+        # we will need it, because constants have different access paths between ver. 2 and 3
         try:
-            self.opencvMajorVersion = int(cv.__version__[0]) # we will need it, because constants have different access paths between ver. 2 and 3
+            self.opencvMajorVersion = int(cv.__version__[0])
         except NameError:
             self.opencvMajorVersion = int(cv2.__version__[0])
-            
+
         self._device = None
         super(CameraOpenCV, self).__init__(**kwargs)
 
-    def init_camera(self):    
+    def init_camera(self):
         # consts have changed locations between versions 2 and 3
-        if self.opencvMajorVersion == 3: 
+        if self.opencvMajorVersion == 3:
             PROPERTY_WIDTH = cv2.CAP_PROP_FRAME_WIDTH
-            PROPERTY_HEIGHT=cv2.CAP_PROP_FRAME_HEIGHT
+            PROPERTY_HEIGHT = cv2.CAP_PROP_FRAME_HEIGHT
             PROPERTY_FPS = cv2.CAP_PROP_FPS
         elif self.opencvMajorVersion == 2:
-            PROPERTY_WIDTH=cv2.cv.CV_CAP_PROP_FRAME_WIDTH
-            PROPERTY_HEIGHT =cv2.cv.CV_CAP_PROP_FRAME_HEIGHT
+            PROPERTY_WIDTH = cv2.cv.CV_CAP_PROP_FRAME_WIDTH
+            PROPERTY_HEIGHT = cv2.cv.CV_CAP_PROP_FRAME_HEIGHT
             PROPERTY_FPS = cv2.cv.CV_CAP_PROP_FPS
         elif self.opencvMajorVersion == 1:
             PROPERTY_WIDTH = cv.CV_CAP_PROP_FRAME_WIDTH
@@ -74,7 +79,7 @@ class CameraOpenCV(CameraBase):
             PROPERTY_FPS = cv.CV_CAP_PROP_FPS
 
         Logger.debug('Using opencv ver.' + str(self.opencvMajorVersion))
-        
+
         if self.opencvMajorVersion == 1:
             # create the device
             self._device = hg.cvCreateCameraCapture(self._index)
@@ -103,7 +108,9 @@ class CameraOpenCV(CameraBase):
                              self.resolution[1])
             # and get frame to check if it's ok
             ret, frame = self._device.read()
-            self._resolution = (int(frame.shape[1]), int(frame.shape[0])) # source: http://stackoverflow.com/questions/32468371/video-capture-propid-parameters-in-opencv
+
+            # source: http://stackoverflow.com/questions/32468371/video-capture-propid-parameters-in-opencv
+            self._resolution = (int(frame.shape[1]), int(frame.shape[0]))
             # get fps
             self.fps = self._device.get(PROPERTY_FPS)
 

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -14,60 +14,99 @@ from kivy.graphics.texture import Texture
 from kivy.core.camera import CameraBase
 
 try:
+    # opencv 1 case
     import opencv as cv
-    import opencv.highgui as hg
-except ImportError:
-    import cv
+    try:
+        import opencv.highgui as hg
+    except ImportError: 
+        class Hg(object):
+            '''
+            On OSX, not only are the import names different, but the API also
+            differs. There is no module called 'highgui' but the names are directly
+            available in the 'cv' module. Some of them even have a different
+            names.
 
-    class Hg(object):
-        '''
-        On OSX, not only are the import names different, but the API also
-        differs. There is no module called 'highgui' but the names are directly
-        available in the 'cv' module. Some of them even have a different
-        names.
+            Therefore we use this proxy object.
+            '''
 
-        Therefore we use this proxy object.
-        '''
-
-        def __getattr__(self, attr):
-            if attr.startswith('cv'):
-                attr = attr[2:]
-            got = getattr(cv, attr)
-            return got
+            def __getattr__(self, attr):
+                if attr.startswith('cv'):
+                    attr = attr[2:]
+                got = getattr(cv, attr)
+                return got
 
     hg = Hg()
 
+except ImportError:
+    # opencv 2 case (and also opencv 3, because it still uses cv2 module name)
+    try:
+        import cv2
+        # here missing this OSX specific highgui thing. I'm not on OSX so don't know if it is still valid in opencv >= 2
+    except ImportError:
+        raise
 
 class CameraOpenCV(CameraBase):
     '''Implementation of CameraBase using OpenCV
     '''
 
-    _update_ev = None
-
     def __init__(self, **kwargs):
+        try:
+            self.opencvMajorVersion = int(cv.__version__[0]) # we will need it, because constants have different access paths between ver. 2 and 3
+        except NameError:
+            self.opencvMajorVersion = int(cv2.__version__[0])
+            
         self._device = None
         super(CameraOpenCV, self).__init__(**kwargs)
 
-    def init_camera(self):
-        # create the device
-        self._device = hg.cvCreateCameraCapture(self._index)
+    def init_camera(self):    
+        # consts have changed locations between versions 2 and 3
+        if self.opencvMajorVersion == 3: 
+            PROPERTY_WIDTH = cv2.CAP_PROP_FRAME_WIDTH
+            PROPERTY_HEIGHT=cv2.CAP_PROP_FRAME_HEIGHT
+            PROPERTY_FPS = cv2.CAP_PROP_FPS
+        elif self.opencvMajorVersion == 2:
+            PROPERTY_WIDTH=cv2.cv.CV_CAP_PROP_FRAME_WIDTH
+            PROPERTY_HEIGHT =cv2.cv.CV_CAP_PROP_FRAME_HEIGHT
+            PROPERTY_FPS = cv2.cv.CV_CAP_PROP_FPS
+        elif self.opencvMajorVersion == 1:
+            PROPERTY_WIDTH = cv.CV_CAP_PROP_FRAME_WIDTH
+            PROPERTY_HEIGHT = cv.CV_CAP_PROP_FRAME_HEIGHT
+            PROPERTY_FPS = cv.CV_CAP_PROP_FPS
 
-        # Set preferred resolution
-        cv.SetCaptureProperty(self._device, cv.CV_CAP_PROP_FRAME_WIDTH,
-                              self.resolution[0])
-        cv.SetCaptureProperty(self._device, cv.CV_CAP_PROP_FRAME_HEIGHT,
-                              self.resolution[1])
+        Logger.debug('Using opencv ver.' + str(self.opencvMajorVersion))
+        
+        if self.opencvMajorVersion == 1:
+            # create the device
+            self._device = hg.cvCreateCameraCapture(self._index)
+            # Set preferred resolution
+            cv.SetCaptureProperty(self._device, cv.CV_CAP_PROP_FRAME_WIDTH,
+                                  self.resolution[0])
+            cv.SetCaptureProperty(self._device, cv.CV_CAP_PROP_FRAME_HEIGHT,
+                                  self.resolution[1])
+            # and get frame to check if it's ok
+            frame = hg.cvQueryFrame(self._device)
+            # Just set the resolution to the frame we just got, but don't use
+            # self.resolution for that as that would cause an infinite recursion
+            # with self.init_camera (but slowly as we'd have to always get a
+            # frame).
+            self._resolution = (int(frame.width), int(frame.height))
+            # get fps
+            self.fps = cv.GetCaptureProperty(self._device, cv.CV_CAP_PROP_FPS)
 
-        # and get frame to check if it's ok
-        frame = hg.cvQueryFrame(self._device)
-        # Just set the resolution to the frame we just got, but don't use
-        # self.resolution for that as that would cause an infinite recursion
-        # with self.init_camera (but slowly as we'd have to always get a
-        # frame).
-        self._resolution = (int(frame.width), int(frame.height))
+        elif self.opencvMajorVersion == 2 or self.opencvMajorVersion == 3:
+            # create the device
+            self._device = cv2.VideoCapture(self._index)
+            # Set preferred resolution
+            self._device.set(PROPERTY_WIDTH,
+                             self.resolution[0])
+            self._device.set(PROPERTY_HEIGHT,
+                             self.resolution[1])
+            # and get frame to check if it's ok
+            ret, frame = self._device.read()
+            self._resolution = (int(frame.shape[1]), int(frame.shape[0])) # source: http://stackoverflow.com/questions/32468371/video-capture-propid-parameters-in-opencv
+            # get fps
+            self.fps = self._device.get(PROPERTY_FPS)
 
-        # get fps
-        self.fps = cv.GetCaptureProperty(self._device, cv.CV_CAP_PROP_FPS)
         if self.fps <= 0:
             self.fps = 1 / 30.
 
@@ -83,7 +122,7 @@ class CameraOpenCV(CameraBase):
             self._texture.flip_vertical()
             self.dispatch('on_load')
         try:
-            frame = hg.cvQueryFrame(self._device)
+            ret, frame = self._device.read()
             self._format = 'bgr'
             try:
                 self._buffer = frame.imageData
@@ -97,12 +136,9 @@ class CameraOpenCV(CameraBase):
 
     def start(self):
         super(CameraOpenCV, self).start()
-        if self._update_ev is not None:
-            self._update_ev.cancel()
-        self._update_ev = Clock.schedule_interval(self._update, self.fps)
+        Clock.unschedule(self._update)
+        Clock.schedule_interval(self._update, self.fps)
 
     def stop(self):
         super(CameraOpenCV, self).stop()
-        if self._update_ev is not None:
-            self._update_ev.cancel()
-            self._update_ev = None
+        Clock.unschedule(self._update)


### PR DESCRIPTION
I updated this file to deal with current opencv versions 2.4 and 3.x.
There are elif branches to initalize everything accordingly. Methods differ. My fav one is @ line 106 'frame.width' -> 'frame.shape[0]' indicating different datatype..
Opencv's naming convention is sick IMO.
(tested both on win10 and ver.3 on RPi)

*** that's my first PR, so please correct me if I'm wrong or something ***