### PR TITLE
Fixed get_deps_minimal crash in Python3

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -196,9 +196,18 @@ def get_deps_minimal(exclude_ignored=True, **kwargs):
         core_mods.remove(mod_name)
 
         mods.append(full_name)
-        if isinstance(val, basestring):
-            mods.append('kivy.core.{0}.{0}_{1}'.format(mod_name, val))
+        single_mod = False
+        if sys.version < '3.0':
+            # Mod name could potentially be any basestring subclass
+            if isinstance(val, basestring):
+                single_mod = True
+                mods.append('kivy.core.{0}.{0}_{1}'.format(mod_name, val))
         else:
+            # There is no `basestring` in Py3 and unicode string could reasonably be either str or bytes
+            if isinstance(val, (str, bytes)):
+                single_mod = True
+                mods.append('kivy.core.{0}.{0}_{1}'.format(mod_name, val))
+        if not single_mod:
             for v in val:
                 mods.append('kivy.core.{0}.{0}_{1}'.format(mod_name, v))
 

--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -203,7 +203,7 @@ def get_deps_minimal(exclude_ignored=True, **kwargs):
                 single_mod = True
                 mods.append('kivy.core.{0}.{0}_{1}'.format(mod_name, val))
         else:
-            # There is no `basestring` in Py3 and unicode string could reasonably be either str or bytes
+            # There is no `basestring` in Py3 
             if isinstance(val, (str, bytes)):
                 single_mod = True
                 mods.append('kivy.core.{0}.{0}_{1}'.format(mod_name, val))


### PR DESCRIPTION
A better fix for the issue I tried to adress in rejected #4811 
Basically, the entire thing was crashing in Python3 due to using `basestring` for checks and now it doesn't.