### PR TITLE
Add Window position manipulation

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -680,12 +680,32 @@ class WindowBase(EventDispatcher):
     def _set_cursor_state(self, value):
         pass
 
+    def _get_window_pos(self):
+        pass
+
+    def _set_window_pos(self, x, y):
+        pass
+
+    def _get_left(self):
+        return self._get_window_pos()[0]
+
+    def _set_left(self, value):
+        pos = self._get_window_pos()
+        self._set_window_pos(value, pos[1])
+
+    def _get_top(self):
+        return self._get_window_pos()[1]
+
+    def _set_top(self, value):
+        pos = self._get_window_pos()
+        self._set_window_pos(pos[0], value)
+
     @property
     def __self__(self):
         return self
 
-    top = NumericProperty(None, allownone=True)
-    left = NumericProperty(None, allownone=True)
+    top = AliasProperty(_get_top, _set_top)
+    left = AliasProperty(_get_left, _set_left)
     position = OptionProperty('auto', options=['auto', 'custom'])
     render_context = ObjectProperty(None)
     canvas = ObjectProperty(None)

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -700,12 +700,38 @@ class WindowBase(EventDispatcher):
         pos = self._get_window_pos()
         self._set_window_pos(pos[0], value)
 
+    top = AliasProperty(_get_top, _set_top)
+    '''Top position of the window.
+
+    .. note:: It's an SDL2 property with `[0, 0]` in the top-left corner.
+
+    .. versionchanged:: 1.9.2
+        :attr:`top` is now an :class:`~kivy.properties.AliasProperty`
+
+    .. versionadded:: 1.9.1
+
+    :attr:`top` is an :class:`~kivy.properties.AliasProperty` and defaults to
+    position set in :class:`~kivy.config.Config`.
+    '''
+
+    left = AliasProperty(_get_left, _set_left)
+    '''Left position of the window.
+
+    .. note:: It's an SDL2 property with `[0, 0]` in the top-left corner.
+
+    .. versionchanged:: 1.9.2
+        :attr:`left` is now an :class:`~kivy.properties.AliasProperty`
+
+    .. versionadded:: 1.9.1
+
+    :attr:`left` is an :class:`~kivy.properties.AliasProperty` and defaults to
+    position set in :class:`~kivy.config.Config`.
+    '''
+
     @property
     def __self__(self):
         return self
 
-    top = AliasProperty(_get_top, _set_top)
-    left = AliasProperty(_get_left, _set_left)
     position = OptionProperty('auto', options=['auto', 'custom'])
     render_context = ObjectProperty(None)
     canvas = ObjectProperty(None)

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -218,8 +218,16 @@ cdef class _WindowSDL2Storage:
         IF not USE_IOS:
             SDL_SetWindowFullscreen(self.win, mode)
 
-    def set_window_title(self,  title):
+    def set_window_title(self, title):
         SDL_SetWindowTitle(self.win, <bytes>title.encode('utf-8'))
+
+    def get_window_pos(self):
+        cdef int x, y
+        SDL_GetWindowPosition(self.win, &x, &y)
+        return x, y
+
+    def set_window_pos(self, x, y):
+        SDL_SetWindowPosition(self.win, x, y)
 
     def set_window_icon(self, filename):
         icon = IMG_Load(<bytes>filename.encode('utf-8'))

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -379,6 +379,12 @@ class WindowSDL(WindowBase):
         self._win.flip()
         super(WindowSDL, self).flip()
 
+    def _get_window_pos(self):
+        return self._win.get_window_pos()
+
+    def _set_window_pos(self, x, y):
+        self._win.set_window_pos(x, y)
+
     def _set_cursor_state(self, value):
         self._win._set_cursor_state(value)
 


### PR DESCRIPTION
ref #3799

```
from kivy.app import App
from kivy.clock import Clock
from kivy.core.window import Window


class TestApp(App):
    def show(self, dt):
        pos = Window._get_window_pos()
        Window._set_window_pos(*[p + 1 for p in pos])

    def build(self):
        Clock.schedule_interval(self.show, 0)
TestApp().run()
```

For now getter and setter only. Not sure if it needs to be a separate thing from `Window.top` for example, or if it needs to _update_ those two properties.

@dessant @matham ? 😋 