### PR TITLE
Add 'mp4' to audio_gstplayer.py

### DIFF
--- a/kivy/core/audio/audio_gstplayer.py
+++ b/kivy/core/audio/audio_gstplayer.py
@@ -38,7 +38,7 @@ class SoundGstplayer(Sound):
 
     @staticmethod
     def extensions():
-        return ('wav', 'ogg', 'mp3', 'm4a', 'flac')
+        return ('wav', 'ogg', 'mp3', 'm4a', 'flac', 'mp4')
 
     def __init__(self, **kwargs):
         self.player = None


### PR DESCRIPTION
Since programs such as LMMS create '.mp4' files that are purely audio even though they should be 'm4a' I have added support for 'mp4' files it will work so long as they are audio only.