### PR TITLE
textinput cursor going outside bound problem solved

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2536,8 +2536,6 @@ class TextInput(FocusBehavior, Widget):
         cr = boundary(pos[1], 0, len(l) - 1)
         cc = boundary(pos[0], 0, len(l[cr]))
         cursor = cc, cr
-        if self._cursor == cursor:
-            return
 
         self._cursor = cursor
 


### PR DESCRIPTION
Well the problem was because when the application is  getting started and text in the textinput exceeds the height of the textinput (leading to the cursor going out of bounds) , then the scroll_x as well as scroll_y are not updated. Removing that check (self._cursor == cursor) doesn't breaks anything except that it leads to execution of below code https://github.com/kivy/kivy/blob/master/kivy/uix/textinput.py#L2542-L2572 when scroll_x and scroll_y haven't changed. 