### PR TITLE
Added note to seek that sound must be playing.

### DIFF
--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -205,8 +205,11 @@ class Sound(EventDispatcher):
 
     def seek(self, position):
         '''Go to the <position> (in seconds).
+
         .. note::
-            Most sound providers can not seek when the audio is stopped. Play then seek.'''
+            Most sound providers cannot seek when the audio is stopped.
+            Play then seek.
+        '''
         pass
 
     def on_play(self):

--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -204,7 +204,9 @@ class Sound(EventDispatcher):
         self.dispatch('on_stop')
 
     def seek(self, position):
-        '''Go to the <position> (in seconds).'''
+        '''Go to the <position> (in seconds).
+        .. note::
+            Most sound providers can not seek when the audio is stopped. Play then seek.'''
         pass
 
     def on_play(self):


### PR DESCRIPTION
Update documentation to reflect that most sound providers require the sound to be playing in order to seek.
Closes kivy/kivy/issues/4852