### PR TITLE
Remove pygst as a provider for Camera.

### DIFF
--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -141,9 +141,6 @@ elif platform == 'macosx':
                    'CameraAVFoundation'), )
 elif platform == 'android':
     providers += (('android', 'camera_android', 'CameraAndroid'), )
-else:
-    # providers += (('gi', 'camera_gi', 'CameraGi'), )
-    providers += (('pygst', 'camera_pygst', 'CameraPyGst'), )
 
 providers += (('opencv', 'camera_opencv', 'CameraOpenCV'), )
 


### PR DESCRIPTION
Prevents a crash on import of pygst which is no longer an official Kivy dependency.
Next I will remove camera_pygst.py, but before I do it I want to get confirmation from Kivy developers.
This will help address https://github.com/kivy/kivy/issues/4224 , and is part 1 of several.