### PR TITLE
Fix clipboard example

### DIFF
--- a/examples/miscellaneous/clipboard.py
+++ b/examples/miscellaneous/clipboard.py
@@ -9,28 +9,26 @@ Builder.load_string('''
 #:import Clipboard kivy.core.clipboard.Clipboard
 <Clip>:
     orientation: 'vertical'
-    BoxLayout:
+    GridLayout:
+        cols: 3
         size_hint_y: None
-        height: self.height
+        height: self.minimum_height
         Button:
-            text: 'Paste raw clipboard'
+            text: 'Paste raw'
             size_hint_y: None
             height: 60
-            pos_hint: {'top': 1}
             on_release: root.make_labels(Clipboard.paste())
 
         Button:
-            text: 'Paste & format clipboard'
+            text: 'Paste & format'
             size_hint_y: None
             height: 60
-            pos_hint: {'top': 1}
             on_release: root.make_pretty_labels(Clipboard.paste())
 
         Button:
             text: 'Remove widgets'
             size_hint_y: None
             height: 60
-            pos_hint: {'top': 1}
             on_release: container.clear_widgets()
 
     ScrollView:


### PR DESCRIPTION
ref #4884 + excluded unnecessary positioning. Also, now the text shouldn't overlap on android.