### PR TITLE
Version statements removed in examples

### DIFF
--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -6,17 +6,6 @@ Be careful if you change anything in !
 
 '''
 
-ignore_list = (
-    'kivy._clock',
-    'kivy._event',
-    'kivy.factory_registers',
-    'kivy.graphics.buffer',
-    'kivy.graphics.vbo',
-    'kivy.graphics.vertex',
-    'kivy.uix.recycleview.__init__',
-    'kivy.setupconfig'
-)
-
 import os
 import sys
 from glob import glob
@@ -63,6 +52,19 @@ import kivy.interactive
 import kivy.garden
 from kivy.factory import Factory
 from kivy.lib import osc, ddsfile, mtdev
+
+
+ignore_list = (
+    'kivy._clock',
+    'kivy._event',
+    'kivy.factory_registers',
+    'kivy.graphics.buffer',
+    'kivy.graphics.vbo',
+    'kivy.graphics.vertex',
+    'kivy.uix.recycleview.__init__',
+    'kivy.setupconfig'
+)
+
 
 # check for silenced build
 BE_QUIET = True

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -15,6 +15,11 @@
 
 import os
 import sys
+import sphinx.ext.autodoc
+import kivy
+import gallery
+
+from kivy import setupconfig
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
@@ -37,7 +42,7 @@ todo_include_todos = True
 
 # XXX HACK mathieu: monkey patch the autodoc module, to give a better priority
 # for ClassDocumenter, or the cython class will be documented as AttributeClass
-import sphinx.ext.autodoc
+
 sphinx.ext.autodoc.ClassDocumenter.priority = 10
 
 # Add any paths that contain templates here, relative to this directory.
@@ -60,7 +65,7 @@ copyright = '2010, The Kivy Authors'
 # other places throughout the built documents.
 #
 os.environ['KIVY_DOC_INCLUDE'] = '1'
-import kivy
+
 print(kivy.__file__)
 
 version = kivy.__version__
@@ -68,7 +73,6 @@ release = kivy.__version__
 base = 'autobuild.py-done'
 if not os.path.exists(os.path.join(os.path.dirname(base_dir), base)):
     import autobuild
-import gallery
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -213,7 +217,6 @@ latex_use_parts = True
 # If false, no module index is generated.
 # latex_use_modindex = True
 
-from kivy import setupconfig
 
 replacements = {
     'cython_install': 'Cython==' + setupconfig.CYTHON_MAX,

--- a/doc/sources/sphinxext/autodoc.py
+++ b/doc/sources/sphinxext/autodoc.py
@@ -25,6 +25,8 @@ class KivyClassDocumenter(ClassDocumenter):
                          for b in self.object.__bases__]
                 self.add_line(_('   Bases: %s') % ', '.join(bases),
                               '<autodoc>')
+
+
 def setup(app):
     core_setup(app)
     app.add_autodocumenter(KivyClassDocumenter)

--- a/doc/sources/sphinxext/kivy_pygments_theme.py
+++ b/doc/sources/sphinxext/kivy_pygments_theme.py
@@ -11,12 +11,12 @@ class KivyStyle(Style):
 
     styles = {
         # No corresponding class for the following:
-        #Text:                     "", # class:  ''
+        # Text:                     "", # class:  ''
         Whitespace:                "underline #ffffff",      # class: 'w'
-        Error:                     "#FF0000 border:#FF0000", # class: 'err'
+        Error:                     "#FF0000 border:#FF0000",  # class: 'err'
         Other:                     "#FF0000",                # class 'x'
 
-        Comment:                   "italic #666385", # class: 'c'
+        Comment:                   "italic #666385",  # class: 'c'
         Comment.Preproc:           "noitalic",       # class: 'cp'
 
         Keyword:                   "bold #000000",   # class: 'k'
@@ -63,7 +63,7 @@ class KivyStyle(Style):
         String:                    "#74171b",        # class: 's'
         String.Backtick:           "#4e9a06",        # class: 'sb'
         String.Char:               "#4e9a06",        # class: 'sc'
-        String.Doc:                "italic #640000", # class: 'sd' - like a comment
+        String.Doc:                "italic #640000",  # class: 'sd' - like a comment
         String.Double:             "#74171b",        # class: 's2'
         String.Escape:             "#74171b",        # class: 'se'
         String.Heredoc:            "#74171b",        # class: 'sh'
@@ -75,7 +75,7 @@ class KivyStyle(Style):
 
         Generic:                   "#000000",        # class: 'g'
         Generic.Deleted:           "#a40000",        # class: 'gd'
-        Generic.Emph:              "italic #000000", # class: 'ge'
+        Generic.Emph:              "italic #000000",  # class: 'ge'
         Generic.Error:             "#ef2929",        # class: 'gr'
         Generic.Heading:           "bold #000080",   # class: 'gh'
         Generic.Inserted:          "#00A000",        # class: 'gi'

--- a/doc/sources/sphinxext/preprocess.py
+++ b/doc/sources/sphinxext/preprocess.py
@@ -8,11 +8,13 @@ import sys
 from os.path import dirname, join
 from sphinx.ext.autodoc import MethodDocumenter
 
+
 class CythonMethodDocumenter(MethodDocumenter):
     # XXX i don't understand the impact of having a priority more than the
     # attribute or instance method but the things is, if it's a cython module,
     # the attribute will be prefer over method.
     priority = 12
+
 
 def is_cython_extension(what, obj):
     # try to check if the first line of the doc is a signature
@@ -39,6 +41,7 @@ def is_cython_extension(what, obj):
         if not re.match('^([a-zA-Z_][a-zA-Z0-9_]*)\((.*)\)', doc):
             return False
         return True
+
 
 def callback_docstring(app, what, name, obj, options, lines):
     if what == 'module':
@@ -86,7 +89,9 @@ def callback_docstring(app, what, name, obj, options, lines):
                     continue
                 if not line.startswith(spaces):
                     continue
+
                 lines[idx] = line[min_space:]
+
 
 def callback_signature(app, what, name, obj, options, signature,
                        return_annotation):
@@ -103,6 +108,7 @@ def callback_signature(app, what, name, obj, options, signature,
             pass
         except IndexError:
             pass
+
 
 def setup(app):
     import kivy

--- a/examples/android/compass/main.py
+++ b/examples/android/compass/main.py
@@ -27,7 +27,6 @@ from kivy.properties import NumericProperty
 from kivy.clock import Clock
 from kivy.vector import Vector
 from kivy.animation import Animation
-kivy.require('1.7.0')
 
 
 Hardware = autoclass('org.renpy.android.Hardware')

--- a/examples/android/compass/main.py
+++ b/examples/android/compass/main.py
@@ -20,7 +20,6 @@ You can compile it with::
 
 
 import kivy
-kivy.require('1.7.0')
 
 from jnius import autoclass
 from kivy.app import App
@@ -28,6 +27,8 @@ from kivy.properties import NumericProperty
 from kivy.clock import Clock
 from kivy.vector import Vector
 from kivy.animation import Animation
+kivy.require('1.7.0')
+
 
 Hardware = autoclass('org.renpy.android.Hardware')
 

--- a/examples/android/takepicture/main.py
+++ b/examples/android/takepicture/main.py
@@ -18,8 +18,6 @@ If you want to compile it, don't forget to add the CAMERA permission::
 
 '''
 
-__version__ = '0.1'
-
 from kivy.app import App
 from os.path import exists
 from jnius import autoclass, cast
@@ -28,8 +26,8 @@ from functools import partial
 from kivy.clock import Clock
 from kivy.uix.scatter import Scatter
 from kivy.properties import StringProperty
-
 from PIL import Image
+__version__ = '0.1'
 
 Intent = autoclass('android.content.Intent')
 MediaStore = autoclass('android.provider.MediaStore')

--- a/examples/animation/animate.py
+++ b/examples/animation/animate.py
@@ -8,11 +8,11 @@ an animation when clicked.
 '''
 
 import kivy
-kivy.require('1.0.7')
 
 from kivy.animation import Animation
 from kivy.app import App
 from kivy.uix.button import Button
+kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/animation/animate.py
+++ b/examples/animation/animate.py
@@ -12,7 +12,6 @@ import kivy
 from kivy.animation import Animation
 from kivy.app import App
 from kivy.uix.button import Button
-kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/application/app_suite.py
+++ b/examples/application/app_suite.py
@@ -19,12 +19,12 @@ import re
 from random import choice
 
 import kivy
-kivy.require('1.8.0')  # 1.8 is when kv_directory became part of app.
+
 from kivy.app import App
 from kivy.uix.button import Button
 from kivy.lang import Builder
-
 from kivy.uix.floatlayout import FloatLayout
+kivy.require('1.8.0')  # 1.8 is when kv_directory became part of app.
 # Note that importing FloatLayout causes Kivy to execute, including
 # starting up the Logger and some other messages.
 print("** In main program, done with imports")

--- a/examples/application/app_suite.py
+++ b/examples/application/app_suite.py
@@ -24,7 +24,7 @@ from kivy.app import App
 from kivy.uix.button import Button
 from kivy.lang import Builder
 from kivy.uix.floatlayout import FloatLayout
-kivy.require('1.8.0')  # 1.8 is when kv_directory became part of app.
+# 1.8 is when kv_directory became part of app.
 # Note that importing FloatLayout causes Kivy to execute, including
 # starting up the Logger and some other messages.
 print("** In main program, done with imports")

--- a/examples/application/app_with_build.py
+++ b/examples/application/app_with_build.py
@@ -10,7 +10,6 @@ import kivy
 
 from kivy.app import App
 from kivy.uix.button import Button
-kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/application/app_with_build.py
+++ b/examples/application/app_with_build.py
@@ -7,10 +7,10 @@ self.root.
 '''
 
 import kivy
-kivy.require('1.0.7')
 
 from kivy.app import App
 from kivy.uix.button import Button
+kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/application/app_with_kv.py
+++ b/examples/application/app_with_kv.py
@@ -12,9 +12,8 @@ contains a root Widget.
 '''
 
 import kivy
-kivy.require('1.0.7')
-
 from kivy.app import App
+kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/application/app_with_kv.py
+++ b/examples/application/app_with_kv.py
@@ -13,7 +13,6 @@ contains a root Widget.
 
 import kivy
 from kivy.app import App
-kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/application/app_with_kv_in_template1.py
+++ b/examples/application/app_with_kv_in_template1.py
@@ -14,9 +14,9 @@ file contains the root widget.
 '''
 
 import kivy
-kivy.require('1.0.7')
 
 from kivy.app import App
+kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/application/app_with_kv_in_template1.py
+++ b/examples/application/app_with_kv_in_template1.py
@@ -16,7 +16,6 @@ file contains the root widget.
 import kivy
 
 from kivy.app import App
-kivy.require('1.0.7')
 
 
 class TestApp(App):

--- a/examples/audio/main.py
+++ b/examples/audio/main.py
@@ -20,7 +20,6 @@ from kivy.core.audio import SoundLoader
 from kivy.properties import StringProperty, ObjectProperty, NumericProperty
 from glob import glob
 from os.path import dirname, join, basename
-kivy.require('1.0.8')
 
 
 class AudioButton(Button):

--- a/examples/audio/main.py
+++ b/examples/audio/main.py
@@ -12,7 +12,6 @@ All the sounds are from the http://woolyss.com/chipmusic-samples.php
 '''
 
 import kivy
-kivy.require('1.0.8')
 
 from kivy.app import App
 from kivy.uix.button import Button
@@ -21,6 +20,7 @@ from kivy.core.audio import SoundLoader
 from kivy.properties import StringProperty, ObjectProperty, NumericProperty
 from glob import glob
 from os.path import dirname, join, basename
+kivy.require('1.0.8')
 
 
 class AudioButton(Button):

--- a/examples/canvas/fbo_canvas.py
+++ b/examples/canvas/fbo_canvas.py
@@ -8,7 +8,6 @@ button labelled 'FBO' in the bottom left corner. Clicking it
 animates the button moving right to left.
 '''
 
-__all__ = ('FboFloatLayout', )
 
 from kivy.graphics import Color, Rectangle, Canvas, ClearBuffers, ClearColor
 from kivy.graphics.fbo import Fbo
@@ -18,6 +17,7 @@ from kivy.app import App
 from kivy.core.window import Window
 from kivy.animation import Animation
 from kivy.factory import Factory
+__all__ = ('FboFloatLayout', )
 
 
 class FboFloatLayout(FloatLayout):

--- a/examples/canvas/rounded_rectangle.py
+++ b/examples/canvas/rounded_rectangle.py
@@ -95,8 +95,7 @@ class RoundedRectangleWidget(Widget):
             Color(*ORANGE)
             RoundedRectangle(
                 pos=(200, 25),
-                radius=[(40, 20),
-                45.5, 45.5, 0],
+                radius=[(40, 20), 45.5, 45.5, 0],
                 segments=[2, 3, 3, 1], size=(125, 100))
 
             Color(*RED)

--- a/examples/demo/kivycatalog/main.py
+++ b/examples/demo/kivycatalog/main.py
@@ -20,7 +20,7 @@ kivycatalog.kv.
 Known bugs include some issue with the drop
 '''
 import kivy
-kivy.require('1.4.2')
+
 import os
 import sys
 from kivy.app import App
@@ -31,7 +31,7 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.codeinput import CodeInput
 from kivy.animation import Animation
 from kivy.clock import Clock
-
+kivy.require('1.4.2')
 CATALOG_ROOT = os.path.dirname(__file__)
 
 # Config.set('graphics', 'width', '1024')

--- a/examples/demo/kivycatalog/main.py
+++ b/examples/demo/kivycatalog/main.py
@@ -31,7 +31,7 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.codeinput import CodeInput
 from kivy.animation import Animation
 from kivy.clock import Clock
-kivy.require('1.4.2')
+
 CATALOG_ROOT = os.path.dirname(__file__)
 
 # Config.set('graphics', 'width', '1024')

--- a/examples/demo/multistroke/gesturedatabase.py
+++ b/examples/demo/multistroke/gesturedatabase.py
@@ -1,4 +1,3 @@
-__all__ = ('GestureDatabase', 'GestureDatabaseItem')
 
 from kivy.clock import Clock
 from kivy.lang import Builder
@@ -12,6 +11,7 @@ from kivy.multistroke import Recognizer
 
 # local libraries
 from helpers import InformationPopup
+__all__ = ('GestureDatabase', 'GestureDatabaseItem')
 
 
 Builder.load_file('gesturedatabase.kv')

--- a/examples/demo/multistroke/helpers.py
+++ b/examples/demo/multistroke/helpers.py
@@ -1,10 +1,11 @@
-__all__ = ('InformationPopup', )
 
 from kivy.uix.popup import Popup
 from kivy.properties import StringProperty
 from kivy.factory import Factory
 from kivy.lang import Builder
 from kivy.clock import Clock
+__all__ = ('InformationPopup', )
+
 
 Builder.load_string('''
 <InformationPopup>:

--- a/examples/demo/multistroke/historymanager.py
+++ b/examples/demo/multistroke/historymanager.py
@@ -1,4 +1,4 @@
-__all__ = ('GestureHistoryManager', 'GestureVisualizer')
+
 
 from kivy.app import App
 from kivy.clock import Clock
@@ -14,6 +14,7 @@ from kivy.compat import PY2
 # local libraries
 from helpers import InformationPopup
 from settings import MultistrokeSettingsContainer
+__all__ = ('GestureHistoryManager', 'GestureVisualizer')
 
 
 # refuse heap permute for gestures with more strokes than 3

--- a/examples/demo/multistroke/settings.py
+++ b/examples/demo/multistroke/settings.py
@@ -1,6 +1,4 @@
-__all__ = ('MultistrokeSettingsContainer', 'MultistrokeSettingItem',
-           'MultistrokeSettingBoolean', 'MultistrokeSettingSlider',
-           'MultistrokeSettingString', 'MultistrokeSettingTitle')
+
 
 from kivy.factory import Factory
 from kivy.lang import Builder
@@ -9,6 +7,9 @@ from kivy.uix.label import Label
 from kivy.properties import (StringProperty, NumericProperty, OptionProperty,
                              BooleanProperty)
 from kivy.uix.popup import Popup
+__all__ = ('MultistrokeSettingsContainer', 'MultistrokeSettingItem',
+           'MultistrokeSettingBoolean', 'MultistrokeSettingSlider',
+           'MultistrokeSettingString', 'MultistrokeSettingTitle')
 
 Builder.load_file('settings.kv')
 

--- a/examples/demo/pictures/main.py
+++ b/examples/demo/pictures/main.py
@@ -24,7 +24,6 @@ domain.
 '''
 
 import kivy
-kivy.require('1.0.6')
 
 from glob import glob
 from random import randint
@@ -33,6 +32,7 @@ from kivy.app import App
 from kivy.logger import Logger
 from kivy.uix.scatter import Scatter
 from kivy.properties import StringProperty
+kivy.require('1.0.6')
 
 
 class Picture(Scatter):

--- a/examples/demo/pictures/main.py
+++ b/examples/demo/pictures/main.py
@@ -32,7 +32,6 @@ from kivy.app import App
 from kivy.logger import Logger
 from kivy.uix.scatter import Scatter
 from kivy.properties import StringProperty
-kivy.require('1.0.6')
 
 
 class Picture(Scatter):

--- a/examples/demo/shadereditor/main.py
+++ b/examples/demo/shadereditor/main.py
@@ -16,7 +16,6 @@ the error is visible as logging message in your terminal.
 
 import sys
 import kivy
-kivy.require('1.0.6')
 
 from kivy.app import App
 from kivy.uix.floatlayout import FloatLayout
@@ -26,6 +25,8 @@ from kivy.graphics import RenderContext
 from kivy.properties import StringProperty, ObjectProperty
 from kivy.clock import Clock
 from kivy.compat import PY2
+kivy.require('1.0.6')
+
 
 fs_header = '''
 #ifdef GL_ES

--- a/examples/demo/touchtracer/main.py
+++ b/examples/demo/touchtracer/main.py
@@ -23,10 +23,10 @@ Kivy Launcher Android application. For Android devices, you can
 copy/paste this directory into /sdcard/kivy/touchtracer on your Android device.
 
 '''
-__version__ = '1.0'
+
 
 import kivy
-kivy.require('1.0.6')
+
 
 from kivy.app import App
 from kivy.uix.floatlayout import FloatLayout
@@ -34,6 +34,8 @@ from kivy.uix.label import Label
 from kivy.graphics import Color, Rectangle, Point, GraphicException
 from random import random
 from math import sqrt
+kivy.require('1.0.6')
+__version__ = '1.0'
 
 
 def calculate_points(x1, y1, x2, y2, steps=5):

--- a/examples/frameworks/twisted/echo_client_app.py
+++ b/examples/frameworks/twisted/echo_client_app.py
@@ -1,10 +1,12 @@
 # install_twisted_rector must be called before importing the reactor
+from kivy.app import App
+from kivy.uix.label import Label
+from kivy.uix.textinput import TextInput
+from kivy.uix.boxlayout import BoxLayout
+from twisted.internet import reactor, protocol
 from kivy.support import install_twisted_reactor
 install_twisted_reactor()
-
-
 # A simple Client that send messages to the echo server
-from twisted.internet import reactor, protocol
 
 
 class EchoClient(protocol.Protocol):
@@ -26,17 +28,11 @@ class EchoFactory(protocol.ClientFactory):
 
     def clientConnectionFailed(self, conn, reason):
         self.app.print_message("connection failed")
-
-
-from kivy.app import App
-from kivy.uix.label import Label
-from kivy.uix.textinput import TextInput
-from kivy.uix.boxlayout import BoxLayout
-
-
 # A simple kivy App, with a textbox to enter messages, and
 # a large label to display all the messages received from
 # the server
+
+
 class TwistedClientApp(App):
     connection = None
 

--- a/examples/frameworks/twisted/echo_server_app.py
+++ b/examples/frameworks/twisted/echo_server_app.py
@@ -1,10 +1,11 @@
 # install_twisted_rector must be called before importing  and using the reactor
-from kivy.support import install_twisted_reactor
-install_twisted_reactor()
-
+from kivy.app import App
+from kivy.uix.label import Label
 
 from twisted.internet import reactor
 from twisted.internet import protocol
+from kivy.support import install_twisted_reactor
+install_twisted_reactor()
 
 
 class EchoProtocol(protocol.Protocol):
@@ -19,10 +20,6 @@ class EchoFactory(protocol.Factory):
 
     def __init__(self, app):
         self.app = app
-
-
-from kivy.app import App
-from kivy.uix.label import Label
 
 
 class TwistedServerApp(App):

--- a/examples/frameworks/twisted/twistd_app.py
+++ b/examples/frameworks/twisted/twistd_app.py
@@ -1,5 +1,3 @@
-from kivy.support import install_twisted_reactor
-install_twisted_reactor()
 
 import os
 import sys
@@ -8,6 +6,9 @@ from kivy.app import App
 from kivy.uix.gridlayout import GridLayout
 from kivy.properties import BooleanProperty
 from kivy.lang import Builder
+from kivy.support import install_twisted_reactor
+install_twisted_reactor()
+
 
 from twisted.scripts._twistd_unix import UnixApplicationRunner, ServerOptions
 from twisted.application.service import IServiceCollection

--- a/examples/guide/designwithkv/main.py
+++ b/examples/guide/designwithkv/main.py
@@ -1,9 +1,9 @@
 import kivy
-kivy.require('1.0.5')
 
 from kivy.uix.floatlayout import FloatLayout
 from kivy.app import App
 from kivy.properties import ObjectProperty, StringProperty
+kivy.require('1.0.5')
 
 
 class Controller(FloatLayout):

--- a/examples/guide/designwithkv/main.py
+++ b/examples/guide/designwithkv/main.py
@@ -3,7 +3,6 @@ import kivy
 from kivy.uix.floatlayout import FloatLayout
 from kivy.app import App
 from kivy.properties import ObjectProperty, StringProperty
-kivy.require('1.0.5')
 
 
 class Controller(FloatLayout):

--- a/examples/guide/quickstart/main.py
+++ b/examples/guide/quickstart/main.py
@@ -2,7 +2,6 @@ import kivy
 
 from kivy.app import App
 from kivy.uix.button import Button
-kivy.require('1.0.6')  # replace with your current kivy version !
 
 
 class MyApp(App):

--- a/examples/guide/quickstart/main.py
+++ b/examples/guide/quickstart/main.py
@@ -1,8 +1,8 @@
 import kivy
-kivy.require('1.0.6')  # replace with your current kivy version !
 
 from kivy.app import App
 from kivy.uix.button import Button
+kivy.require('1.0.6')  # replace with your current kivy version !
 
 
 class MyApp(App):

--- a/examples/kv/ids/id_in_kv/id_in_kv.py
+++ b/examples/kv/ids/id_in_kv/id_in_kv.py
@@ -7,9 +7,8 @@ to another within KV.
 '''
 
 import kivy
-kivy.require('1.8.0')
-
 from kivy.app import App
+kivy.require('1.8.0')
 
 
 class TestApp(App):

--- a/examples/kv/ids/kv_and_py/kv_and_py.py
+++ b/examples/kv/ids/kv_and_py/kv_and_py.py
@@ -6,10 +6,11 @@ This example shows how to refer to an id from a Python file.
 '''
 
 import kivy
-kivy.require('1.8.0')
+
 
 from kivy.app import App
 from kivy.uix.boxlayout import BoxLayout
+kivy.require('1.8.0')
 
 
 class RootWidget(BoxLayout):

--- a/examples/tutorials/notes/final/main.py
+++ b/examples/tutorials/notes/final/main.py
@@ -6,7 +6,6 @@ Simple application for reading/writing notes.
 
 '''
 
-__version__ = '1.0'
 
 import json
 from os.path import join, exists
@@ -17,6 +16,7 @@ from kivy.properties import ListProperty, StringProperty, \
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.floatlayout import FloatLayout
 from kivy.clock import Clock
+__version__ = '1.0'
 
 
 class MutableTextInput(FloatLayout):

--- a/examples/tutorials/pong/main.py
+++ b/examples/tutorials/pong/main.py
@@ -1,5 +1,5 @@
 import kivy
-kivy.require('1.1.1')
+
 
 from kivy.app import App
 from kivy.uix.widget import Widget
@@ -7,6 +7,7 @@ from kivy.properties import NumericProperty, ReferenceListProperty,\
     ObjectProperty
 from kivy.vector import Vector
 from kivy.clock import Clock
+kivy.require('1.1.1')
 
 
 class PongPaddle(Widget):

--- a/examples/tutorials/pong/main.py
+++ b/examples/tutorials/pong/main.py
@@ -7,7 +7,6 @@ from kivy.properties import NumericProperty, ReferenceListProperty,\
     ObjectProperty
 from kivy.vector import Vector
 from kivy.clock import Clock
-kivy.require('1.1.1')
 
 
 class PongPaddle(Widget):

--- a/examples/widgets/customcollide.py
+++ b/examples/widgets/customcollide.py
@@ -19,7 +19,6 @@ import kivy
 from kivy.uix.scatter import Scatter
 from kivy.properties import ListProperty
 from kivy.lang import Builder
-kivy.require('1.0.8')
 
 
 Builder.load_string('''

--- a/examples/widgets/customcollide.py
+++ b/examples/widgets/customcollide.py
@@ -16,11 +16,10 @@ We are using a external method that will check if a point is inside a polygon
 
 
 import kivy
-kivy.require('1.0.8')
-
 from kivy.uix.scatter import Scatter
 from kivy.properties import ListProperty
 from kivy.lang import Builder
+kivy.require('1.0.8')
 
 
 Builder.load_string('''

--- a/examples/widgets/image_mipmap.py
+++ b/examples/widgets/image_mipmap.py
@@ -12,7 +12,6 @@ from kivy.app import App
 from kivy.uix.scatter import ScatterPlane
 from kivy.uix.image import Image
 from os.path import join
-kivy.require('1.0.7')
 
 
 class LabelMipmapTest(App):

--- a/examples/widgets/image_mipmap.py
+++ b/examples/widgets/image_mipmap.py
@@ -7,12 +7,12 @@ The lower image is normal, and the top image is mipmapped.
 '''
 
 import kivy
-kivy.require('1.0.7')
 
 from kivy.app import App
 from kivy.uix.scatter import ScatterPlane
 from kivy.uix.image import Image
 from os.path import join
+kivy.require('1.0.7')
 
 
 class LabelMipmapTest(App):

--- a/examples/widgets/keyboardlistener.py
+++ b/examples/widgets/keyboardlistener.py
@@ -2,7 +2,6 @@ import kivy
 
 from kivy.core.window import Window
 from kivy.uix.widget import Widget
-kivy.require('1.0.8')
 
 
 class MyKeyboardListener(Widget):

--- a/examples/widgets/keyboardlistener.py
+++ b/examples/widgets/keyboardlistener.py
@@ -1,8 +1,8 @@
 import kivy
-kivy.require('1.0.8')
 
 from kivy.core.window import Window
 from kivy.uix.widget import Widget
+kivy.require('1.0.8')
 
 
 class MyKeyboardListener(Widget):

--- a/examples/widgets/label_mipmap.py
+++ b/examples/widgets/label_mipmap.py
@@ -7,11 +7,11 @@ non mipmapped and mipmapped label.
 '''
 
 import kivy
-kivy.require('1.0.7')
 
 from kivy.app import App
 from kivy.uix.scatter import ScatterPlane
 from kivy.uix.label import Label
+kivy.require('1.0.7')
 
 
 class LabelMipmapTest(App):

--- a/examples/widgets/label_mipmap.py
+++ b/examples/widgets/label_mipmap.py
@@ -11,7 +11,6 @@ import kivy
 from kivy.app import App
 from kivy.uix.scatter import ScatterPlane
 from kivy.uix.label import Label
-kivy.require('1.0.7')
 
 
 class LabelMipmapTest(App):

--- a/examples/widgets/label_text_size.py
+++ b/examples/widgets/label_text_size.py
@@ -1,4 +1,5 @@
 
+
 '''
 Label textsize
 ============
@@ -8,10 +9,10 @@ to format label widget
 '''
 
 import kivy
-kivy.require('1.0.7')
 
 from kivy.app import App
 from kivy.uix.label import Label
+kivy.require('1.0.7')
 
 
 _long_text = ("""Lorem ipsum dolor sit amet, consectetur adipiscing elit. """

--- a/examples/widgets/label_text_size.py
+++ b/examples/widgets/label_text_size.py
@@ -12,7 +12,6 @@ import kivy
 
 from kivy.app import App
 from kivy.uix.label import Label
-kivy.require('1.0.7')
 
 
 _long_text = ("""Lorem ipsum dolor sit amet, consectetur adipiscing elit. """

--- a/examples/widgets/scrollview.py
+++ b/examples/widgets/scrollview.py
@@ -4,7 +4,6 @@ from kivy.app import App
 from kivy.uix.button import Button
 from kivy.uix.scrollview import ScrollView
 from kivy.uix.gridlayout import GridLayout
-kivy.require('1.0.8')
 
 
 class ScrollViewApp(App):

--- a/examples/widgets/scrollview.py
+++ b/examples/widgets/scrollview.py
@@ -1,10 +1,10 @@
 import kivy
-kivy.require('1.0.8')
 
 from kivy.app import App
 from kivy.uix.button import Button
 from kivy.uix.scrollview import ScrollView
 from kivy.uix.gridlayout import GridLayout
+kivy.require('1.0.8')
 
 
 class ScrollViewApp(App):

--- a/examples/widgets/sequenced_images/main.py
+++ b/examples/widgets/sequenced_images/main.py
@@ -6,7 +6,6 @@ from kivy.uix.gridlayout import GridLayout
 from uix.custom_button import AnimatedButton
 from kivy.uix.scatter import Scatter
 from kivy.properties import ObjectProperty
-kivy.require('1.0.8')
 
 
 class gifScatter(Scatter):

--- a/examples/widgets/sequenced_images/main.py
+++ b/examples/widgets/sequenced_images/main.py
@@ -1,5 +1,4 @@
 import kivy
-kivy.require('1.0.8')
 
 from kivy.app import App
 from kivy.uix.floatlayout import FloatLayout
@@ -7,6 +6,7 @@ from kivy.uix.gridlayout import GridLayout
 from uix.custom_button import AnimatedButton
 from kivy.uix.scatter import Scatter
 from kivy.properties import ObjectProperty
+kivy.require('1.0.8')
 
 
 class gifScatter(Scatter):

--- a/examples/widgets/sequenced_images/uix/custom_button.py
+++ b/examples/widgets/sequenced_images/uix/custom_button.py
@@ -1,12 +1,10 @@
-
-__all__ = ('AnimatedButton')
-
 from kivy.factory import Factory
 from kivy.uix.label import Label
 from kivy.uix.image import Image
 from kivy.graphics import *
 from kivy.properties import StringProperty, OptionProperty, \
                             ObjectProperty, BooleanProperty
+__all__ = ('AnimatedButton')
 
 
 class AnimatedButton(Label):

--- a/examples/widgets/tabbed_panel_showcase.py
+++ b/examples/widgets/tabbed_panel_showcase.py
@@ -10,6 +10,7 @@ from kivy.animation import Animation
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.tabbedpanel import TabbedPanel, TabbedPanelHeader
 from kivy.factory import Factory
+from kivy.lang import Builder
 
 
 class StandingHeader(TabbedPanelHeader):
@@ -23,7 +24,6 @@ class CloseableHeader(TabbedPanelHeader):
 Factory.register('StandingHeader', cls=StandingHeader)
 Factory.register('CloseableHeader', cls=CloseableHeader)
 
-from kivy.lang import Builder
 
 Builder.load_string('''
 <TabShowcase>

--- a/examples/widgets/textinput.py
+++ b/examples/widgets/textinput.py
@@ -26,7 +26,7 @@ from kivy.uix.button import Button
 from kivy.uix.label import Label
 from kivy.config import Config
 from kivy.base import runTouchApp
-kivy.require('1.0.8')
+
 
 if __name__ == '__main__':
 

--- a/examples/widgets/textinput.py
+++ b/examples/widgets/textinput.py
@@ -18,8 +18,6 @@ Run this test as::
 '''
 
 import kivy
-kivy.require('1.0.8')
-
 from kivy.core.window import Window
 from kivy.uix.textinput import TextInput
 from kivy.uix.floatlayout import FloatLayout
@@ -28,6 +26,7 @@ from kivy.uix.button import Button
 from kivy.uix.label import Label
 from kivy.config import Config
 from kivy.base import runTouchApp
+kivy.require('1.0.8')
 
 if __name__ == '__main__':
 

--- a/examples/widgets/unicode_textinput.py
+++ b/examples/widgets/unicode_textinput.py
@@ -9,6 +9,7 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.spinner import SpinnerOption
 from kivy.uix.popup import Popup
 import os
+from kivy.utils import reify
 
 
 Builder.load_string('''
@@ -213,9 +214,6 @@ Yiddish:        דער גיך ברוין פוקס דזשאַמפּס איבער 
         self._popup = Popup(title="load file", content=content,
             size_hint=(0.9, 0.9))
         self._popup.open()
-
-
-from kivy.utils import reify
 
 
 class unicode_app(App):

--- a/examples/widgets/videoplayer.py
+++ b/examples/widgets/videoplayer.py
@@ -4,7 +4,6 @@ from sys import argv
 from os.path import dirname, join
 from kivy.app import App
 from kivy.uix.videoplayer import VideoPlayer
-kivy.require('1.2.0')
 # check what formats are supported for your targeted devices
 # for example try h264 video and acc audo for android using an mp4
 # container

--- a/examples/widgets/videoplayer.py
+++ b/examples/widgets/videoplayer.py
@@ -1,11 +1,10 @@
 import kivy
-kivy.require('1.2.0')
 
 from sys import argv
 from os.path import dirname, join
 from kivy.app import App
 from kivy.uix.videoplayer import VideoPlayer
-
+kivy.require('1.2.0')
 # check what formats are supported for your targeted devices
 # for example try h264 video and acc audo for android using an mp4
 # container

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -18,7 +18,16 @@ using `Cython <http://cython.org/>`_.
 
 See http://kivy.org for more information.
 '''
-
+import sys
+import kivy.deps
+import shutil
+from getopt import getopt, GetoptError
+from os import environ, mkdir
+from os.path import dirname, join, basename, exists, expanduser
+import pkgutil
+from kivy.compat import PY2
+from kivy.logger import Logger, LOG_LEVELS
+from kivy.utils import platform
 __all__ = (
     'require',
     'kivy_configure', 'kivy_register_post_configuration',
@@ -30,15 +39,6 @@ __all__ = (
 
 __version__ = '1.9.2-dev0'
 
-import sys
-import shutil
-from getopt import getopt, GetoptError
-from os import environ, mkdir
-from os.path import dirname, join, basename, exists, expanduser
-import pkgutil
-from kivy.compat import PY2
-from kivy.logger import Logger, LOG_LEVELS
-from kivy.utils import platform
 
 # internals for post-configuration
 __kivy_post_configuration = []
@@ -250,7 +250,7 @@ kivy_config_fn = ''
 kivy_usermodules_dir = ''
 
 # if there are deps, import them so they can do their magic.
-import kivy.deps
+
 _packages = []
 for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
     if not ispkg:

--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -81,13 +81,13 @@ For flow control of animations such as stopping and cancelling, use the methods
 already in place in the animation module.
 '''
 
-__all__ = ('Animation', 'AnimationTransition')
 
 from math import sqrt, cos, sin, pi
 from kivy.event import EventDispatcher
 from kivy.clock import Clock
 from kivy.compat import string_types, iterkeys
 from kivy.weakproxy import WeakProxy
+__all__ = ('Animation', 'AnimationTransition')
 
 
 class Animation(EventDispatcher):

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -309,9 +309,6 @@ Here is a simple example of how on_pause() should be used::
     `on_pause` is called, `on_resume` may not be called at all.
 
 '''
-
-__all__ = ('App', )
-
 import os
 from inspect import getfile
 from os.path import dirname, join, exists, sep, expanduser, isfile
@@ -327,6 +324,7 @@ from kivy.utils import platform as core_platform
 from kivy.uix.widget import Widget
 from kivy.properties import ObjectProperty, StringProperty
 from kivy.setupconfig import USE_SDL2
+__all__ = ('App', )
 
 
 platform = core_platform

--- a/kivy/atlas.py
+++ b/kivy/atlas.py
@@ -135,15 +135,13 @@ Manual usage of the Atlas
     <kivy.graphics.texture.TextureRegion object at 0x2404d10>
 '''
 
-__all__ = ('Atlas', )
-
 import json
 from os.path import basename, dirname, join, splitext
 from kivy.event import EventDispatcher
 from kivy.logger import Logger
 from kivy.properties import AliasProperty, DictProperty, ListProperty
 import os
-
+__all__ = ('Atlas', )
 
 # late import to prevent recursion
 CoreImage = None

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -12,6 +12,14 @@ Event loop management
 
 '''
 
+import sys
+from kivy.config import Config
+from kivy.logger import Logger
+from kivy.utils import platform
+from kivy.clock import Clock
+from kivy.event import EventDispatcher
+from kivy.lang import Builder
+from kivy.context import register_context
 __all__ = (
     'EventLoop',
     'EventLoopBase',
@@ -21,16 +29,6 @@ __all__ = (
     'runTouchApp',
     'stopTouchApp',
 )
-
-import sys
-from kivy.config import Config
-from kivy.logger import Logger
-from kivy.utils import platform
-from kivy.clock import Clock
-from kivy.event import EventDispatcher
-from kivy.lang import Builder
-from kivy.context import register_context
-
 # private vars
 EventLoop = None
 

--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -24,11 +24,11 @@ If the instance is NULL, the cache may have trashed it because you've
 not used the label for 5 seconds and you've reach the limit.
 '''
 
-__all__ = ('Cache', )
 
 from os import environ
 from kivy.logger import Logger
 from kivy.clock import Clock
+__all__ = ('Cache', )
 
 
 class Cache(object):

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -345,11 +345,6 @@ overwrites the config selection. Its possible values are as follows:
 
 '''
 
-__all__ = (
-    'Clock', 'ClockEvent', 'FreeClockEvent', 'CyClockBase', 'CyClockBaseFree',
-    'ClockBaseBehavior', 'ClockBaseInterruptBehavior',
-    'ClockBaseInterruptFreeBehavior', 'ClockBase', 'ClockBaseInterrupt',
-    'ClockBaseFreeInterruptAll', 'ClockBaseFreeInterruptOnly', 'mainthread')
 
 from sys import platform
 from os import environ
@@ -361,12 +356,16 @@ from kivy.compat import clock as _default_time, PY2
 import time
 from kivy._clock import CyClockBase, ClockEvent, FreeClockEvent, \
     CyClockBaseFree
+from threading import Event as ThreadingEvent
+__all__ = (
+    'Clock', 'ClockEvent', 'FreeClockEvent', 'CyClockBase', 'CyClockBaseFree',
+    'ClockBaseBehavior', 'ClockBaseInterruptBehavior',
+    'ClockBaseInterruptFreeBehavior', 'ClockBase', 'ClockBaseInterrupt',
+    'ClockBaseFreeInterruptAll', 'ClockBaseFreeInterruptOnly', 'mainthread')
 try:
     from multiprocessing import Event as MultiprocessingEvent
 except ImportError:  # https://bugs.python.org/issue3770
     from threading import Event as MultiprocessingEvent
-from threading import Event as ThreadingEvent
-
 # some reading: http://gameprogrammingpatterns.com/game-loop.html
 
 

--- a/kivy/compat.py
+++ b/kivy/compat.py
@@ -6,12 +6,12 @@ This module provides a set of utility types and functions for optimization and
 to aid in writing Python 2/3 compatibile code.
 '''
 
-__all__ = ('PY2', 'clock', 'string_types', 'queue', 'iterkeys',
-           'itervalues', 'iteritems', 'isclose')
 
 import sys
 import time
 from math import isinf, fabs
+__all__ = ('PY2', 'clock', 'string_types', 'queue', 'iterkeys',
+           'itervalues', 'iteritems', 'isclose')
 try:
     import queue
 except ImportError:

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -299,13 +299,6 @@ Available configuration tokens
     removed from the widget. `keyboard_mode` and `keyboard_layout` have
     been added to the kivy section.
 '''
-
-__all__ = ('Config', 'ConfigParser')
-
-try:
-    from ConfigParser import ConfigParser as PythonConfigParser
-except ImportError:
-    from configparser import RawConfigParser as PythonConfigParser
 from os import environ
 from os.path import exists
 from kivy import kivy_config_fn
@@ -314,6 +307,13 @@ from collections import OrderedDict
 from kivy.utils import platform
 from kivy.compat import PY2, string_types
 from weakref import ref
+
+__all__ = ('Config', 'ConfigParser')
+
+try:
+    from ConfigParser import ConfigParser as PythonConfigParser
+except ImportError:
+    from configparser import RawConfigParser as PythonConfigParser
 
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 

--- a/kivy/event.py
+++ b/kivy/event.py
@@ -3,9 +3,11 @@
 # conflict. We have one conflict with pygame.event and kivy.event => Both are
 # python extension and have the same "initevent" symbol. So right now, just
 # rename this one.
-__all__ = ('EventDispatcher', 'ObjectWithUid', 'Observable')
 
 import kivy._event
+__all__ = ('EventDispatcher', 'ObjectWithUid', 'Observable')
+
+
 __doc__ = kivy._event.__doc__
 EventDispatcher = kivy._event.EventDispatcher
 ObjectWithUid = kivy._event.ObjectWithUid

--- a/kivy/factory.py
+++ b/kivy/factory.py
@@ -37,10 +37,8 @@ classname before you re-assign it::
     >>> Factory.register('MyWidget', cls=CustomWidget)
     >>> customWidget = Factory.MyWidget()
 '''
-
-__all__ = ('Factory', 'FactoryException')
-
 from kivy.logger import Logger
+__all__ = ('Factory', 'FactoryException')
 
 
 class FactoryException(Exception):

--- a/kivy/geometry.py
+++ b/kivy/geometry.py
@@ -4,10 +4,9 @@ Geometry utilities
 
 This module contains some helper functions for geometric calculations.
 '''
+from kivy.vector import Vector
 
 __all__ = ('circumcircle', 'minimum_bounding_circle')
-
-from kivy.vector import Vector
 
 
 def circumcircle(a, b, c):

--- a/kivy/gesture.py
+++ b/kivy/gesture.py
@@ -31,8 +31,6 @@ gestures and compare them::
 
 '''
 
-__all__ = ('Gesture', 'GestureDatabase', 'GesturePoint', 'GestureStroke')
-
 import pickle
 import base64
 import zlib
@@ -41,6 +39,7 @@ import math
 from kivy.vector import Vector
 
 from io import BytesIO
+__all__ = ('Gesture', 'GestureDatabase', 'GesturePoint', 'GestureStroke')
 
 
 class GestureDatabase(object):

--- a/kivy/interactive.py
+++ b/kivy/interactive.py
@@ -156,9 +156,6 @@ Could be re-written with a context-manager style i.e. ::
 Any use cases besides compacting code?
 
 '''
-
-__all__ = ('SafeMembrane', 'InteractiveLauncher')
-
 import inspect
 from threading import Thread, Event
 
@@ -166,6 +163,7 @@ from kivy.app import App
 from kivy.base import EventLoop
 from kivy.clock import Clock
 from kivy.utils import deprecated
+__all__ = ('SafeMembrane', 'InteractiveLauncher')
 
 
 def safeWait(dt):

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -32,9 +32,6 @@ parameters:
   GPU to do per frame.
 
 '''
-
-__all__ = ('Loader', 'LoaderBase', 'ProxyImage')
-
 from kivy import kivy_data_dir
 from kivy.logger import Logger
 from kivy.clock import Clock
@@ -48,6 +45,8 @@ from os.path import join
 from os import write, close, unlink, environ
 import threading
 import mimetypes
+__all__ = ('Loader', 'LoaderBase', 'ProxyImage')
+
 
 # Register a cache for loader
 Cache.register('kv.loader', limit=500, timeout=60)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ from os import walk, environ
 from distutils.version import LooseVersion
 from collections import OrderedDict
 from time import sleep
+import kivy
+from kivy.tools.packaging.factory import FactoryBuild
 
 if environ.get('KIVY_USE_SETUPTOOLS'):
     from setuptools import setup, Extension
@@ -317,13 +319,12 @@ def _check_and_fix_sdl2_mixer(f_path):
 # -----------------------------------------------------------------------------
 # extract version (simulate doc generation, kivy will be not imported)
 environ['KIVY_DOC_INCLUDE'] = '1'
-import kivy
 
 # extra build commands go in the cmdclass dict {'command-name': CommandClass}
 # see tools.packaging.{platform}.build.py for custom build commands for
 # portable packages. Also e.g. we use build_ext command from cython if its
 # installed for c extensions.
-from kivy.tools.packaging.factory import FactoryBuild
+
 cmdclass = {
     'build_factory': FactoryBuild,
     'build_ext': KivyBuildExt}


### PR DESCRIPTION
@KeyWeeUsr 
[Version tags suggestion](https://github.com/kivy/kivy/pull/4890)
Removed version statements from examples as for now. Other changes may be good according to pep8 guidelines but can harm the code base, so its best to ignore other changes for now.