### PR TITLE
Multiple Radiobutton selected simultaneously.

### DIFF
--- a/kivy/uix/behaviors/togglebutton.py
+++ b/kivy/uix/behaviors/togglebutton.py
@@ -78,9 +78,10 @@ class ToggleButtonBehavior(ButtonBehavior):
     :attr:`allow_no_selection` is a :class:`BooleanProperty` and defaults to
     `True`
     '''
-    check_variable = BooleanProperty(False)
+
     def __init__(self, **kwargs):
         self._previous_group = None
+        self.check_variable = BooleanProperty(False)
         super(ToggleButtonBehavior, self).__init__(**kwargs)
 
     def on_group(self, *largs):

--- a/kivy/uix/behaviors/togglebutton.py
+++ b/kivy/uix/behaviors/togglebutton.py
@@ -83,7 +83,7 @@ class ToggleButtonBehavior(ButtonBehavior):
     '''This private variable is used to check at various places when
     the state/activeness of togglebutton is changed via code.
 
-    :attr:`_check_variable` is a :class:`BooleanProperty` and defaults to 
+    :attr:`_check_variable` is a :class:`BooleanProperty` and defaults to
     `False`
     '''
 

--- a/kivy/uix/behaviors/togglebutton.py
+++ b/kivy/uix/behaviors/togglebutton.py
@@ -78,13 +78,12 @@ class ToggleButtonBehavior(ButtonBehavior):
     :attr:`allow_no_selection` is a :class:`BooleanProperty` and defaults to
     `True`
     '''
-
+    check_variable = BooleanProperty(False)
     def __init__(self, **kwargs):
         self._previous_group = None
         super(ToggleButtonBehavior, self).__init__(**kwargs)
 
     def on_group(self, *largs):
-        #print 'Inside on_group'
         groups = ToggleButtonBehavior.__groups
         if self._previous_group:
             group = groups[self._previous_group]
@@ -97,6 +96,8 @@ class ToggleButtonBehavior(ButtonBehavior):
             groups[group] = []
         r = ref(self, ToggleButtonBehavior._clear_groups)
         groups[group].append(r)
+        if self.active:
+            self._release_group(self)
 
     def _release_group(self, current):
         if self.group is None:
@@ -108,15 +109,15 @@ class ToggleButtonBehavior(ButtonBehavior):
                 group.remove(item)
             if widget is current:
                 continue
-            widget.x = True
+            widget.check_variable = True
             widget.state = 'normal'
-            widget.x = False
+            widget.check_variable = False
 
     def _do_press(self):
         if (not self.allow_no_selection and
                 self.group and self.state == 'down'):
             return
-        self.x = True
+        self.check_variable = True
         self._release_group(self)
         self.state = 'normal' if self.state == 'down' else 'down'
 

--- a/kivy/uix/behaviors/togglebutton.py
+++ b/kivy/uix/behaviors/togglebutton.py
@@ -79,9 +79,16 @@ class ToggleButtonBehavior(ButtonBehavior):
     `True`
     '''
 
+    _check_variable = BooleanProperty(False)
+    '''This private variable is used to check at various places when
+    the state/activeness of togglebutton is changed via code.
+
+    :attr:`_check_variable` is a :class:`BooleanProperty` and defaults to 
+    `False`
+    '''
+
     def __init__(self, **kwargs):
         self._previous_group = None
-        self.check_variable = BooleanProperty(False)
         super(ToggleButtonBehavior, self).__init__(**kwargs)
 
     def on_group(self, *largs):
@@ -110,15 +117,15 @@ class ToggleButtonBehavior(ButtonBehavior):
                 group.remove(item)
             if widget is current:
                 continue
-            widget.check_variable = True
+            widget._check_variable = True
             widget.state = 'normal'
-            widget.check_variable = False
+            widget._check_variable = False
 
     def _do_press(self):
         if (not self.allow_no_selection and
                 self.group and self.state == 'down'):
             return
-        self.check_variable = True
+        self._check_variable = True
         self._release_group(self)
         self.state = 'normal' if self.state == 'down' else 'down'
 

--- a/kivy/uix/behaviors/togglebutton.py
+++ b/kivy/uix/behaviors/togglebutton.py
@@ -84,6 +84,7 @@ class ToggleButtonBehavior(ButtonBehavior):
         super(ToggleButtonBehavior, self).__init__(**kwargs)
 
     def on_group(self, *largs):
+        #print 'Inside on_group'
         groups = ToggleButtonBehavior.__groups
         if self._previous_group:
             group = groups[self._previous_group]
@@ -107,12 +108,15 @@ class ToggleButtonBehavior(ButtonBehavior):
                 group.remove(item)
             if widget is current:
                 continue
+            widget.x = True
             widget.state = 'normal'
+            widget.x = False
 
     def _do_press(self):
         if (not self.allow_no_selection and
                 self.group and self.state == 'down'):
             return
+        self.x = True
         self._release_group(self)
         self.state = 'normal' if self.state == 'down' else 'down'
 

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -38,7 +38,7 @@ from kivy.uix.behaviors import ToggleButtonBehavior
 class CheckBox(ToggleButtonBehavior, Widget):
     '''CheckBox class, see module documentation for more information.
     '''
-
+    x = BooleanProperty(False)
     active = BooleanProperty(False)
     '''Indicates if the switch is active or inactive.
 
@@ -158,6 +158,8 @@ class CheckBox(ToggleButtonBehavior, Widget):
     '''
 
     def on_state(self, instance, value):
+        if self.x is False:
+            self._toggle_active()
         if value == 'down':
             self.active = True
         else:
@@ -167,7 +169,11 @@ class CheckBox(ToggleButtonBehavior, Widget):
         self._do_press()
 
     def on_active(self, instance, value):
+        if self.x is False:
+            self._toggle_active()
         self.state = 'down' if value else 'normal'
+        if self.x is True:
+            self.x = False
 
 
 if __name__ == '__main__':

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -38,7 +38,6 @@ from kivy.uix.behaviors import ToggleButtonBehavior
 class CheckBox(ToggleButtonBehavior, Widget):
     '''CheckBox class, see module documentation for more information.
     '''
-    x = BooleanProperty(False)
     active = BooleanProperty(False)
     '''Indicates if the switch is active or inactive.
 
@@ -158,7 +157,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
     '''
 
     def on_state(self, instance, value):
-        if self.x is False:
+        if self.check_variable is False and self.group:
             self._toggle_active()
         if value == 'down':
             self.active = True
@@ -169,11 +168,11 @@ class CheckBox(ToggleButtonBehavior, Widget):
         self._do_press()
 
     def on_active(self, instance, value):
-        if self.x is False:
+        if (not self.check_variable) and self.group:
             self._toggle_active()
         self.state = 'down' if value else 'normal'
-        if self.x is True:
-            self.x = False
+        if self.check_variable:
+            self.check_variable = False
 
 
 if __name__ == '__main__':

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -157,7 +157,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
     '''
 
     def on_state(self, instance, value):
-        if self.check_variable is False and self.group:
+        if (not self.check_variable) and self.group:
             self._toggle_active()
         if value == 'down':
             self.active = True

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -157,7 +157,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
     '''
 
     def on_state(self, instance, value):
-        if (not self.check_variable) and self.group:
+        if (not self._check_variable) and self.group:
             self._toggle_active()
         if value == 'down':
             self.active = True
@@ -168,11 +168,11 @@ class CheckBox(ToggleButtonBehavior, Widget):
         self._do_press()
 
     def on_active(self, instance, value):
-        if (not self.check_variable) and self.group:
+        if (not self._check_variable) and self.group:
             self._toggle_active()
         self.state = 'down' if value else 'normal'
-        if self.check_variable:
-            self.check_variable = False
+        if self._check_variable:
+            self._check_variable = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Well there were two bugs basically - first when a number of checkboxes are initiated under a group with active= True, all become active and secondly trying to control the grouped checkboxes via code (for example on_press of a button) results in multiple checkboxes being active as mentioned here #2172 .

I have used a new check_variable so that the checkbox multi-active bug is removed. Before considering this PR for merge one thing that is creating problem are these two test samples .
1. https://gist.github.com/saqib1707/78c38909988bd729d26826ab814056be
2. https://gist.github.com/saqib1707/c4381e815e0e37be36e8dc2193271e6a

In first case , of the two buttons which are made active , the first one(kv lang) (instead of second) remains in the 'down' state. while in the second case(usual python code)  the last checkbox is active.I am not getting where the difference is coming.Can anyone help ?

Fixes : #2172