### PR TITLE
focus till StopIteration

### DIFF
--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -466,7 +466,7 @@ class FocusBehavior(object):
             # if we hit a focusable, walk through focus_xxx
             while getattr(current, focus_dir) is not None:
                 current = getattr(current, focus_dir)
-                if current is self or current is StopIteration:
+                if current is self and current is StopIteration:
                     return None  # make sure we don't loop forever
                 if current.is_focusable and not current.disabled:
                     return current


### PR DESCRIPTION
[#4816](https://github.com/kivy/kivy/issues/4816)
I think the focus has the significance till it stops iterating between widgets on pressing tab and shift+tab.
The  _get_focus_next method returning none for *current is self* which is not good according to me. So the method should return none only at *current is StopIteration*.
If this is true than this method will not be required to make public as well.
Please tell if any other changes needed as well.