### PR TITLE
Removed textinput cursor bug #3237

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2548,10 +2548,6 @@ class TextInput(FocusBehavior, Widget):
         cr = boundary(pos[1], 0, len(l) - 1)
         cc = boundary(pos[0], 0, len(l[cr]))
         cursor = cc, cr
-        if self._cursor == cursor:
-            return
-
-        self._cursor = cursor
 
         # adjust scrollview to ensure that the cursor will be always inside our
         # viewport.
@@ -2581,6 +2577,10 @@ class TextInput(FocusBehavior, Widget):
             sy = offsety
         self.scroll_y = sy
 
+        if self._cursor == cursor:
+            return
+
+        self._cursor = cursor
         return True
 
     cursor = AliasProperty(_get_cursor, _set_cursor)


### PR DESCRIPTION
The bug was that TextInput cursor was showing outside of widget bounds.On reproducing the result with the following testcode i found that scroll view was not getting updated that is why cursor was not visible in viewport.New lines (\n) posed the problems here.
I even experimented with /t string literals and it was working fine.Below testcode signifies it.I would be happy to attach screenshots if required. #3237
[Testcode 1](https://gist.github.com/phunsukwangdu/b7810dedbd02a2ad8a3092da05836af1)
[Testcode 2](https://gist.github.com/phunsukwangdu/3c7e69e121bbf2d45ae914bbaa2863ee)