### PR TITLE
Range slider feature extending the slider

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -59,52 +59,32 @@
             rgba: root.value_track_color if self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos[0], self.center_y - self.value_track_width / 2
+            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos[0] if not self.value_range else self.value_pos_slider[0][0], self.center_y - self.value_track_width / 2
+        Color:
+            rgba: root.value_track_color if self.value_range and self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
+        Line:
+            width: self.value_track_width
+            points: self.width - self.padding, self.center_y - self.value_track_width / 2, self.value_pos_slider[1][0] if self.value_range else self.value_pos[0], self.center_y - self.value_track_width / 2
         Color:
             rgba: root.value_track_color if self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos[1]
+            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos[1] if not self.value_range else self.value_pos_slider[0][1]
         Color:
-            rgba: [1, 1, 1, 1] if self.value_range is None else [1, 1, 1, 0]
+            rgba: root.value_track_color if self.value_range and self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
+        Line:
+            width: self.value_track_width
+            points: self.center_x, self.height - self.padding, self.center_x, self.value_pos[1] if not self.value_range else self.value_pos_slider[1][1]
+        Color:
+            rgba: [1, 1, 1, 1]
         Rectangle:
-            pos: (self.value_pos[0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos[1] - self.cursor_height / 2)
+            pos: ((self.value_pos[0] if not self.value_range else self.value_pos_slider[0][0])- self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, (self.value_pos[1] if not self.value_range else self.value_pos_slider[0][1]) - self.cursor_height / 2)
             size: self.cursor_size
             source: self.cursor_disabled_image if self.disabled else self.cursor_image
-
-<RangeSlider>:
-    canvas:
         Color:
-            rgb: 1, 1, 1
-        BorderImage:
-            border: self.border_horizontal if self.orientation == 'horizontal' else self.border_vertical
-            pos: (self.x + self.padding, self.center_y - self.background_width / 2) if self.orientation == 'horizontal' else (self.center_x - self.background_width / 2, self.y + self.padding)
-            size: (self.width - self.padding * 2, self.background_width) if self.orientation == 'horizontal' else (self.background_width, self.height - self.padding * 2)
-            source: (self.background_disabled_horizontal if self.orientation == 'horizontal' else self.background_disabled_vertical) if self.disabled else (self.background_horizontal if self.orientation == 'horizontal' else self.background_vertical)
-        Color:
-            rgba: root.value_track_color if self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
-        Line:
-            width: self.value_track_width
-            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos_slider[0][0], self.center_y - self.value_track_width / 2
-        Line:
-            width: self.value_track_width
-            points: self.width - self.padding, self.center_y - self.value_track_width / 2, self.value_pos_slider[1][0], self.center_y - self.value_track_width / 2
-        Color:
-            rgba: root.value_track_color if self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
-        Line:
-            width: self.value_track_width
-            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos_slider[0][1]
-        Line:
-            width: self.value_track_width
-            points: self.center_x, self.height - self.padding, self.center_x, self.value_pos_slider[1][1]
-        Color:
-            rgb: 1, 1, 1
+            rgba: [1, 1, 1 ,1] if self.value_range else [1, 1, 1, 0]
         Rectangle:
-            pos: (self.value_pos_slider[0][0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos_slider[0][1] - self.cursor_height / 2)
-            size: self.cursor_size
-            source: self.cursor_disabled_image if self.disabled else self.cursor_image
-        Rectangle:
-            pos: (self.value_pos_slider[1][0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos_slider[1][1] - self.cursor_height / 2)
+            pos: ((self.value_pos_slider[1][0] if self.value_range else self.value_pos[0])- self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, (self.value_pos_slider[1][1] if self.value_range else self.value_pos[1]) - self.cursor_height / 2)
             size: self.cursor_size
             source: self.cursor_disabled_image if self.disabled else self.cursor_image
 

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -59,32 +59,32 @@
             rgba: root.value_track_color if self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos[0] if not self.value_range else self.value_pos_slider[0][0], self.center_y - self.value_track_width / 2
+            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos[0] if not self.value_range else self.value_pos_range[0][0], self.center_y - self.value_track_width / 2
         Color:
             rgba: root.value_track_color if self.value_range and self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.width - self.padding, self.center_y - self.value_track_width / 2, self.value_pos_slider[1][0] if self.value_range else self.value_pos[0], self.center_y - self.value_track_width / 2
+            points: self.width - self.padding, self.center_y - self.value_track_width / 2, self.value_pos_range[1][0] if self.value_range else self.value_pos[0], self.center_y - self.value_track_width / 2
         Color:
             rgba: root.value_track_color if self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos[1] if not self.value_range else self.value_pos_slider[0][1]
+            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos[1] if not self.value_range else self.value_pos_range[0][1]
         Color:
             rgba: root.value_track_color if self.value_range and self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.center_x, self.height - self.padding, self.center_x, self.value_pos[1] if not self.value_range else self.value_pos_slider[1][1]
+            points: self.center_x, self.height - self.padding, self.center_x, self.value_pos[1] if not self.value_range else self.value_pos_range[1][1]
         Color:
             rgba: [1, 1, 1, 1]
         Rectangle:
-            pos: ((self.value_pos[0] if not self.value_range else self.value_pos_slider[0][0])- self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, (self.value_pos[1] if not self.value_range else self.value_pos_slider[0][1]) - self.cursor_height / 2)
+            pos: ((self.value_pos[0] if not self.value_range else self.value_pos_range[0][0])- self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, (self.value_pos[1] if not self.value_range else self.value_pos_range[0][1]) - self.cursor_height / 2)
             size: self.cursor_size
             source: self.cursor_disabled_image if self.disabled else self.cursor_image
         Color:
             rgba: [1, 1, 1 ,1] if self.value_range else [1, 1, 1, 0]
         Rectangle:
-            pos: ((self.value_pos_slider[1][0] if self.value_range else self.value_pos[0])- self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, (self.value_pos_slider[1][1] if self.value_range else self.value_pos[1]) - self.cursor_height / 2)
+            pos: ((self.value_pos_range[1][0] if self.value_range else self.value_pos[0])- self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, (self.value_pos_range[1][1] if self.value_range else self.value_pos[1]) - self.cursor_height / 2)
             size: self.cursor_size
             source: self.cursor_disabled_image if self.disabled else self.cursor_image
 

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -66,9 +66,45 @@
             width: self.value_track_width
             points: self.center_x, self.y + self.padding, self.center_x, self.value_pos[1]
         Color:
-            rgb: 1, 1, 1
+            rgba: [1, 1, 1, 1] if self.value_range is None else [1, 1, 1, 0]
         Rectangle:
             pos: (self.value_pos[0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos[1] - self.cursor_height / 2)
+            size: self.cursor_size
+            source: self.cursor_disabled_image if self.disabled else self.cursor_image
+
+<RangeSlider>:
+    canvas:
+        Color:
+            rgb: 1, 1, 1
+        BorderImage:
+            border: self.border_horizontal if self.orientation == 'horizontal' else self.border_vertical
+            pos: (self.x + self.padding, self.center_y - self.background_width / 2) if self.orientation == 'horizontal' else (self.center_x - self.background_width / 2, self.y + self.padding)
+            size: (self.width - self.padding * 2, self.background_width) if self.orientation == 'horizontal' else (self.background_width, self.height - self.padding * 2)
+            source: (self.background_disabled_horizontal if self.orientation == 'horizontal' else self.background_disabled_vertical) if self.disabled else (self.background_horizontal if self.orientation == 'horizontal' else self.background_vertical)
+        Color:
+            rgba: root.value_track_color if self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
+        Line:
+            width: self.value_track_width
+            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos_slider[0][0], self.center_y - self.value_track_width / 2
+        Line:
+            width: self.value_track_width
+            points: self.width - self.padding, self.center_y - self.value_track_width / 2, self.value_pos_slider[1][0], self.center_y - self.value_track_width / 2
+        Color:
+            rgba: root.value_track_color if self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
+        Line:
+            width: self.value_track_width
+            points: self.center_x, self.y + self.padding, self.center_x, self.value_pos_slider[0][1]
+        Line:
+            width: self.value_track_width
+            points: self.center_x, self.height - self.padding, self.center_x, self.value_pos_slider[1][1]
+        Color:
+            rgb: 1, 1, 1
+        Rectangle:
+            pos: (self.value_pos_slider[0][0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos_slider[0][1] - self.cursor_height / 2)
+            size: self.cursor_size
+            source: self.cursor_disabled_image if self.disabled else self.cursor_image
+        Rectangle:
+            pos: (self.value_pos_slider[1][0] - self.cursor_width / 2, self.center_y - self.cursor_height / 2) if self.orientation == 'horizontal' else (self.center_x - self.cursor_width / 2, self.value_pos_slider[1][1] - self.cursor_height / 2)
             size: self.cursor_size
             source: self.cursor_disabled_image if self.disabled else self.cursor_image
 

--- a/kivy/uix/rangeslider.py
+++ b/kivy/uix/rangeslider.py
@@ -88,12 +88,12 @@ class RangeSlider(Slider):
                                          (y_top - self.y - padding) /
                                          float(self.height - 2 * padding)]
 
-    value_pos_slider = AliasProperty(get_value_pos, set_value_pos,
+    value_pos_range = AliasProperty(get_value_pos, set_value_pos,
                               bind=('x', 'y', 'width', 'height', 'min',
                             'max', 'value_normalized_slider', 'orientation'))
     '''Position of the internal cursor, based on the normalized value.
 
-    :attr:`value_pos_slider` is an :class:`~kivy.properties.AliasProperty`.
+    :attr:`value_pos_range` is an :class:`~kivy.properties.AliasProperty`.
     '''
 
     def on_touch_down(self, touch):
@@ -125,31 +125,31 @@ class RangeSlider(Slider):
         else:
             touch.grab(self)
             i = 0 if self.orientation == 'horizontal' else 1
-            if abs(touch.pos[i] - self.value_pos_slider[0][i]) < abs(
-                            touch.pos[i] - self.value_pos_slider[1][i]):
-                self.value_pos_slider = [touch.pos, self.value_pos_slider[1]]
+            if abs(touch.pos[i] - self.value_pos_range[0][i]) < abs(
+                            touch.pos[i] - self.value_pos_range[1][i]):
+                self.value_pos_range = [touch.pos, self.value_pos_range[1]]
             else:
-                self.value_pos_slider = [self.value_pos_slider[0], touch.pos]
+                self.value_pos_range = [self.value_pos_range[0], touch.pos]
         return True
 
     def on_touch_move(self, touch):
         if touch.grab_current == self:
             i = 0 if self.orientation == 'horizontal' else 1
-            if abs(touch.pos[i] - self.value_pos_slider[0][i]) < abs(
-                            touch.pos[i] - self.value_pos_slider[1][i]):
-                self.value_pos_slider = [touch.pos, self.value_pos_slider[1]]
+            if abs(touch.pos[i] - self.value_pos_range[0][i]) < abs(
+                            touch.pos[i] - self.value_pos_range[1][i]):
+                self.value_pos_range = [touch.pos, self.value_pos_range[1]]
             else:
-                self.value_pos_slider = [self.value_pos_slider[0], touch.pos]
+                self.value_pos_range = [self.value_pos_range[0], touch.pos]
             return True
 
     def on_touch_up(self, touch):
         if touch.grab_current == self:
             i = 0 if self.orientation == 'horizontal' else 1
-            if abs(touch.pos[i] - self.value_pos_slider[0][i]) < abs(
-                            touch.pos[i] - self.value_pos_slider[1][i]):
-                self.value_pos_slider = [touch.pos, self.value_pos_slider[1]]
+            if abs(touch.pos[i] - self.value_pos_range[0][i]) < abs(
+                            touch.pos[i] - self.value_pos_range[1][i]):
+                self.value_pos_range = [touch.pos, self.value_pos_range[1]]
             else:
-                self.value_pos_slider = [self.value_pos_slider[0], touch.pos]
+                self.value_pos_range = [self.value_pos_range[0], touch.pos]
             return True
 
 

--- a/kivy/uix/rangeslider.py
+++ b/kivy/uix/rangeslider.py
@@ -1,0 +1,157 @@
+"""
+RangeSlider
+======
+"""
+
+
+__all__ = ('RangeSlider', )
+
+from kivy.uix.slider import Slider
+from kivy.properties import (AliasProperty, ListProperty)
+
+
+class RangeSlider(Slider):
+    """Class for creating a RangeSlider widget.
+    """
+
+    value_range = ListProperty([0., 100.])
+    '''Current value used for the rangeslider.
+
+    :attr:`value_range` is a :class:`~kivy.properties.ListProperty` and
+    defaults to [0, 100.].'''
+
+    def on_min(self, *largs):
+        self.value_range = [min(self.max, max(self.min, self.value_range[0])),
+                    min(self.max, max(self.min, self.value_range[1]))]
+
+    def on_max(self, *largs):
+        self.value_range = [min(self.max, max(self.min, self.value_range[0])),
+                    min(self.max, max(self.min, self.value_range[1]))]
+
+    def get_norm_value(self):
+        vmin = self.min
+        d = self.max - vmin
+        if d == 0:
+            return 0
+        return [(self.value_range[0] - vmin) / float(d),
+                (self.value_range[1] - vmin) / float(d)]
+
+    def set_norm_value(self, value):
+        vmin = self.min
+        vmax = self.max
+        step = self.step
+        val = [min(value[0] * (vmax - vmin) + vmin, vmax),
+                min(value[1] * (vmax - vmin) + vmin, vmax)]
+        if step == 0:
+            self.value_range = val
+        else:
+            self.value_range = [min(round((val[0] - vmin) / step) * step +
+                             vmin, vmax),
+                             min(round((val[1] - vmin) / step) * step + vmin,
+                             vmax)]
+
+    value_normalized_slider = AliasProperty(get_norm_value, set_norm_value,
+                                bind=('value_range', 'min', 'max', 'step'))
+
+    def get_value_pos(self):
+        padding = self.padding
+        x = self.x
+        y = self.y
+        nval = self.value_normalized_slider
+        if self.orientation == 'horizontal':
+            return [(x + padding + nval[0] * (self.width - 2 * padding), y),
+                    (x + padding + nval[1] * (self.width - 2 * padding), y)]
+        else:
+            return [(x, y + padding + nval[0] * (self.height - 2 * padding)),
+                    (x, y + padding + nval[1] * (self.height - 2 * padding))]
+
+    def set_value_pos(self, pos):
+        padding = self.padding
+        x_left = min(self.right - padding, max(pos[0][0], self.x + padding))
+        y_bottom = min(self.top - padding, max(pos[0][1], self.y + padding))
+        x_right = min(self.right - padding, max(pos[1][0], self.x + padding))
+        y_top = min(self.top - padding, max(pos[1][1], self.y + padding))
+        if self.orientation == 'horizontal':
+            if self.width == 0:
+                self.value_normalized_slider = [0, 1.]
+            else:
+                self.value_normalized_slider = [(x_left - self.x - padding) /
+                                         float(self.width - 2 * padding),
+                                         (x_right - self.x - padding) /
+                                         float(self.width - 2 * padding)]
+        else:
+            if self.height == 0:
+                self.value_normalized_slider = [0, 1.]
+            else:
+                self.value_normalized_slider = [(y_bottom - self.y - padding) /
+                                         float(self.height - 2 * padding),
+                                         (y_top - self.y - padding) /
+                                         float(self.height - 2 * padding)]
+
+    value_pos_slider = AliasProperty(get_value_pos, set_value_pos,
+                              bind=('x', 'y', 'width', 'height', 'min',
+                            'max', 'value_normalized_slider', 'orientation'))
+    '''Position of the internal cursor, based on the normalized value.
+
+    :attr:`value_pos_slider` is an :class:`~kivy.properties.AliasProperty`.
+    '''
+
+    def on_touch_down(self, touch):
+        if self.disabled or not self.collide_point(*touch.pos):
+            return
+        if touch.is_mouse_scrolling:
+            if 'down' in touch.button or 'left' in touch.button:
+                if self.step:
+                    self.value_range = min(self.max, self.value_range +
+                                            self.step)
+                else:
+                    self.value_range = min(
+                        self.max,
+                        self.value_range + (self.max - self.min) / 20)
+            if 'up' in touch.button or 'right' in touch.button:
+                if self.step:
+                    self.value_range = max(self.min, self.value_range -
+                                            self.step)
+                else:
+                    self.value_range = max(
+                        self.min,
+                        self.value_range - (self.max - self.min) / 20)
+        else:
+            touch.grab(self)
+            i = 0 if self.orientation == 'horizontal' else 1
+            if abs(touch.pos[i] - self.value_pos_slider[0][i]) < abs(
+                            touch.pos[i] - self.value_pos_slider[1][i]):
+                self.value_pos_slider = [touch.pos, self.value_pos_slider[1]]
+            else:
+                self.value_pos_slider = [self.value_pos_slider[0], touch.pos]
+        return True
+
+    def on_touch_move(self, touch):
+        if touch.grab_current == self:
+            i = 0 if self.orientation == 'horizontal' else 1
+            if abs(touch.pos[i] - self.value_pos_slider[0][i]) < abs(
+                            touch.pos[i] - self.value_pos_slider[1][i]):
+                self.value_pos_slider = [touch.pos, self.value_pos_slider[1]]
+            else:
+                self.value_pos_slider = [self.value_pos_slider[0], touch.pos]
+            return True
+
+    def on_touch_up(self, touch):
+        if touch.grab_current == self:
+            i = 0 if self.orientation == 'horizontal' else 1
+            if abs(touch.pos[i] - self.value_pos_slider[0][i]) < abs(
+                            touch.pos[i] - self.value_pos_slider[1][i]):
+                self.value_pos_slider = [touch.pos, self.value_pos_slider[1]]
+            else:
+                self.value_pos_slider = [self.value_pos_slider[0], touch.pos]
+            return True
+
+
+if __name__ == '__main__':
+    from kivy.app import App
+
+    class RangeSliderApp(App):
+        def build(self):
+            return RangeSlider(padding=25, value_track=True,
+                value_track_color=[1, 0, 0, 1], value_range=[25, 75])
+    RangeSliderApp().run()

--- a/kivy/uix/rangeslider.py
+++ b/kivy/uix/rangeslider.py
@@ -102,20 +102,26 @@ class RangeSlider(Slider):
         if touch.is_mouse_scrolling:
             if 'down' in touch.button or 'left' in touch.button:
                 if self.step:
-                    self.value_range = min(self.max, self.value_range +
-                                            self.step)
+                    self.value_range = [min(self.max, self.value_range[0] +
+                                        self.step), min(self.max,
+                                        self.value_range[1] + self.step)]
                 else:
-                    self.value_range = min(
-                        self.max,
-                        self.value_range + (self.max - self.min) / 20)
+                    self.value_range = [min(self.max, self.value_range[0] +
+                                        (self.max - self.min) / 20),
+                                        min(self.max, self.value_range[1] +
+                                        (self.max - self.min) / 20)]
+
             if 'up' in touch.button or 'right' in touch.button:
                 if self.step:
-                    self.value_range = max(self.min, self.value_range -
-                                            self.step)
+                    self.value_range = [max(self.min, self.value_range[0] -
+                                            self.step),
+                                        max(self.min, self.value_range[1] -
+                                            self.step)]
                 else:
-                    self.value_range = max(
-                        self.min,
-                        self.value_range - (self.max - self.min) / 20)
+                    self.value_range = [max(self.min, self.value_range[0] -
+                                        (self.max - self.min) / 20),
+                                        max(self.min, self.value_range[1] -
+                                        (self.max - self.min) / 20)]
         else:
             touch.grab(self)
             i = 0 if self.orientation == 'horizontal' else 1
@@ -152,6 +158,6 @@ if __name__ == '__main__':
 
     class RangeSliderApp(App):
         def build(self):
-            return RangeSlider(padding=25, value_track=True,
-                value_track_color=[1, 0, 0, 1], value_range=[25, 75])
+            return RangeSlider(padding=25)
+
     RangeSliderApp().run()

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -39,7 +39,7 @@ class Slider(Widget):
     """
 
     value_range = ObjectProperty(None)
-    '''Value Range is used in RangeSlider class
+    '''Value Range used in RangeSlider class
 
     :attr:`value_range` is a :class:`~kivy.properties.ObjectProperty` and
     defaults to None.'''

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -28,7 +28,8 @@ __all__ = ('Slider', )
 from kivy.uix.widget import Widget
 from kivy.properties import (NumericProperty, AliasProperty, OptionProperty,
                              ReferenceListProperty, BoundedNumericProperty,
-                             StringProperty, ListProperty, BooleanProperty)
+                             StringProperty, ListProperty, BooleanProperty,
+                             ObjectProperty)
 
 
 class Slider(Widget):
@@ -37,9 +38,11 @@ class Slider(Widget):
     Check module documentation for more details.
     """
 
-    value_range = None
-    '''Value Range just for checking purpose
-    '''
+    value_range = ObjectProperty(None)
+    '''Value Range is used in RangeSlider class
+
+    :attr:`value_range` is a :class:`~kivy.properties.ObjectProperty` and
+    defaults to None.'''
 
     value = NumericProperty(0.)
     '''Current value used for the slider.

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -37,6 +37,10 @@ class Slider(Widget):
     Check module documentation for more details.
     """
 
+    value_range = None
+    '''Value Range just for checking purpose
+    '''
+
     value = NumericProperty(0.)
     '''Current value used for the slider.
 


### PR DESCRIPTION
I have modified slider to add a range-slider feature which gives the user an option to set a range for a particular property instead of setting a single value to a property.Well I have the manipulated the rangeslider style feature inside the <Slider> Rule of style.kv. An example of rangeslider is [here](https://refreshless.com/nouislider/) . As mentioned here [#4786comment](https://github.com/kivy/kivy/issues/4786#issuecomment-269769998) , I am also working on adding an option for the user to  show values like max, min and the current value below the slider. So should this feature be there or something should be left for the user to manipulate??.. Suggestions are welcome.