### PR TITLE
Compound selection bug 

### DIFF
--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -485,12 +485,10 @@ class CompoundSelectionBehavior(object):
         select = self.select_node
         sister_nodes = self.get_selectable_nodes()
         end = len(sister_nodes) - 1
-        if self._anchor in self.selected_nodes:
-            pass
-        else:
+        if self._anchor not in self.selected_nodes:
             if self._last_node_idx < self._anchor_idx:
                 for item in sister_nodes[self._anchor_idx:
-                                        self._last_node_idx + 1:-1]:
+                                        self._last_node_idx - 1:-1]:
                     if item in self.selected_nodes:
                         self._anchor = item
                         self._anchor_idx = self.get_index_of_node(
@@ -522,10 +520,7 @@ class CompoundSelectionBehavior(object):
                 idx = self.get_index_of_node(node, sister_nodes)
             except ValueError:
                 return
-        '''
-        if last_idx > idx:
-            last_idx, idx = idx, last_idx
-        '''
+
         if not multiselect:
             self.clear_selection()
         if last_idx < idx:

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -489,20 +489,20 @@ class CompoundSelectionBehavior(object):
             pass
         else:
             if self._last_node_idx < self._anchor_idx:
-                for node in sister_nodes[self._anchor_idx:
+                for item in sister_nodes[self._anchor_idx:
                                         self._last_node_idx + 1:-1]:
-                    if node in self.selected_nodes:
-                        self._anchor = node
+                    if item in self.selected_nodes:
+                        self._anchor = item
                         self._anchor_idx = self.get_index_of_node(
-                                                    node, sister_nodes)
+                                                    item, sister_nodes)
                         break
             else:
-                for node in sister_nodes[self._anchor_idx:
-                                            self._last_node_idx + 1]:
-                    if node in self.selected_nodes:
-                        self._anchor = node
+                for item in sister_nodes[self._anchor_idx:
+                                        self._last_node_idx + 1]:
+                    if item in self.selected_nodes:
+                        self._anchor = item
                         self._anchor_idx = self.get_index_of_node(
-                                                    node, sister_nodes)
+                                                    item, sister_nodes)
                         break
         last_node = self._anchor
         last_idx = self._anchor_idx

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -311,7 +311,6 @@ class CompoundSelectionBehavior(object):
         multi = self.multiselect
         multiselect = multi and (self._ctrl_down or self.touch_multiselect)
         range_select = multi and self._shift_down
-
         if touch and 'button' in touch.profile and touch.button in\
             ('scrollup', 'scrolldown', 'scrollleft', 'scrollright'):
             node_src, idx_src = self._reslove_last_node()
@@ -327,7 +326,6 @@ class CompoundSelectionBehavior(object):
             return True
         if node is None:
             return False
-
         if (node in self.selected_nodes and (not range_select)):  # selected
             if multiselect:
                 self.deselect_node(node)
@@ -365,7 +363,6 @@ class CompoundSelectionBehavior(object):
         multi = self.multiselect
         node_src, idx_src = self._reslove_last_node()
         text = scancode[1]
-
         if text == 'shift':
             self._shift_down = True
         elif text in ('ctrl', 'lctrl', 'rctrl'):
@@ -488,6 +485,25 @@ class CompoundSelectionBehavior(object):
         select = self.select_node
         sister_nodes = self.get_selectable_nodes()
         end = len(sister_nodes) - 1
+        if self._anchor in self.selected_nodes:
+            pass
+        else:
+            if self._last_node_idx < self._anchor_idx:
+                for node in sister_nodes[self._anchor_idx:
+                                        self._last_node_idx + 1:-1]:
+                    if node in self.selected_nodes:
+                        self._anchor = node
+                        self._anchor_idx = self.get_index_of_node(
+                                                    node, sister_nodes)
+                        break
+            else:
+                for node in sister_nodes[self._anchor_idx:
+                                            self._last_node_idx + 1]:
+                    if node in self.selected_nodes:
+                        self._anchor = node
+                        self._anchor_idx = self.get_index_of_node(
+                                                    node, sister_nodes)
+                        break
         last_node = self._anchor
         last_idx = self._anchor_idx
 
@@ -506,13 +522,18 @@ class CompoundSelectionBehavior(object):
                 idx = self.get_index_of_node(node, sister_nodes)
             except ValueError:
                 return
-
+        '''
         if last_idx > idx:
             last_idx, idx = idx, last_idx
+        '''
         if not multiselect:
             self.clear_selection()
-        for item in sister_nodes[last_idx:idx + 1]:
-            select(item)
+        if last_idx < idx:
+            for item in sister_nodes[last_idx:idx + 1]:
+                select(item)
+        else:
+            for item in sister_nodes[idx:last_idx + 1]:
+                select(item)
 
         if keep_anchor:
             self._anchor = last_node

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -311,6 +311,7 @@ class CompoundSelectionBehavior(object):
         multi = self.multiselect
         multiselect = multi and (self._ctrl_down or self.touch_multiselect)
         range_select = multi and self._shift_down
+
         if touch and 'button' in touch.profile and touch.button in\
             ('scrollup', 'scrolldown', 'scrollleft', 'scrollright'):
             node_src, idx_src = self._reslove_last_node()
@@ -326,6 +327,7 @@ class CompoundSelectionBehavior(object):
             return True
         if node is None:
             return False
+
         if (node in self.selected_nodes and (not range_select)):  # selected
             if multiselect:
                 self.deselect_node(node)
@@ -363,6 +365,7 @@ class CompoundSelectionBehavior(object):
         multi = self.multiselect
         node_src, idx_src = self._reslove_last_node()
         text = scancode[1]
+
         if text == 'shift':
             self._shift_down = True
         elif text in ('ctrl', 'lctrl', 'rctrl'):


### PR DESCRIPTION
@dessant This pr fixes #4915 .Well the problem was occuring because after deleting the anchor element in a range selection it was not updated causing all the deleted nodes to reappear as shown in the issue [here](https://github.com/kivy/kivy/issues/4915).So I updated the anchor element to the first next selected element.
Testing-[code](https://github.com/kivy/kivy/blob/master/examples/widgets/compound_selection.py)
