### PR TITLE
Disabled SDL2's accelerometer-as-joystick behaviour

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -78,6 +78,8 @@ cdef class _WindowSDL2Storage:
         elif state == 'hidden':
             self.win_flags |= SDL_WINDOW_HIDDEN
 
+        SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, b'0')
+
         if SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0:
             self.die()
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -417,6 +417,7 @@ cdef extern from "SDL.h":
 
     cdef char *SDL_HINT_ORIENTATIONS
     cdef char *SDL_HINT_VIDEO_WIN_D3DCOMPILER
+    cdef char *SDL_HINT_ACCELEROMETER_AS_JOYSTICK
 
     cdef int SDL_QUERY               = -1
     cdef int SDL_IGNORE              =  0


### PR DESCRIPTION
On platforms with an accelerometer, SDL2 currently passes a constant stream of joystick events. Even if these are desired, users would normally use Kivy's other methods of accessing the joystick, and these events probably just slow things down - there are a lot of them, around 145 per second on my Android device! They're also annoying if you want to listen to real joystick events.

This change just disables the SDL2 behaviour.

Fixes https://github.com/kivy/python-for-android/issues/885

Edit: Although I noticed it on Android, this PR also fixes the same behaviour on iOS.