### PR TITLE
Added an allow_screensaver property for Window

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -318,7 +318,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 17
+KIVY_CONFIG_VERSION = 18
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -818,6 +818,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
                 'data/fonts/Roboto-Italic.ttf',
                 'data/fonts/Roboto-Bold.ttf',
                 'data/fonts/Roboto-BoldItalic.ttf'])
+
+        elif version == 17:
+            Config.setdefault('graphics', 'allow_screensaver', '1')
 
         # elif version == 1:
         #    # add here the command for upgrading from configuration 0 to 1

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -197,6 +197,9 @@ Available configuration tokens
     'data/fonts/Roboto-Bold.ttf', 'data/fonts/Roboto-BoldItalic.ttf']
 
         Default font used for widgets displaying any text.
+    `allow_screensaver`: int, one of 0 or 1, defaults to 1
+        Allow the device to show a screen saver, or to go to sleep
+        on mobile devices. Only works for the sdl2 window provider.
 
 :input:
 
@@ -269,9 +272,10 @@ Available configuration tokens
     arguments.
 
 .. versionchanged:: 1.9.2
-    `min_state_time` has been added to the `graphics` section.
-    `kivy_clock` has been added to the kivy section
-    `default_font` has beed added to the kivy section
+    `min_state_time`  and `allow_screensaver` have been added
+    to the `graphics` section.
+    `kivy_clock` has been added to the kivy section.
+    `default_font` has beed added to the kivy section.
 
 .. versionchanged:: 1.9.0
     `borderless` and `window_state` have been added to the graphics section.

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -215,6 +215,10 @@ class WindowBase(EventDispatcher):
             Minimum width of the window (only works for sdl2 window provider).
         `minimum_height`: int
             Minimum height of the window (only works for sdl2 window provider).
+        `allow_screensaver`: bool
+            Allow the device to show a screen saver, or to go to sleep
+            on mobile devices. Defaults to True. Only works for sdl2 window
+            provider.
 
     :Events:
         `on_motion`: etype, motionevent
@@ -390,6 +394,16 @@ class WindowBase(EventDispatcher):
 
     :attr:`minimum_height` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 0.
+    '''
+
+    allow_screensaver = BooleanProperty(True)
+    '''Whether the screen saver is enabled, or on mobile devices whether the
+    device is allowed to go to sleep while the app is open.
+
+    .. versionadded:: 1.10.0
+
+    :attr:`allow_screensaver` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to True.
     '''
 
     size = AliasProperty(_get_size, _set_size, bind=('_size', ))
@@ -748,6 +762,9 @@ class WindowBase(EventDispatcher):
         if 'minimum_height' not in kwargs:
             kwargs['minimum_height'] = Config.getint('graphics',
                                                      'minimum_height')
+        if 'allow_screensaver' not in kwargs:
+            kwargs['allow_screensaver'] = Config.getint('graphics',
+                                                        'allow_screensaver')
         if 'rotation' not in kwargs:
             kwargs['rotation'] = Config.getint('graphics', 'rotation')
         if 'position' not in kwargs:

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -763,8 +763,8 @@ class WindowBase(EventDispatcher):
             kwargs['minimum_height'] = Config.getint('graphics',
                                                      'minimum_height')
         if 'allow_screensaver' not in kwargs:
-            kwargs['allow_screensaver'] = Config.getint('graphics',
-                                                        'allow_screensaver')
+            kwargs['allow_screensaver'] = Config.getboolean(
+                'graphics', 'allow_screensaver')
         if 'rotation' not in kwargs:
             kwargs['rotation'] = Config.getint('graphics', 'rotation')
         if 'position' not in kwargs:

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -190,6 +190,12 @@ cdef class _WindowSDL2Storage:
     def set_minimum_size(self, w, h):
         SDL_SetWindowMinimumSize(self.win, w, h)
 
+    def set_allow_screensaver(self, allow_screensaver):
+        if allow_screensaver:
+            SDL_EnableScreenSaver()
+        else:
+            SDL_DisableScreenSaver()
+
     def maximize_window(self):
         SDL_MaximizeWindow(self.win)
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -185,6 +185,8 @@ class WindowSDL(WindowBase):
         self.bind(minimum_width=self._set_minimum_size,
                   minimum_height=self._set_minimum_size)
 
+        self.bind(allow_screensaver=self._set_allow_screensaver)
+
     def _set_minimum_size(self, *args):
         minimum_width = self.minimum_width
         minimum_height = self.minimum_height
@@ -194,6 +196,10 @@ class WindowSDL(WindowBase):
             Logger.warning(
                 'Both Window.minimum_width and Window.minimum_height must be '
                 'bigger than 0 for the size restriction to take effect.')
+
+    def _set_allow_screensaver(self, *args):
+        allow_screensaver = self.allow_screensaver
+        self._win.set_allow_screensaver(allow_screensaver)
 
     def _event_filter(self, action):
         from kivy.app import App
@@ -272,6 +278,7 @@ class WindowSDL(WindowBase):
             # will be fired.
             self._pos = (0, 0)
             self._set_minimum_size()
+            self._set_allow_screensaver()
 
             if state == 'hidden':
                 self._focus = False

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -198,8 +198,7 @@ class WindowSDL(WindowBase):
                 'bigger than 0 for the size restriction to take effect.')
 
     def _set_allow_screensaver(self, *args):
-        allow_screensaver = self.allow_screensaver
-        self._win.set_allow_screensaver(allow_screensaver)
+        self._win.set_allow_screensaver(self.allow_screensaver)
 
     def _event_filter(self, action):
         from kivy.app import App


### PR DESCRIPTION
Currently SDL2 automatically disables the screensaver, but has functions for enabling or disabling manually. Kivy doesn't do anything other than the default, so this affects all Kivy apps. It isn't very noticeable on the desktop, but probably isn't desirable as a default, and on mobile devices it prevents them from sleeping.

This PR adds a property to Window that exposes the SDL2 setting. As such, it will only work with the SDL2 provider, but since it's not the only one that doesn't seem too controversial. Other providers could potentially support it too.

I considered just disabling this behaviour on Android, but since it does affect desktop and iOS as well, and the SDL2 management of it is quite nice, it seemed better to resolve it with an option.

Resolves https://github.com/kivy/python-for-android/issues/969.