### PR TITLE
Prevented attempted import of AndroidJoystick with SDL2

### DIFF
--- a/kivy/input/providers/__init__.py
+++ b/kivy/input/providers/__init__.py
@@ -9,6 +9,7 @@ import os
 
 from kivy.utils import platform as core_platform
 from kivy.logger import Logger
+from kivy.setupconfig import USE_SDL2
 
 import kivy.input.providers.tuio
 import kivy.input.providers.mouse
@@ -52,7 +53,7 @@ if platform == 'linux' or 'KIVY_DOC' in os.environ:
         err = 'Input: LinuxWacom is not supported by your version of linux'
         Logger.exception(err)
 
-if platform == 'android' or 'KIVY_DOC' in os.environ:
+if (platform == 'android' and not USE_SDL2) or 'KIVY_DOC' in os.environ:
     try:
         import kivy.input.providers.androidjoystick
     except:


### PR DESCRIPTION
Currently this attempted import leaves a confusing error in the logs. This PR just disables the import if SDL2 is being used.

Fixes https://github.com/kivy/python-for-android/issues/962.