### PR TITLE
Fix sdl2 exit on Android home button press

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -210,6 +210,8 @@ class WindowSDL(WindowBase):
             if not app:
                 Logger.info('WindowSDL: No running App found, exit.')
                 stopTouchApp()
+                # self.close() is missing ?
+                # see discussion: https://github.com/kivy/kivy/pull/4927
                 return 0
 
             if not app.dispatch('on_pause'):

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -216,6 +216,7 @@ class WindowSDL(WindowBase):
                 Logger.info(
                     'WindowSDL: App doesn\'t support pause mode, stop.')
                 stopTouchApp()
+                self.close()
                 return 0
 
             self._pause_loop = True
@@ -608,6 +609,7 @@ class WindowSDL(WindowBase):
         if not app.dispatch('on_pause'):
             Logger.info('WindowSDL: App doesn\'t support pause mode, stop.')
             stopTouchApp()
+            self.close()
             return
 
         # XXX FIXME wait for sdl resume


### PR DESCRIPTION
This PR is about to fix https://github.com/kivy/python-for-android/issues/978

If our app doesn't support sleep mode, behavior on home button press should be same as [on pressing back button](https://github.com/kivy/kivy/blob/master/kivy/core/window/__init__.py#L1400), while now [it's not](https://github.com/kivy/kivy/blob/master/kivy/core/window/window_sdl2.py#L608) (`self.close()` miss). This leads to crush.

While this PR fixes error, I think it can be improved:
1) Above the `on_close` handling [there's](https://github.com/kivy/kivy/blob/master/kivy/core/window/window_sdl2.py#L603) also condition when `app` is `None`. When can it happen? Should this block also contain `self.close()` call?
2) Can anyone say what exactly should be fixed [here](https://github.com/kivy/kivy/blob/master/kivy/core/window/window_sdl2.py#L613)?
