### PR TITLE
Fix Window position from Config

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -687,14 +687,16 @@ class WindowBase(EventDispatcher):
         pass
 
     def _get_left(self):
-        return self._get_window_pos()[0]
+        left = self._get_window_pos()[0]
+        return left if left != -10000 else Config.getint('graphics', 'left')
 
     def _set_left(self, value):
         pos = self._get_window_pos()
         self._set_window_pos(value, pos[1])
 
     def _get_top(self):
-        return self._get_window_pos()[1]
+        top = self._get_window_pos()[1]
+        return top if top != -10000 else Config.getint('graphics', 'top')
 
     def _set_top(self, value):
         pos = self._get_window_pos()

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -687,18 +687,24 @@ class WindowBase(EventDispatcher):
         pass
 
     def _get_left(self):
-        left = self._get_window_pos()[0]
-        return left if left != -10000 else Config.getint('graphics', 'left')
+        sdl_left = self._get_window_pos()[0]
+        if self._left != sdl_left:
+            return self._left
+        return sdl_left
 
     def _set_left(self, value):
+        self._left = value
         pos = self._get_window_pos()
         self._set_window_pos(value, pos[1])
 
     def _get_top(self):
-        top = self._get_window_pos()[1]
-        return top if top != -10000 else Config.getint('graphics', 'top')
+        sdl_top = self._get_window_pos()[1]
+        if self._top != sdl_top:
+            return self._top
+        return sdl_top
 
     def _set_top(self, value):
+        self._top = value
         pos = self._get_window_pos()
         self._set_window_pos(pos[0], value)
 
@@ -804,11 +810,13 @@ class WindowBase(EventDispatcher):
         if 'top' in kwargs:
             kwargs['position'] = 'custom'
             kwargs['top'] = kwargs['top']
+            self._top = kwargs['top']
         else:
             kwargs['top'] = Config.getint('graphics', 'top')
         if 'left' in kwargs:
             kwargs['position'] = 'custom'
             kwargs['left'] = kwargs['left']
+            self._left = kwargs['left']
         else:
             kwargs['left'] = Config.getint('graphics', 'left')
         kwargs['_size'] = (kwargs.pop('width'), kwargs.pop('height'))

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -688,7 +688,8 @@ class WindowBase(EventDispatcher):
 
     def _get_left(self):
         sdl_left = self._get_window_pos()[0]
-        if self._left != sdl_left:
+        if not self.initialized:
+            # use Config
             return self._left
         return sdl_left
 
@@ -699,7 +700,7 @@ class WindowBase(EventDispatcher):
 
     def _get_top(self):
         sdl_top = self._get_window_pos()[1]
-        if self._top != sdl_top:
+        if not self.initialized:
             return self._top
         return sdl_top
 

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -687,25 +687,20 @@ class WindowBase(EventDispatcher):
         pass
 
     def _get_left(self):
-        sdl_left = self._get_window_pos()[0]
         if not self.initialized:
-            # use Config
             return self._left
-        return sdl_left
+        return self._get_window_pos()[0]
 
     def _set_left(self, value):
-        self._left = value
         pos = self._get_window_pos()
         self._set_window_pos(value, pos[1])
 
     def _get_top(self):
-        sdl_top = self._get_window_pos()[1]
         if not self.initialized:
             return self._top
-        return sdl_top
+        return self._get_window_pos()[1]
 
     def _set_top(self, value):
-        self._top = value
         pos = self._get_window_pos()
         self._set_window_pos(pos[0], value)
 
@@ -810,16 +805,14 @@ class WindowBase(EventDispatcher):
                                                    'auto')
         if 'top' in kwargs:
             kwargs['position'] = 'custom'
-            kwargs['top'] = kwargs['top']
             self._top = kwargs['top']
         else:
-            kwargs['top'] = Config.getint('graphics', 'top')
+            self._top = Config.getint('graphics', 'top')
         if 'left' in kwargs:
             kwargs['position'] = 'custom'
-            kwargs['left'] = kwargs['left']
             self._left = kwargs['left']
         else:
-            kwargs['left'] = Config.getint('graphics', 'left')
+            self._left = Config.getint('graphics', 'left')
         kwargs['_size'] = (kwargs.pop('width'), kwargs.pop('height'))
         if 'show_cursor' not in kwargs:
             kwargs['show_cursor'] = Config.getboolean('graphics',

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -224,7 +224,8 @@ cdef class _WindowSDL2Storage:
         SDL_SetWindowTitle(self.win, <bytes>title.encode('utf-8'))
 
     def get_window_pos(self):
-        cdef int x, y
+        cdef int x = -10000
+        cdef int y = -10000
         SDL_GetWindowPosition(self.win, &x, &y)
         return x, y
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -224,8 +224,7 @@ cdef class _WindowSDL2Storage:
         SDL_SetWindowTitle(self.win, <bytes>title.encode('utf-8'))
 
     def get_window_pos(self):
-        cdef int x = -10000
-        cdef int y = -10000
+        cdef int x, y
         SDL_GetWindowPosition(self.win, &x, &y)
         return x, y
 


### PR DESCRIPTION
Before Window is actually created, fetch values from Config (`if not self.initialized`) and set it to a private property. That property is used in setter+getter, so it gets updated.

After the Window is initialized, just fetch values from SDL2.

For testing purposes see the moving Window and console output for each step (uncommenting). Should be fine now 🍡 

```
from kivy.config import Config
from kivy.clock import Clock
from functools import partial
# position: screen center

# Config.set('graphics', 'position', 'custom')
# position: 0, 0

# Config.set('graphics', 'top', 100)
# position: 0, 100

# Config.set('graphics', 'left', 100)
# position: 100, 100

from kivy.app import runTouchApp
from kivy.core.window import Window
# Window.left = 200
# position: 200, 100

# Window.top = 200
# position: 200, 200

def printf(*_):
    print(Window.left, Window.top)
Clock.schedule_interval(printf, 0.5)
def move(*_):
    Window.left += 10
    Window.top += 10
Clock.schedule_interval(move, 1)
runTouchApp()
```