### PR TITLE
Normalize version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,7 @@ build_script:
 
     $env:PATH = $PYTHON_ROOT+"\share\glew\bin;"+$PYTHON_ROOT+"\share\sdl2\bin;"+$PYTHON_ROOT+"\share\gstreamer\bin;"+$env:PATH
 
-    $WHEEL_DATE = python -c "from time import strftime;print(strftime('%d%m%Y'))"
+    $WHEEL_DATE = python -c "from datetime import datetime;print(datetime.utcnow().strftime('%Y%m%d'))"
 
     Check-Error
 

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -43,11 +43,16 @@ MINOR = 9
 MICRO = 2
 RELEASE = False
 
+__version__ = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+
+if not RELEASE and '.dev0' not in __version__:
+    __version__ += '.dev0'
+
 try:
-    from kivy.version import __version__, __hash__
+    from kivy.version import __hash__, __date__
+    __hash__ = __hash__[:7]
 except ImportError:
-    __version__ = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
-    __hash__ = 'Unknown'
+    __hash__ = __date__ = 'Unknown'
 
 # internals for post-configuration
 __kivy_post_configuration = []
@@ -447,6 +452,5 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     if platform == 'android':
         Config.set('input', 'androidtouch', 'android')
 
-Logger.info('Kivy: v%s' % (__version__))
-Logger.info('Kivy rev.: %s' % (__hash__))
+Logger.info('Kivy: v%s, %s, %s' % (__version__, __hash__, __date__))
 Logger.info('Python: v{}'.format(sys.version))

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -28,8 +28,6 @@ __all__ = (
     'kivy_config_fn', 'kivy_usermodules_dir',
 )
 
-__version__ = '1.9.2-dev0'
-
 import sys
 import shutil
 from getopt import getopt, GetoptError
@@ -39,6 +37,11 @@ import pkgutil
 from kivy.compat import PY2
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
+
+try:
+    from kivy.version import __version__
+except ImportError:
+    __version__ = 'Unknown'
 
 # internals for post-configuration
 __kivy_post_configuration = []
@@ -101,8 +104,9 @@ def require(version):
 
         # check x y z
         v = version.split('.')
-        if len(v) != 3:
-            raise Exception('Revision format must be X.Y.Z[-tag]')
+        if len(v) == 4:
+            tag, tagrev = v[3].split('+')
+            return [int(x) for x in v[:3]], tag, tagrev
         return [int(x) for x in v], tag, tagrev
 
     # user version

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -52,7 +52,7 @@ try:
     from kivy.version import __hash__, __date__
     __hash__ = __hash__[:7]
 except ImportError:
-    __hash__ = __date__ = 'Unknown'
+    __hash__ = __date__ = ''
 
 # internals for post-configuration
 __kivy_post_configuration = []
@@ -452,5 +452,8 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     if platform == 'android':
         Config.set('input', 'androidtouch', 'android')
 
-Logger.info('Kivy: v%s, %s, %s' % (__version__, __hash__, __date__))
+if RELEASE:
+    Logger.info('Kivy: v%s' % (__version__))
+elif not RELEASE and __hash__ and __date__:
+    Logger.info('Kivy: v%s, git-%s, %s' % (__version__, __hash__, __date__))
 Logger.info('Python: v{}'.format(sys.version))

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -38,10 +38,16 @@ from kivy.compat import PY2
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
 
+MAJOR = 1
+MINOR = 9
+MICRO = 2
+RELEASE = False
+
 try:
-    from kivy.version import __version__
+    from kivy.version import __version__, __hash__
 except ImportError:
-    __version__ = 'Unknown'
+    __version__ = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+    __hash__ = 'Unknown'
 
 # internals for post-configuration
 __kivy_post_configuration = []
@@ -104,9 +110,11 @@ def require(version):
 
         # check x y z
         v = version.split('.')
-        if len(v) == 4:
-            tag, tagrev = v[3].split('+')
-            return [int(x) for x in v[:3]], tag, tagrev
+        if len(v) != 3:
+            if 'dev0' in v:
+                tag = v.pop()
+            else:
+                raise Exception('Revision format must be X.Y.Z[-tag]')
         return [int(x) for x in v], tag, tagrev
 
     # user version
@@ -440,4 +448,5 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         Config.set('input', 'androidtouch', 'android')
 
 Logger.info('Kivy: v%s' % (__version__))
+Logger.info('Kivy rev.: %s' % (__hash__))
 Logger.info('Python: v{}'.format(sys.version))

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ from distutils.version import LooseVersion
 from collections import OrderedDict
 from time import sleep
 from subprocess import check_output, CalledProcessError
+from datetime import datetime
 
 if environ.get('KIVY_USE_SETUPTOOLS'):
     from setuptools import setup, Extension
@@ -35,7 +36,7 @@ if PY3:  # fix error with py3's LooseVersion comparisons
 
 def get_version(filename='kivy/version.py'):
     VERSION = kivy.__version__
-    RELEASE = kivy.RELEASE
+    DATE = datetime.utcnow().strftime('%Y%m%d')
     try:
         GIT_REVISION = check_output(
             ['git', 'rev-parse', 'HEAD']
@@ -43,19 +44,18 @@ def get_version(filename='kivy/version.py'):
     except CalledProcessError:
         GIT_REVISION = "Unknown"
 
-    if not RELEASE and '.dev0' not in VERSION:
-        VERSION += '.dev0'
-
     cnt = (
         "# THIS FILE IS GENERATED FROM KIVY SETUP.PY\n"
         "__version__ = '%(version)s'\n"
         "__hash__ = '%(hash)s'\n"
+        "__date__ = '%(date)s'\n"
     )
 
     with open(filename, 'w') as f:
         f.write(cnt % {
             'version': VERSION,
             'hash': GIT_REVISION,
+            'date': DATE
         })
     return VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,9 @@ if PY3:  # fix error with py3's LooseVersion comparisons
     LooseVersion.__eq__ = ver_equal
 
 
-MAJOR = 1
-MINOR = 9
-MICRO = 2
-RELEASED = environ.get('KIVY_RELEASE', False)
-VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
-
-
 def get_version(filename='kivy/version.py'):
+    VERSION = kivy.__version__
+    RELEASE = kivy.RELEASE
     try:
         GIT_REVISION = check_output(
             ['git', 'rev-parse', 'HEAD']
@@ -48,22 +43,19 @@ def get_version(filename='kivy/version.py'):
     except CalledProcessError:
         GIT_REVISION = "Unknown"
 
-    global VERSION
-    if not RELEASED:
-        VERSION += '.dev0+' + GIT_REVISION[:7]
+    if not RELEASE and '.dev0' not in VERSION:
+        VERSION += '.dev0'
 
     cnt = (
         "# THIS FILE IS GENERATED FROM KIVY SETUP.PY\n"
         "__version__ = '%(version)s'\n"
-        "git_revision = '%(git_revision)s'\n"
-        "release = %(release)s\n"
+        "__hash__ = '%(hash)s'\n"
     )
 
     with open(filename, 'w') as f:
         f.write(cnt % {
             'version': VERSION,
-            'git_revision': GIT_REVISION,
-            'release': str(RELEASED)
+            'hash': GIT_REVISION,
         })
     return VERSION
 


### PR DESCRIPTION
ref #4861 

Standardized format for version in X.Y.Z[.dev0+hash] shape. Can be turned off for a release with env variable `KIVY_RELEASE`.

There were necessary changes in `parse_version`, otherwise it won't accept such a version. It might break the previous `kivy.require()` in some cases.

Hopefully there won't be much appveyor script can break in this and as discussed before, since this change there'll be necessary to *force* install each master version, because there'll be no way how to compare the versions because of the hash (unless `MICRO` changes):

```
from packaging.version import parse
parse('1.9.2-dev0.24012017.e4d8cb9c') < parse('1.9.2-dev0.25012017.a9d5d756')
# True
parse('1.9.2-dev0+e4d8cb9c') < parse('1.9.2-dev0+a9d5d756')
# False
```