### PR TITLE
Fix animation transition around the unit circle in Android compass example

### DIFF
--- a/examples/android/compass/main.py
+++ b/examples/android/compass/main.py
@@ -23,6 +23,7 @@ import kivy
 kivy.require('1.7.0')
 
 from jnius import autoclass
+from math import floor
 from kivy.app import App
 from kivy.properties import NumericProperty
 from kivy.clock import Clock
@@ -47,6 +48,14 @@ class CompassApp(App):
 
         # calculate the angle
         needle_angle = Vector(x, y).angle((0, 1)) + 90.
+
+        # fix animation transition around the unit circle
+        if (self.needle_angle % 360) - needle_angle > 180:
+            needle_angle += 360
+        elif (self.needle_angle % 360) - needle_angle < -180:
+            needle_angle -= 360
+        # add the number of revolutions to the result
+        needle_angle += 360 * floor(self.needle_angle / 360.)
 
         # animate the needle
         if self._anim:


### PR DESCRIPTION
For example if the previous angle was 269 and the new angle is -84, then the current code would rotate the needle in a clockwise direction. This fix would add 360 to -84, so the new angle would be 276, which would result in the correct behaviour of the needle rotating anti-clockwise.