### PR TITLE
Add multiple joysticks support

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -148,7 +148,11 @@ cdef class _WindowSDL2Storage:
             self.ctx = SDL_GL_CreateContext(self.win)
             if not self.ctx:
                 self.die()
-        SDL_JoystickOpen(0)
+
+        # Open all available joysticks
+        cdef int joy_i
+        for joy_i in range(SDL_NumJoysticks()):
+            SDL_JoystickOpen(joy_i)
 
         SDL_SetEventFilter(_event_filter, <void *>self)
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -567,7 +567,7 @@ cdef extern from "SDL.h":
     cdef void SDL_GL_SwapWindow(SDL_Window * window)
     cdef void SDL_GL_DeleteContext(SDL_GLContext context)
 
-    cdef int SDL_NumJoysticks(void)
+    cdef int SDL_NumJoysticks()
     cdef SDL_Joystick * SDL_JoystickOpen(int index)
     cdef SDL_Window * SDL_GetKeyboardFocus()
     cdef Uint8 *SDL_GetKeyboardState(int *numkeys)

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -567,6 +567,7 @@ cdef extern from "SDL.h":
     cdef void SDL_GL_SwapWindow(SDL_Window * window)
     cdef void SDL_GL_DeleteContext(SDL_GLContext context)
 
+    cdef int SDL_NumJoysticks(void)
     cdef SDL_Joystick * SDL_JoystickOpen(int index)
     cdef SDL_Window * SDL_GetKeyboardFocus()
     cdef Uint8 *SDL_GetKeyboardState(int *numkeys)


### PR DESCRIPTION
Doesn't work for me with a single physical device and vJoy, but apparently works for **physical** devices. ref #4872 

@yglazner please compile from this branch like a casual installation for your platform and confirm if it works for you - 2+ devices connected at the same time give values with [this](https://github.com/kivy/kivy/blob/master/examples/miscellaneous/joystick.py) or a similar example just with a different **id**, for example if a button is pressed on each of the devices, the value in console is the same with **id** of the stick being the only thing different.

Or if you have different devices (different brand/model), then try to get the same axis/button/hat that returns the same value and compare ids.

    pip install https://github.com/KeyWeeUsr/kivy/archive/multi_joystick.zip