### PR TITLE
Fix OSC.py for py3 and py2

### DIFF
--- a/kivy/lib/osc/OSC.py
+++ b/kivy/lib/osc/OSC.py
@@ -103,6 +103,8 @@ class OSCMessage:
 
     def rawAppend(self, data):
         """Appends raw data to the message.  Use append()."""
+        if not isinstance(data, bytes): 
+            data = data.encode('utf-8')
         self.message = self.message + data
 
     def getBinary(self):


### PR DESCRIPTION
I fixed this already once but seems it never got accepted or was reversed and thus is broke again. Tested on py3 so please let the Travis test complete to ensure all is good for py2.