### PR TITLE
Video: update 'loaded' on new video, unload previous video 

### DIFF
--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -163,8 +163,7 @@ class Video(Image):
     def _do_video_load(self, *largs):
         if CoreVideo is None:
             return
-        if self._video:
-            self._video.stop()
+        self.unload()
         if not self.source:
             self._video = None
             self.texture = None
@@ -235,6 +234,7 @@ class Video(Image):
             self._video.stop()
             self._video.unload()
             self._video = None
+        self.loaded = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1) Currently `loaded` updates only once: when some video loaded and remain `True` even if we unload this video or load new one. It's not correct, this property should be updated to `False` when video unloaded and again to `True` when new video loaded.

2) It also makes sense to `unload` current video when we change `source` (instead of just stopping it).