### PR TITLE
filechooser: Fix a crash when using a file as the path

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -102,7 +102,7 @@ from kivy.properties import (
 from os import listdir
 from os.path import (
     basename, join, sep, normpath, expanduser, altsep,
-    splitdrive, realpath, getsize, isdir, abspath)
+    splitdrive, realpath, getsize, isdir, abspath, isfile, dirname)
 from fnmatch import fnmatch
 import collections
 
@@ -838,6 +838,8 @@ class FileChooserController(RelativeLayout):
 
     def _add_files(self, path, parent=None):
         path = expanduser(path)
+        if isfile(path):
+            path = dirname(path)
 
         files = []
         fappend = files.append


### PR DESCRIPTION
Currently, if you select a file (not a folder) in ```filechooser```, and then open a new ```filechooser``` using the same path, you will get a crash, because it expects a folder. Most noticeable when using ```kivy.uix.settings.SettingPath```, as you can select a file, and the next time you try and change that setting, the ```filechooser``` will be completely blank. 

This is just a simple fix that:
* Checks to see if the path is a file
* If it is, it will load the parent directory, instead of trying to use the file like a folder