### PR TITLE
added support for opencv 2 and 3 (camera)

### DIFF
--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -53,6 +53,8 @@ class CameraOpenCV(CameraBase):
     '''
     Implementation of CameraBase using OpenCV
     '''
+    
+    _update_ev = None
 
     def __init__(self, **kwargs):
         # we will need it, because constants have
@@ -146,9 +148,12 @@ class CameraOpenCV(CameraBase):
 
     def start(self):
         super(CameraOpenCV, self).start()
-        Clock.unschedule(self._update)
-        Clock.schedule_interval(self._update, self.fps)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+        self._update_ev = Clock.schedule_interval(self._update, self.fps)
 
     def stop(self):
         super(CameraOpenCV, self).stop()
-        Clock.unschedule(self._update)
+        if self._update_ev is not None:
+            self._update_ev.cancel()
+            self._update_ev = None

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -53,7 +53,6 @@ class CameraOpenCV(CameraBase):
     '''
     Implementation of CameraBase using OpenCV
     '''
-    
     _update_ev = None
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
The following pr is the rework of #4828 .Here camera support is expanded for opencv2 and opencv3.
Further works include unscheduling by event for faster execution time.It is because unscheduling by event is faster than unscheduling by callback in kivy.
For more details about the above topic following links ([link1](https://github.com/kivy/kivy/wiki/Kivy-clock-experiments), [link2](https://github.com/kivy/kivy/pull/4412#issuecomment-228455735)) would be helpful.They helped me to grasp the concept.

EDIT:-
 * I am still testing out the pr and will update the status soon.

EDIT 2:-
* Working fine!.Tested on platform :-
    * kivy 1.9.2dev
    * ubuntu 14.04 lts 
    * opencv 2.4.8