### PR TITLE
A trigger call should never return True

### DIFF
--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -72,7 +72,6 @@ cdef class ClockEvent(object):
                 self.clock._last_event = self
             self.clock.on_schedule(self)
             self.clock._lock_release()
-            return True
         self.clock._lock_release()
 
     cpdef get_callback(self):


### PR DESCRIPTION
When it returned True, binding a trigger to an event with e.g. fbind would stop the dispatch chain when the trigger is called if the trigger was already triggered.