### PR TITLE
- there is no sys.stdout.encoding when piped or frozen

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -577,7 +577,8 @@ class WindowSDL(WindowBase):
                     try:
                         kstr_chr = unichr(key)
                         try:
-                            kstr_chr.encode(sys.stdout.encoding)
+                            encoding = sys.stdout.encoding or 'utf8'
+                            kstr_chr.encode(encoding)
                             kstr = kstr_chr
                         except UnicodeError:
                             pass


### PR DESCRIPTION
sometimes sys.stdout.encoding is None (eg. when piped or when frozen with pyinstaller). in such case pressing any key crashes app. 