### PR TITLE
fix ActionDropDown.on_touch_down: return True

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -264,6 +264,7 @@ class ActionDropDown(DropDown):
         if super(ActionDropDown, self).on_touch_down(touch):
             if self.auto_dismiss:
                 self.dismiss()
+            return True
 
 
 class ActionGroup(ActionItem, Spinner):


### PR DESCRIPTION
this fixes event propagation when a dropdown menu is pressed.
on_touch_down should return True if the parent returns True.
