### PR TITLE
Fix inconistent naming, where kv files are not unloaded

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -319,6 +319,8 @@ class BuilderBase(object):
             if y[2] != filename:
                 templates[x] = y
         self.templates = templates
+
+        filename = resource_find(filename) or filename
         if filename in self.files:
             self.files.remove(filename)
 
@@ -340,7 +342,7 @@ class BuilderBase(object):
         # put a warning if a file is loaded multiple times
         if fn in self.files:
             Logger.warning(
-                'Lang: The file {} is loaded multiples times, '
+                'Builder: The file {} is loaded multiples times, '
                 'you might have unwanted behaviors.'.format(fn))
 
         try:

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -342,7 +342,7 @@ class BuilderBase(object):
         # put a warning if a file is loaded multiple times
         if fn in self.files:
             Logger.warning(
-                'Builder: The file {} is loaded multiples times, '
+                'Lang: The file {} is loaded multiples times, '
                 'you might have unwanted behaviors.'.format(fn))
 
         try:


### PR DESCRIPTION
This fixes an issue where Builder.unload_string fails. The Builder.load_file function adds the full path before adding it to the 'files' property (line 285).
```
   filename = resource_find(filename) or filename
```
This is not done when unloading, so the filename is not found in 'files'and nothing is unloaded.