### PR TITLE
Avoid an android crash introduced in #5003 (git: 92464860).

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -577,7 +577,9 @@ class WindowSDL(WindowBase):
                     try:
                         kstr_chr = unichr(key)
                         try:
-                            encoding = getattr(sys.stdout, 'encoding', 'utf8')
+                            # On android, there is no 'encoding' attribute.
+                            # On other platforms, if stdout is redirected, 'encoding' may be None
+                            encoding = getattr(sys.stdout, 'encoding', 'utf8') or 'utf8'
                             kstr_chr.encode(encoding)
                             kstr = kstr_chr
                         except UnicodeError:

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -578,8 +578,10 @@ class WindowSDL(WindowBase):
                         kstr_chr = unichr(key)
                         try:
                             # On android, there is no 'encoding' attribute.
-                            # On other platforms, if stdout is redirected, 'encoding' may be None
-                            encoding = getattr(sys.stdout, 'encoding', 'utf8') or 'utf8'
+                            # On other platforms, if stdout is redirected,
+                            # 'encoding' may be None
+                            encoding = getattr(sys.stdout, 'encoding',
+                                               'utf8') or 'utf8'
                             kstr_chr.encode(encoding)
                             kstr = kstr_chr
                         except UnicodeError:

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -577,7 +577,7 @@ class WindowSDL(WindowBase):
                     try:
                         kstr_chr = unichr(key)
                         try:
-                            encoding = sys.stdout.encoding or 'utf8'
+                            encoding = getattr(sys.stdout, 'encoding', 'utf8')
                             kstr_chr.encode(encoding)
                             kstr = kstr_chr
                         except UnicodeError:


### PR DESCRIPTION
On android, sys.stdout.encoding does not exist (sys.stdout is redirected - of type LogFile - which has no `encoding` attribute).