### PR TITLE
doc: Update Raspbian Jessie install instructions.

### DIFF
--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -17,7 +17,12 @@ Manual installation (On Raspbian Jessie)
        pkg-config libgl1-mesa-dev libgles2-mesa-dev \
        python-setuptools libgstreamer1.0-dev git-core \
        gstreamer1.0-plugins-{bad,base,good,ugly} \
-       gstreamer1.0-{omx,alsa} python-dev cython
+       gstreamer1.0-{omx,alsa} python-dev libmtdev-dev \
+       xclip
+
+#. Install a new enough version of Cython::
+
+    sudo pip install -I Cython==0.23
 
 
 #. Install Kivy globally on your system::


### PR DESCRIPTION
Update install instructions to reflect what I did to get current
master of kivy working on Raspbian Jesse.  The packaged version of
Cython was not new enough, so it must be installed via pip.  libmtdev
is also required or errors will be encountered when starting a kivy
app.