### PR TITLE
stopTouchApp(): don't simply return, try stop in the next frame, prev…

### DIFF
--- a/kivy/base.py
+++ b/kivy/base.py
@@ -106,6 +106,7 @@ class EventLoopBase(EventDispatcher):
         self.input_events = []
         self.postproc_modules = []
         self.status = 'idle'
+        self.stopping = False
         self.input_providers = []
         self.input_providers_autoremove = []
         self.event_listeners = []
@@ -190,6 +191,7 @@ class EventLoopBase(EventDispatcher):
         # ensure any restart will not break anything later.
         self.input_events = []
 
+        self.stopping = False
         self.status = 'stopped'
         self.dispatch('on_stop')
 
@@ -510,7 +512,12 @@ def stopTouchApp():
     '''Stop the current application by leaving the main loop'''
     if EventLoop is None:
         return
+    if EventLoop.status in ('stopped', 'closed'):
+        return
     if EventLoop.status != 'started':
+        if not EventLoop.stopping:
+            EventLoop.stopping = True
+            Clock.schedule_once(lambda dt: stopTouchApp(), 0)
         return
     Logger.info('Base: Leaving application in progress...')
     EventLoop.close()


### PR DESCRIPTION
…ent bugs

Fixes #4634. Its the continuation of the #4637, but on the new branch with @matham proposals taken into account.

I've added support for `Eventloop.stopping`. The `stopTouchApp` handles all states correctly:
1) if `EventLoop` is None, it returns, however this code could be easily removed, because EventLoop as module instance in 99% cases cannot be None after stopTouchApp was imported. One case when it can be None is when we explicitly call:
```python
from kivy import base
base.EventLoop = None
```
But that situation is... cmon :)
2) If EventLoop.status is `stopped` or `closed`, we return too, as it means we dont need to do anything. Ive added that because stopTouchApp() is called from a lot of places, and per app normal run its minimum 2 calls (I checked). No need to call `EventLoop.close()` every time.
3) If `EventLoop` havent started, and `EventLoop.stopping` is `False`, we schedule the stop for the next frame. It works like a charm.
4) If `EventLoop` has started, we do the behavior we know right know: we close the EventLoop.

Example to test:

```python
from kivy.app import App
from kivy.uix.widget import Widget


class ExampleApp(App):

    def build(self):
        self.root = Widget()
        self.stop()


if __name__ == '__main__':
    ExampleApp().run()
```