### PR TITLE
Logger: purge_logs(): Replace hardcoded value *maxfiles* with config setting *log_maxfiles*.

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -89,11 +89,15 @@ Available configuration tokens
         Set the minimum log level to use.
     `log_name`: string
         Format string to use for the filename of log file.
-    `log_maxfiles`: int, greater or equal 0
+
+    `log_maxfiles`: int
         Keep log_maxfiles recent logfiles while purging the log directory. Set
-        'log_maxfiles' to 0 to disable logfile purging (eg keep all logfiles).
-        Note: You end up with 'log_maxfiles + 1' logfiles because the logger
-        adds a new one after purging.
+        'log_maxfiles' to -1 to disable logfile purging (eg keep all logfiles).
+
+        .. note::
+            You end up with 'log_maxfiles + 1' logfiles because the logger
+            adds a new one after purging.
+
     `window_icon`: string
         Path of the window icon. Use this if you want to replace the default
         pygame icon.

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -89,6 +89,8 @@ Available configuration tokens
         Set the minimum log level to use.
     `log_name`: string
         Format string to use for the filename of log file.
+    `log_maxfiles`: int, greater 0
+        Keep log_maxfiles recent logfiles while purging the log directory.
     `window_icon`: string
         Path of the window icon. Use this if you want to replace the default
         pygame icon.
@@ -322,7 +324,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 18
+KIVY_CONFIG_VERSION = 19
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -825,6 +827,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 17:
             Config.setdefault('graphics', 'allow_screensaver', '1')
+
+        elif version == 18:
+            Config.setdefault('kivy', 'log_maxfiles', '100')
 
         # elif version == 1:
         #    # add here the command for upgrading from configuration 0 to 1

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -92,8 +92,8 @@ Available configuration tokens
     `log_maxfiles`: int, greater or equal 0
         Keep log_maxfiles recent logfiles while purging the log directory. Set
         'log_maxfiles' to 0 to disable logfile purging (eg keep all logfiles).
-        Note: You end up with 'log_maxfiles + 1' logfiles because the logger adds
-        a new one after purging.
+        Note: You end up with 'log_maxfiles + 1' logfiles because the logger
+        adds a new one after purging.
     `window_icon`: string
         Path of the window icon. Use this if you want to replace the default
         pygame icon.

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -89,8 +89,11 @@ Available configuration tokens
         Set the minimum log level to use.
     `log_name`: string
         Format string to use for the filename of log file.
-    `log_maxfiles`: int, greater 0
-        Keep log_maxfiles recent logfiles while purging the log directory.
+    `log_maxfiles`: int, greater or equal 0
+        Keep log_maxfiles recent logfiles while purging the log directory. Set
+        'log_maxfiles' to 0 to disable logfile purging (eg keep all logfiles).
+        Note: You end up with 'log_maxfiles + 1' logfiles because the logger adds
+        a new one after purging.
     `window_icon`: string
         Path of the window icon. Use this if you want to replace the default
         pygame icon.

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -59,7 +59,6 @@ import os
 import sys
 import kivy
 from kivy.compat import PY2
-from kivy.config import Config
 from random import randint
 from functools import partial
 
@@ -117,6 +116,7 @@ class FileHandler(logging.Handler):
         if randint(0, 20) != 0:
             return
 
+        from kivy.config import Config
         maxfiles = Config.getint('kivy', 'log_maxfiles')
 
         if maxfiles <= 0:
@@ -150,6 +150,7 @@ class FileHandler(logging.Handler):
 
     def _configure(self, *largs, **kwargs):
         from time import strftime
+        from kivy.config import Config
         log_dir = Config.get('kivy', 'log_dir')
         log_name = Config.get('kivy', 'log_name')
 
@@ -222,6 +223,7 @@ class FileHandler(logging.Handler):
         if FileHandler.fd is None:
             try:
                 self._configure()
+                from kivy.config import Config
                 Config.add_callback(self._configure, 'kivy', 'log_dir')
                 Config.add_callback(self._configure, 'kivy', 'log_name')
             except Exception:

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -119,7 +119,7 @@ class FileHandler(logging.Handler):
         from kivy.config import Config
         maxfiles = Config.getint('kivy', 'log_maxfiles')
 
-        if maxfiles <= 0:
+        if maxfiles < 0:
             return
 
         print('Purge log fired. Analysing...')
@@ -136,7 +136,7 @@ class FileHandler(logging.Handler):
             lst = sorted(lst, key=lambda x: x['ctime'])
 
             # get the oldest (keep last maxfiles)
-            lst = lst[:-maxfiles]
+            lst = lst[:-maxfiles] if maxfiles else lst
             print('Purge %d log files' % len(lst))
 
             # now, unlink every file in the list


### PR DESCRIPTION
The number of kept logfiles in FileHandler.purge_logs() is hardcoded to 100 (*maxfiles*). This pull request adds a new config setting *log_maxfiles* that is used instead of this hardcoded value. Default value is the previous value of 100. Bumped KIVY_CONFIG_VERSION up to 19.