### PR TITLE
Unload matching rules. references #5054

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -312,6 +312,7 @@ class BuilderBase(object):
             template invocation.
         '''
         # remove rules and templates
+        filename = resource_find(filename) or filename
         self.rules = [x for x in self.rules if x[1].ctx.filename != filename]
         self._clear_matchcache()
         templates = {}
@@ -320,7 +321,6 @@ class BuilderBase(object):
                 templates[x] = y
         self.templates = templates
 
-        filename = resource_find(filename) or filename
         if filename in self.files:
             self.files.remove(filename)
 


### PR DESCRIPTION
PR 5054 did not fix the unloading of rules. This PR moves the full expansion of the file name to the beginning of the function so that the resetting on the rules in line 315 (now 316) finds the proper match.