### PR TITLE
Fix get_pixel_format for py3

### DIFF
--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -464,4 +464,4 @@ cdef class Fbo(RenderContext):
         data = py_glReadPixels(wx, wy, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)
         self.release()
 
-        return [ord(i) if PY2 else i for i in raw_data]
+        return [ord(i) if PY2 else i for i in data]

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -71,6 +71,7 @@ include "../include/config.pxi"
 include "opcodes.pxi"
 
 from os import environ
+from kivy.compat import PY2
 from kivy.logger import Logger
 from kivy.weakmethod import WeakMethod
 from kivy.graphics.texture cimport Texture
@@ -464,4 +465,4 @@ cdef class Fbo(RenderContext):
         self.release()
         raw_data = str(data)
 
-        return [ord(i) for i in raw_data]
+        return [ord(i) if PY2 else i for i in raw_data]

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -463,6 +463,5 @@ cdef class Fbo(RenderContext):
         self.bind()
         data = py_glReadPixels(wx, wy, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)
         self.release()
-        raw_data = str(data)
 
         return [ord(i) if PY2 else i for i in raw_data]


### PR DESCRIPTION
closes #5072 

I haven't compiled it, because with my luck I'll cripple my environment in the process, but I've tried with the example from the issue and you can see that a part of cpdefed method raises an error. Put at the end of `on_touch_down`'s method this (with imports from `opengl.pyx` `glReadPixels`, and GL types):

    print([ord(i) for i in glReadPixels(touch.x, touch.y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)])

happilly throws an error, which for some reason is silenced within Cython code (_this could be damn bad issue!_).

    TypeError: ord() expected string of length 1, but int found

The fix is basically a check for python and ignoring `ord()` as the bytearray in py3 already consists of integers (therefore conversion isn't desired). Tested with:

    from kivy.compat import PY2
    print([ord(i) if PY2 else i for i in glReadPixels(
          touch.x, touch.y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)])
