### PR TITLE
doc: Mention pygame in installation dependencies

### DIFF
--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -28,6 +28,7 @@ Other optional libraries (mutually independent) are:
     * `OpenCV 2.0 <http://sourceforge.net/projects/opencvlibrary/>`_ -- Camera input.
     * `Pillow <https://python-pillow.github.io/>`_ -- Image and text display.
     * `PyEnchant <https://pythonhosted.org/pyenchant/>`_ -- Spelling correction.
+    * `Pygame <https://www.pygame.org/news>`_ -- Window display
 
 
 That said, **DON'T PANIC**!


### PR DESCRIPTION
Pygame is mostly required for window display in kivy.

Fixes https://github.com/kivy/kivy/issues/3910