### PR TITLE
Fix Recycleview.scroll_to method crash

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -898,10 +898,11 @@ class ScrollView(StencilView):
 
         # if _viewport is layout and has pending operation, reschedule
         if hasattr(self._viewport, 'do_layout'):
-            if self._viewport._trigger_layout.is_triggered:
-                Clock.schedule_once(
-                     lambda *dt: self.scroll_to(widget, padding, animate))
-                return
+            if hasattr(self._viewport._trigger_layout, 'is_triggered'):
++               if self._viewport._trigger_layout.is_triggered:
++                   Clock.schedule_once(
++                       lambda *dt: self.scroll_to(widget, padding, animate))
++                   return
 
         if isinstance(padding, (int, float)):
             padding = (padding, padding)


### PR DESCRIPTION
RecycleBoxLayout does not have a _trigger_layout.is_triggered attribute, this change adds a check before scheduling