### PR TITLE
Fix TextInput crash when text, focus is set and enter pressed at same time

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -671,7 +671,7 @@ class TextInput(FocusBehavior, Widget):
         '''Insert new text at the current cursor position. Override this
         function in order to pre-process text for input validation.
         '''
-        if self.readonly or not substring:
+        if self.readonly or not substring or not self._lines:
             return
 
         if isinstance(substring, bytes):


### PR DESCRIPTION
Hello, i've been making and using a lot of hotkeys lately and managed to crash it with an "Enter" select button.
Here are scripts for a testapp https://gist.github.com/Bakterija/b2feec023e4e047cb53e4708fda6ddc3.
Here is a traceback https://gist.github.com/Bakterija/80cf9dcd92423288dc3206d62b9b4430.

This happens only when text is set to an empty string.

Further lines in the function require the line list to have something in it, my change makes it check if line list is empty before attempting to add text.