### PR TITLE
Add textedit event for text editing by IME

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -412,6 +412,9 @@ cdef class _WindowSDL2Storage:
         elif event.type == SDL_TEXTINPUT:
             s = event.text.text.decode('utf-8')
             return ('textinput', s)
+        elif event.type == SDL_TEXTEDITING:
+            s = event.edit.text.decode('utf-8')
+            return ('textedit', s)
         else:
             #    print('receive unknown sdl event', event.type)
             pass


### PR DESCRIPTION
Added code to return _windowSDL2Storage.poll () 'textedit' event to notify the text being edited when typing in IME.

In this code, It's get to editted text from the parameter of SDL_TextEditingEvent.
https://wiki.libsdl.org/Tutorials/TextInput

The objective is to make a basis for displaying text being edited in IME with Textinput (or its subclass).
(Improve the situation like #434 and #735)

*Sample code that dispatches textedit on WindowSDL
https://github.com/Adachinski/kivy/tree/textedit_patch_smple

*Sample code to display the text being edited on the label
https://github.com/Adachinski/kivy_textedit_sample