### PR TITLE
Fix issue when using multiple RecycleViews with different view classes.

### DIFF
--- a/kivy/uix/recycleview/views.py
+++ b/kivy/uix/recycleview/views.py
@@ -139,10 +139,12 @@ class RecycleDataAdapter(EventDispatcher):
     with this instance.
     '''
 
-    # internals
-    views = {}  # current displayed items
-    # items whose attrs, except for pos/size is still accurate
-    dirty_views = defaultdict(dict)
+    def __init__(self):
+        super(RecycleDataAdapter, self).__init__()
+        # internals
+        self.views = {}  # current displayed items
+        # items whose attrs, except for pos/size is still accurate
+        self.dirty_views = defaultdict(dict)
 
     _sizing_attrs = {
         'size', 'width', 'height', 'size_hint', 'size_hint_x', 'size_hint_y',


### PR DESCRIPTION
This change fixes an issue where a class variable was being used across multiple instances of RecycleDataAdapter. This meant that stale data was being used on the first update of the next RecycleView to be created.