### PR TITLE
Fix py3 dict_keys in LoadIdentity getter

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -21,6 +21,7 @@ __all__ = ('Color', 'BindTexture', 'PushMatrix', 'PopMatrix',
            'Rotate', 'Scale', 'Translate', 'MatrixInstruction',
            'gl_init_resources')
 
+from kivy.compat import PY2
 from kivy.graphics.instructions cimport *
 from kivy.graphics.transformation cimport *
 
@@ -405,7 +406,10 @@ cdef class LoadIdentity(ContextInstruction):
         'projection_mat'.
         '''
         def __get__(self):
-            return list(self.context_state.keys())[0]
+            if PY2:
+                return self.context_state.keys()[0]
+            else:
+                return list(self.context_state.keys())[0]
         def __set__(self, value):
             self.context_state = {value: Matrix()}
 

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -405,7 +405,7 @@ cdef class LoadIdentity(ContextInstruction):
         'projection_mat'.
         '''
         def __get__(self):
-            return self.context_state.keys()[0]
+            return list(self.context_state.keys())[0]
         def __set__(self, value):
             self.context_state = {value: Matrix()}
 

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -100,7 +100,7 @@ include "opcodes.pxi"
 include "gl_debug_logger.pxi"
 
 from kivy.graphics.cgl cimport *
-
+from kivy.compat import PY2
 from kivy.graphics.instructions cimport Instruction
 
 cdef int _stencil_level = 0
@@ -214,7 +214,10 @@ cdef class StencilUse(Instruction):
 
         def __get__(self):
             index = _gl_stencil_op.values().index(self._op)
-            return _gl_stencil_op.keys()[index]
+            if PY2:
+                return _gl_stencil_op.keys()[index]
+            else:
+                return list(_gl_stencil_op.keys())[index]
 
         def __set__(self, x):
             cdef int op = _stencil_op_to_gl(x)

--- a/kivy/input/providers/leapfinger.py
+++ b/kivy/input/providers/leapfinger.py
@@ -98,7 +98,7 @@ class LeapFingerEventProvider(MotionEventProvider):
                     touch = touches[uid]
                     touch.move(args)
                     events.append(('update', touch))
-        for key in touches.keys()[:]:
+        for key in list(touches.keys())[:]:
             if key not in available_uid:
                 events.append(('end', touches[key]))
                 del touches[key]

--- a/kivy/storage/dictstore.py
+++ b/kivy/storage/dictstore.py
@@ -86,4 +86,4 @@ class DictStore(AbstractStore):
         return len(self._data)
 
     def store_keys(self):
-        return self._data.keys()
+        return list(self._data.keys())


### PR DESCRIPTION
For reference see https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects, this will clearly break on Py3 and will work correctly on Py2, thus converting the keys() to list first, then indexing.