### PR TITLE
Fix listing modules

### DIFF
--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -153,7 +153,9 @@ class ModuleBase:
                 module = sys.modules[name]
             except ImportError:
                 Logger.exception('Modules: unable to import <%s>' % name)
-                raise
+                # protect against missing module dependency crash
+                self.mods[name]['module'] = None
+                return
         # basic check on module
         if not hasattr(module, 'start'):
             Logger.warning('Modules: Module <%s> missing start() function' %

--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -267,10 +267,9 @@ class ModuleBase:
             self.mods[name]['module'].configure(config)
 
     def usage_list(self):
-        print()
         print('Available modules')
         print('=================')
-        for module in self.list():
+        for module in sorted(self.list()):
             if 'module' not in self.mods[module]:
                 self.import_module(module)
 
@@ -279,8 +278,15 @@ class ModuleBase:
                 continue
 
             text = self.mods[module]['module'].__doc__.strip("\n ")
+            text = text.split('\n')
+            # make sure we don't get IndexError along the way
+            # then pretty format the header
+            if len(text) > 2:
+                if text[1].startswith('='):
+                    # '\n%-12s: %s' -> 12 spaces + ": "
+                    text[1] = '=' * (14 + len(text[1]))
+            text = '\n'.join(text)
             print('\n%-12s: %s' % (module, text))
-        print()
 
 
 Modules = ModuleBase()

--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -271,8 +271,13 @@ class ModuleBase:
         for module in self.list():
             if 'module' not in self.mods[module]:
                 self.import_module(module)
+
+            # ignore modules without docstring
+            if not self.mods[module]['module'].__doc__:
+                continue
+
             text = self.mods[module]['module'].__doc__.strip("\n ")
-            print('%-12s: %s' % (module, text))
+            print('\n%-12s: %s' % (module, text))
         print()
 
 


### PR DESCRIPTION
The `self.mods[name]['module'] = None` instead of `raise` protects the part when a user wants to list all modules via `python file.py -m list` which now in master just throws an error and it's rather harmless fix because when running with:

    from kivy.app import runTouchApp
    from kivy.config import Config
    Config.set('modules', 'webdebugger', '')
    runTouchApp()

without Flask, it crashes almost the same way and it's probably better explained with `None` and `AttributeError` rather than with a `KeyError`. Also there are some changes such as making the output consistent(sorted), ignoring files without docstrings (`__doc__`) and some visual fixes. Now, when `python file.py -m list` is used, the docs part is printed and _then_ the user is notified with an ImportError warning from the logger.

```
touchring   : Touchring
=======================
```
vs
```
touchring   : Touchring
=========
```


```
[ERROR  ] [WebDebugger ] unable to import Flask. Install it!
[ERROR  ] [WebDebugger ] unable to import Flask. Install it!
[ERROR  ] [Modules     ] unable to import <webdebugger>
Traceback (most recent call last):
  File "kivy\modules\__init__.py", line 148, in import_module
    module = __import__(name=modname)
  File "kivy\modules\webdebugger.py", line 28, in <module>
    from kivy.modules._webdebugger import start, stop
  File "kivy\modules\_webdebugger.py", line 12, in <module>
    from flask import Flask, render_template_string, make_response
ImportError: No module named 'flask'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "kivy\modules\__init__.py", line 152, in import_module
    module = __import__(name=name)
  File "kivy\modules\webdebugger.py", line 28, in <module>
    from kivy.modules._webdebugger import start, stop
  File "kivy\modules\_webdebugger.py", line 12, in <module>
    from flask import Flask, render_template_string, make_response
ImportError: No module named 'flask'
 Traceback (most recent call last):
   File "kivy\modules\__init__.py", line 225, in update
     self.activate_module(name, win)
   File "kivy\modules\__init__.py", line 188, in activate_module
     pymod.start(win, context)
 AttributeError: 'NoneType' object has no attribute 'start'
[CRITICAL] [Window      ] Unable to find any valuable Window provider.
sdl2 - AttributeError: 'NoneType' object has no attribute 'start'
  File "kivy\core\__init__.py", line 67, in core_select_lib
    cls = cls()
  File "kivy\core\window\window_sdl2.py", line 143, in __init__
    super(WindowSDL, self).__init__()
  File "kivy\core\window\__init__.py", line 904, in __init__
    Modules.register_window(self)
  File "kivy\modules\__init__.py", line 208, in register_window
    self.update()
  File "kivy\modules\__init__.py", line 225, in update
    self.activate_module(name, win)
  File "kivy\modules\__init__.py", line 188, in activate_module
    pymod.start(win, context)

[INFO   ] [Text        ] Provider: sdl2
[INFO   ] [Base        ] Start application main loop
[ERROR  ] [Base        ] No event listeners have been created
[ERROR  ] [Base        ] Application will leave
```

instead of:

```[ERROR  ] [WebDebugger ] unable to import Flask. Install it!
[ERROR  ] [WebDebugger ] unable to import Flask. Install it!
[ERROR  ] [Modules     ] unable to import <webdebugger>
Traceback (most recent call last):
  File "kivy\modules\__init__.py", line 148, in import_module
    module = __import__(name=modname)
  File "kivy\modules\webdebugger.py", line 28, in <module>
    from kivy.modules._webdebugger import start, stop
  File "kivy\modules\_webdebugger.py", line 12, in <module>
    from flask import Flask, render_template_string, make_response
ImportError: No module named 'flask'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "kivy\modules\__init__.py", line 152, in import_module
    module = __import__(name=name)
  File "kivy\modules\webdebugger.py", line 28, in <module>
    from kivy.modules._webdebugger import start, stop
  File "kivy\modules\_webdebugger.py", line 12, in <module>
    from flask import Flask, render_template_string, make_response
ImportError: No module named 'flask'
 Traceback (most recent call last):
   File "kivy\modules\__init__.py", line 226, in update
     self.activate_module(name, win)
   File "kivy\modules\__init__.py", line 183, in activate_module
     pymod = mod['module']
 KeyError: 'module'
[CRITICAL] [Window      ] Unable to find any valuable Window provider.
sdl2 - KeyError: 'module'
  File "kivy\core\__init__.py", line 67, in core_select_lib
    cls = cls()
  File "kivy\core\window\window_sdl2.py", line 143, in __init__
    super(WindowSDL, self).__init__()
  File "kivy\core\window\__init__.py", line 904, in __init__
    Modules.register_window(self)
  File "kivy\modules\__init__.py", line 209, in register_window
    self.update()
  File "kivy\modules\__init__.py", line 226, in update
    self.activate_module(name, win)
  File "kivy\modules\__init__.py", line 183, in activate_module
    pymod = mod['module']

[INFO   ] [Text        ] Provider: sdl2
[INFO   ] [Base        ] Start application main loop
[ERROR  ] [Base        ] No event listeners have been created
[ERROR  ] [Base        ] Application will leave
```