### PR TITLE
Fixed crash on python3, due to items not being subscriptable

### DIFF
--- a/kivy/core/clipboard/clipboard_pygame.py
+++ b/kivy/core/clipboard/clipboard_pygame.py
@@ -47,10 +47,11 @@ class ClipboardPygame(ClipboardBase):
         if not self._types:
             self.init()
             types = pygame.scrap.get_types()
-            for mime, pygtype in self._aliases.items()[:]:
+            for mime, pygtype in list(self._aliases.items())[:]:
                 if mime in types:
                     del self._aliases[mime]
                 if pygtype in types:
                     types.append(mime)
             self._types = types
         return self._types
+


### PR DESCRIPTION
I found a crash on Kivy with Python3 when attempting to paste into a TextField. This change seems to fix the problem.

Thanks

Jack