### PR TITLE
Fix KV include for quoted paths

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -422,6 +422,10 @@ class Parser(object):
                     ref = ref[6:].strip()
                     force_load = True
 
+                # if #:include [force] "path with quotes around"
+                if ref.startswith('"') or ref.startswith("'"):
+                    ref = ref.strip("'").strip('"')
+
                 if ref[-3:] != '.kv':
                     Logger.warn('Lang: {0} does not have a valid Kivy'
                                 'Language extension (.kv)'.format(ref))

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -423,7 +423,7 @@ class Parser(object):
                     force_load = True
 
                 # if #:include [force] "path with quotes around"
-                if ref.startswith('"') or ref.startswith("'"):
+                if ref[0] == ref[-1] and ref[0] in ('"', "'"):
                     ref = ref.strip("'").strip('"')
 
                 if ref[-3:] != '.kv':

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -424,7 +424,7 @@ class Parser(object):
 
                 # if #:include [force] "path with quotes around"
                 if ref[0] == ref[-1] and ref[0] in ('"', "'"):
-                    ref = ref.strip("'").strip('"')
+                    ref = ref[1:-1]
 
                 if ref[-3:] != '.kv':
                     Logger.warn('Lang: {0} does not have a valid Kivy'

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -424,7 +424,8 @@ class Parser(object):
 
                 # if #:include [force] "path with quotes around"
                 if ref[0] == ref[-1] and ref[0] in ('"', "'"):
-                    ref = ref[1:-1]
+                    c = ref[:3].count(ref[0])
+                    ref = ref[c:-c]
 
                 if ref[-3:] != '.kv':
                     Logger.warn('Lang: {0} does not have a valid Kivy'

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -425,7 +425,7 @@ class Parser(object):
                 # if #:include [force] "path with quotes around"
                 if ref[0] == ref[-1] and ref[0] in ('"', "'"):
                     c = ref[:3].count(ref[0])
-                    ref = ref[c:-c]
+                    ref = ref[c:-c] if c != 2 else ref
 
                 if ref[-3:] != '.kv':
                     Logger.warn('Lang: {0} does not have a valid Kivy'


### PR DESCRIPTION
This should be a nice change. Generally, it works even _without_ this patch if a user leaves out the quotes, but it basically looks like this:

    #:include [force] C:\\my path
    ------------------------^ wat? works because of eval, but otherwise makes no sense

It's rather expected from a user to think that "yay, it uses some arg parser, I'll quote it just to be safe"

    #:include [force] "C:\\my path"
    ------------------^-----------^ well, nope

On Windows you can't have a file with quotes in it, on Mac I think it's forbidden too, but GNU/Linux distros can do "fancy" stuff even without it, so... I have 3 alternatives:

* let's play on lisp -> a single quote on ref[0] is enough to trigger stripping everything
* check if it ends with the same quotes and then strip the quotes anyway
* check for ref[0] and ref[-1], then return ref[1:-1] (strip 2 chars)
<br>

    1 #:include [force] "C:\\my path
    2 #:include [force] """"C:\\my path""""""
    3 #:include [force] "C:\\my path" # no multiple quotes allowed
