### PR TITLE
Fix unicode image source in Python 2

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -253,7 +253,7 @@ class Image(Widget):
             if self._coreimage is not None:
                 self._coreimage.unbind(on_texture=self._on_tex_change)
             try:
-                if PY2:
+                if PY2 and isinstance(filename, str):
                     filename = filename.decode('utf-8')
                 self._coreimage = ci = CoreImage(filename, mipmap=mipmap,
                                                  anim_delay=self.anim_delay,


### PR DESCRIPTION
If someone is using unicode paths in their code, resource_find(self.source) will return an unicode string which would then be wrongly decoded in line 256, causing an exception which will prevent loading the file.