### PR TITLE
Fix Windows clipboard when pasting a file

### DIFF
--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -27,9 +27,13 @@ class ClipboardWindows(ClipboardBase):
         GetClipboardData.restype = wintypes.HANDLE
 
         user32.OpenClipboard(user32.GetActiveWindow())
-        # 1 is CF_TEXT
+        # Standard Clipboard Format "1" is "CF_TEXT"
         pcontents = GetClipboardData(13)
+
+        # if someone pastes a FILE, the content is None for SCF 13
+        # and the clipboard is locked if not closed properly
         if not pcontents:
+            user32.CloseClipboard()
             return ''
         data = c_wchar_p(pcontents).value.encode(self._encoding)
         user32.CloseClipboard()


### PR DESCRIPTION
Always close the clipboard correctly or it'll lock itself until the window(or handle I guess?) dies.

Also, some [docs](https://msdn.microsoft.com/en-us/library/windows/desktop/ms649039(v=vs.85).aspx) trivia about the clipboard:

>The clipboard controls the handle that the GetClipboardData function returns, not the application. The application should copy the data immediately. The application must not free the handle nor leave it locked. The application must not use the handle after the EmptyClipboard or CloseClipboard function is called, or after the SetClipboardData function is called with the same clipboard format. 

If someone feels adventurous, the way for fetching a non-text data for Windows is mentioned at [Standard Clipboard Formats](https://msdn.microsoft.com/en-us/library/windows/desktop/ff729168(v=vs.85).aspx) docs page.