### PR TITLE
Fix touch passing down when overlapping

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1334,22 +1334,22 @@ class TextInput(FocusBehavior, Widget):
             if scroll_type == 'down':
                 if self.multiline:
                     if self.scroll_y <= 0:
-                        return
+                        return True
                     self.scroll_y -= self.line_height
                 else:
                     if self.scroll_x <= 0:
-                        return
+                        return True
                     self.scroll_x -= self.line_height
             if scroll_type == 'up':
                 if self.multiline:
                     if (self._lines_rects[-1].pos[1] > self.y +
                             self.line_height):
-                        return
+                        return True
                     self.scroll_y += self.line_height
                 else:
                     if (self.scroll_x + self.width >=
                             self._lines_rects[-1].texture.size[0]):
-                        return
+                        return True
                     self.scroll_x += self.line_height
 
         touch.grab(self)
@@ -1376,9 +1376,6 @@ class TextInput(FocusBehavior, Widget):
         if CutBuffer and 'button' in touch.profile and \
                 touch.button == 'middle':
             self.insert_text(CutBuffer.get_cutbuffer())
-            return True
-
-        if self.readonly:
             return True
 
         return True

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1378,6 +1378,9 @@ class TextInput(FocusBehavior, Widget):
             self.insert_text(CutBuffer.get_cutbuffer())
             return True
 
+        if self.readonly:
+            return True
+
         return False
 
     def on_touch_move(self, touch):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1381,7 +1381,7 @@ class TextInput(FocusBehavior, Widget):
         if self.readonly:
             return True
 
-        return False
+        return True
 
     def on_touch_move(self, touch):
         if touch.grab_current is not self:


### PR DESCRIPTION
Needs a testing probably because of #940 however I think it should be ok because the android keyboard is handled with a separate IF for `readonly`, therefore this `return True` shouldn't affect it.

Fixes #5092. `TextInput` in the current state makes the touch pass down to another widget which if it's also a `TextInput`, then the touch will be present in both therefore e.g. scrolling, focusing and other touch stuff handled by `on_touch_down` will be dispatched in each of the overlapping widgets. We basically *need* to `return True` but I'm not sure if it's the right place. It works correctly on desktop though.

```
from kivy.app import runTouchApp
from kivy.lang import Builder
runTouchApp(Builder.load_string('''
<TI@TextInput>:
    text: '1234567890\\n2\\n3\\n4\\n'*20
FloatLayout:
    TI:
        size_hint: 0.2, 0.3
    TI:
        pos: 40, 50
        size_hint: 0.2, 0.3
    TI:
        pos: 290, 0
        size_hint: 0.2, 0.3
        readonly: True
    TI:
        pos: 340, 50
        size_hint: 0.2, 0.3
    TI:
        pos: 0, 300
        size_hint: 0.2, 0.3
        readonly: True
    TI:
        pos: 40, 350
        size_hint: 0.2, 0.3
        readonly: True
    TI:
        pos: 290, 300
        size_hint: 0.2, 0.3
        text: 'one two ' * 10
        multiline: False
    TI:
        pos: 340, 350
        size_hint: 0.2, 0.3
    TI:
        pos: 590, 0
        size_hint: 0.2, 0.3
        text: 'one two ' * 10
        disabled: True
    TI:
        pos: 640, 50
        size_hint: 0.2, 0.3
        disabled: True
        readonly: True
    TI:
        pos: 590, 300
        size_hint: 0.2, 0.3
        text: 'one two ' * 10
        disabled: True
        multiline: False
    TI:
        pos: 640, 350
        size_hint: 0.2, 0.3
'''))
```