### PR TITLE
Add on_load to AsyncImage

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -359,9 +359,6 @@ class AsyncImage(Image):
                 nocache=self.nocache, mipmap=self.mipmap,
                 anim_delay=self.anim_delay)
 
-            # 1st _on_source_load, then on_load
-            # (executing is reversed)
-            image.bind(on_load=self.on_load)
             image.bind(on_load=self._on_source_load)
             image.bind(on_error=self._on_source_error)
             image.bind(on_texture=self._on_tex_change)
@@ -372,6 +369,7 @@ class AsyncImage(Image):
         if not image:
             return
         self.texture = image.texture
+        self.dispatch('on_load')
 
     def _on_source_error(self, instance, error=None):
         self.dispatch('on_error', error)

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -332,7 +332,7 @@ class AsyncImage(Image):
         on how to handle events around asynchronous image loading.
     '''
 
-    __events__ = ('on_error', 'on_complete')
+    __events__ = ('on_error', 'on_load')
 
     def __init__(self, **kwargs):
         self._coreimage = None
@@ -359,6 +359,9 @@ class AsyncImage(Image):
                 nocache=self.nocache, mipmap=self.mipmap,
                 anim_delay=self.anim_delay)
 
+            # 1st _on_source_load, then on_load
+            # (executing is reversed)
+            image.bind(on_load=self.on_load)
             image.bind(on_load=self._on_source_load)
             image.bind(on_error=self._on_source_error)
             image.bind(on_texture=self._on_tex_change)
@@ -369,7 +372,6 @@ class AsyncImage(Image):
         if not image:
             return
         self.texture = image.texture
-        self.dispatch('on_complete')
 
     def _on_source_error(self, instance, error=None):
         self.dispatch('on_error', error)
@@ -377,7 +379,7 @@ class AsyncImage(Image):
     def on_error(self, error):
         pass
 
-    def on_complete(self):
+    def on_load(self, *args):
         pass
 
     def is_uri(self, filename):

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -332,7 +332,7 @@ class AsyncImage(Image):
         on how to handle events around asynchronous image loading.
     '''
 
-    __events__ = ('on_error', )
+    __events__ = ('on_error', 'on_complete')
 
     def __init__(self, **kwargs):
         self._coreimage = None
@@ -369,11 +369,15 @@ class AsyncImage(Image):
         if not image:
             return
         self.texture = image.texture
+        self.dispatch('on_complete')
 
     def _on_source_error(self, instance, error=None):
         self.dispatch('on_error', error)
 
     def on_error(self, error):
+        pass
+
+    def on_complete(self):
         pass
 
     def is_uri(self, filename):


### PR DESCRIPTION
When we bind to `texture` or `texture_size` it's still a bad workaround for the action when an image is downloaded and the texture updated because:

* texture is updated anyway *during* the downloading (the circle gif)
* texture_size might be the same

this event makes it clear when the image is ready for use.