### PR TITLE
Fix image size and comment handling in RST

### DIFF
--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -975,17 +975,38 @@ class _Visitor(nodes.NodeVisitor):
             assert(self.text == '')
 
         elif cls is nodes.image:
+            # docutils parser breaks path with spaces
+            # e.g. "C:/my path" -> "C:/mypath"
             uri = node['uri']
+            align = node.get('align', 'center')
+            image_size=[
+                node.get('width'),
+                node.get('height')
+            ]
+
+            # use user's size if defined
+            def set_size(img, size):
+                img.size = [
+                    size[0] or img.width,
+                    size[1] or img.height
+                ]
+
             if uri.startswith('/') and self.root.document_root:
                 uri = join(self.root.document_root, uri[1:])
+
             if uri.startswith('http://') or uri.startswith('https://'):
                 image = RstAsyncImage(source=uri)
+                image.bind(on_load=lambda *a: set_size(image, image_size))
             else:
                 image = RstImage(source=uri)
+                set_size(image, image_size)
 
-            align = node.get('align', 'center')
-            root = AnchorLayout(size_hint_y=None, anchor_x=align,
-                                height=image.height)
+            root = AnchorLayout(
+                size_hint_y=None,
+                anchor_x=align,
+                height=image.height
+            )
+
             image.bind(height=root.setter('height'))
             root.add_widget(image)
             self.current.add_widget(root)

--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -851,8 +851,15 @@ class _Visitor(nodes.NodeVisitor):
 
     def dispatch_visit(self, node):
         cls = node.__class__
+        # cls contains the sane selector, but then the node
+        # is opened and if it contains e.g. a comment or ref,
+        # it has a specific tagname that we need to check for
+        # when we handle the plain text with nodes.Text
         if cls is nodes.document:
             self.push(self.root.content)
+
+        elif cls is nodes.comment:
+            return
 
         elif cls is nodes.section:
             self.section += 1
@@ -879,6 +886,9 @@ class _Visitor(nodes.NodeVisitor):
                     return
                 elif node.parent.tagname == 'substitution_reference':
                     # |ref|
+                    return
+                elif node.parent.tagname == 'comment':
+                    # .. COMMENT
                     return
 
             if self.do_strip_text:

--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -851,10 +851,6 @@ class _Visitor(nodes.NodeVisitor):
 
     def dispatch_visit(self, node):
         cls = node.__class__
-        # cls contains the sane selector, but then the node
-        # is opened and if it contains e.g. a comment or ref,
-        # it has a specific tagname that we need to check for
-        # when we handle the plain text with nodes.Text
         if cls is nodes.document:
             self.push(self.root.content)
 

--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -975,7 +975,7 @@ class _Visitor(nodes.NodeVisitor):
             # e.g. "C:/my path" -> "C:/mypath"
             uri = node['uri']
             align = node.get('align', 'center')
-            image_size=[
+            image_size = [
                 node.get('width'),
                 node.get('height')
             ]


### PR DESCRIPTION
- [x] comments
- [x] image sizing
<s>
- [ ] footnotes (classic, autonum, autosym)
- [ ] citations
- [ ] option lists
- [ ] line blocks</s>

Sticking those together isn't a good idea. A lot of stuff is happening just for the footnotes. The remaining things will be in separate PRs when I finish it.