### PR TITLE
Added `abs_tol` argument to isclose call to ensure no float edge cases

### DIFF
--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -224,7 +224,7 @@ class Layout(Widget):
         # magically equals the amount of the widgets that were made larger
         # so we're all good
         margin = oversize_amt - undersize_amt
-        if isclose(oversize_amt, undersize_amt):
+        if isclose(oversize_amt, undersize_amt, abs_tol=1e-15):
             return
 
         # we need to redistribute the margin among all widgets


### PR DESCRIPTION
Without setting the argument `abs_tol`, `isclose()` will return `False` for two numbers such as `1e-20` and `2e-20`. However, it is assumed at line 236 with the if/elif that `abs(margin)` is greater than `1e-15`. This means that if `oversize_amt` and `undersize_amt` have values such as `1e-20` and `2e-20`, then the `isclose()` will be `False`, and then neither of the the if/elif conditions will be true, and `contrib_amt` goes undefined resulting in the error
```
UnboundLocalError: local variable 'contrib_amt' referenced before assignment
```

and kivy crashes. Thus I added `abs_tol=1e-15` to ensure that if `abs(margin) <= 1e-15` kivy will not crash (which was in fact happening in my app).