### PR TITLE
Add support for footnotes to RST

### DIFF
--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -840,7 +840,6 @@ class _ToctreeVisitor(nodes.NodeVisitor):
             self.push(section)
         elif cls is nodes.title:
             self.text = ''
-
         elif cls is nodes.Text:
             self.text += node
 
@@ -868,6 +867,8 @@ class _Visitor(nodes.NodeVisitor):
 
         # store refblock here while building
         self.foot_refblock = None
+
+        # store order for autonum/sym footnotes+refs
         self.footnotes = {
             'autonum': 0,
             'autosym': 0,
@@ -948,10 +949,6 @@ class _Visitor(nodes.NodeVisitor):
 
     def dispatch_visit(self, node):
         cls = node.__class__
-        # cls contains the sane selector, but then the node
-        # is opened and if it contains e.g. a comment or ref,
-        # it has a specific tagname that we need to check for
-        # when we handle the plain text with nodes.Text
         if cls is nodes.document:
             self.push(self.root.content)
             self.brute_refs(node)
@@ -1094,15 +1091,6 @@ class _Visitor(nodes.NodeVisitor):
             )
             self.text += text
             self.text_have_anchor = True
-#            self.set_text(self.current, 'link')
-#            self.root.add_anchors(self.current)
-
-        elif cls is nodes.citation_reference:
-            return
-            raise NotImplementedError()
-            table = RstTable(cols=0)
-            self.current.add_widget(table)
-            self.push(table)
 
         elif cls is nodes.title:
             label = RstTitle(section=self.section, document=self.root)
@@ -1352,7 +1340,6 @@ class _Visitor(nodes.NodeVisitor):
 
         elif cls is nodes.paragraph:
             self.do_strip_text = False
-
             assert(isinstance(self.current, RstParagraph))
             self.set_text(self.current, 'paragraph')
             self.pop()
@@ -1430,7 +1417,6 @@ class _Visitor(nodes.NodeVisitor):
         elif cls is nodes.footnote:
             self.pop()
             self.set_text(self.current, 'link')
-            return
 
         elif cls is nodes.footnote_reference:
             # close opened footnote [x]

--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -318,7 +318,7 @@ Builder.load_string('''
     size_hint: 0.2, 1
     color: (0, 0, 0, 1)
     bold: True
-    text_size: self.width-10, self.height - 10
+    text_size: self.width - 10, self.height - 10
     valign: 'top'
     font_size: sp(self.document.base_font_size / 2.0)
 
@@ -326,6 +326,21 @@ Builder.load_string('''
     cols: 1
     size_hint_y: None
     height: self.minimum_height
+
+<RstFootnote>:
+    cols: 2
+    size_hint_y: None
+    height: self.minimum_height
+
+<RstFootName>:
+    markup: True
+    valign: 'top'
+    size_hint: 0.2, 1
+    color: (0, 0, 0, 1)
+    bold: True
+    text_size: self.width - 10, self.height - 10
+    valign: 'top'
+    font_size: sp(self.document.base_font_size / 2.0)
 
 <RstTable>:
     size_hint_y: None
@@ -761,6 +776,15 @@ class RstFieldBody(GridLayout):
     pass
 
 
+class RstFootnote(GridLayout):
+    pass
+
+
+class RstFootName(Label):
+
+    document = ObjectProperty(None)
+
+
 class RstGridLayout(GridLayout):
     pass
 
@@ -816,6 +840,7 @@ class _ToctreeVisitor(nodes.NodeVisitor):
             self.push(section)
         elif cls is nodes.title:
             self.text = ''
+
         elif cls is nodes.Text:
             self.text += node
 
@@ -840,6 +865,30 @@ class _Visitor(nodes.NodeVisitor):
         self.section = 0
         self.do_strip_text = False
         self.substitution = {}
+
+        # store refblock here while building
+        self.foot_refblock = None
+        self.footnotes = {
+            'autonum': 0,
+            'autosym': 0,
+            'autonum_ref': 0,
+            'autosym_ref': 0,
+        }
+
+        # last four default chars aren't in our Roboto font,
+        # those were replaced with something else
+        self.footlist = [
+            '\u002A',  # asterisk
+            '\u2020',  # dagger
+            '\u2021',  # doubledagger
+            '\u00A7',  # section
+            '\u00B6',  # pilcrow
+            '\u0023',  # number
+            '\u2206',  # cap delta
+            '\u220F',  # cap pi
+            '\u0470',  # cap psi
+            '\u0466',  # cap yus
+        ]
         nodes.NodeVisitor.__init__(self, *largs)
 
     def push(self, widget):
@@ -849,10 +898,63 @@ class _Visitor(nodes.NodeVisitor):
     def pop(self):
         self.current = self.current_list.pop()
 
+    def brute_refs(self, node):
+        # get foot/cit refs manually because the output from
+        # docutils' parser doesn't contain any of these:
+        # node's refid, refname, backref, ...  and/or are just ''/[]
+
+        def get_refs(condition, backref=False):
+            # backref=True is used in nodes.footnote
+            autonum = autosym = 0
+            _nodes = node.traverse(condition=condition, ascend=False)
+
+            for f in _nodes:
+                id = f['ids'][0]
+                auto = ''
+                if 'auto' in f:
+                    auto = f['auto']
+
+                # auto is either 1(int) or '*'
+                if auto == 1:
+                    autonum += 1
+                    key = 'backref' + str(autonum) if backref else str(autonum)
+                    self.root.refs_assoc[key] = id
+                elif auto == '*':
+                    sym = self.footlist[
+                        autosym % 10
+                    ] * (int(autosym / 10) + 1)
+                    key = 'backref' + sym if backref else sym
+                    self.root.refs_assoc[key] = id
+                    autosym += 1
+                else:
+                    if not backref:
+                        key = f['names'][0]
+                        if key:
+                            self.root.refs_assoc[key] = id
+                        continue
+
+                    key = 'backref' + f['refname'][0]
+
+                    if key in self.root.refs_assoc:
+                        self.root.refs_assoc[key].append(id)
+                    else:
+                        self.root.refs_assoc[key] = [id, ]
+
+        # these are unique and need to go FIRST
+        get_refs(nodes.footnote, backref=False)
+
+        # autonum & autosym are unique
+        get_refs(nodes.footnote_reference, backref=True)
+
     def dispatch_visit(self, node):
         cls = node.__class__
+        # cls contains the sane selector, but then the node
+        # is opened and if it contains e.g. a comment or ref,
+        # it has a specific tagname that we need to check for
+        # when we handle the plain text with nodes.Text
         if cls is nodes.document:
             self.push(self.root.content)
+            self.brute_refs(node)
 
         elif cls is nodes.comment:
             return
@@ -866,7 +968,141 @@ class _Visitor(nodes.NodeVisitor):
 
         elif cls is nodes.substitution_reference:
             node = self.substitution[node.attributes['refname']]
-            self.text += node
+            # it can be e.g. image or something else too!
+            if isinstance(node, nodes.Text):
+                self.text += node
+
+        elif cls is nodes.footnote:
+            # .. [x] footnote
+            text = ''
+            foot = RstFootnote()
+            ids = node.attributes['ids']
+            self.current.add_widget(foot)
+            self.push(foot)
+
+            # check if its autonumbered
+            auto = ''
+            if 'auto' in node.attributes:
+                auto = node.attributes['auto']
+
+            # auto is either 1(int) or '*'
+            if auto == 1:
+                self.footnotes['autonum'] += 1
+                name = str(self.footnotes['autonum'])
+                node_id = node.attributes['ids'][0]
+            elif auto == '*':
+                autosym = self.footnotes['autosym']
+                name = self.footlist[
+                    autosym % 10
+                ] * (int(autosym / 10) + 1)
+                self.footnotes['autosym'] += 1
+                node_id = node.attributes['ids'][0]
+            else:
+                # can have multiple refs:
+                # [8] (1, 2) Footnote ref
+                name = node.attributes['names'][0]
+                node_id = node['ids'][0]
+
+            # we can have a footnote without any link or ref
+            # .. [1] Empty footnote
+            link = self.root.refs_assoc.get(name, '')
+
+            # handle no refs
+            ref = self.root.refs_assoc.get('backref' + name, '')
+
+            # colorize only with refs
+            colorized = self.colorize(name, 'link') if ref else name
+
+            # has no refs
+            if not ref:
+                text = '&bl;%s&br;' % (colorized)
+            # list of refs
+            elif ref and isinstance(ref, list):
+                ref_block = [
+                    '[ref=%s][u]%s[/u][/ref]' % (r, i + 1)
+                    for i, r in enumerate(ref)
+                ]
+                # [1] ( 1, 2, ...) Footnote
+                self.foot_refblock = ''.join([
+                    '[i]( ', ', '.join(ref_block), ' )[/i]'
+                ])
+
+                text = '[anchor=%s]&bl;%s&br;' % (
+                    node['ids'][0], colorized
+                )
+            # single ref
+            else:
+                text = '[anchor=%s][ref=%s]&bl;%s&br;[/ref]' % (
+                    node['ids'][0], ref, colorized
+                )
+
+            name = RstFootName(
+                document=self.root,
+                text=text,
+            )
+            self.current.add_widget(name)
+            # give it anchor + event manually
+            self.root.add_anchors(name)
+            name.bind(on_ref_press=self.root.on_ref_press)
+
+        elif cls is nodes.footnote_reference:
+            self.text += '&bl;'
+            text = ''
+            name = ''
+
+            # check if its autonumbered
+            auto = ''
+            if 'auto' in node.attributes:
+                auto = node.attributes['auto']
+
+            # auto is either 1(int) or '*'
+            if auto == 1:
+                self.footnotes['autonum_ref'] += 1
+                name = str(self.footnotes['autonum_ref'])
+                node_id = node.attributes['ids'][0]
+            elif auto == '*':
+                autosym = self.footnotes['autosym_ref']
+                name = self.footlist[
+                    autosym % 10
+                ] * (int(autosym / 10) + 1)
+                self.footnotes['autosym_ref'] += 1
+                node_id = node.attributes['ids'][0]
+            else:
+                # can have multiple refs:
+                # [8] (1, 2) Footnote ref
+                name = node.children[0]
+                node_id = node['ids'][0]
+            text += name
+
+            refs = self.root.refs_assoc.get(name, '')
+            if not refs and auto in (1, '*'):
+                # parser should trigger it when checking
+                # for backlinks, but we don't have **any** refs
+                # to work with, so we have to trigger it manually
+                raise Exception(
+                    'Too many autonumbered or autosymboled '
+                    'footnote references!'
+                )
+
+            # has a single or no refs ( '' )
+            text = '[anchor=%s][ref=%s][color=%s]%s' % (
+                node_id, refs,
+                self.root.colors.get(
+                    'link', self.root.colors.get('paragraph')
+                ),
+                text
+            )
+            self.text += text
+            self.text_have_anchor = True
+#            self.set_text(self.current, 'link')
+#            self.root.add_anchors(self.current)
+
+        elif cls is nodes.citation_reference:
+            return
+            raise NotImplementedError()
+            table = RstTable(cols=0)
+            self.current.add_widget(table)
+            self.push(table)
 
         elif cls is nodes.title:
             label = RstTitle(section=self.section, document=self.root)
@@ -886,6 +1122,12 @@ class _Visitor(nodes.NodeVisitor):
                 elif node.parent.tagname == 'comment':
                     # .. COMMENT
                     return
+                elif node.parent.tagname == 'footnote_reference':
+                    # .. [#]_
+                    # .. [*]_
+                    # rewrite it to handle autonum/sym here
+                    # close tags with departure
+                    return
 
             if self.do_strip_text:
                 node = node.replace('\n', ' ')
@@ -902,6 +1144,13 @@ class _Visitor(nodes.NodeVisitor):
 
         elif cls is nodes.paragraph:
             self.do_strip_text = True
+
+            if isinstance(node.parent, nodes.footnote):
+                if self.foot_refblock:
+                    self.text = self.foot_refblock + ' '
+                self.foot_refblock = None
+                # self.do_strip_text = False
+
             label = RstParagraph(document=self.root)
             if isinstance(self.current, RstEntry):
                 label.mx = 10
@@ -1006,6 +1255,10 @@ class _Visitor(nodes.NodeVisitor):
             image.bind(height=root.setter('height'))
             root.add_widget(image)
             self.current.add_widget(root)
+            # TODO:
+            # .. _img: <url>
+            # .. |img| image:: <img>
+            # |img|_ <- needs refs and on_ref_press
 
         elif cls is nodes.definition_list:
             lst = RstDefinitionList(document=self.root)
@@ -1099,6 +1352,7 @@ class _Visitor(nodes.NodeVisitor):
 
         elif cls is nodes.paragraph:
             self.do_strip_text = False
+
             assert(isinstance(self.current, RstParagraph))
             self.set_text(self.current, 'paragraph')
             self.pop()
@@ -1172,6 +1426,19 @@ class _Visitor(nodes.NodeVisitor):
 
         elif cls is nodes.reference:
             self.text += '[/color][/ref]'
+
+        elif cls is nodes.footnote:
+            self.pop()
+            self.set_text(self.current, 'link')
+            return
+
+        elif cls is nodes.footnote_reference:
+            # close opened footnote [x]
+            # self.text += '[/ref]'
+            # self.set_text(self.current, 'link')
+            self.text += '[/color][/ref]'
+            # self.text += '[/color][/ref]'
+            self.text += '&br;'
 
         elif cls is role_doc:
             docname = self.text[self.doc_index:]


### PR DESCRIPTION
Test with this and don't forget to click on both footnote numbers/symbols and on the ref numbers/symbols. It has to scroll between them properly.

```python
from kivy.app import App
from kivy.lang import Builder
class My(App):
    def build(self):
        self.string='''
Test title
==========

Footnote reference: [8]_

space

space

Footnote [#]_

space

space

autonumbered: [#]_

space

space

Footnote [*]_

space

space

autosymbol: [*]_

space

space

Text text text text text text text

text text text text text text text [8]_

space

space

.. [8] Footnote ref
.. [#] 1Footnote autonum
.. [#] 2Footnote autonum
.. [*] 1Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym
.. [*] 2Footnote autosym etc
'''
        return Builder.load_string('''
RstDocument:
    text: app.string
''')
My().run()
```

Also a note about the `brute_refs`: I tried to find something less shitty and with the parser directly, but all I got back was either an empty strng or an empty list, therefore you can deduce why such name. It basically does the same thing like a visitor, but we *need* to do it **before** we even use our Visitor class, so that we have the references and backreferences set up. If someone has a better idea, feel free to share. 😄 