### PR TITLE
Redeclare Svg.reload as throwing an exception.

### DIFF
--- a/kivy/graphics/svg.pxd
+++ b/kivy/graphics/svg.pxd
@@ -56,6 +56,7 @@ cdef class Svg(RenderContext):
     cdef Texture line_texture
     cdef StripMesh last_mesh
 
+    cdef void reload(self) except *
     cdef parse_tree(self, tree)
     cdef parse_element(seld, e)
     cdef list parse_transform(self, transform_def)


### PR DESCRIPTION
The .pxd file must match the .pyx file lest cimporters don't check for an exception.