### PR TITLE
Fix App.get_application_config() not being called in load_config()

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -691,15 +691,13 @@ class App(EventDispatcher):
             config = ConfigParser(name='app')
         self.config = config
         self.build_config(config)
-        # if no sections are created, that's mean the user don't have
-        # configuration.
-        if len(config.sections()) == 0:
-            return
         # ok, the user have some sections, read the default file if exist
         # or write it !
         filename = self.get_application_config()
-        if filename is None:
-            return config
+        if not filename:
+            if config.sections():
+                return config
+            return
         Logger.debug('App: Loading configuration <{0}>'.format(filename))
         if exists(filename):
             try:


### PR DESCRIPTION
Hello, i was testing [this](https://github.com/kivy/kivy/issues/5224) issue and noticed that the changed code lines were preventing get_application_config() from being called. It seems to me that the configuration file should be read always.