### PR TITLE
Clean hanging code

### DIFF
--- a/examples/demo/touchtracer/main.py
+++ b/examples/demo/touchtracer/main.py
@@ -41,7 +41,7 @@ def calculate_points(x1, y1, x2, y2, steps=5):
     dy = y2 - y1
     dist = sqrt(dx * dx + dy * dy)
     if dist < steps:
-        return None
+        return
     o = []
     m = dist / steps
     for i in range(1, int(m)):

--- a/examples/widgets/colorpicker.py
+++ b/examples/widgets/colorpicker.py
@@ -120,7 +120,7 @@ def calculate_points(x1, y1, x2, y2, steps=5):
     dy = y2 - y1
     dist = sqrt(dx * dx + dy * dy)
     if dist < steps:
-        return None
+        return
     o = []
     m = dist / steps
     for i in range(1, int(m)):

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -13,17 +13,6 @@ handlers.
 
 __all__ = ('EventDispatcher', 'ObjectWithUid', 'Observable')
 
-
-cdef extern from "Python.h":
-    ctypedef int (*visitproc)(PyObject *, void *)
-    ctypedef int (*inquiry)(PyObject *)
-    ctypedef int (*traverseproc)(PyObject *, visitproc, void *)
-    ctypedef struct PyTypeObject:
-        traverseproc tp_traverse
-        inquiry tp_clear
-    void Py_INCREF(PyObject *)
-    void Py_DECREF(PyObject *)
-
 from libc.stdlib cimport malloc, free
 from libc.string cimport memset
 

--- a/kivy/core/clipboard/__init__.py
+++ b/kivy/core/clipboard/__init__.py
@@ -31,7 +31,7 @@ class ClipboardBase(object):
         '''Get the current data in clipboard, using the mimetype if possible.
         You not use this method directly. Use :meth:`paste` instead.
         '''
-        return None
+        pass
 
     def put(self, data, mimetype):
         '''Put data on the clipboard, and attach a mimetype.

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -15,6 +15,10 @@ from kivy.base import stopTouchApp, EventLoop, ExceptionManager
 from kivy.utils import platform
 from os import environ
 
+# force include the file
+cdef extern from "window_x11_core.c":
+    pass
+
 cdef extern from "X11/Xutil.h":
     int KeyPress
     int KeyRelease

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -15,9 +15,6 @@ from kivy.base import stopTouchApp, EventLoop, ExceptionManager
 from kivy.utils import platform
 from os import environ
 
-cdef extern from "window_x11_core.c":
-    pass
-
 cdef extern from "X11/Xutil.h":
     int KeyPress
     int KeyRelease

--- a/kivy/input/factory.py
+++ b/kivy/input/factory.py
@@ -33,4 +33,3 @@ class MotionEventFactory:
         '''Get a provider class from the provider id'''
         if name in MotionEventFactory.__providers__:
             return MotionEventFactory.__providers__[name]
-        return None

--- a/kivy/input/postproc/doubletap.py
+++ b/kivy/input/postproc/doubletap.py
@@ -64,7 +64,6 @@ class InputPostprocDoubleTap(object):
                 continue
             touch.double_tap_distance = distance
             return touch
-        return None
 
     def process(self, events):
         if self.double_tap_distance == 0 or self.double_tap_time == 0:

--- a/kivy/input/postproc/tripletap.py
+++ b/kivy/input/postproc/tripletap.py
@@ -68,7 +68,6 @@ class InputPostprocTripleTap(object):
                 continue
             touch.triple_tap_distance = distance
             return touch
-        return None
 
     def process(self, events):
         if self.triple_tap_distance == 0 or self.triple_tap_time == 0:

--- a/kivy/input/providers/linuxwacom.py
+++ b/kivy/input/providers/linuxwacom.py
@@ -147,7 +147,7 @@ else:
             if not args:
                 Logger.error('LinuxWacom: No filename given in config')
                 Logger.error('LinuxWacom: Use /dev/input/event0 for example')
-                return None
+                return
 
             # read filename
             self.input_fn = args[0]

--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -111,7 +111,7 @@ else:
             if not args:
                 Logger.error('MTD: No filename pass to MTD configuration')
                 Logger.error('MTD: Use /dev/input/event0 for example')
-                return None
+                return
 
             # read filename
             self.input_fn = args[0]

--- a/kivy/input/providers/tuio.py
+++ b/kivy/input/providers/tuio.py
@@ -96,14 +96,14 @@ class TuioMotionEventProvider(MotionEventProvider):
             Logger.error('Tuio: Format must be ip:port (eg. 127.0.0.1:3333)')
             err = 'Tuio: Current configuration is <%s>' % (str(','.join(args)))
             Logger.error(err)
-            return None
+            return
         ipport = args[0].split(':')
         if len(ipport) != 2:
             Logger.error('Tuio: Invalid configuration for TUIO provider')
             Logger.error('Tuio: Format must be ip:port (eg. 127.0.0.1:3333)')
             err = 'Tuio: Current configuration is <%s>' % (str(','.join(args)))
             Logger.error(err)
-            return None
+            return
         self.ip, self.port = args[0].split(':')
         self.port = int(self.port)
         self.handlers = {}

--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -243,11 +243,11 @@ class TreeViewProperty(BoxLayout, TreeViewNode):
     def _get_widget(self):
         wr = self.widget_ref
         if wr is None:
-            return None
+            return
         wr = wr()
         if wr is None:
             self.widget_ref = None
-            return None
+            return
         return wr
     widget = AliasProperty(_get_widget, None, bind=('widget_ref', ))
 
@@ -280,7 +280,7 @@ class WidgetTree(TreeView):
                     return node
             except ReferenceError:
                 pass
-        return None
+        return
 
     def update_selected_widget(self, widget):
         if widget:

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -48,7 +48,7 @@ def resource_find(filename):
     Use resource_add_path to add a custom path to the search.
     '''
     if not filename:
-        return None
+        return
     if filename[:8] == 'atlas://':
         return filename
     if exists(abspath(filename)):
@@ -59,7 +59,6 @@ def resource_find(filename):
             return output
     if filename[:5] == 'data:':
         return filename
-    return None
 
 
 def resource_add_path(path):

--- a/kivy/tools/gles_compat/subset_gles.py
+++ b/kivy/tools/gles_compat/subset_gles.py
@@ -122,4 +122,4 @@ print('''
 print('#ifdef __cplusplus')
 print('}')
 print('#endif')
-print()
+print('\n')

--- a/kivy/tools/report.py
+++ b/kivy/tools/report.py
@@ -206,8 +206,8 @@ print('\n'.join(report_dict['Global'] + report_dict['OpenGL'] +
                 report_dict['Configuration'] +
                 report_dict['InputAvailablity'] +
                 report_dict['Environ'] + report_dict['Options']))
-print()
-print()
+print('\n')
+print('\n')
 
 try:
     print('The report will be sent as an anonymous gist.')
@@ -221,11 +221,11 @@ if reply.lower().strip() in ('', 'y'):
 
     paste_url = send_report(report_dict)
 
-    print()
-    print()
+    print('\n')
+    print('\n')
     print('REPORT posted at %s' % paste_url)
-    print()
-    print()
+    print('\n')
+    print('\n')
 else:
     print('No report posted.')
 

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -187,7 +187,6 @@ class ModalView(AnchorLayout):
         a = Animation(_anim_alpha=1., d=self._anim_duration)
         a.bind(on_complete=lambda *x: self.dispatch('on_open'))
         a.start(self)
-        return
 
     def dismiss(self, *largs, **kwargs):
         '''Close the view if it is open. If you really want to close the
@@ -214,7 +213,6 @@ class ModalView(AnchorLayout):
         else:
             self._anim_alpha = 0
             self._real_remove_widget()
-        return
 
     def _align_center(self, *l):
         if self._window:


### PR DESCRIPTION
Basically the default behavior for a Python function is returning a `None` if not told otherwise, so there's no need for the hanging `None`, nor for hanging `return` at the end of some functions + it doesn't match the rest of the codebase (either `return` or `return <value>` or nothing).

The `Python.h` extern is from older @matham's code that apparently isn't around (or at least the imported stuff isn't used), ref #2566

I'm not sure about the X11 Cython code, because it doesn't import anything from the C code apparently, only makes it required at the compile time I guess? But then the `window_x11_keytab.c` isn't required this way, so... That's @tito's code, so I'm not sure about it. ref https://github.com/kivy/kivy/commit/adb5a850c52ef7127201f78bac16f55df8c9ca32

Also, in py2 `print()` prints a tuple (`()`), which will break the output (the GLES file) and I've seen it even in the `report.py`.