### PR TITLE
Change android App.config path

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -666,7 +666,6 @@ class App(EventDispatcher):
             activity = autoclass('org.kivy.android.PythonActivity').mActivity
             defaultpath = join(
                 activity.getFilesDir().getAbsolutePath(),
-                'app',
                 '.%(appname)s.ini'
             )
 

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -679,6 +679,9 @@ class App(EventDispatcher):
                     'App: get_application_config sdcard path is deprecated, '
                     'moving to the new one - %s.' % new_path
                 )
+                if not exists(dirname(new_path)):
+                    # recursive mkdir, just in case
+                    os.makedirs(dirname(new_path))
                 copyfile(old_path, new_path)
 
         elif platform == 'ios':

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -307,14 +307,13 @@ Here is a simple example of how on_pause() should be used::
 
     Both `on_pause` and `on_stop` must save important data because after
     `on_pause` is called, `on_resume` may not be called at all.
-
 '''
 
 __all__ = ('App', )
 
 import os
 from inspect import getfile
-from os.path import dirname, join, exists, sep, expanduser, isfile
+from os.path import dirname, join, exists, sep, expanduser, isfile, abspath
 from kivy.config import ConfigParser
 from kivy.base import runTouchApp, stopTouchApp
 from kivy.compat import string_types
@@ -626,13 +625,21 @@ class App(EventDispatcher):
             defaultpath parameter for desktop OS's (not applicable to iOS
             and Android.)
 
+        .. versionchanged:: 1.10.1
+            Android Application config path is changed to the the path
+            provided by Context.getFilesDir() + '/app/.<appname>.ini'.
+            By default no `WRITE_EXTERNAL_STORAGE` permission is required now.
+
         Return the filename of your application configuration. Depending
         on the platform, the application file will be stored in
         different locations:
 
-            - on iOS: <appdir>/Documents/.<appname>.ini
-            - on Android: /sdcard/.<appname>.ini
-            - otherwise: <appdir>/<appname>.ini
+            - on iOS: `<appdir>/Documents/.<appname>.ini`
+            - on Android: `Context.getFilesDir() + '/app/.<appname>.ini'`
+
+              for example `/data/data/<app dir>/files/app/.<appname>.ini`
+
+            - otherwise: `<appdir>/<appname>.ini`
 
         When you are distributing your application on Desktops, please
         note that if the application is meant to be installed
@@ -654,7 +661,10 @@ class App(EventDispatcher):
         '''
 
         if platform == 'android':
-            defaultpath = '/sdcard/.%(appname)s.ini'
+            defaultpath = join(
+                dirname(abspath(sys.executable)),
+                '.%(appname)s.ini'
+            )
         elif platform == 'ios':
             defaultpath = '~/Documents/%(appname)s.ini'
         elif platform == 'win':


### PR DESCRIPTION
More about why is in the linked issue (#4777), but this change also does something "bad" in the sense that an ordinary user won't be able to edit and most likely even view the config file. On the other hand, the file will get removed by uninstalling the application and probably will be safe for updating the Kivy app (I think the `<app>/files/app` folder isn't removed with an update. Not sure though).

This change removes the necessity of having a `WRITE_EXTERNAL_STORAGE` permission for the default Kivy app and if required, the dev can change the folder manually by overriding the method if the dev would like to create the file in `/sdcard/<somewhere>` with adding the permission by own needs.

I think `sys.executable` returns such a path because of [this line](https://github.com/kivy/python-for-android/blob/c45bd81ea15b345815450dc2fd14ff884fb12fbb/pythonforandroid/bootstraps/sdl2/build/src/org/kivy/android/PythonActivity.java#L351) which is used in `start.c` to set the Python paths.

I'm not sure, is this considered an API break if we change the path only and not the call directly? I mean, a dev should use the API we provide and not the raw path, so this should be safe, I guess?