### PR TITLE
Settings in example are faulty

### DIFF
--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -61,8 +61,7 @@ settings. Here is an example::
             "title": "Fullscreen",
             "desc": "Set the window in windowed or fullscreen",
             "section": "graphics",
-            "key": "fullscreen",
-            "true": "auto"
+            "key": "fullscreen"
         }
     ]
 


### PR DESCRIPTION
with "true": "auto" set

   File "/usr/local/lib/python3.6/dist-packages/kivy/uix/settings.py", line 975, in add_json_panel
     panel = self.create_json_panel(title, config, filename, data)
   File "/usr/local/lib/python3.6/dist-packages/kivy/uix/settings.py", line 1015, in create_json_panel
     instance = cls(panel=panel, **str_settings)
   File "/usr/local/lib/python3.6/dist-packages/kivy/uix/settings.py", line 289, in __init__
     super(SettingItem, self).__init__(**kwargs)
   File "/usr/local/lib/python3.6/dist-packages/kivy/uix/floatlayout.py", line 65, in __init__
     super(FloatLayout, self).__init__(**kwargs)
   File "/usr/local/lib/python3.6/dist-packages/kivy/uix/layout.py", line 76, in __init__
     super(Layout, self).__init__(**kwargs)
   File "/usr/local/lib/python3.6/dist-packages/kivy/uix/widget.py", line 337, in __init__
     super(Widget, self).__init__(**kwargs)
   File "kivy/_event.pyx", line 254, in kivy._event.EventDispatcher.__init__ (/tmp/pycharm-packaging393/Kivy/kivy/_event.c:5332)
 TypeError: object.__init__() takes no parameters

without is working as expected
also there is nothing in docs about this parameter. Outdated?