### PR TITLE
Fix race condition in AsyncImage

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -350,6 +350,7 @@ class AsyncImage(Image):
         if not source:
             if self._coreimage is not None:
                 self._coreimage.unbind(on_texture=self._on_tex_change)
+                self._coreimage.unbind(on_load=self._on_source_load)
             self.texture = None
             self._coreimage = None
         else:


### PR DESCRIPTION
If AsyncImage starts loading a remote image, but then has its source changed back to '', it can crash when `_coreimage`'s binding on `on_load` triggers.