### PR TITLE
Avoid Animation.cancel_all(Window) that interfers with user animations

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -572,6 +572,10 @@ class WindowBase(EventDispatcher):
     _keyboard_changed = BooleanProperty(False)
     _kheight = NumericProperty(0)
 
+    _kanimation = None
+    def _free_kanimation(self, *largs):
+        WindowBase._kanimation = None
+
     def _animate_content(self):
         '''Animate content to IME height.
         '''
@@ -579,10 +583,13 @@ class WindowBase(EventDispatcher):
         global Animation
         if not Animation:
             from kivy.animation import Animation
-        Animation.cancel_all(self)
-        Animation(
+        if WindowBase._kanimation:
+            WindowBase._kanimation.cancel(self)
+        WindowBase._kanimation = kanim = Animation(
             _kheight=self.keyboard_height + self.keyboard_padding,
-            d=kargs['d'], t=kargs['t']).start(self)
+            d=kargs['d'], t=kargs['t'])
+        kanim.bind(on_complete=self._free_kanimation)
+        kanim.start(self)
 
     def _upd_kbd_height(self, *kargs):
         self._keyboard_changed = not self._keyboard_changed


### PR DESCRIPTION
Fixes #5213 

I think this is non-obtrusive - do we even need to start this animation when self.keyboard_height is 0?
