### PR TITLE
Remove dead code for SDL2 windowresized event

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -505,9 +505,6 @@ class WindowSDL(WindowBase):
                 else:
                     ev()
 
-            elif action == 'windowresized':
-                self.canvas.ask_update()
-
             elif action == 'windowrestored':
                 self.dispatch('on_restore')
                 self.canvas.ask_update()


### PR DESCRIPTION
I don't know the original intent here, but this is never called due to
same condition in elif block above. Maybe the canvas.ask_update should
be included, maybe it was intended for handling a different event...