### PR TITLE
Fix crash when instantiating ActionView(use_separator=True)

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -485,7 +485,8 @@ class ActionView(BoxLayout):
     def on_use_separator(self, instance, value):
         for group in self._list_action_group:
             group.use_separator = value
-        self.overflow_group.use_separator = value
+        if self.overflow_group:
+            self.overflow_group.use_separator = value
 
     def remove_widget(self, widget):
         super(ActionView, self).remove_widget(widget)


### PR DESCRIPTION
The on_use_separator method is called when ``super().__init__`` sets the property to True, but at this point the default ActionOverflow instance has not been created

```python
from kivy.factory import Factory
x = Factory.ActionView(use_separator=True)
```

```
 Traceback (most recent call last):
   File "test.py", line 2, in <module>
     x = Factory.ActionView(use_separator=True)
   File "/home/terje/kivy/kivy/uix/actionbar.py", line 451, in __init__
     super(ActionView, self).__init__(**kwargs)
   File "/home/terje/kivy/kivy/uix/boxlayout.py", line 131, in __init__
     super(BoxLayout, self).__init__(**kwargs)
   File "/home/terje/kivy/kivy/uix/layout.py", line 76, in __init__
     super(Layout, self).__init__(**kwargs)
   File "/home/terje/kivy/kivy/uix/widget.py", line 337, in __init__
     super(Widget, self).__init__(**kwargs)
   File "kivy/_event.pyx", line 262, in kivy._event.EventDispatcher.__init__ (kivy/_event.c:5807)
   File "kivy/properties.pyx", line 478, in kivy.properties.Property.__set__ (kivy/properties.c:5572)
   File "kivy/properties.pyx", line 516, in kivy.properties.Property.set (kivy/properties.c:6405)
   File "kivy/properties.pyx", line 571, in kivy.properties.Property.dispatch (kivy/properties.c:7105)
   File "kivy/_event.pyx", line 1214, in kivy._event.EventObservers.dispatch (kivy/_event.c:14035)
   File "kivy/_event.pyx", line 1120, in kivy._event.EventObservers._dispatch (kivy/_event.c:13193)
   File "/home/terje/kivy/kivy/uix/actionbar.py", line 488, in on_use_separator
     self.overflow_group.use_separator = value
 AttributeError: 'NoneType' object has no attribute 'use_separator'

```