### PR TITLE
doc: add missing escape characters into Linux installation instructions

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -201,8 +201,8 @@ In the following command use "python" and "python-dev" for Python 2, or "python3
         
     # Install gstreamer for audio, video (optional)
     sudo apt-get install -y \
-        libgstreamer1.0
-        gstreamer1.0-plugins-base
+        libgstreamer1.0 \
+        gstreamer1.0-plugins-base \
         gstreamer1.0-plugins-good
         
 


### PR DESCRIPTION
There was missing escape characters into the GStreamer installation instructions