### PR TITLE
WIP: Added new SDL_DropEvent

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -318,6 +318,24 @@ class WindowBase(EventDispatcher):
             You can listen to this one, and clean whatever you can.
 
             .. versionadded:: 1.9.0
+
+        `on_dropbegin`:
+            Fired when a new set of drops is beginning on the application.
+
+            .. note::
+
+               This event works with sdl2 window provider(>2.0.5).
+
+            .. versionadded:: 1.10.1
+
+        `on_dropcomplete`:
+            Fired when a current set of drops is now complete on the application.
+
+            .. note::
+
+               This event works with sdl2 window provider(>2.0.5).
+
+            .. versionadded:: 1.10.1
     '''
 
     __instance = None
@@ -802,7 +820,8 @@ class WindowBase(EventDispatcher):
         'on_key_down', 'on_key_up', 'on_textinput', 'on_dropfile',
         'on_request_close', 'on_cursor_enter', 'on_cursor_leave',
         'on_joy_axis', 'on_joy_hat', 'on_joy_ball',
-        'on_joy_button_down', 'on_joy_button_up', 'on_memorywarning')
+        'on_joy_button_down', 'on_joy_button_up', 'on_memorywarning',
+        'on_dropbegin', 'on_dropcomplete')
 
     def __new__(cls, **kwargs):
         if cls.__instance is None:
@@ -1558,6 +1577,28 @@ class WindowBase(EventDispatcher):
             (ios, android etc.)
 
         .. versionadded:: 1.2.0
+        '''
+        pass
+
+    def on_dropbegin(self):
+        '''Event called when a new set of drops is beginning on the application.
+
+        .. warning::
+
+            This event currently works with sdl2 window provider(>2.0.5).
+
+        .. versionadded:: 1.10.1
+        '''
+        pass
+
+    def on_dropcomplete(self):
+        '''Event called when a current set of drops is now complete on the application.
+
+        .. warning::
+
+            This event currently works with sdl2 window provider(>2.0.5).
+
+        .. versionadded:: 1.10.1
         '''
         pass
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -156,7 +156,6 @@ cdef class _WindowSDL2Storage:
 
         SDL_SetEventFilter(_event_filter, <void *>self)
 
-        SDL_EventState(SDL_DROPFILE, SDL_ENABLE)
         cdef int w, h
         SDL_GetWindowSize(self.win, &w, &h)
         return w, h
@@ -323,6 +322,10 @@ cdef class _WindowSDL2Storage:
             return ('quit', )
         elif event.type == SDL_DROPFILE:
             return ('dropfile', event.drop.file)
+        elif event.type == SDL_DROPBEGIN:
+            return ('dropbegin', )
+        elif event.type == SDL_DROPCOMPLETE:
+            return ('dropcomplete', )
         elif event.type == SDL_MOUSEMOTION:
             x = event.motion.x
             y = event.motion.y

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -494,6 +494,10 @@ class WindowSDL(WindowBase):
             elif action == 'dropfile':
                 dropfile = args
                 self.dispatch('on_dropfile', dropfile[0])
+            elif action == 'dropbegin':
+                self.dispatch('on_dropbegin')
+            elif action == 'dropcomplete':
+                self.dispatch('on_dropcomplete')
             # video resize
             elif action == 'windowresized':
                 self._size = self._win.window_size

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -138,6 +138,9 @@ cdef extern from "SDL.h":
     ctypedef enum SDL_EventType:
         SDL_FIRSTEVENT     = 0,
         SDL_DROPFILE       = 0x1000,
+        SDL_DROPTEXT
+        SDL_DROPBEGIN
+        SDL_DROPCOMPLETE
         SDL_QUIT           = 0x100
         SDL_WINDOWEVENT    = 0x200
         SDL_SYSWMEVENT


### PR DESCRIPTION
SDL_DROPTEXT, SDL_DROPBEGIN, and SDL_DROPCOMPLETE are available since SDL 2.0.5.

- Remove `SDL_EventState(SDL_DROPFILE, SDL_ENABLE)` as these events are enabled by default.

## Testing Environment
Platform: Darwin-16.6.0-x86_64-i386-64bit
Python: 2.7.13
SDL: 2.0.5
Kivy: 1.10.1.dev0

- [ ] SDL_DROPTEXT
- [x] SDL_DROPBEGIN
- [x] SDL_DROPCOMPLETE