### PR TITLE
Gridlayout min size bounds check

### DIFF
--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -317,10 +317,12 @@ class GridLayout(Layout):
         self._rows_sh_max = [None] * current_rows
 
         # update minimum size from the dicts
-        # FIXME index might be outside the bounds ?
-        for index, value in self.cols_minimum.items():
+        items = (i for i in self.cols_minimum.items() if i[0] < len(cols))
+        for index, value in items:
             cols[index] = max(value, cols[index])
-        for index, value in self.rows_minimum.items():
+
+        items = (i for i in self.rows_minimum.items() if i[0] < len(cols))
+        for index, value in items:
             rows[index] = max(value, rows[index])
         return True
 

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -321,7 +321,7 @@ class GridLayout(Layout):
         for index, value in items:
             cols[index] = max(value, cols[index])
 
-        items = (i for i in self.rows_minimum.items() if i[0] < len(cols))
+        items = (i for i in self.rows_minimum.items() if i[0] < len(rows))
         for index, value in items:
             rows[index] = max(value, rows[index])
         return True


### PR DESCRIPTION
Changing the number of rows/columns in a GridLayout can cause an exception if `rows_minimum` or `cols_minimum` has a key that is greater than the new row/column count, respectively.

I ran into this error when changing data in a `RecycleView` with a viewclass that subclassed `GridLayout` and attempted to synchronize auto-widths for data columns. If the number of data columns changed between data sets, Kivy vomited everywhere. I found a `#FIXME` in the source, so I did. 😏 

I used a generator expression, so the resulting iterable should have similar performance/memory characteristics to the original `cols_minimum.items()`, yes?