### PR TITLE
Refactor _img_sdl2.pyx load_from_surface (cleanup)

### DIFF
--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -28,11 +28,12 @@ cdef extern from "SDL.h":
     int SDL_WINDOWPOS_UNDEFINED
 
     ctypedef enum:
+        SDL_PIXELFORMAT_BGRA8888
         SDL_PIXELFORMAT_ARGB8888
         SDL_PIXELFORMAT_RGBA8888
-        SDL_PIXELFORMAT_RGB888
         SDL_PIXELFORMAT_ABGR8888
-        SDL_PIXELFORMAT_BGR888
+        SDL_PIXELFORMAT_RGB24
+        SDL_PIXELFORMAT_BGR24
 
     ctypedef enum SDL_GLattr:
         SDL_GL_RED_SIZE
@@ -481,10 +482,9 @@ cdef extern from "SDL.h":
     cdef int SDL_SetTextureBlendMode(SDL_Texture * texture, SDL_BlendMode blendMode)
     cdef int SDL_GetTextureBlendMode(SDL_Texture * texture, SDL_BlendMode *blendMode)
     cdef SDL_Surface * SDL_CreateRGBSurfaceFrom(void *pixels, int width, int height, int depth, int pitch, Uint32 Rmask, Uint32 Gmask, Uint32 Bmask, Uint32 Amask)
-    cdef SDL_Surface* SDL_ConvertSurface(SDL_Surface* src, SDL_PixelFormat* fmt, Uint32 flags)
-    cdef SDL_Surface* SDL_ConvertSurfaceFormat(SDL_Surface* src, Uint32
-            pixel_format, Uint32 flags)
+    cdef SDL_Surface* SDL_ConvertSurfaceFormat(SDL_Surface* src, Uint32 pixel_format, Uint32 flags) nogil
     cdef const char* SDL_GetPixelFormatName(Uint32 format)
+    cdef int SDL_GetColorKey(SDL_Surface *surface, Uint32 *key)
     cdef int SDL_Init(Uint32 flags)
     cdef void SDL_Quit()
     cdef int SDL_EnableUNICODE(int enable)
@@ -626,6 +626,11 @@ cdef extern from "SDL.h":
     Uint16 AUDIO_F32LSB #0x8120  /**< 32-bit floating point samples */
     Uint16 AUDIO_F32MSB #0x9120  /**< As above, but big-endian byte order */
     Uint16 AUDIO_F32    #AUDIO_F32LSB
+
+    # Endianness
+    Uint16 SDL_BYTEORDER
+    Uint16 SDL_LIL_ENDIAN
+    Uint16 SDL_BIG_ENDIAN
 
 cdef extern from "SDL_shape.h":
     cdef SDL_Window * SDL_CreateShapedWindow(


### PR DESCRIPTION
Closes #5269. This supersedes PR #5274, squashed to avoid commit spam + some minor cleanup (release gil during conversion, change order of some tests, added comments)

Summary of changes:

* Fix loading of SDL_PIXELFORMAT_BGR24 surfaces (BMP2, BMP3 images)
* Fix loading of (some) PNG formats with binary alpha
* Fix byte order for big-endian arch (untested)
* Some other surface formats were incorrectly handled, but not used by SDL_Image

Known issues:

* Some PNG48 images with binary transparency are still not loading correctly
* 8/16-bit grayscale PNGs are not supported. This seems like an issue with SDL_Image, it returns unexpected SDL_PIXELFORMAT_RGB565 instead of expected grayscale palette.

Details:

* Log of PR against test images: [link](https://gist.github.com/bionoid/ecb09b6db036faac77e4618fa9d82b2f) (100% pass)
* Log of original implementation with same images: [link](https://gist.github.com/bionoid/1738bce4170df332350a530b7a36553d) (AssertionError: _img_sdl2: 100 of 1832 tests failed, these are all BMP2/BMP3 images. Plus unreported failures, see below)
  * Some of the tested ``_BINARY`` (binary alpha) png files loaded here are reported with 'pass' but they don't "really" pass. The test doesn't mandate the returned pixel format, it just verifies that the pixels are consistent with the returned format. So these are  correctly converted to RGB, **but we lost alpha**
  * Hence, the PR test lists all ``_BINARY`` images as 'rgba', while 116 of them are incorrectly listed as "pass" with "rgb" above.

Tested formats (ImageMagick):

* Opaque: TIFF, BMP2, BMP3, PNG, GIF87
* Binary: GIF, PNG8, PNG24, PNG48, BMP
* Full Alpha: PNG32, PNG64, TGA

Notes:

* All formats above were tested with fully opaque pixels
* "Binary" and "Full Alpha" were tested with binary transparency
* "Full Alpha" were tested with the same images as for opaque, but semitransparent.
* TIFF is only tested as opaque, because the test doesn't support premultiplied alpha
* JPG not tested because pixel values are unpredictable (lossy compression)

