### PR TITLE
Docs: Fetch cython version from setup.py

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -218,6 +218,9 @@ latex_toplevel_sectioning = 'part'
 
 from kivy import setupconfig
 
+# if used in a code-block, the block has to be marked with
+# .. parse-literal::, otherwise it won't be replaced
+# !!! doesn't work for "::", ".. code::" or ".. code-block::"
 replacements = {
     'cython_install': 'Cython==' + setupconfig.CYTHON_MAX,
     'cython_note': (

--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -167,6 +167,7 @@ Kivy       Cython
 1.8        0.20.2
 1.9        0.21.2
 1.9.1      0.23
+1.10.1     0.25
 ========   =============
 
 
@@ -238,7 +239,7 @@ Installation
     . kivyinstall/bin/activate
 
     # Use correct Cython version here
-    pip install Cython==0.23
+    pip install |cython_install|
 
     # Install stable version of Kivy into the virtualenv
     pip install kivy
@@ -339,7 +340,7 @@ Installation
 
     pip install numpy
 
-    pip install Cython==0.23
+    pip install |cython_install|
 
     # If you want to install pygame backend instead of sdl2
     # you can install pygame using command below and enforce using

--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -221,7 +221,7 @@ Installation
 ------------
 
 
-::
+.. parsed-literal::
 
     # Make sure Pip, Virtualenv and Setuptools are updated
     sudo pip install --upgrade pip virtualenv setuptools
@@ -321,7 +321,7 @@ OpenSuse
 Installation
 ------------
 
-::
+.. parsed-literal::
 
     # Make sure Pip, Virtualenv and Setuptools are updated
     sudo pip install --upgrade pip virtualenv setuptools

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -22,7 +22,7 @@ Manual installation (On Raspbian Jessie)
 
 #. Install a new enough version of Cython::
 
-    sudo pip install -I Cython==0.23
+    sudo pip install -U |cython_install|
 
 
 #. Install Kivy globally on your system::
@@ -66,9 +66,9 @@ Manual installation (On Raspbian Wheezy)
     wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
     sudo python get-pip.py
 
-#. Install Cython from sources (debian package are outdated)::
+#. Install Cython from sources (debian packages are outdated)::
 
-    sudo pip install cython
+    sudo pip install -U cython
 
 #. Install Kivy globally on your system::
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -20,9 +20,11 @@ Manual installation (On Raspbian Jessie)
        gstreamer1.0-{omx,alsa} python-dev libmtdev-dev \
        xclip
 
-#. Install a new enough version of Cython::
+#. Install a new enough version of Cython:
 
-    sudo pip install -U |cython_install|
+   .. parsed-literal::
+
+       sudo pip install -U |cython_install|
 
 
 #. Install Kivy globally on your system::


### PR DESCRIPTION
For `1.10.1` is necessary at least `0.25` because of #5220 + we shouldn't write various versions for each install file if we already define the range of supported cython versions in the `setup.py`. Also, the changed flag is preferred (`--upgrade`/`-U` vs `--ignore-installed`/`-I`) as we already use it in some other places.