### PR TITLE
Add ImageLoader test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ kivy/lib/gstplayer/_gstplayer.c
 kivy/core/camera/camera_avfoundation.c
 kivy/tests/build
 kivy/tests/results
-kivy/tests/testimages
+kivy/tests/image-testsuite
 kivy/garden
 .last_known_portable_deps_hash
 deps.zip

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ kivy/lib/gstplayer/_gstplayer.c
 kivy/core/camera/camera_avfoundation.c
 kivy/tests/build
 kivy/tests/results
+kivy/tests/testimages
 kivy/garden
 .last_known_portable_deps_hash
 deps.zip

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ hook:
 	cp kivy/tools/pep8checker/pre-commit.githook .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 
-testimages:
-	mkdir -p "${KIVY_DIR}tests/testimages"
-	-kivy/tools/create-testimages.sh "${KIVY_DIR}tests/testimages"
+image-testsuite:
+	mkdir -p "${KIVY_DIR}tests/image-testsuite"
+	-${KIVY_DIR}tools/image-testsuite/imagemagick-testsuite.sh "${KIVY_DIR}tests/image-testsuite"
 
 test:
 	-rm -rf kivy/tests/build

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ hook:
 	cp kivy/tools/pep8checker/pre-commit.githook .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 
+testimages:
+	mkdir -p "${KIVY_DIR}tests/testimages"
+	-kivy/tools/create-testimages.sh "${KIVY_DIR}tests/testimages"
+
 test:
 	-rm -rf kivy/tests/build
 	$(NOSETESTS) kivy/tests

--- a/kivy/tests/test_imageloader.py
+++ b/kivy/tests/test_imageloader.py
@@ -392,6 +392,10 @@ class ImageLoaderTestCase(unittest.TestCase):
         loadercls = LOADERS.get('ImageLoaderTex')
         ctx = self._test_imageloader(loadercls)
 
+    def test_ImageLoaderImageIO(self):
+        loadercls = LOADERS.get('ImageLoaderImageIO')
+        ctx = self._test_imageloader(loadercls)
+
     def test_missing_tests(self):
         for loader in ImageLoader.loaders:
             key = 'test_{}'.format(loader.__name__)

--- a/kivy/tests/test_imageloader.py
+++ b/kivy/tests/test_imageloader.py
@@ -1,0 +1,358 @@
+import os
+import re
+import unittest
+from pprint import pprint
+from kivy.core.image import ImageLoader
+from kivy.core.image.img_sdl2 import ImageLoaderSDL2
+
+DEBUG = False
+ASSETDIR = 'testimages'
+LOADERS = {x.__name__: x for x in ImageLoader.loaders}
+
+if 'ImageLoaderPygame' not in LOADERS:
+    try:
+        from kivy.core.image.img_pygame import ImageLoaderPygame
+        LOADERS['ImageLoaderPygame'] = ImageLoaderPygame
+    except:
+        pass
+
+
+def asset(*fn):
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), *fn))
+
+
+def has_alpha(fmt):
+    return fmt in ('rgba', 'bgra', 'argb', 'abgr')
+
+
+def bytes_per_pixel(fmt):
+    if fmt in ('rgb', 'bgr'):
+        return 3
+    if fmt in ('rgba', 'bgra', 'argb', 'abgr'):
+        return 4
+    raise Exception('bytes_per_pixel: unknown format {}'.format(fmt))
+
+
+# Generate RGBA pixel predictions from pattern + alpha. When testing
+# "1x3_rgb_FF" is processed here as pat='rgb' and alpha='FF'. Returns a list
+# of bytes objects representing accepted pixel data
+def pattern_to_predictions(pat, alpha='FF'):
+    assert len(alpha) == 2
+    assert len(pat) >= 1
+    PIXELS = {
+        'w': b'\xFF\xFF\xFF', 'x': b'\x00\x00\x00',  # 't' is below
+        'r': b'\xFF\x00\x00', 'g': b'\x00\xFF\x00', 'b': b'\x00\x00\xFF',
+        'y': b'\xFF\xFF\x00', 'c': b'\x00\xFF\xFF', 'p': b'\xFF\x00\xFF'}
+
+    # Some loaders/formats/conversion processes can result in binary
+    # transparency represented as white+a00 or black+a00 - we accept
+    # both variations for a 't' pixel
+    pixelmaps = []
+    if 't' in pat:
+        pixelmaps = ([dict(PIXELS, t=x) for x in (b'\x00' * 3, b'\xFF' * 3)])
+    else:
+        pixelmaps = [PIXELS]
+
+    alphamap = lambda x: x == 't' and b'\x00' or bytearray.fromhex(alpha)
+    out = []
+    for pm in pixelmaps:
+        out.append(b''.join([bytes(pm.get(p) + alphamap(p)) for p in pat]))
+    return out
+
+
+# Converts (predicted) rgba pixels to the format claimed by image loader
+def rgba_to(pix_in, target_fmt, w, h, pitch=None):
+    assert w > 0 and h > 0, "Must specify w and h"
+    assert len(pix_in) == w * h * 4, "Invalid rgba pixel data"
+    assert target_fmt in ('rgba', 'bgra', 'argb', 'abgr', 'rgb', 'bgr')
+
+    if target_fmt == 'rgba':
+        return pix_in
+
+    pixels = [pix_in[i:i + 4] for i in range(0, len(pix_in), 4)]
+    if target_fmt == 'bgra':
+        return b''.join([p[:3][::-1] + p[3:] for p in pixels])
+    elif target_fmt == 'abgr':
+        return b''.join([p[3:] + p[:3][::-1] for p in pixels])
+    elif target_fmt == 'argb':
+        return b''.join([p[3:] + p[:3] for p in pixels])
+
+    # rgb/bgr, default to 4 byte alignment
+    if pitch is None:
+        pitch = ((3 * w) + 3) & ~3
+    # Assume pitch 0 == unaligned
+    elif pitch == 0:
+        pitch = 3 * w
+
+    out = b''
+    padding = b'\0' * (pitch - w * 3)
+    for row in [pix_in[i:i + w * 4] for i in range(0, len(pix_in), w * 4)]:
+        pixelrow = [row[i:i + 4] for i in range(0, len(row), 4)]
+        if target_fmt == 'rgb':
+            out += b''.join([p[:3] for p in pixelrow])
+        elif target_fmt == 'bgr':
+            out += b''.join([p[:3][::-1] for p in pixelrow])
+        out += padding
+
+    return out
+
+
+class TestContext(object):
+    def __init__(self, loadercls):
+        self.loadercls = loadercls
+        self._fn = None
+        self._ok = 0
+        self._skip = 0
+        self._fail = 0
+
+    @property
+    def results(self):
+        return (self._ok, self._skip, self._fail)
+
+    def start(self, fn):
+        assert not self._fn, "unexpected ctx.start(), already started"
+        self._fn = fn
+
+    def end(self, fn=None):
+        assert not fn or self._fn == fn, "unexpected ctx.end(), fn mismatch"
+        self._fn = None
+
+    def ok(self, info):
+        assert self._fn, "unexpected ctx.ok(), fn=None"
+        self._ok += 1
+        self.dbg('PASS', info)
+        self.end(self._fn)
+
+    def skip(self, info):
+        assert self._fn, "unexpected ctx.skip(), fn=None"
+        self._skip += 1
+        self.dbg('SKIP', info)
+        self.end(self._fn)
+
+    def fail(self, info):
+        assert self._fn, "unexpected ctx.fail(), fn=None"
+        self._fail += 1
+        self.dbg('FAIL', info)
+        self.end(self._fn)
+
+    def dbg(self, msgtype, info):
+        assert self._fn, "unexpected ctx.dbg(), fn=None"
+        if DEBUG:
+            print("{} {} {}: {}"
+                  .format(self.loadercls.__name__, msgtype, self._fn, info))
+
+
+@unittest.skipIf(not os.path.isdir(asset(ASSETDIR)),
+                 "Need 'make testimages' to run test")
+class ImageLoaderTestCase(unittest.TestCase):
+
+    # Matches generated file names
+    FILE_RE = re.compile('^(\d+)x(\d+)_'
+                         '([wxrgbycpt]+)_'
+                         '([0-9A-Fa-f]{2})_'
+                         '([\w_]+)\.([a-z]+)$')
+
+    def setUp(self):
+        self._prepare_images()
+
+    def _prepare_images(self):
+        self._image_files = {}
+        for filename in os.listdir(asset(ASSETDIR)):
+            matches = self.FILE_RE.match(filename)
+            if not matches:
+                continue
+            w, h, pat, alpha, info, ext = matches.groups()
+            self._image_files[filename] = {
+                'w': int(w),
+                'h': int(h),
+                'alpha': alpha,
+                'ext': ext,
+                'info': info,
+                'pattern': pat,
+                'predictions': pattern_to_predictions(pat, alpha),
+                'require_alpha': 'BINARY' in info or 'ALPHA' in info,
+            }
+
+    def _test_imageloader(self, loadercls, extensions=None):
+        if not loadercls:
+            return
+        if not extensions:
+            extensions = loadercls.extensions()
+
+        ctx = TestContext(loadercls)
+        for filename in sorted(self._image_files.keys()):
+            filedata = self._image_files[filename]
+
+            if filedata['ext'] not in extensions:
+                continue
+            try:
+                ctx.start(filename)
+                result = loadercls(asset(ASSETDIR, filename), keep_data=True)
+                if not result:
+                    raise Exception('invalid result')
+            except:
+                ctx.skip('Error loading file, result=None')
+                continue
+            self._test_image(filedata, ctx, loadercls, filename, result)
+            ctx.end()
+
+        ok, skip, fail = ctx.results
+        if fail:
+            self.fail('{}: {} passed, {} skipped, {} failed'
+                      .format(loadercls.__name__, ok, skip, fail))
+        return ctx
+
+    def _test_image(self, fd, ctx, loadercls, fn, imgdata):
+        w, h, pixels, pitch = imgdata._data[0].get_mipmap(0)
+        fmt = imgdata._data[0].fmt
+
+        # required for FFPy memview
+        if not isinstance(pixels, bytes):
+            pixels = bytearray(pixels)
+
+        # Convert RGBA prediction to imageloaders returned format
+        predictions = [rgba_to(pix, fmt, fd['w'], fd['h'], pitch=pitch)
+                       for pix in fd['predictions']]
+
+        def debug():
+            if not DEBUG:
+                return
+            print("    format: {}".format(fmt))
+            print("     pitch: got {} (want {})".format(pitch, want_pitch))
+            if pixels not in predictions:
+                print("     ERROR: Mismatch")
+                for p in predictions:
+                    print(" predicted: {}".format(p))
+                print("       got: {}".format(bytearray(pixels)))
+            else:
+                print("        OK: Pixel data matches")
+
+        # Assume pitch 0 = unaligned
+        want_pitch = (pitch == 0) and bytes_per_pixel(fmt) * w or pitch
+        if pitch == 0 and bytes_per_pixel(fmt) * w * h != len(pixels):
+            ctx.dbg("PITCH", "pitch=0, expected fmt={} to be "
+                             "unaligned @ ({}bpp) = {} bytes, got {}"
+                             .format(fmt, bytes_per_pixel(fmt),
+                                     bytes_per_pixel(fmt) * w * h,
+                                     len(pixels)))
+        elif pitch and want_pitch != pitch:
+            ctx.dbg("PITCH", "fmt={}, pitch={}, expected {}"
+                             .format(fmt, pitch, want_pitch))
+
+        if pixels not in predictions:
+            ctx.fail('Pixel data mismatch')
+            debug()
+        elif fd['require_alpha'] and not has_alpha(fmt):
+            ctx.fail('Missing expected alpha channel')
+            debug()
+        else:
+            ctx.ok("Passed test as {}x{} {}".format(w, h, fmt))
+
+    def test_ImageLoaderSDL2(self):
+        loadercls = LOADERS.get('ImageLoaderSDL2')
+        # GIF format not listed as supported in sdl2 loader
+        if loadercls:
+            exts = list(loadercls.extensions()) + ['gif']
+            ctx = self._test_imageloader(loadercls, exts)
+
+    def test_ImageLoaderPIL(self):
+        loadercls = LOADERS.get('ImageLoaderPIL')
+        ctx = self._test_imageloader(loadercls)
+
+    def test_ImageLoaderPygame(self):
+        loadercls = LOADERS.get('ImageLoaderPygame')
+        ctx = self._test_imageloader(loadercls)
+
+    def test_ImageLoaderFFPy(self):
+        loadercls = LOADERS.get('ImageLoaderFFPy')
+        ctx = self._test_imageloader(loadercls)
+
+    def test_ImageLoaderGIF(self):
+        loadercls = LOADERS.get('ImageLoaderGIF')
+        ctx = self._test_imageloader(loadercls)
+
+    def test_ImageLoaderDDS(self):
+        loadercls = LOADERS.get('ImageLoaderDDS')
+        ctx = self._test_imageloader(loadercls)
+
+
+class ConverterTestCase(unittest.TestCase):
+    def test_internal_converter_2x1(self):
+        correct = {
+            'rgba': b'\x01\x02\x03\xA1\x04\x05\x06\xA2',
+            'abgr': b'\xA1\x03\x02\x01\xA2\x06\x05\x04',
+            'bgra': b'\x03\x02\x01\xA1\x06\x05\x04\xA2',
+            'argb': b'\xA1\x01\x02\x03\xA2\x04\x05\x06',
+            'rgb': b'\x01\x02\x03\x04\x05\x06',
+            'bgr': b'\x03\x02\x01\x06\x05\x04',
+            'rgb_align4': b'\x01\x02\x03\x04\x05\x06\x00\x00',
+            'bgr_align4': b'\x03\x02\x01\x06\x05\x04\x00\x00'}
+        src = correct.get
+        rgba = src('rgba')
+        self.assertEqual(rgba_to(rgba, 'rgba', 2, 1, 0), src('rgba'))
+        self.assertEqual(rgba_to(rgba, 'abgr', 2, 1, 0), src('abgr'))
+        self.assertEqual(rgba_to(rgba, 'bgra', 2, 1, 0), src('bgra'))
+        self.assertEqual(rgba_to(rgba, 'argb', 2, 1, 0), src('argb'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 2, 1, 0), src('rgb'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 2, 1, 0), src('bgr'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 2, 1, None), src('rgb_align4'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 2, 1, None), src('bgr_align4'))
+
+    def test_internal_converter_3x1(self):
+        pad6 = b'\x00' * 6
+        correct = {
+            'rgba': b'\x01\x02\x03\xFF\x04\x05\x06\xFF\x07\x08\x09\xFF',
+            'abgr': b'\xFF\x03\x02\x01\xFF\x06\x05\x04\xFF\x09\x08\x07',
+            'bgra': b'\x03\x02\x01\xFF\x06\x05\x04\xFF\x09\x08\x07\xFF',
+            'argb': b'\xFF\x01\x02\x03\xFF\x04\x05\x06\xFF\x07\x08\x09',
+            'rgb_align2': b'\x01\x02\x03\x04\x05\x06\x07\x08\x09\x00',
+            'bgr_align2': b'\x03\x02\x01\x06\x05\x04\x09\x08\x07\x00',
+            'rgb_align8': b'\x01\x02\x03\x04\x05\x06\x07\x08\x09\x00' + pad6,
+            'bgr_align8': b'\x03\x02\x01\x06\x05\x04\x09\x08\x07\x00' + pad6}
+        src = correct.get
+        rgba = src('rgba')
+        self.assertEqual(rgba_to(rgba, 'bgra', 3, 1, 0), src('bgra'))
+        self.assertEqual(rgba_to(rgba, 'argb', 3, 1, 0), src('argb'))
+        self.assertEqual(rgba_to(rgba, 'abgr', 3, 1, 0), src('abgr'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 3, 1, 10), src('rgb_align2'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 3, 1, 10), src('bgr_align2'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 3, 1, 16), src('rgb_align8'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 3, 1, 16), src('bgr_align8'))
+
+    def test_internal_converter_1x3(self):
+        pad5 = b'\x00' * 5
+        correct = {
+            'rgba': b'\x01\x02\x03\xFF\x04\x05\x06\xFF\x07\x08\x09\xFF',
+            'rgb_raw': b'\x01\x02\x03\x04\x05\x06\x07\x08\x09',
+            'bgr_raw': b'\x03\x02\x01\x06\x05\x04\x09\x08\x07',
+            'rgb_align2': b'\x01\x02\x03\x00\x04\x05\x06\x00\x07\x08\x09\x00',
+            'bgr_align2': b'\x03\x02\x01\x00\x06\x05\x04\x00\x09\x08\x07\x00',
+            'rgb_align4': b'\x01\x02\x03\x00\x04\x05\x06\x00\x07\x08\x09\x00',
+            'bgr_align4': b'\x03\x02\x01\x00\x06\x05\x04\x00\x09\x08\x07\x00',
+            'rgb_align8': (b'\x01\x02\x03' + pad5 +
+                           b'\x04\x05\x06' + pad5 +
+                           b'\x07\x08\x09' + pad5),
+            'bgr_align8': (b'\x03\x02\x01' + pad5 +
+                           b'\x06\x05\x04' + pad5 +
+                           b'\x09\x08\x07' + pad5),
+        }
+        src = correct.get
+        rgba = src('rgba')
+        self.assertEqual(rgba_to(rgba, 'rgb', 1, 3, 4), src('rgb_align2'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 1, 3, 4), src('bgr_align2'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 1, 3, None), src('rgb_align4'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 1, 3, None), src('bgr_align4'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 1, 3, 0), src('rgb_raw'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 1, 3, 0), src('bgr_raw'))
+        self.assertEqual(rgba_to(rgba, 'rgb', 1, 3, 8), src('rgb_align8'))
+        self.assertEqual(rgba_to(rgba, 'bgr', 1, 3, 8), src('bgr_align8'))
+
+
+if __name__ == '__main__':
+    import sys
+    accept_filter = ['ImageLoader{}'.format(x) for x in sys.argv[1:]]
+    if accept_filter:
+        LOADERS = {x: LOADERS[x] for x in accept_filter}
+
+    DEBUG = True
+    unittest.main(argv=sys.argv[:1])

--- a/kivy/tests/test_imageloader.py
+++ b/kivy/tests/test_imageloader.py
@@ -231,7 +231,7 @@ class TestContext(object):
 
 
 @unittest.skipIf(not os.path.isdir(asset(ASSETDIR)),
-                 "Need 'make testimages' to run test")
+                 "Need 'make image-testsuite' to run test")
 class ImageLoaderTestCase(unittest.TestCase):
     def setUp(self):
         self._context = None

--- a/kivy/tests/test_imageloader.py
+++ b/kivy/tests/test_imageloader.py
@@ -44,7 +44,13 @@ def pattern_to_predictions(pat, alpha='FF'):
     PIXELS = {
         'w': b'\xFF\xFF\xFF', 'x': b'\x00\x00\x00',  # 't' is below
         'r': b'\xFF\x00\x00', 'g': b'\x00\xFF\x00', 'b': b'\x00\x00\xFF',
-        'y': b'\xFF\xFF\x00', 'c': b'\x00\xFF\xFF', 'p': b'\xFF\x00\xFF'}
+        'y': b'\xFF\xFF\x00', 'c': b'\x00\xFF\xFF', 'p': b'\xFF\x00\xFF',
+        '0': b'\x00\x00\x00', '1': b'\x11\x11\x11', '2': b'\x22\x22\x22',
+        '3': b'\x33\x33\x33', '4': b'\x44\x44\x44', '5': b'\x55\x55\x55',
+        '6': b'\x66\x66\x66', '7': b'\x77\x77\x77', '8': b'\x88\x88\x88',
+        '9': b'\x99\x99\x99', 'A': b'\xAA\xAA\xAA', 'B': b'\xBB\xBB\xBB',
+        'C': b'\xCC\xCC\xCC', 'D': b'\xDD\xDD\xDD', 'E': b'\xEE\xEE\xEE',
+        'F': b'\xFF\xFF\xFF'}
 
     # Some loaders/formats/conversion processes can result in binary
     # transparency represented as white+a00 or black+a00 - we accept
@@ -150,7 +156,7 @@ class ImageLoaderTestCase(unittest.TestCase):
 
     # Matches generated file names
     FILE_RE = re.compile('^v0_(\d+)x(\d+)_'
-                         '([wxrgbycpt]+)_'
+                         '([wxrgbycptA-F0-9]+)_'
                          '([0-9A-Fa-f]{2})_'
                          '([\w_]+)\.([a-z]+)$')
 

--- a/kivy/tests/test_imageloader.py
+++ b/kivy/tests/test_imageloader.py
@@ -3,7 +3,6 @@ import re
 import unittest
 from pprint import pprint
 from kivy.core.image import ImageLoader
-from kivy.core.image.img_sdl2 import ImageLoaderSDL2
 
 DEBUG = False
 ASSETDIR = 'testimages'

--- a/kivy/tools/create-testimages.sh
+++ b/kivy/tools/create-testimages.sh
@@ -63,21 +63,20 @@ EOM
 draw_pattern() {
     pattern=$1
     direction="${2:-x}"
-    alpha=${3:-FF}
     pos=0
     for char in $(echo $pattern | fold -w1); do
         case $char in
             t) fill="#00000000" ;;
-            w) fill="#FFFFFF${alpha}" ;;
-            x) fill="#000000${alpha}" ;;
-            r) fill="#FF0000${alpha}" ;;
-            g) fill="#00FF00${alpha}" ;;
-            b) fill="#0000FF${alpha}" ;;
-            y) fill="#FFFF00${alpha}" ;;
-            c) fill="#00FFFF${alpha}" ;;
-            p) fill="#FF00FF${alpha}" ;;
+            w) fill="#FFFFFF${TESTALPHA}" ;;
+            x) fill="#000000${TESTALPHA}" ;;
+            r) fill="#FF0000${TESTALPHA}" ;;
+            g) fill="#00FF00${TESTALPHA}" ;;
+            b) fill="#0000FF${TESTALPHA}" ;;
+            y) fill="#FFFF00${TESTALPHA}" ;;
+            c) fill="#00FFFF${TESTALPHA}" ;;
+            p) fill="#FF00FF${TESTALPHA}" ;;
             0|1|2|3|4|5|6|7|8|9|A|B|C|D|E|F)
-                fill="#${char}${char}${char}${char}${char}${char}${alpha}"
+                fill="#${char}${char}${char}${char}${char}${char}${TESTALPHA}"
             ;;
             *) (>&2 echo "Error: Invalid pattern char: $char"); exit 100 ;;
         esac
@@ -108,7 +107,7 @@ make_images() {
     ending="${TESTALPHA}_${TESTFMT}_${TESTNAME}.${TESTEXT}"
     outfile="v0_${len}x1_${pattern}_${ending}"
     eval convert -size ${len}x1 xc:none -quality 100% $TESTARGS \
-        $(draw_pattern "$pattern" "x" "$alpha") \
+        $(draw_pattern "$pattern" "x") \
         ${convert_args} \
         "${TESTFMT}:$destdir/$outfile"
 
@@ -116,7 +115,7 @@ make_images() {
     if [ $len -ne 1 ]; then
         outfile="v0_1x${len}_${pattern}_${ending}"
         eval convert -size 1x${len} xc:none -quality 100% $TESTARGS \
-            $(draw_pattern "$pattern" "y" "$alpha") \
+            $(draw_pattern "$pattern" "y") \
             "${TESTFMT}:$destdir/$outfile"
     fi
 }

--- a/kivy/tools/create-testimages.sh
+++ b/kivy/tools/create-testimages.sh
@@ -12,13 +12,17 @@ Creates test images in many formats using ImageMagick 'convert'
 utility. The pixel values are encoded in the filename, so they
 can be reconstructed and verified.
 
-<W>x<H>_<pattern>_<alpha>_<format>_<info>.<extension>
+v0_<W>x<H>_<pattern>_<alpha>_<format>_<info>.<extension>
 
-  Example: "3x1_rgb_FF_PNG24_OPAQUE.png" is a 3x1 image with
+  Example: "v0_3x1_rgb_FF_PNG24_OPAQUE.png" is a 3x1 image with
   red, green and blue pixels. Alpha is FF, the ImageMagick
   format is PNG24. <info> is used to distinguish tests that
   use the same pattern but differ in other parameters
   (currently _OPAQUE, _BINARY and _ALPHA)
+
+  The leading 'v0_' indicates version 0 of the test protocol,
+  which is defined by this implementation. All v0 images are
+  either a single row or single column of pixels with values:
 
 Pattern legend:
 
@@ -81,14 +85,14 @@ make_images() {
     fi
 
     # Nx1
-    outfile="${len}x1_${pattern}_${alpha}_${format}${name}.${ext}"
+    outfile="v0_${len}x1_${pattern}_${alpha}_${format}${name}.${ext}"
     eval convert -size ${len}x1 xc:none -quality 100% -alpha on \
         $(draw_pattern "$pattern" "x" "$alpha") \
         "${format}:$destdir/$outfile"
 
     # 1xN - don't create duplicates for single pixel
     if [ $len -ne 1 ]; then
-        outfile="1x${len}_${pattern}_${alpha}_${format}${name}.${ext}"
+        outfile="v0_1x${len}_${pattern}_${alpha}_${format}${name}.${ext}"
         eval convert -size 1x${len} xc:none -quality 100% -alpha on \
             $(draw_pattern "$pattern" "y" "$alpha") \
             "${format}:$destdir/$outfile"
@@ -103,11 +107,6 @@ if [ "$#" -ne 1 ] || [ -z "$1" ]; then
     exit 1
 fi
 
-if [ ! -x "$(command -v convert)" ]; then
-    (2>&1 echo "Required ImageMagick 'convert' not found in path")
-    exit 2
-fi
-
 case $1 in
     -h|--help) usage; exit 1 ;;
 esac
@@ -120,6 +119,11 @@ elif [ ! -w "$1" ]; then
     exit 2
 fi
 destdir=$(cd "$1"; echo $(pwd))
+
+if [ ! -x "$(command -v convert)" ]; then
+    (2>&1 echo "Required ImageMagick 'convert' not found in path")
+    exit 3
+fi
 
 # Make a random pattern from given characters $1 at length $2
 # FIXME: portability?

--- a/kivy/tools/create-testimages.sh
+++ b/kivy/tools/create-testimages.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env sh
+
+# ImageMagickFormat:extension
+FMT_OPAQUE="TIFF:tiff BMP:bmp BMP3:bmp PNG:png GIF87:gif CUR:cur"
+FMT_BINARY="BMP:bmp GIF:gif PNG8:png PNG24:png PNG48:png ICO:ico"
+FMT_ALPHA="PNG32:png PNG64:png TGA:tga SGI:sgi DPX:dpx"
+
+usage() { cat <<EOM
+Usage: $0 <target-directory>
+
+Creates test images in many formats using ImageMagick 'convert'
+utility. The pixel values are encoded in the filename, so they
+can be reconstructed and verified.
+
+<W>x<H>_<pattern>_<alpha>_<format>_<info>.<extension>
+
+  Example: "3x1_rgb_FF_PNG24_OPAQUE.png" is a 3x1 image with
+  red, green and blue pixels. Alpha is FF, the ImageMagick
+  format is PNG24. <info> is used to distinguish tests that
+  use the same pattern but differ in other parameters
+  (currently _OPAQUE, _BINARY and _ALPHA)
+
+Pattern legend:
+
+  w: White  (#fff)    x: Black (#000)** t: Transp (#0000)**
+  r: Red    (#f00)    g: Green (#0f0)   b: Blue   (#00f)
+  y: Yellow (#ff0)    c: Cyan  (#0ff)   p: Purple (#f0f)
+
+  ** 't' and 'x' cannot be combined in the same pattern for
+     testing binary transparency (all black pixels become
+     transparent for some formats, causing tests to fail).
+
+EOM
+}
+
+# Outputs command line arguments for convert to draw pixels from the
+# specifed pattern in the specified direction. It is always 1 in w or h.
+draw_pattern() {
+    pattern=$1
+    direction="${2:-x}"
+    alpha=${3:-FF}
+    pos=0
+    for char in $(echo $pattern | fold -w1); do
+        case $char in
+            t) fill="#00000000" ;;
+            w) fill="#FFFFFF${alpha}" ;;
+            x) fill="#000000${alpha}" ;;
+            r) fill="#FF0000${alpha}" ;;
+            g) fill="#00FF00${alpha}" ;;
+            b) fill="#0000FF${alpha}" ;;
+            y) fill="#FFFF00${alpha}" ;;
+            c) fill="#00FFFF${alpha}" ;;
+            p) fill="#FF00FF${alpha}" ;;
+            *) (>&2 echo "Error: Invalid pattern char: $char"); exit 100 ;;
+        esac
+        case $direction in
+            y|height) echo -n "-draw 'fill $fill color 0, $pos point' " ;;
+            x|width)  echo -n "-draw 'fill $fill color $pos, 0 point' " ;;
+        esac
+        pos=$((pos+1))
+    done
+}
+
+# Creates 1xN and Nx1 test images from the given pattern, in the given
+# format. Only use alpha != FF if you are actually testing alpha.
+make_images() {
+    pattern=$1
+    format=$2
+    ext=$3
+    alpha=${4:-FF}
+    name=$5
+    len=${#pattern}
+
+    if [ -z $pattern ] || [ -z $format ] || [ -z $ext ]; then
+        (>&2 echo "make_images() missing required arguments")
+        exit 101
+    fi
+    if [ ${#alpha} != 2 ]; then
+        (>&2 echo "make_images() invalid alpha: $alpha")
+        exit 102
+    fi
+
+    # Nx1
+    outfile="${len}x1_${pattern}_${alpha}_${format}${name}.${ext}"
+    eval convert -size ${len}x1 xc:none -quality 100% -alpha on \
+        $(draw_pattern "$pattern" "x" "$alpha") \
+        "${format}:$destdir/$outfile"
+
+    # 1xN - don't create duplicates for single pixel
+    if [ $len -ne 1 ]; then
+        outfile="1x${len}_${pattern}_${alpha}_${format}${name}.${ext}"
+        eval convert -size 1x${len} xc:none -quality 100% -alpha on \
+            $(draw_pattern "$pattern" "y" "$alpha") \
+            "${format}:$destdir/$outfile"
+    fi
+}
+
+# ------------------------------------------------------------
+# Main
+# ------------------------------------------------------------
+if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+    echo "Usage: $0 <target-directory>  (or -h for help)"
+    exit 1
+fi
+
+if [ ! -x "$(command -v convert)" ]; then
+    (2>&1 echo "Required ImageMagick 'convert' not found in path")
+    exit 2
+fi
+
+case $1 in
+    -h|--help) usage; exit 1 ;;
+esac
+
+if [ ! -d "$1" ]; then
+    (>&2 echo "Error: Destination directory '$1' does not exist")
+    exit 2
+elif [ ! -w "$1" ]; then
+    (>&2 echo "Error: Destination directory '$1' not writeable")
+    exit 2
+fi
+destdir=$(cd "$1"; echo $(pwd))
+
+# Make a random pattern from given characters $1 at length $2
+# FIXME: portability?
+mkpattern() {
+    < /dev/urandom LC_ALL=C tr -dc "$1" | head -c $2
+}
+
+# Opaque patterns only include solid colors, alpha is fixed at FF
+PAT_opaque="w x r g b y c p wx cy cp xyx rgb rgbw rgbwx cyp cypw cypwx"
+for i in $(seq 2 9) $(seq 14 17) $(seq 31 33); do
+    new=$(mkpattern "wxrgbcyp" "$i")
+    PAT_opaque="${PAT_opaque} ${new}"
+done
+for rawfmt in $FMT_OPAQUE $FMT_BINARY $FMT_ALPHA; do
+    fmt=${rawfmt%:*}
+    ext=${rawfmt#*:}
+    echo "[OPAQUE] Creating ${fmt} test images ..."
+    for pat in $PAT_opaque; do
+        make_images "$pat" "$fmt" "$ext" "FF" "_OPAQUE"
+    done
+done
+
+# Binary patterns MUST include 't' pixels and MUST NOT include 'x'
+PAT_binary="t tw tr tg tb tc ty tp tt twrt trgb trgbt tcypt rtg rttg rtttg"
+for i in $(seq 2 9) $(seq 14 17) $(seq 31 33); do
+    new=$(mkpattern "twrgbcyp" "$i")
+    PAT_binary="${PAT_binary} t${new}"
+done
+for rawfmt in $FMT_BINARY $FMT_ALPHA; do
+    fmt=${rawfmt%:*}
+    ext=${rawfmt#*:}
+    echo "[BINARY] Creating ${fmt} test images ..."
+    for pat in $PAT_binary; do
+        make_images "$pat" "$fmt" "$ext" "FF" "_BINARY"
+    done
+done
+
+# Reuse binary/opaque for alpha patterns. These are generated with the
+# same pixel values, but differeent (per-pixel) alpha. Also test
+# white, black and fully-transparent pixels in one pattern.
+PAT_alpha="${PAT_opaque} ${PAT_binary} twx wtx xwt xxttww"
+for rawfmt in $FMT_ALPHA; do
+    fmt=${rawfmt%:*}
+    ext=${rawfmt#*:}
+    echo "[ALPHA] Creating ${fmt} test images ..."
+    for alpha in 7F F0; do
+        for pat in $PAT_alpha; do
+            make_images "$pat" "$fmt" "$ext" "$alpha" "_ALPHA"
+        done
+    done
+done
+

--- a/kivy/tools/image-testsuite/README.md
+++ b/kivy/tools/image-testsuite/README.md
@@ -1,0 +1,148 @@
+Generating the image test suite
+-------------------------------
+
+On Linux/unix systems, you can use the `imagemagick-testsuite.sh` script
+to create an image test suite using the `convert` command line utility. You
+must have ImageMagick installed ("apt install imagemagick" on debian
+derivatives). There is also a rule in the Makefile, `make testimages`.
+
+A more comprehensive test suite can be generated using Gimp (tested on
+version 2.8.18). To install the plugin, copy `gimp28-testsuite.py` to your
+gimp plugins directory, on linux/unix systems usually `~/.gimp-2.8/plug-ins`.
+You can find the plugin location via the Gimp menu `Edit` - `Preferences` -
+`Folders` - `Plug-Ins`. Once installed, the plugin should appear in "Tools"
+menu, named "Kivy image testsuite".
+
+Test images must be saved in the `kivy/tests/image-testsuite` directory,
+after this you can run the test. It is (currently) preferable to run it
+directly as a script, instead of via `make test`, since the latter won't
+give you useful debug output.
+
+    cd kivy/tests
+    python test_imageloader.py | less
+
+or to get only the summary report:
+
+    python test_imageloader.py | grep REPORT | less
+
+
+Kivy ImageLoader testsuite
+--------------------------
+
+These tools generate a wide range of images for testing Kivy's ImageLoaders.
+The pixel data is encoded in the file name, and reproduced "from the sideline"
+in order to verify the pixel data loaded from file. This is used to expose
+issues in the Kivy core and underlying provider libraries.
+
+The filenames consist of sections separated by an underscore `_`:
+
+    v0_ <W> x <H> _ <pat> _ <alpha> _ <fmt> _ <testname> _ <encoder> . <ext>
+
+Variables are enclosed in pointy brackets. The leading `v0_` indicates that
+it conforms to version 0 of the test protocol (described in this document)
+and must be present.
+
+    v0_5x1_rgb_FF_PNG24_OPAQUE_magick.png
+
+This is a 5x1 image, pattern is "rgb", alpha is "FF". `PNG24` is the internal
+file format name (ImageMagick-specific), and `OPAQUE` is the test we  are
+performing (drawing opaque pixels only), see test names below.
+
+* <pattern> indicates the pixel colors (in order), as they are drawn in the
+  image file.
+
+* <alpha> is the global alpha from 00-FF (2 bytes, ascii) which is applied to
+  all pixels except 't' (transparent) which have fixed alpha at 00
+
+* <fmt> (aka fmtinfo) is an encoder-specific string with information about the
+  format or process that generated the file. For example, if the same image
+  is saved with and without interlacing, it will contain "I1" and "I0" to
+  distinguish the files.
+  * ImageMagick test suite generator uses magick format name, such as `PNG24`
+  * The Gimp generator plugin adds information about the layer that was
+    exported to form the image:
+      * BPP1G = 1 byte per pixel, gray
+      * BPP2GA = 2 bytes per pixel, gray + alpha
+      * BPP3 = 3 bytes per pixel, rgb
+      * BPP4 = 4 bytes per pixel, rgba
+      * IX = indexed, IXA = indexed+alpha
+      * Note: Indexed images are drawn in RGB or GRAY images (with alpha if
+        needed), and converted to indexed before export. These values
+        represent the layer type at time of export, it affects the parameters
+        used for encoding the output data.
+
+* <testname> is a special string that indicates what type of data is expected
+  in the file. Options are OPAQUE, BINARY, ALPHA and repeated for grayscale,
+  GRAY-OPAQUE, GRAY-BINARY, GRAY-ALPHA. We expect BINARY and ALPHA tests to
+  result in an alpha channel (details below)
+
+* <encoder> identifies the software that created the file, "magick", "gimp" ..
+
+* <ext> is the extension, must be lowercase and match the extensions
+  supported by Kivy image loaders (or they will be ignored)
+
+
+Test names
+----------
+
+* `OPAQUE` tests opaque pixels (normal RGB) (lossess formats)
+* `BINARY` tests opaque + fully transparent pixels (GIF etc)
+* `ALPHA` tests semi-transparent pixels (normal RGBA) (PNG32 etc)
+* `GRAY-OPAQUE` tests opaque grayscale only (various PNG, tga, )
+* `GRAY-BINARY` tests opaque grayscale + fully transparent pixels (PNGs)
+* `GRAY-ALPHA` tests semi-transparent grayscale pixels (TGA, XCF)
+
+Patterns must conform to the specific test. For example, the pattern "rgb" has
+undefined behavior for a grayscale test, since r/g/b can't be represented
+in grayscale. So all grayscale formats must use 0-9A-F only, and optionally 
+'t' for transparent pixels in GRAY-BINARY/GRAY-ALPHA.
+
+
+| Test name    | Valid pattern characters                                    |
+| -----------: | :---------------------------------------------------------- |
+| OPAQUE       | `wxrgbcyp`, and full grayscale\*\*                          |
+| GRAY-OPAQUE  | `0123456789ABCDEF` (full grayscale)                         |
+| BINARY       | `t` REQUIRED + `wrgbcyp`, limited grayscale (no 0/x!!!)     |
+| GRAY-BINARY  | `t` REQUIRED + limited grayscale (no 0/x!!!)                |
+| ALPHA        | `t`, `wxrbgcyp` and full grayscale\*\*                      |
+| GRAY-ALPHA   | `t`, `0123456789ABCDEF` (full grayscale)                    |
+
+* `**`: While grayscale is supported here, it is generally better to use
+  colors, since all the bytes in a grayscale pixel represented as rgb are
+  identical. For example, 'A' or \xAA\xAA\xAA will pass despite a byte
+  order problem.
+
+* `!!!`: In some cases, black color is used for binary transparency. So
+  if you use "0"`(or "x"), test_imageloader will expect #000000FF in RGBA,
+  but the pixel becomes transparent (a=00) and test fails. All BINARY tests
+  **MUST** include at least one "t" pixel to ensure that the image is
+  saved with an alpha channel.
+
+
+Pixel values
+------------
+
+Each character in the pattern represents the color of a single pixel. It is
+important that you include only the correct type of pixel values for the
+different test types (see table above). Individual pixel values get their
+alpha from global setting (<alpha> in filename), but 't' pixels always have
+alpha = 0x00 regardless of the test's alpha setting.
+
+
+    OPAQUE, BINARY, ALPHA (lowercase)
+    -----------------------------------------
+    "w" White (#fff)     "x" Black  (#000)!!!
+    "r" Red   (#f00)     "g" Green  (#0f0)
+    "b" Blue  (#00f)     "y" Yellow (#ff0)
+    "c" Cyan  (#0ff)     "p" Purple (#f0f)
+
+
+    GRAY-OPAQUE, GRAY-BINARY, GRAY-ALPHA (uppercase)
+    ------------------------------------------------
+    "0" #000!!!  "1" #111     "2" #222     "3" #333
+    "4" #444     "5" #555     "6" #666     "7" #777
+    "8" #888     "9" #999     "A" #AAA     "B" #BBB
+    "C" #CCC     "D" #DDD     "E" #EEE     "F" #FFF
+
+    !!! See warnings above regarding BINARY tests
+

--- a/kivy/tools/image-testsuite/README.md
+++ b/kivy/tools/image-testsuite/README.md
@@ -113,7 +113,7 @@ in grayscale. So all grayscale formats must use 0-9A-F only, and optionally
   order problem.
 
 * `!!!`: In some cases, black color is used for binary transparency. So
-  if you use "0"`(or "x"), test_imageloader will expect #000000FF in RGBA,
+  if you use "0" (or "x"), test_imageloader will expect #000000FF in RGBA,
   but the pixel becomes transparent (a=00) and test fails. All BINARY tests
   **MUST** include at least one "t" pixel to ensure that the image is
   saved with an alpha channel.

--- a/kivy/tools/image-testsuite/README.md
+++ b/kivy/tools/image-testsuite/README.md
@@ -4,7 +4,7 @@ Generating the image test suite
 On Linux/unix systems, you can use the `imagemagick-testsuite.sh` script
 to create an image test suite using the `convert` command line utility. You
 must have ImageMagick installed ("apt install imagemagick" on debian
-derivatives). There is also a rule in the Makefile, `make testimages`.
+derivatives). There is also a rule in the Makefile, `make image-testsuite`.
 
 A more comprehensive test suite can be generated using Gimp (tested on
 version 2.8.18). To install the plugin, copy `gimp28-testsuite.py` to your

--- a/kivy/tools/image-testsuite/gimp28-testsuite.py
+++ b/kivy/tools/image-testsuite/gimp28-testsuite.py
@@ -262,6 +262,13 @@ def makepatterns(allow, include=None, exclude=None):
 
 
 def plugin_main(dirname, do_opaque, do_binary, do_alpha):
+    if not dirname:
+        pdb.gimp_message("No ouput directory selected, aborting")
+        return
+    if not os.path.isdir(dirname) or not os.access(dirname, os.W_OK):
+        pdb.gimp_message("Invalid / non-writeable output directory, aborting")
+        return
+
     tests = []
     tests.extend({
         0: ['OPAQUE', 'GRAY-OPAQUE'],

--- a/kivy/tools/image-testsuite/gimp28-testsuite.py
+++ b/kivy/tools/image-testsuite/gimp28-testsuite.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python
+import os
+import re
+import random
+from gimpfu import *
+
+# Test suite configuration - key is test name, values are:
+#
+# alpha....: global alpha, used for all pixels except 't'
+# patterns.: allowed v0 pattern characters (+ force include and exclude)
+# *_IMAGE..: gimp layer types to export for this test, w/target extensions
+TESTSUITE_CONFIG = {
+    'OPAQUE': {
+        'alpha': [255],
+        'patterns': ('wxrgbcyp', None, None),
+        RGB_IMAGE: ['xcf', 'png', 'tga', 'tiff', 'ppm',
+                    'sgi', 'pcx', 'fits', 'ras'],
+        INDEXED_IMAGE: ['xcf', 'png', 'tga', 'tiff', 'ppm', 'gif', 'ras'],
+    },
+
+    'GRAY-OPAQUE': {
+        'alpha': [255],
+        'patterns': ('0123456789ABCDEF', None, None),
+        GRAY_IMAGE: ['xcf', 'png', 'tga', 'tiff',
+                     'pgm', 'sgi', 'fits', 'ras'],
+        INDEXED_IMAGE: ['xcf', 'png', 'tga', 'tiff', 'pgm', 'fits', 'ras'],
+    },
+
+    'BINARY': {
+        'alpha': [255],
+        'patterns': ('twrgbcyp', 't', None),
+        RGBA_IMAGE: ['xcf', 'png', 'tga', 'ico', 'sgi'],
+        INDEXEDA_IMAGE: ['xcf', 'png', 'tga', 'gif'],
+    },
+    'GRAY-BINARY': {
+        'alpha': [255],
+        'patterns': ('t123456789ABCDEF', 't', None),
+        GRAYA_IMAGE: ['xcf', 'tga', 'png', 'sgi'],
+        INDEXEDA_IMAGE: ['xcf', 'tga', 'png'],
+    },
+
+    "ALPHA": {
+        'alpha': [0x7F, 0xF0],
+        'patterns': ('twxrgbcyp', None, None),
+        RGBA_IMAGE: ['xcf', 'png', 'tga', 'sgi'],
+    },
+    'GRAY-ALPHA': {
+        'alpha': [0x7F, 0xF0],
+        'patterns': ('t0123456789ABCDEF', None, None),
+        GRAYA_IMAGE: ['xcf', 'png', 'tga', 'sgi'],
+    },
+}
+
+
+# kivy image test protocol v0 data: key is pattern char, value is pixel w/o a
+v0_PIXELS = {
+    'w': [0xFF, 0xFF, 0xFF], 'x': [0x00, 0x00, 0x00], 'r': [0xFF, 0x00, 0x00],
+    'g': [0x00, 0xFF, 0x00], 'b': [0x00, 0x00, 0xFF], 'y': [0xFF, 0xFF, 0x00],
+    'c': [0x00, 0xFF, 0xFF], 'p': [0xFF, 0x00, 0xFF], '0': [0x00, 0x00, 0x00],
+    '1': [0x11, 0x11, 0x11], '2': [0x22, 0x22, 0x22], '3': [0x33, 0x33, 0x33],
+    '4': [0x44, 0x44, 0x44], '5': [0x55, 0x55, 0x55], '6': [0x66, 0x66, 0x66],
+    '7': [0x77, 0x77, 0x77], '8': [0x88, 0x88, 0x88], '9': [0x99, 0x99, 0x99],
+    'A': [0xAA, 0xAA, 0xAA], 'B': [0xBB, 0xBB, 0xBB], 'C': [0xCC, 0xCC, 0xCC],
+    'D': [0xDD, 0xDD, 0xDD], 'E': [0xEE, 0xEE, 0xEE], 'F': [0xFF, 0xFF, 0xFF]}
+
+
+# kivy image test protocol v0: return pixel data for given pattern char
+def v0_pattern_pixel(char, alpha, fmt):
+    if fmt == 'rgba':
+        if char == 't':
+            return [0, 0, 0, 0]
+        return v0_PIXELS[char] + [alpha]
+    if fmt == 'rgb':
+        if char == 't':
+            return [0, 0, 0]
+        return v0_PIXELS[char]
+    if fmt == 'gray':
+        assert char in '0123456789ABCDEF'
+        return [v0_PIXELS[char][0]]
+    if fmt == 'graya':
+        assert char in 't0123456789ABCDEF'
+        if char == 't':
+            return [0, 0]
+        return [v0_PIXELS[char][0]] + [alpha]
+    raise Exception('v0_pattern_pixel: unknown format {}'.format(fmt))
+
+
+# kivy image test protocol v0: filename
+def v0_filename(w, h, pat, alpha, fmtinfo, testname, ext):
+    return 'v0_{}x{}_{}_{:02X}_{}_{}_gimp.{}'.format(
+            w, h, pat, alpha, fmtinfo, testname, ext)
+
+
+# Saves an image to one or more files. We can't specify these details when
+# saving by extension. (This declaration is PEP8 compliant, 's all good)
+def save_image(dirname, img, lyr, w, h, pat, alpha, v0_fmtinfo, testname, ext):
+    def filename(fmtinfo_in=None):
+        fmtinfo = fmtinfo_in and v0_fmtinfo + '-' + fmtinfo_in or v0_fmtinfo
+        return v0_filename(w, h, pat, alpha, fmtinfo, testname, ext)
+
+    def savepath(fn):
+        return os.path.join(dirname, fn)
+
+    if ext in ('ppm', 'pgm', 'pbm', 'pnm', 'pam'):
+        fn = filename('ASCII')
+        pdb.file_pnm_save(img, lyr, savepath(fn), fn, 0)
+        fn = filename('RAW')
+        pdb.file_pnm_save(img, lyr, savepath(fn), fn, 1)
+
+    elif ext == 'tga':
+        # FIXME: Last argument to file_tga_save is undocumented, not sure what
+        fn = filename('RAW')
+        pdb.file_tga_save(img, lyr, savepath(fn), fn, 0, 0)
+        fn = filename('RLE')
+        pdb.file_tga_save(img, lyr, savepath(fn), fn, 1, 0)
+
+    elif ext == 'gif':
+        fn = filename('I0')
+        pdb.file_gif_save(img, lyr, savepath(fn), fn, 0, 0, 0, 0)
+        fn = filename('I1')
+        pdb.file_gif_save(img, lyr, savepath(fn), fn, 1, 0, 0, 0)
+
+    elif ext == 'png':
+        bits = [0, 1]
+        # interlaced, bkgd block, gama block
+        for i, b, g in [(i, b, g) for i in bits for b in bits for g in bits]:
+            fn = filename('I{}B{}G{}'.format(i, b, g))
+            pdb.file_png_save(img, lyr, savepath(fn), fn, i, 9, b, g, 1, 1, 1)
+
+    elif ext == 'sgi':
+        fn = filename('RAW')
+        pdb.file_sgi_save(img, lyr, savepath(fn), fn, 0)
+        fn = filename('RLE')
+        pdb.file_sgi_save(img, lyr, savepath(fn), fn, 1)
+        fn = filename('ARLE')
+        pdb.file_sgi_save(img, lyr, savepath(fn), fn, 2)
+
+    elif ext == 'tiff':
+        fn = filename('RAW')
+        pdb.file_tiff_save(img, lyr, savepath(fn), fn, 0)
+        fn = filename('LZW')
+        pdb.file_tiff_save(img, lyr, savepath(fn), fn, 1)
+        fn = filename('PACKBITS')
+        pdb.file_tiff_save(img, lyr, savepath(fn), fn, 2)
+        fn = filename('DEFLATE')
+        pdb.file_tiff_save(img, lyr, savepath(fn), fn, 3)
+
+    elif ext == 'ras':
+        fn = filename('RAW')
+        pdb.file_sunras_save(img, lyr, savepath(fn), fn, 0)
+        fn = filename('RLE')
+        pdb.file_sunras_save(img, lyr, savepath(fn), fn, 1)
+
+    else:
+        fn = filename()
+        pdb.gimp_file_save(img, lyr, savepath(fn), fn)
+
+
+# Draw pattern on layer, helper for make_images() below
+def draw_pattern(lyr, pat, alpha, direction, pixelgetter):
+    assert 0 <= alpha <= 255
+    assert re.match('[twxrgbycp0-9A-F]+$', pat)
+    assert direction in ('x', 'y', 'width', 'height')
+    dirx = direction in ('x', 'width')
+    for i in range(0, len(pat)):
+        pixel = pixelgetter(pat[i], alpha)
+        if dirx:
+            pdb.gimp_drawable_set_pixel(lyr, i, 0, len(pixel), pixel)
+        else:
+            pdb.gimp_drawable_set_pixel(lyr, 0, i, len(pixel), pixel)
+
+
+# Create an image from the given pattern, with the specified layertype_in*,
+# draw the pattern with given alpha, and save to the given extensions. Gimp
+# adjust the encoder accordingly.
+# * cheat for indexed formats: draw in RGB(A) and let gimp make palette
+def make_images(testname, pattern, alpha, layertype_in, extensions, dirname):
+    assert testname.upper() == testname
+    assert len(pattern) > 0
+    assert len(extensions) > 0
+    assert isinstance(extensions, (list, tuple))
+    assert re.match('[wxtrgbcypA-F0-9]+$', pattern)
+
+    test_alpha = 'ALPHA' in testname or 'BINARY' in testname
+    grayscale = 'GRAY' in testname
+
+    # Indexed layer types are drawn in RGB/RGBA, and converted later
+    imgtype, v0_fmtinfo = {
+        GRAY_IMAGE: (GRAY, 'BPP1G'),
+        GRAYA_IMAGE: (GRAY, 'BPP2GA'),
+        RGB_IMAGE: (RGB, 'BPP3'),
+        RGBA_IMAGE: (RGB, 'BPP4'),
+        INDEXED_IMAGE: (grayscale and GRAY or RGB, 'IX'),
+        INDEXEDA_IMAGE: (grayscale and GRAY or RGB, 'IXA'),
+    }[layertype_in]
+
+    # We need to supply pixels of the format of the layer
+    PP = v0_pattern_pixel
+    pixelgetter = {
+        GRAY_IMAGE: lambda c, a: PP(c, a, 'gray'),
+        GRAYA_IMAGE: lambda c, a: PP(c, a, 'graya'),
+        RGB_IMAGE: lambda c, a: PP(c, a, 'rgb'),
+        RGBA_IMAGE: lambda c, a: PP(c, a, 'rgba'),
+        INDEXED_IMAGE: lambda c, a: PP(c, a, grayscale and 'gray' or 'rgb'),
+        INDEXEDA_IMAGE: lambda c, a: PP(c, a, grayscale and 'graya' or 'rgba'),
+    }[layertype_in]
+
+    # Pick the correct layer type for indexed formats
+    layertype = {
+        INDEXED_IMAGE: grayscale and GRAY_IMAGE or RGB_IMAGE,
+        INDEXEDA_IMAGE: grayscale and GRAYA_IMAGE or RGBA_IMAGE,
+    }.get(layertype_in, layertype_in)
+
+    # Draw pattern Nx1 and 1xN variations
+    for direction in 'xy':
+        # Create the gimp image, and the layer we will draw on
+        w, h = (direction == 'x') and (len(pattern), 1) or (1, len(pattern))
+        img = pdb.gimp_image_new(w, h, imgtype)
+        lyr = pdb.gimp_layer_new(img, w, h, layertype, 'P', 100, NORMAL_MODE)
+
+        # Add alpha layer if we are planning on encoding alpha information
+        if test_alpha:
+            pdb.gimp_layer_add_alpha(lyr)
+            pdb.gimp_drawable_fill(lyr, TRANSPARENT_FILL)
+        pdb.gimp_image_add_layer(img, lyr, 0)
+
+        # Draw it
+        draw_pattern(lyr, pattern, alpha, direction, pixelgetter)
+
+        # Convert to indexed before saving, if needed
+        if layertype_in in (INDEXED_IMAGE, INDEXEDA_IMAGE):
+            colors = len(set(pattern)) + (test_alpha and 1 or 0)
+            pdb.gimp_convert_indexed(img, 0, 0, colors, 0, 0, "ignored")
+
+        # Save each individual extension
+        for ext in extensions:
+            save_image(dirname, img, lyr,
+                       w, h, pattern, alpha, v0_fmtinfo, testname, ext)
+        # FIXME: this fails?
+        # pdb.gimp_image_delete(img)
+
+
+# FIXME: pattern generation needs thought, this sucks..
+def makepatterns(allow, include=None, exclude=None):
+    src = set()
+    src.update([x for x in allow])
+    src.update([allow[:i] for i in range(1, len(allow) + 1)])
+    for i in range(len(allow)):
+        pick1, pick2 = random.choice(allow), random.choice(allow)
+        src.update([pick1 + pick2])
+    for i in range(3, 11) + range(14, 18) + range(31, 34):
+        src.update([''.join([random.choice(allow) for k in range(i)])])
+    out = []
+    for srcpat in src:
+        if exclude and exclude in srcpat:
+            continue
+        if include and include not in srcpat:
+            out.append(include + srcpat[1:])
+            continue
+        out.append(srcpat)
+    return list(set(out))
+
+
+def plugin_main(dirname, do_opaque, do_binary, do_alpha):
+    tests = []
+    tests.extend({
+        0: ['OPAQUE', 'GRAY-OPAQUE'],
+        2: ['OPAQUE'],
+        3: ['GRAY-OPAQUE'],
+    }.get(do_opaque, []))
+    tests.extend({
+        0: ['BINARY', 'GRAY-BINARY'],
+        2: ['BINARY'],
+        3: ['GRAY-BINARY'],
+    }.get(do_binary, []))
+    tests.extend({
+        0: ['ALPHA', 'GRAY-ALPHA'],
+        2: ['ALPHA'],
+        3: ['GRAY-ALPHA'],
+    }.get(do_alpha, []))
+
+    suite_cfg = dict(TESTSUITE_CONFIG)
+    for testname, cfg in suite_cfg.items():
+        if testname not in tests:
+            continue
+        pchars, inc, exc = cfg.pop('patterns')
+        if not pchars:
+            continue
+        patterns = makepatterns(pchars, inc, exc)
+        for alpha in cfg.pop('alpha', [255]):
+            for layertype, exts in cfg.items():
+                if not exts:
+                    continue
+                for p in patterns:
+                    make_images(testname, p, alpha, layertype, exts, dirname)
+
+
+register(
+    proc_name="kivy_image_testsuite",
+    help="Creates image test suite for Kivy ImageLoader",
+    blurb=("Creates image test suite for Kivy ImageLoader. "
+          "Warning: This will create thousands of images"),
+    author="For kivy.org, Terje Skjaeveland",
+    copyright="Copyright 2017 kivy.org (MIT license)",
+    date="2017",
+    imagetypes="",
+    params=[
+        (PF_DIRNAME, "outputdir", "Output directory:", 0),
+        (PF_OPTION, "opaque", "OPAQUE tests?", 0,
+                    ["All", "None", "OPAQUE", "GRAY-OPAQUE"]),
+        (PF_OPTION, "binary", "BINARY tests?", 0,
+                    ["All", "None", "BINARY", "GRAY-BINARY"]),
+        (PF_OPTION, "alpha", "ALPHA tests?", 0,
+                    ["All", "None", "ALPHA", "GRAY-ALPHA"]),
+    ],
+    results=[],
+    function=plugin_main,
+    menu="<Image>/Tools/_Kivy image testsuite...",
+    label="Generate images...")
+
+main()


### PR DESCRIPTION
**Summary of changes**

Add test case for image loaders, skipped by default. The test works by generating a wide range of image files with predictable pixel values (encoded in filename). These images are loaded using available image providers, and the resulting pixel data is compared to a prediction made from the filename. Only lossless formats are tested.

* Add ``tests/test_imageloader.py`` and ``tools/create-testimages.sh``
* Add ``testimages`` rule to Makefile (populates kivy/tests/testimages)

**Running the test**

1. Install ImageMagick (convert utility must be in path) + pillow, pygame, ffpyplayer, sdl2 to run all tests
2. ``make testimages``
3. Run ``kivy/tests/test_imageloader.py`` as a script to enable debug output to console (py3 recommended, missing some pretty printing for pixel data). Generates lots of output. You can specify providers as arguments to limit which tests are run, ``SDL2``, ``Pygame``, ``FFPy``, ``PIL``, ``GIF``, ..


**Test results**

Numbers will not be reproduced exactly due to randomly generated images, different library versions, etc. Passed = exact match with prediction, skipped = supported extension but loading failed, fail = image loaded, but pixel data mismatch.

* **ImageLoaderSDL2:** 1664 passed, 0 skipped, 182 failed
  * With #5300 applied: 100% passed
* **ImageLoaderFFPy:** 2329 passed, 0 skipped, 336 failed
  * Only issue I've spotted is +1 from expected value, seems like precision/rounding/conversion, F0 becomes F1, DD->DE etc. PNG32 passes and PNG64 fails for the same pixel data in at least one case.
* **ImageLoaderGIF:** 68 passed, 0 skipped, 101 failed
  * I think incorrect byte order in one case, and one seems plain wrong (1x1 fully opaque colored pixel returned as \x00\x00\x00\x00), needs research
* **ImageLoaderPIL:** 1833 passed, 403 skipped, 130 failed
  * Various problems, needs research
* **ImageLoaderPygame:** 1378 passed, 169 skipped, 130 failed
  * Ignores colorkey for some binary transparency (maybe other problems)


**Notes**

* The binary alpha tests allow white and black with 00 alpha as a fully transparent pixel. This could cause some tests to pass incorrectly (esp for small image dimensions). It should be caught by larger images, and I'm not sure if it even happens
* Many of the image loaders return pitch=0
  * Probably only affects rgb/bgr, but is there a reason for using 0 over w*4 for rgba for example?
  * I don't know the reasoning or full extend of the consequences here
  * The test assumes pitch 0 == no pitch alignment (raw bytes)
* magick PCX are unreadable by gimp and kivy providers, not included
* magick DDS (+DXT1, DXT5) are unreadable by ImageLoaderDDS, not included
* magick XV unreadable, not included
* img_sdl2 does not have 'gif' format listed as supported. I guess this is a deliberate priority choice? It's tested explicitly
* PIL lists SGI format support, but fails to load magick SGI files. FFPy reads them, so I left it enabled. Should probably 
* TIFF transparency is not tested, because it uses premultiplied alpha which the test does not support
* JPG is not tested, because lossy compression = unpredictable pixel values
