### PR TITLE
img_pygame: Fix loading of binary alpha formats

### DIFF
--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -65,7 +65,7 @@ class ImageLoaderPygame(ImageLoaderBase):
             raise
 
         fmt = ''
-        if im.get_bytesize() == 3:
+        if im.get_bytesize() == 3 and not im.get_colorkey():
             fmt = 'rgb'
         elif im.get_bytesize() == 4:
             fmt = 'rgba'


### PR DESCRIPTION
Fixes Pygame imageloader for binary alpha formats, passes imageloader test 100% after this. It just forces  the conversion process if a colorkey is present, which gives us an alpha channel