### PR TITLE
Add sdl2 system cursors

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -732,6 +732,19 @@ class WindowBase(EventDispatcher):
     def _set_cursor_state(self, value):
         pass
 
+    def set_system_cursor(self, cursor_name):
+        '''Set cursor to a SDL_SystemCursor
+        available cursors are: 'arrow', 'ibeam', 'wait', 'crosshair',
+        'wait_arrow', 'size_nwse', 'size_nesw', 'size_we', 'size_ns',
+        'size_all', 'no', 'hand'
+
+        .. versionadded:: 1.10.1
+
+        .. note::
+            This feature requires the SDL2 window provider.
+        '''
+        pass
+
     def _get_window_pos(self):
         pass
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -164,6 +164,40 @@ cdef class _WindowSDL2Storage:
     def _set_cursor_state(self, value):
         SDL_ShowCursor(value)
 
+    def set_system_cursor(self, str name):
+        if name == 'arrow':
+            num = SDL_SYSTEM_CURSOR_ARROW
+        elif name == 'ibeam':
+            num = SDL_SYSTEM_CURSOR_IBEAM
+        elif name == 'wait':
+            num = SDL_SYSTEM_CURSOR_WAIT
+        elif name == 'crosshair':
+            num = SDL_SYSTEM_CURSOR_CROSSHAIR
+        elif name == 'wait_arrow':
+            SDL_SYSTEM_CURSOR_WAITARROW
+        elif name == 'size_nwse':
+            num = SDL_SYSTEM_CURSOR_SIZENWSE
+        elif name == 'size_nesw':
+            num = SDL_SYSTEM_CURSOR_SIZENESW
+        elif name == 'size_we':
+            num = SDL_SYSTEM_CURSOR_SIZEWE
+        elif name == 'size_ns':
+            num = SDL_SYSTEM_CURSOR_SIZENS
+        elif name == 'size_all':
+            num = SDL_SYSTEM_CURSOR_SIZEALL
+        elif name == 'no':
+            num = SDL_SYSTEM_CURSOR_NO
+        elif name == 'hand':
+            num = SDL_SYSTEM_CURSOR_HAND
+        else:
+            return False
+        new_cursor = SDL_CreateSystemCursor(num)
+        self.set_cursor(new_cursor)
+        return True
+
+    cdef void set_cursor(self, SDL_Cursor * cursor):
+        SDL_SetCursor(cursor)
+
     def raise_window(self):
         SDL_RaiseWindow(self.win)
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -386,8 +386,8 @@ class WindowSDL(WindowBase):
         self._win.flip()
         super(WindowSDL, self).flip()
 
-    def set_system_cursor(self, value):
-        result = self._win.set_system_cursor(value)
+    def set_system_cursor(self, cursor_name):
+        result = self._win.set_system_cursor(cursor_name)
         return result
 
     def _get_window_pos(self):

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -386,6 +386,10 @@ class WindowSDL(WindowBase):
         self._win.flip()
         super(WindowSDL, self).flip()
 
+    def set_system_cursor(self, value):
+        result = self._win.set_system_cursor(value)
+        return result
+
     def _get_window_pos(self):
         return self._win.get_window_pos()
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -57,12 +57,25 @@ cdef extern from "SDL.h":
         SDL_GL_CONTEXT_FLAGS
         SDL_GL_CONTEXT_PROFILE_MASK
 
+    ctypedef enum SDL_SystemCursor:
+        SDL_SYSTEM_CURSOR_ARROW
+        SDL_SYSTEM_CURSOR_IBEAM
+        SDL_SYSTEM_CURSOR_WAIT
+        SDL_SYSTEM_CURSOR_CROSSHAIR
+        SDL_SYSTEM_CURSOR_WAITARROW
+        SDL_SYSTEM_CURSOR_SIZENWSE
+        SDL_SYSTEM_CURSOR_SIZENESW
+        SDL_SYSTEM_CURSOR_SIZEWE
+        SDL_SYSTEM_CURSOR_SIZENS
+        SDL_SYSTEM_CURSOR_SIZEALL
+        SDL_SYSTEM_CURSOR_NO
+        SDL_SYSTEM_CURSOR_HAND
+
     ctypedef enum SDL_BlendMode:
         SDL_BLENDMODE_NONE = 0x00000000
         SDL_BLENDMODE_BLEND = 0x00000001
         SDL_BLENDMODE_ADD = 0x00000002
         SDL_BLENDMODE_MOD = 0x00000004
-
 
     ctypedef enum SDL_TextureAccess:
         SDL_TEXTUREACCESS_STATIC
@@ -120,6 +133,8 @@ cdef extern from "SDL.h":
 
 
     cdef struct SDL_BlitMap
+
+    cdef struct SDL_Cursor
 
     cdef struct SDL_Surface:
         Uint32 flags
@@ -538,6 +553,8 @@ cdef extern from "SDL.h":
     cdef void SDL_SetWindowBordered(SDL_Window * window, SDL_bool bordered)
     cdef void SDL_ShowWindow(SDL_Window * window)
     cdef int SDL_ShowCursor(int toggle)
+    cdef void SDL_SetCursor(SDL_Cursor * cursor)
+    cdef SDL_Cursor* SDL_CreateSystemCursor(SDL_SystemCursor id)
     cdef void SDL_HideWindow(SDL_Window * window)
     cdef void SDL_RaiseWindow(SDL_Window * window)
     cdef void SDL_MaximizeWindow(SDL_Window * window)


### PR DESCRIPTION
Hello.
I have tested kivy  with sdl2 system cursors on windows, ubuntu, android 4.4 and everything works very nicely. I would like to share it with other people.

This commit adds necessary structs from SDL2 and a set_system_cursor method for kivy window where you can replace your app cursor.