### PR TITLE
#5146: Measure the OpenCV camera's frame rate and invert it.

### DIFF
--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -59,6 +59,7 @@ class CameraBase(EventDispatcher):
         self.stopped = kwargs.get('stopped')
         self._resolution = kwargs.get('resolution')
         self._index = kwargs.get('index')
+        self._frame_sample_size = kwargs.get('frame_sample_size')
         self._buffer = None
         self._format = 'rgb'
         self._texture = None

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -6,7 +6,7 @@ OpenCV Camera: Implement CameraBase with OpenCV
 # TODO: make usage of thread or multiprocess
 #
 
-__all__ = ('CameraOpenCV')
+__all__ = ('CameraOpenCV', )
 
 import functools
 import math
@@ -54,6 +54,7 @@ except ImportError:
     except ImportError:
         raise
 
+
 class CameraOpenCV(CameraBase):
     '''
     Implementation of CameraBase using OpenCV
@@ -70,8 +71,8 @@ class CameraOpenCV(CameraBase):
         :param threshold: The minimum frequency of a relevant frame rate
                           measurement.
         :return: The measured frame rate.
-        :raises RuntimeError: The specified number of frames cannot be read from
-                              the video capture.
+        :raises RuntimeError: The specified number of frames cannot be read
+                              from the video capture.
         '''
         frame_count = 0
         rates = Counter()
@@ -81,22 +82,22 @@ class CameraOpenCV(CameraBase):
                 break
             duration = time.time() - start
             Logger.debug('OpenCV: Captured frame {}/{} in {}s.'.format(
-                             frame_count + 1, frame_sample_size, duration))
+                frame_count + 1, frame_sample_size, duration))
             frame_count += 1
             rates[round(1 / duration)] += 1
         if frame_count != frame_sample_size:
             raise RuntimeError(('OpenCV: Unable to measure the frame rate, '
                                 'grabbed only {} out of {} frames.').format(
-                                   frame_count, frame_sample_size))
+                frame_count, frame_sample_size))
         rate_frequencies = rates.most_common()
         Logger.debug('OpenCV: Capture (fps, frequency)s are {!r}.'.format(
-                         rate_frequencies))
+            rate_frequencies))
         return Fraction(
             math.floor(
                 operator.div(
                     *functools.reduce(
                         lambda x, y: (x[0] + operator.mul(*y), x[1] + y[1])
-                                     if y[1] >= threshold else x,
+                        if y[1] >= threshold else x,
                         rate_frequencies,
                         (0, 0)))))
 
@@ -160,7 +161,7 @@ class CameraOpenCV(CameraBase):
                                              self._frame_sample_size)
         Logger.info(("Camera {}'s frame rate is {}fps based on {} "
                      "sample frames.").format(
-                        self._index, frame_rate, self._frame_sample_size))
+            self._index, frame_rate, self._frame_sample_size))
         # The event interval is the inverse of the camera's frame rate.
         self.fps = float(1 / frame_rate)
 

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -99,7 +99,7 @@ class CameraOpenCV(CameraBase):
             # always get a frame).
             self._resolution = (int(frame.width), int(frame.height))
             # get fps
-            self.fps = cv.GetCaptureProperty(self._device, cv.CV_CAP_PROP_FPS)
+            fps = cv.GetCaptureProperty(self._device, cv.CV_CAP_PROP_FPS)
 
         elif self.opencvMajorVersion == 2 or self.opencvMajorVersion == 3:
             # create the device
@@ -116,10 +116,10 @@ class CameraOpenCV(CameraBase):
             # http://stackoverflow.com/questions/32468371/video-capture-propid-parameters-in-opencv # noqa
             self._resolution = (int(frame.shape[1]), int(frame.shape[0]))
             # get fps
-            self.fps = self._device.get(PROPERTY_FPS)
+            fps = self._device.get(PROPERTY_FPS)
 
-        if self.fps <= 0:
-            self.fps = 1 / 30.
+        # The event interval is the inverse of the frame rate.
+        self.fps = 1 / float(fps if fps > 0 else 30)
 
         if not self.stopped:
             self.start()

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -81,16 +81,16 @@ class CameraOpenCV(CameraBase):
                 break
             duration = time.time() - start
             Logger.debug('OpenCV: Captured frame {}/{} in {}s.'.format(
-                frame_count + 1, frame_sample_size, duration))
+                             frame_count + 1, frame_sample_size, duration))
             frame_count += 1
             rates[round(1 / duration)] += 1
         if frame_count != frame_sample_size:
             raise RuntimeError(('OpenCV: Unable to measure the frame rate, '
                                 'grabbed only {} out of {} frames.').format(
-                frame_count, frame_sample_size))
+                                   frame_count, frame_sample_size))
         rate_frequencies = rates.most_common()
         Logger.debug('OpenCV: Capture (fps, frequency)s are {!r}.'.format(
-            rate_frequencies))
+                         rate_frequencies))
         return Fraction(
             math.floor(
                 operator.div(

--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -80,14 +80,15 @@ class Camera(Image):
     '''
 
     # source:
-    # https://www.learnopencv.com/how-to-find-frame-rate-or-frames-per-second-fps-in-opencv-python-cpp/
-    frame_sample_size = BoundedNumericProperty(120, min=1)
+    # https://www.learnopencv.com/how-to-find-frame-rate-or-frames-per-second-fps-in-opencv-python-cpp
+    frame_sample_size = BoundedNumericProperty(0, min=0)
     '''Number of frames to sample in order to measure the camera's frame rate.
-    Choose a large number for greater accuracy and a small number for a shorter
-    delay.
+    Choose a large number for greater accuracy or a small number for a shorter
+    delay. Choose 0 to get the camera's frame rate property instead of
+    measuring for it.
 
     :attr:`frame_sample_size` is a :class:
-    ~kivy.properties.BoundedNumericProperty` and defaults to 120.
+    ~kivy.properties.BoundedNumericProperty` and defaults to 0.
     '''
 
     def __init__(self, **kwargs):

--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -29,8 +29,8 @@ __all__ = ('Camera', )
 
 from kivy.uix.image import Image
 from kivy.core.camera import Camera as CoreCamera
-from kivy.properties import NumericProperty, ListProperty, \
-    BooleanProperty
+from kivy.properties import (BooleanProperty, BoundedNumericProperty,
+                             ListProperty, NumericProperty)
 
 
 class Camera(Image):
@@ -79,6 +79,17 @@ class Camera(Image):
     to [-1, -1].
     '''
 
+    # source:
+    # https://www.learnopencv.com/how-to-find-frame-rate-or-frames-per-second-fps-in-opencv-python-cpp/
+    frame_sample_size = BoundedNumericProperty(120, min=1)
+    '''Number of frames to sample in order to measure the camera's frame rate.
+    Choose a large number for greater accuracy and a small number for a shorter 
+    delay.
+    
+    :attr:`frame_sample_size` is a :class:
+    ~kivy.properties.BoundedNumericProperty` and defaults to 120.
+    '''
+
     def __init__(self, **kwargs):
         self._camera = None
         super(Camera, self).__init__(**kwargs)
@@ -100,7 +111,8 @@ class Camera(Image):
         if self.resolution[0] < 0 or self.resolution[1] < 0:
             return
         self._camera = CoreCamera(index=self.index,
-                                  resolution=self.resolution, stopped=True)
+                                  resolution=self.resolution, stopped=True,
+                                  frame_sample_size=self.frame_sample_size)
         self._camera.bind(on_load=self._camera_loaded)
         if self.play:
             self._camera.start()

--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -83,9 +83,9 @@ class Camera(Image):
     # https://www.learnopencv.com/how-to-find-frame-rate-or-frames-per-second-fps-in-opencv-python-cpp/
     frame_sample_size = BoundedNumericProperty(120, min=1)
     '''Number of frames to sample in order to measure the camera's frame rate.
-    Choose a large number for greater accuracy and a small number for a shorter 
+    Choose a large number for greater accuracy and a small number for a shorter
     delay.
-    
+
     :attr:`frame_sample_size` is a :class:
     ~kivy.properties.BoundedNumericProperty` and defaults to 120.
     '''


### PR DESCRIPTION
From #5147:
> The fps returned by the driver should not be trusted, a better approach is to measure the frame rate when the stream begins, then limit the texture refresh rate according to the measured frame rate.