### PR TITLE
ffpyplayer video: disable builtin subtitles by default

### DIFF
--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -304,7 +304,8 @@ class VideoFFPy(VideoBase):
         self._out_fmt = 'rgba'
         ff_opts = {
             'paused': True,
-            'out_fmt': self._out_fmt
+            'out_fmt': self._out_fmt,
+            'sn': True,
         }
         self._ffplayer = MediaPlayer(
                 self._filename, callback=self._player_callback,


### PR DESCRIPTION
Right now if video has builtin subtitle streams, ffpyplayer will show first one of them as text in front of video.
We can't disable it, change stream or change text view.

This behavior seems to be unwanted, it makes sense to disable it until builtin subtitles support wouldn't be implemented for all providers.