### PR TITLE
Fix build with cython 0.26

### DIFF
--- a/kivy/lib/vidcore_lite/egl.pyx
+++ b/kivy/lib/vidcore_lite/egl.pyx
@@ -2,6 +2,7 @@
 from libc.stdlib cimport malloc, free
 from bcm cimport DISPMANX_ELEMENT_HANDLE_T, ElementHandle
 cimport bcm
+import bcm
 
 cdef extern from "/opt/vc/include/EGL/egl.h":
     ctypedef int EGLint ###maybe wrong


### PR DESCRIPTION
I think this is necessary for the build to work with cython 0.26, probably because the cimport only imports from the bcm.pxd file while egl.pyx needs some things from bcm.pyx. I guess this is a change in the new cython version.

It might be worth checking the details, I've tested this only during the Android build, and it resolves the issue there.