### PR TITLE
Docs: Rewrite system cursor

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -733,15 +733,48 @@ class WindowBase(EventDispatcher):
         pass
 
     def set_system_cursor(self, cursor_name):
-        '''Set cursor to a SDL_SystemCursor
-        available cursors are: 'arrow', 'ibeam', 'wait', 'crosshair',
-        'wait_arrow', 'size_nwse', 'size_nesw', 'size_we', 'size_ns',
-        'size_all', 'no', 'hand'
+        '''Set type of a mouse cursor in the Window.
+
+        It can be one of 'arrow', 'ibeam', 'wait', 'crosshair', 'wait_arrow',
+        'size_nwse', 'size_nesw', 'size_we', 'size_ns', 'size_all', 'no', or
+        'hand'.
+
+        On some platforms there might not be a specific cursor supported and
+        such an option falls back to one of the substitutable alternatives:
+
+        +------------+-----------+------------+-----------+---------------+
+        |            | Windows   | MacOS      | Linux X11 | Linux Wayland |
+        +============+===========+============+===========+===============+
+        | arrow      | arrow     | arrow      | arrow     | arrow         |
+        +------------+-----------+------------+-----------+---------------+
+        | ibeam      | ibeam     | ibeam      | ibeam     | ibeam         |
+        +------------+-----------+------------+-----------+---------------+
+        | wait       | wait      | arrow      | wait      | wait          |
+        +------------+-----------+------------+-----------+---------------+
+        | crosshair  | crosshair | crosshair  | crosshair | hand          |
+        +------------+-----------+------------+-----------+---------------+
+        | wait_arrow | arrow     | arrow      | wait      | wait          |
+        +------------+-----------+------------+-----------+---------------+
+        | size_nwse  | size_nwse | size_all   | size_all  | hand          |
+        +------------+-----------+------------+-----------+---------------+
+        | size_nesw  | size_nesw | size_all   | size_all  | hand          |
+        +------------+-----------+------------+-----------+---------------+
+        | size_we    | size_we   | size_we    | size_we   | hand          |
+        +------------+-----------+------------+-----------+---------------+
+        | size_ns    | size_ns   | size_ns    | size_ns   | hand          |
+        +------------+-----------+------------+-----------+---------------+
+        | size_all   | size_all  | size_all   | size_all  | hand          |
+        +------------+-----------+------------+-----------+---------------+
+        | no         | no        | no         | no        | ibeam         |
+        +------------+-----------+------------+-----------+---------------+
+        | hand       | hand      | hand       | hand      | hand          |
+        +------------+-----------+------------+-----------+---------------+
 
         .. versionadded:: 1.10.1
 
         .. note::
-            This feature requires the SDL2 window provider.
+            This feature requires the SDL2 window provider and is currently
+            only supported on desktop platforms.
         '''
         pass
 


### PR DESCRIPTION
Add more info about fallbacks to other cursors according to the used SDL2 files on specific platforms + a note about only being available on desktops. For more info see files at:

    https://hg.libsdl.org/SDL/file/<hash>/src/video/<provider>/<mouse .c/.m/.cpp file>

Feel free to comment about specific changes. If the cursor is different as stated in the docs, comment **with a screenshot included**. You can run this example:

```python
from kivy.clock import Clock
from kivy.lang import Builder
from kivy.app import runTouchApp
from kivy.uix.button import Button
from kivy.core.window import Window as win
from kivy.uix.gridlayout import GridLayout


class Root(GridLayout):
    def __init__(self, **kwargs):
        super(Root, self).__init__(**kwargs)
        cursors = (
            'arrow', 'ibeam', 'wait', 'crosshair', 'wait_arrow',
            'size_nwse', 'size_nesw', 'size_we', 'size_ns',
            'size_all', 'no', 'hand'
        )

        for i in cursors:
            button = Button(text=i)
            button.bind(on_release=lambda ins: self.reset(ins.text))
            self.add_widget(button)

    def reset(self, cursor):
        win.set_system_cursor(cursor)
        Clock.schedule_once(
            lambda *dt: win.set_system_cursor('arrow'), 1.0
        )


runTouchApp(Root(cols=4))
```