### PR TITLE
issue #5333 - actionbar throws exception when resized

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -491,7 +491,8 @@ class ActionView(BoxLayout):
         super(ActionView, self).remove_widget(widget)
         if isinstance(widget, ActionOverflow):
             for item in widget.list_action_item:
-                self._list_action_items.remove(item)
+                if item in self._list_action_items:
+                    self._list_action_items.remove(item)
 
         if widget in self._list_action_items:
             self._list_action_items.remove(widget)


### PR DESCRIPTION
prevent attempts to remove items that are not present in the target list (ActionView._list_action_items)
This is a minimal fix for Issue #5333 