### PR TITLE
actionbar: entries get swapped between the dropdowns of consecutively clicked actiongroups

### DIFF
--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -338,17 +338,20 @@ class ActionGroup(ActionItem, Spinner):
 
     def _build_dropdown(self, *largs):
         if self._dropdown:
-            self._dropdown.unbind(on_dismiss=self._toggle_dropdown)
+            self._dropdown.unbind(on_dismiss=self._dismissed)
             self._dropdown.dismiss()
             self._dropdown = None
         self._dropdown = self.dropdown_cls()
-        self._dropdown.bind(on_dismiss=self._toggle_dropdown)
+        self._dropdown.bind(on_dismiss=self._dismissed)
 
     def _update_dropdown(self, *largs):
         pass
 
+    def _dismissed(self, *largs):
+        self.is_open = False
+
     def _toggle_dropdown(self, *largs):
-        self.is_open = not self.is_open
+        self.is_open = True
         ddn = self._dropdown
         ddn.size_hint_x = None
         if not ddn.container:


### PR DESCRIPTION
Proposed fix for #5338 
The on_release and dismiss events previously triggered _toggle_dropdown. This change routes the events to two different functions with fixed values for the is_open property
