### PR TITLE
Remove DropDown.dismiss in on_touch_down

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -303,8 +303,6 @@ class DropDown(ScrollView):
         if (self.attach_to and self.attach_to.collide_point(
                 *self.attach_to.to_widget(*touch.pos))):
             return True
-        if self.auto_dismiss:
-            self.dismiss()
 
     def on_touch_up(self, touch):
         if super(DropDown, self).on_touch_up(touch):


### PR DESCRIPTION
`DropDown.on_touch_down()` tries to `dismiss()`. That particular part is also called in `DropDown.on_touch_up()`, so it's there most likely as a design flaw as almost all `DropDown` widgets I've seen dismiss the "popup"-like part when a touch/button is released. It means that the `on_dismiss` event is called twice if the `DropDown` or `Spinner` aren't dismissed correctly.

This part also causes some errors in the `ActionGroup` widget before implementing #5339.