### PR TITLE
Revert "Fix App.get_application_config() not being called in load_config()"

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -692,13 +692,15 @@ class App(EventDispatcher):
             config = ConfigParser(name='app')
         self.config = config
         self.build_config(config)
+        # if no sections are created, that's mean the user don't have
+        # configuration.
+        if len(config.sections()) == 0:
+            return
         # ok, the user have some sections, read the default file if exist
         # or write it !
         filename = self.get_application_config()
-        if not filename:
-            if config.sections():
-                return config
-            return
+        if filename is None:
+            return config
         Logger.debug('App: Loading configuration <{0}>'.format(filename))
         if exists(filename):
             try:


### PR DESCRIPTION
Reverts kivy/kivy#5225

This PR introduces a bug where a config file `.ini` is created no matter if the `get_application_config()` is called or not, therefore even an empty one without a user's intention to create one.

The behavior is present only for an application using/inheriting from `App` class and not for the simple `runTouchApp()` alternatives.