### PR TITLE
[WIP] Various improvement for speeding up Widget instanciation

### DIFF
--- a/kivy/_event.pxd
+++ b/kivy/_event.pxd
@@ -8,13 +8,13 @@ cdef class Observable(ObjectWithUid):
     cdef object __fbind_mapping
     cdef object bound_uid
 
-
 cdef class EventDispatcher(ObjectWithUid):
     cdef dict __event_stack
     cdef dict __properties
     cdef dict __storage
     cdef object __weakref__
     cdef public set _kwargs_applied_init
+    cdef object _proxy_ref
     cpdef dict properties(self)
 
 

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -857,9 +857,8 @@ will first be unloaded and then reloaded again. For example:
 '''
 
 
-from kivy.lang.builder import (Observable, Builder, BuilderBase,
-                               BuilderException)
 from kivy.lang.parser import Parser, ParserException, global_idmap
+from kivy.lang.builder import Builder, BuilderBase, BuilderException
 
-__all__ = ('Observable', 'Builder', 'BuilderBase', 'BuilderException',
+__all__ = ('Builder', 'BuilderBase', 'BuilderException',
            'Parser', 'ParserException', 'global_idmap')

--- a/kivy/lang/_speed.pyx
+++ b/kivy/lang/_speed.pyx
@@ -1,0 +1,224 @@
+
+from cpython.dict cimport PyDict_Update
+from kivy._event cimport EventDispatcher, Observable
+from kivy.properties cimport Property
+import sys
+import types
+from collections import defaultdict
+from functools import partial
+
+# class types to check with isinstance
+from kivy.compat import PY2
+if PY2:
+    _cls_type = (type, types.ClassType)
+else:
+    _cls_type = (type, )
+
+cdef tuple cls_observable = (EventDispatcher, Observable)
+
+_handlers = {}
+global_idmap = {}
+_delayed_start = None
+
+
+def update_intermediates(base, keys, bound, s, fn, args, instance, value):
+    ''' Function that is called when an intermediate property is updated
+    and `rebind` of that property is True. In that case, we unbind
+    all bound funcs that were bound to attrs of the old value of the
+    property and rebind to the new value of the property.
+
+    For example, if the rule is `self.a.b.c.d`, then when b is changed, we
+    unbind from `b`, `c` and `d`, if they were bound before (they were not
+    None and `rebind` of the respective properties was True) and we rebind
+    to the new values of the attrs `b`, `c``, `d` that are not None and
+    `rebind` is True.
+
+    :Parameters:
+        `base`
+            A (proxied) ref to the base widget, `self` in the example
+            above.
+        `keys`
+            A list of the name off the attrs of `base` being watched. In
+            the example above it'd be `['a', 'b', 'c', 'd']`.
+        `bound`
+            A list 4-tuples, each tuple being (widget, attr, callback, uid)
+            representing callback functions bound to the attributed `attr`
+            of `widget`. `uid` is returned by `fbind` when binding.
+            The callback may be None, in which case the attr
+            was not bound, but is there to be able to walk the attr tree.
+            E.g. in the example above, if `b` was not an eventdispatcher,
+            `(_b_ref_, `c`, None)` would be added to the list so we can get
+            to `c` and `d`, which may be eventdispatchers and their attrs.
+        `s`
+            The index in `keys` of the of the attr that needs to be
+            updated. That is all the keys from `s` and further will be
+            rebound, since the `s` key was changed. In bound, the
+            corresponding index is `s - 1`. If `s` is None, we start from
+            1 (first attr).
+        `fn`
+            The function to be called args, `args` on bound callback.
+    '''
+    # first remove all the old bound functions from `s` and down.
+    for f, k, fun, uid in bound[s:]:
+        if fun is None:
+            continue
+        try:
+            f.unbind_uid(k, uid)
+        except ReferenceError:
+            pass
+    del bound[s:]
+
+    # find the first attr from which we need to start rebinding.
+    f = getattr(*bound[-1][:2])
+    if f is None:
+        fn(args, None, None)
+        return
+    s += 1
+    append = bound.append
+
+    # bind all attrs, except last to update_intermediates
+    for val in keys[s:-1]:
+        # if we need to dynamically rebind, bindm otherwise just
+        # add the attr to the list
+        if isinstance(f, cls_observable):
+            prop = f.property(val, True)
+            if prop is not None and getattr(prop, 'rebind', False):
+                # fbind should not dispatch, otherwise
+                # update_intermediates might be called in the middle
+                # here messing things up
+                uid = f.fbind(
+                    val, update_intermediates, base, keys, bound, s, fn, args)
+                append([f.proxy_ref, val, update_intermediates, uid])
+            else:
+                append([f.proxy_ref, val, None, None])
+        else:
+            append([getattr(f, 'proxy_ref', f), val, None, None])
+
+        f = getattr(f, val, None)
+        if f is None:
+            break
+        s += 1
+
+    # for the last attr we bind directly to the setting function,
+    # because that attr sets the value of the rule.
+    if isinstance(f, cls_observable):
+        uid = f.fbind(keys[-1], fn, args)
+        if uid:
+            append([f.proxy_ref, keys[-1], fn, uid])
+    # when we rebind we have to update the
+    # rule with the most recent value, otherwise, the value might be wrong
+    # and wouldn't be updated since we might not have tracked it before.
+    # This only happens for a callback when rebind was True for the prop.
+    fn(args, None, None)
+
+
+def call_fn(args, instance, v):
+    element, key, value, rule, idmap = args
+    rule.count += 1
+    e_value = eval(value, idmap)
+    setattr(element, key, e_value)
+
+
+def delayed_call_fn(args, instance, v):
+    # it's already on the list
+    if args[-1] is not None:
+        return
+
+    global _delayed_start
+    if _delayed_start is None:
+        _delayed_start = args
+        args[-1] = StopIteration
+    else:
+        args[-1] = _delayed_start
+        _delayed_start = args
+
+
+def create_handler(iself, element, key, value, rule, dict idmap, delayed=False):
+    cdef:
+        dict _handlers_uids
+        list bound_list
+        list bound
+        int was_bound, k
+        Property prop
+        list keys
+        object val
+
+    idmap = idmap.copy()
+    PyDict_Update(idmap, global_idmap)
+    idmap['self'] = iself.proxy_ref
+
+    if iself.uid not in _handlers:
+        _handlers_uids = _handlers[iself.uid] = {}
+    else:
+        _handlers_uids = _handlers[iself.uid]
+
+    if key not in _handlers_uids:
+        bound_list = _handlers_uids[key] = []
+    else:
+        bound_list = _handlers_uids[key]
+
+    # we need a hash for when delayed, so we don't execute duplicate canvas
+    # callbacks from the same handler during a sync op
+    if delayed:
+        fn = delayed_call_fn
+        args = [element, key, value, rule, idmap, None]  # see _delayed_start
+    else:
+        fn = call_fn
+        args = (element, key, value, rule, idmap)
+
+    # bind every key.value
+    cdef list watched_keys = rule.watched_keys
+    if watched_keys is not None:
+        for keys in watched_keys:
+            base = idmap.get(keys[0])
+            if base is None:
+                continue
+            f = base = getattr(base, 'proxy_ref', base)
+            bound = []
+            was_bound = 0
+
+            # bind all attrs, except last to update_intermediates
+            k = 1
+            for val in keys[1:-1]:
+                # if we need to dynamically rebind, bindm otherwise
+                # just add the attr to the list
+                if isinstance(f, cls_observable):
+                    prop = f.property(val, True)
+                    if prop is not None and prop.rebind:
+                        # fbind should not dispatch, otherwise
+                        # update_intermediates might be called in the middle
+                        # here messing things up
+                        uid = f.fbind(
+                            val, update_intermediates, base, keys, bound, k,
+                            fn, args)
+                        bound.append([f.proxy_ref, val, update_intermediates, uid])
+                        was_bound = 1
+                    else:
+                        bound.append([f.proxy_ref, val, None, None])
+                elif not isinstance(f, _cls_type):
+                    bound.append([getattr(f, 'proxy_ref', f), val, None, None])
+                else:
+                    bound.append([f, val, None, None])
+                f = getattr(f, val, None)
+                if f is None:
+                    break
+                k += 1
+
+            # for the last attr we bind directly to the setting
+            # function, because that attr sets the value of the rule.
+            if isinstance(f, cls_observable):
+                uid = f.fbind(keys[-1], fn, args)  # f is not None
+                if uid:
+                    bound.append([f.proxy_ref, keys[-1], fn, uid])
+                    was_bound = 1
+            if was_bound:
+                bound_list.append(bound)
+
+    try:
+        return eval(value, idmap), bound_list
+    except Exception as e:
+        tb = sys.exc_info()[2]
+        from kivy.lang import BuilderException
+        raise BuilderException(rule.ctx, rule.line,
+                               '{}: {}'.format(e.__class__.__name__, e),
+                               cause=tb)

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -14,8 +14,9 @@ from types import CodeType
 from functools import partial
 
 from kivy.factory import Factory
-from kivy.lang.parser import Parser, ParserException, _handlers, global_idmap,\
-    ParserRuleProperty
+from kivy.lang.parser import Parser, ParserException, ParserRuleProperty
+from kivy.lang._speed import (
+    _handlers, global_idmap, create_handler, call_fn)
 from kivy.logger import Logger
 from kivy.utils import QueryDict
 from kivy.cache import Cache
@@ -23,9 +24,8 @@ from kivy import kivy_data_dir
 from kivy.compat import PY2, iteritems, iterkeys
 from kivy.context import register_context
 from kivy.resources import resource_find
-from kivy._event import Observable, EventDispatcher
 
-__all__ = ('Observable', 'Builder', 'BuilderBase', 'BuilderException')
+__all__ = ('Builder', 'BuilderBase', 'BuilderException')
 
 
 trace = Logger.trace
@@ -38,12 +38,6 @@ else:
 
 # late import
 Instruction = None
-
-# delayed calls are canvas expression triggered during an loop. It is one
-# directional linked list of args to call call_fn with. Each element is a list
-# whos last element points to the next list of args to execute when
-# Builder.sync is called.
-_delayed_start = None
 
 
 class BuilderException(ParserException):
@@ -62,196 +56,6 @@ def get_proxy(widget):
 def custom_callback(__kvlang__, idmap, *largs, **kwargs):
     idmap['args'] = largs
     exec(__kvlang__.co_value, idmap)
-
-
-def call_fn(args, instance, v):
-    element, key, value, rule, idmap = args
-    if __debug__:
-        trace('Lang: call_fn %s, key=%s, value=%r, %r' % (
-            element, key, value, rule.value))
-    rule.count += 1
-    e_value = eval(value, idmap)
-    if __debug__:
-        trace('Lang: call_fn => value=%r' % (e_value, ))
-    setattr(element, key, e_value)
-
-
-def delayed_call_fn(args, instance, v):
-    # it's already on the list
-    if args[-1] is not None:
-        return
-
-    global _delayed_start
-    if _delayed_start is None:
-        _delayed_start = args
-        args[-1] = StopIteration
-    else:
-        args[-1] = _delayed_start
-        _delayed_start = args
-
-
-def update_intermediates(base, keys, bound, s, fn, args, instance, value):
-    ''' Function that is called when an intermediate property is updated
-    and `rebind` of that property is True. In that case, we unbind
-    all bound funcs that were bound to attrs of the old value of the
-    property and rebind to the new value of the property.
-
-    For example, if the rule is `self.a.b.c.d`, then when b is changed, we
-    unbind from `b`, `c` and `d`, if they were bound before (they were not
-    None and `rebind` of the respective properties was True) and we rebind
-    to the new values of the attrs `b`, `c``, `d` that are not None and
-    `rebind` is True.
-
-    :Parameters:
-        `base`
-            A (proxied) ref to the base widget, `self` in the example
-            above.
-        `keys`
-            A list of the name off the attrs of `base` being watched. In
-            the example above it'd be `['a', 'b', 'c', 'd']`.
-        `bound`
-            A list 4-tuples, each tuple being (widget, attr, callback, uid)
-            representing callback functions bound to the attributed `attr`
-            of `widget`. `uid` is returned by `fbind` when binding.
-            The callback may be None, in which case the attr
-            was not bound, but is there to be able to walk the attr tree.
-            E.g. in the example above, if `b` was not an eventdispatcher,
-            `(_b_ref_, `c`, None)` would be added to the list so we can get
-            to `c` and `d`, which may be eventdispatchers and their attrs.
-        `s`
-            The index in `keys` of the of the attr that needs to be
-            updated. That is all the keys from `s` and further will be
-            rebound, since the `s` key was changed. In bound, the
-            corresponding index is `s - 1`. If `s` is None, we start from
-            1 (first attr).
-        `fn`
-            The function to be called args, `args` on bound callback.
-    '''
-    # first remove all the old bound functions from `s` and down.
-    for f, k, fun, uid in bound[s:]:
-        if fun is None:
-            continue
-        try:
-            f.unbind_uid(k, uid)
-        except ReferenceError:
-            pass
-    del bound[s:]
-
-    # find the first attr from which we need to start rebinding.
-    f = getattr(*bound[-1][:2])
-    if f is None:
-        fn(args, None, None)
-        return
-    s += 1
-    append = bound.append
-
-    # bind all attrs, except last to update_intermediates
-    for val in keys[s:-1]:
-        # if we need to dynamically rebind, bindm otherwise just
-        # add the attr to the list
-        if isinstance(f, (EventDispatcher, Observable)):
-            prop = f.property(val, True)
-            if prop is not None and getattr(prop, 'rebind', False):
-                # fbind should not dispatch, otherwise
-                # update_intermediates might be called in the middle
-                # here messing things up
-                uid = f.fbind(
-                    val, update_intermediates, base, keys, bound, s, fn, args)
-                append([f.proxy_ref, val, update_intermediates, uid])
-            else:
-                append([f.proxy_ref, val, None, None])
-        else:
-            append([getattr(f, 'proxy_ref', f), val, None, None])
-
-        f = getattr(f, val, None)
-        if f is None:
-            break
-        s += 1
-
-    # for the last attr we bind directly to the setting function,
-    # because that attr sets the value of the rule.
-    if isinstance(f, (EventDispatcher, Observable)):
-        uid = f.fbind(keys[-1], fn, args)
-        if uid:
-            append([f.proxy_ref, keys[-1], fn, uid])
-    # when we rebind we have to update the
-    # rule with the most recent value, otherwise, the value might be wrong
-    # and wouldn't be updated since we might not have tracked it before.
-    # This only happens for a callback when rebind was True for the prop.
-    fn(args, None, None)
-
-
-def create_handler(iself, element, key, value, rule, idmap, delayed=False):
-    idmap = copy(idmap)
-    idmap.update(global_idmap)
-    idmap['self'] = iself.proxy_ref
-    bound_list = _handlers[iself.uid][key]
-    handler_append = bound_list.append
-
-    # we need a hash for when delayed, so we don't execute duplicate canvas
-    # callbacks from the same handler during a sync op
-    if delayed:
-        fn = delayed_call_fn
-        args = [element, key, value, rule, idmap, None]  # see _delayed_start
-    else:
-        fn = call_fn
-        args = (element, key, value, rule, idmap)
-
-    # bind every key.value
-    if rule.watched_keys is not None:
-        for keys in rule.watched_keys:
-            base = idmap.get(keys[0])
-            if base is None:
-                continue
-            f = base = getattr(base, 'proxy_ref', base)
-            bound = []
-            was_bound = False
-            append = bound.append
-
-            # bind all attrs, except last to update_intermediates
-            k = 1
-            for val in keys[1:-1]:
-                # if we need to dynamically rebind, bindm otherwise
-                # just add the attr to the list
-                if isinstance(f, (EventDispatcher, Observable)):
-                    prop = f.property(val, True)
-                    if prop is not None and getattr(prop, 'rebind', False):
-                        # fbind should not dispatch, otherwise
-                        # update_intermediates might be called in the middle
-                        # here messing things up
-                        uid = f.fbind(
-                            val, update_intermediates, base, keys, bound, k,
-                            fn, args)
-                        append([f.proxy_ref, val, update_intermediates, uid])
-                        was_bound = True
-                    else:
-                        append([f.proxy_ref, val, None, None])
-                elif not isinstance(f, _cls_type):
-                    append([getattr(f, 'proxy_ref', f), val, None, None])
-                else:
-                    append([f, val, None, None])
-                f = getattr(f, val, None)
-                if f is None:
-                    break
-                k += 1
-
-            # for the last attr we bind directly to the setting
-            # function, because that attr sets the value of the rule.
-            if isinstance(f, (EventDispatcher, Observable)):
-                uid = f.fbind(keys[-1], fn, args)  # f is not None
-                if uid:
-                    append([f.proxy_ref, keys[-1], fn, uid])
-                    was_bound = True
-            if was_bound:
-                handler_append(bound)
-
-    try:
-        return eval(value, idmap), bound_list
-    except Exception as e:
-        tb = sys.exc_info()[2]
-        raise BuilderException(rule.ctx, rule.line,
-                               '{}: {}'.format(e.__class__.__name__, e),
-                               cause=tb)
 
 
 class BuilderBase(object):
@@ -681,8 +485,8 @@ class BuilderBase(object):
 
         .. versionadded:: 1.7.0
         '''
-        global _delayed_start
-        next_args = _delayed_start
+        import kivy.lang._speed as speed
+        next_args = speed._delayed_start
         if next_args is None:
             return
 
@@ -696,7 +500,7 @@ class BuilderBase(object):
             args = next_args
             next_args = args[-1]
             args[-1] = None
-        _delayed_start = None
+        speed._delayed_start = None
 
     def unbind_widget(self, uid):
         '''Unbind all the handlers created by the KV rules of the

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -14,19 +14,18 @@ from types import CodeType
 from functools import partial
 from collections import OrderedDict, defaultdict
 
-import kivy.lang.builder  # imported as absolute to avoid circular import
 from kivy.logger import Logger
 from kivy.cache import Cache
 from kivy import require
 from kivy.resources import resource_find
 from kivy.utils import rgba
+from kivy.lang._speed import _handlers, global_idmap
 import kivy.metrics as Metrics
 
 __all__ = ('Parser', 'ParserException')
 
 
 trace = Logger.trace
-global_idmap = {}
 
 # register cache for creating new classtype (template)
 Cache.register('kv.lang')
@@ -44,10 +43,6 @@ lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile('([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile('(_\()')
 lang_cls_split_pat = re.compile(', *')
-
-# all the widget handlers, used to correctly unbind all the callbacks then the
-# widget is deleted
-_handlers = defaultdict(partial(defaultdict, list))
 
 
 class ProxyApp(object):

--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -1,4 +1,4 @@
-from kivy._event cimport EventDispatcher, EventObservers
+from kivy._event cimport EventDispatcher, EventObservers, Observable
 
 cdef class PropertyStorage:
     cdef object value
@@ -25,6 +25,7 @@ cdef class Property:
     cdef object errorhandler
     cdef int errorvalue_set
     cdef public object defaultvalue
+    cdef public int rebind
     cdef init_storage(self, EventDispatcher obj, PropertyStorage storage)
     cpdef link(self, EventDispatcher obj, str name)
     cpdef link_deps(self, EventDispatcher obj, str name)
@@ -33,12 +34,23 @@ cdef class Property:
     cpdef unbind(self, EventDispatcher obj, observer)
     cpdef funbind(self, EventDispatcher obj, observer, tuple largs=*, dict kwargs=*)
     cpdef unbind_uid(self, EventDispatcher obj, object uid)
-    cdef compare_value(self, a, b)
+    cdef int compare_value(self, a, b)
     cpdef set(self, EventDispatcher obj, value)
     cpdef get(self, EventDispatcher obj)
     cdef check(self, EventDispatcher obj, x)
     cdef convert(self, EventDispatcher obj, x)
     cpdef dispatch(self, EventDispatcher obj)
+
+cdef class ObservableList(list):
+    cdef Property prop
+    cdef object obj
+    cdef str last_op_command
+    cdef object last_op_value
+
+cdef class ObservableDict(dict):
+    cdef Property prop
+    cdef object obj
+    cdef object _weak_return(self, item)
 
 cdef class NumericProperty(Property):
     cdef float parse_str(self, EventDispatcher obj, value)
@@ -51,11 +63,10 @@ cdef class ListProperty(Property):
     pass
 
 cdef class DictProperty(Property):
-    cdef public int rebind
+    pass
 
 cdef class ObjectProperty(Property):
     cdef object baseclass
-    cdef public int rebind
 
 cdef class BooleanProperty(Property):
     pass
@@ -81,7 +92,6 @@ cdef class AliasProperty(Property):
     cdef object setter
     cdef list bind_objects
     cdef int use_cache
-    cdef public int rebind
     cpdef trigger_change(self, EventDispatcher obj, value)
 
 cdef class VariableListProperty(Property):

--- a/setup.py
+++ b/setup.py
@@ -734,6 +734,7 @@ sources = {
     '_event.pyx': merge(base_flags, {'depends': ['properties.pxd']}),
     '_clock.pyx': {},
     'weakproxy.pyx': {},
+    'lang/_speed.pyx': merge(base_flags, {'depends': ['properties.pxd', '_event.pxd']}),
     'properties.pyx': merge(base_flags, {'depends': ['_event.pxd']}),
     'graphics/buffer.pyx': merge(base_flags, gl_flags_base),
     'graphics/context.pyx': merge(base_flags, gl_flags_base),


### PR DESCRIPTION
The changes:
- cythonized ObservableDict and ObservableList (+22% faster for Widget
instanciation, +8.74% for Label, +2.80% for Button)
- created a kivy.lang._speed and moved some part into it. Right now,
only create_handler got optimized as much as possible. There is room for
property/fbind optimization if somehow we can pass C function to it.
update_intermediates is not cythonized. (22% (no changes) faster for
Widget, 14% for Label, 12% for Button)

The test script is available here: https://gist.github.com/tito/9714e53fd76fe08153f11d5aef1b80e0
My speed test is how much widget i can create within 2 seconds.

Here is the number:
- Original version (v1.10.1.dev0 at 1st september 2017): 27554 Widgets, 6278 Labels, 3290 Buttons
- After both modifications: 33328 Widgets, 6909 Labels, 3539 Buttons

(full document for reference: https://docs.google.com/spreadsheets/d/1qliYdec3SPJd8qNJI8GDZtjcCR_SVEMkGgr6Fm_oeFU/edit?usp=sharing)
