### PR TITLE
Unittesting features

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -283,3 +283,18 @@ class GraphicUnitTest(_base):
         root.mainloop()
 
         return self.retval
+
+    def advance_frames(self, count):
+        '''Render the new frames and:
+
+        * tick the Clock
+
+        * dispatch input from all registered providers
+
+        * flush all the canvas operations
+
+        * redraw Window canvas if necessary
+        '''
+        from kivy.base import EventLoop
+        for i in range(count):
+            EventLoop.idle()

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -21,6 +21,8 @@ _base = object
 if 'mock' != cgl_get_backend_name():
     _base = unittest.TestCase
 
+make_screenshots = os.environ.get('KIVY_UNITTEST_SCREENSHOTS')
+
 
 class GraphicUnitTest(_base):
 
@@ -100,10 +102,8 @@ class GraphicUnitTest(_base):
         if self.framecount > 0:
             return
 
-        # don't create screenshots if a specific var is in env
-        ignore = ['TRAVIS_OS_NAME', 'APPVEYOR_BUILD_FOLDER']
-        from os import environ
-        if any(i in environ for i in ignore):
+        # don't create screenshots if not requested manually
+        if not make_screenshots:
             EventLoop.stop()
             return
 


### PR DESCRIPTION
This PR disables creating of the screenshots unless explicitly asked for it via env var, which lets our `common.py` module to be *the* way for unittesting without workarounds such as creating a folder for the screenshots, cleaning it later and making the tests to behave "correctly", so that the `GraphicUnitTest.render()` doesn't raise an error if you render a single frame at the end after `EventLoop.idle()` the second time you run the test (visible on plain `python test_uix_slider.py`).

I also added a method for moving the frames in more visible way instead of forcing the user to go and dig through the internals. And then there's a simple `MotionEvent` that represents a single touch with methods highly similar to those we use in the `Widget` (obvious to use just by the name). In the future (dunno when) I'd like to add more events, so that we can write tests related to desktop platforms only for example, or so that we can write a tests for providers (if we can expect the data retrieved from the provider to be sane, we can then just test our classes with some constant input).