### PR TITLE
Fix all ScreenManagers sharing the same transition

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -906,7 +906,7 @@ class ScreenManager(FloatLayout):
     to None.
     '''
 
-    transition = ObjectProperty(SlideTransition(), baseclass=TransitionBase)
+    transition = ObjectProperty(baseclass=TransitionBase)
     '''Transition object to use for animating the transition from the current
     screen to the next one being shown.
 
@@ -966,6 +966,7 @@ class ScreenManager(FloatLayout):
     def __init__(self, **kwargs):
         super(ScreenManager, self).__init__(**kwargs)
         self.fbind('pos', self._update_pos)
+        self.transition = SlideTransition()
 
     def _screen_name_changed(self, screen, name):
         self.property('screen_names').dispatch(self)

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -964,7 +964,8 @@ class ScreenManager(FloatLayout):
     '''
 
     def __init__(self, **kwargs):
-        self.transition = SlideTransition()
+        if 'transition' not in kwargs:
+            self.transition = SlideTransition()
         super(ScreenManager, self).__init__(**kwargs)
         self.fbind('pos', self._update_pos)
 

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -964,9 +964,9 @@ class ScreenManager(FloatLayout):
     '''
 
     def __init__(self, **kwargs):
+        self.transition = SlideTransition()
         super(ScreenManager, self).__init__(**kwargs)
         self.fbind('pos', self._update_pos)
-        self.transition = SlideTransition()
 
     def _screen_name_changed(self, screen, name):
         self.property('screen_names').dispatch(self)


### PR DESCRIPTION
All ScreenManagers share the same SlideTransition instance by default, which can cause some timing issues and other weirdness (and is more generally a bad idea). This PR fixes the issue.