### PR TITLE
Let dpi formatting exceptions in kv propagate out from cython.

### DIFF
--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -41,8 +41,8 @@ cdef class Property:
     cpdef dispatch(self, EventDispatcher obj)
 
 cdef class NumericProperty(Property):
-    cdef float parse_str(self, EventDispatcher obj, value)
-    cdef float parse_list(self, EventDispatcher obj, value, ext)
+    cdef float parse_str(self, EventDispatcher obj, value) except *
+    cdef float parse_list(self, EventDispatcher obj, value, ext) except *
 
 cdef class StringProperty(Property):
     pass
@@ -87,8 +87,8 @@ cdef class AliasProperty(Property):
 cdef class VariableListProperty(Property):
     cdef public int length
     cdef _convert_numeric(self, EventDispatcher obj, x)
-    cdef float parse_str(self, EventDispatcher obj, value)
-    cdef float parse_list(self, EventDispatcher obj, value, ext)
+    cdef float parse_str(self, EventDispatcher obj, value) except *
+    cdef float parse_list(self, EventDispatcher obj, value, ext) except *
 
 cdef class ConfigParserProperty(Property):
     cdef object config

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -288,7 +288,7 @@ cdef float g_fontscale = -1
 
 NUMERIC_FORMATS = ('in', 'px', 'dp', 'sp', 'pt', 'cm', 'mm')
 
-cpdef float dpi2px(value, ext):
+cpdef float dpi2px(value, ext) except *:
     # 1in = 2.54cm = 25.4mm = 72pt = 12pc
     global g_dpi, g_density, g_fontscale
     if g_dpi == -1:
@@ -633,13 +633,13 @@ cdef class NumericProperty(Property):
                 obj.__class__.__name__,
                 self.name, x))
 
-    cdef float parse_str(self, EventDispatcher obj, value):
+    cdef float parse_str(self, EventDispatcher obj, value) except *:
         if value[-2:] in NUMERIC_FORMATS:
             return self.parse_list(obj, value[:-2], value[-2:])
         else:
             return float(value)
 
-    cdef float parse_list(self, EventDispatcher obj, value, ext):
+    cdef float parse_list(self, EventDispatcher obj, value, ext) except *:
         cdef PropertyStorage ps = obj.__storage[self._name]
         ps.numeric_fmt = ext
         return dpi2px(value, ext)
@@ -1599,10 +1599,10 @@ cdef class VariableListProperty(Property):
                 obj.__class__.__name__,
                 self.name, x))
 
-    cdef float parse_str(self, EventDispatcher obj, value):
+    cdef float parse_str(self, EventDispatcher obj, value) except *:
         return self.parse_list(obj, value[:-2], value[-2:])
 
-    cdef float parse_list(self, EventDispatcher obj, value, ext):
+    cdef float parse_list(self, EventDispatcher obj, value, ext) except *:
         return dpi2px(value, ext)
 
 


### PR DESCRIPTION
I've had many times where e.g. I write `padding: '0', '55dp'` and then you get a notice from cython that an exception was ignored in dpi2x. 

Generally in a large program it's impossible to find out where in kv the exception is coming from because cython eats the exception. With this PR, the exception will propagate out so it'll show which kv line is causing it.