### PR TITLE
Fix Json+DictStore not raising error for non-existing folder + unittest

### DIFF
--- a/kivy/storage/dictstore.py
+++ b/kivy/storage/dictstore.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import pickle
 
-from os.path import exists
+from os.path import exists, abspath, dirname
 from kivy.compat import iteritems
 from kivy.storage import AbstractStore
 
@@ -36,6 +36,12 @@ class DictStore(AbstractStore):
         if self.filename is None:
             return
         if not exists(self.filename):
+            folder = abspath(dirname(self.filename))
+            if not exists(folder):
+                raise IOError(
+                    "The folder '{}' doesn't exist!"
+                    "".format(folder)
+                )
             return
         with open(self.filename, 'rb') as fd:
             data = fd.read()

--- a/kivy/storage/dictstore.py
+++ b/kivy/storage/dictstore.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     import pickle
 
+import errno
 from os.path import exists, abspath, dirname
 from kivy.compat import iteritems
 from kivy.storage import AbstractStore
@@ -38,10 +39,12 @@ class DictStore(AbstractStore):
         if not exists(self.filename):
             folder = abspath(dirname(self.filename))
             if not exists(folder):
-                raise IOError(
+                not_found = IOError(
                     "The folder '{}' doesn't exist!"
                     "".format(folder)
                 )
+                not_found.errno = errno.ENOENT
+                raise not_found
             return
         with open(self.filename, 'rb') as fd:
             data = fd.read()

--- a/kivy/storage/jsonstore.py
+++ b/kivy/storage/jsonstore.py
@@ -9,6 +9,7 @@ a json file.
 __all__ = ('JsonStore', )
 
 
+import errno
 from os.path import exists, abspath, dirname
 from kivy.compat import iteritems
 from kivy.storage import AbstractStore
@@ -31,10 +32,12 @@ class JsonStore(AbstractStore):
         if not exists(self.filename):
             folder = abspath(dirname(self.filename))
             if not exists(folder):
-                raise IOError(
+                not_found = IOError(
                     "The folder '{}' doesn't exist!"
                     "".format(folder)
                 )
+                not_found.errno = errno.ENOENT
+                raise not_found
             return
         with open(self.filename) as fd:
             data = fd.read()

--- a/kivy/storage/jsonstore.py
+++ b/kivy/storage/jsonstore.py
@@ -9,7 +9,7 @@ a json file.
 __all__ = ('JsonStore', )
 
 
-from os.path import exists
+from os.path import exists, abspath, dirname
 from kivy.compat import iteritems
 from kivy.storage import AbstractStore
 from json import loads, dump
@@ -29,6 +29,12 @@ class JsonStore(AbstractStore):
 
     def store_load(self):
         if not exists(self.filename):
+            folder = abspath(dirname(self.filename))
+            if not exists(folder):
+                raise IOError(
+                    "The folder '{}' doesn't exist!"
+                    "".format(folder)
+                )
             return
         with open(self.filename) as fd:
             data = fd.read()
@@ -40,7 +46,11 @@ class JsonStore(AbstractStore):
         if not self._is_changed:
             return
         with open(self.filename, 'w') as fd:
-            dump(self._data, fd, indent=self.indent, sort_keys=self.sort_keys)
+            dump(
+                self._data, fd,
+                indent=self.indent,
+                sort_keys=self.sort_keys
+            )
         self._is_changed = False
 
     def store_exists(self, key):

--- a/kivy/tests/test_storage.py
+++ b/kivy/tests/test_storage.py
@@ -5,6 +5,7 @@ Storage tests
 
 import unittest
 from os.path import abspath, dirname, join
+import errno
 import os
 
 
@@ -125,8 +126,9 @@ class StorageTestCase(unittest.TestCase):
             '__i_dont_exist__',
             'test.' + ext
         )
-        with self.assertRaises(IOError):
+        with self.assertRaises(IOError) as context:
             store = store_cls(path)
+        self.assertEqual(context.exception.errno, errno.ENOENT)
 
 
 if __name__ == '__main__':

--- a/kivy/tests/test_storage.py
+++ b/kivy/tests/test_storage.py
@@ -4,6 +4,7 @@ Storage tests
 '''
 
 import unittest
+from os.path import abspath, dirname, join
 import os
 
 
@@ -21,6 +22,14 @@ class StorageTestCase(unittest.TestCase):
             self._do_store_test_filled(DictStore(tmpfn))
         finally:
             unlink(tmpfn)
+
+    def test_dict_storage_nofolder(self):
+        from kivy.storage.dictstore import DictStore
+        self._do_store_test_nofolder(DictStore)
+
+    def test_json_storage_nofolder(self):
+        from kivy.storage.jsonstore import JsonStore
+        self._do_store_test_nofolder(JsonStore)
 
     def test_json_storage(self):
         from kivy.storage.jsonstore import JsonStore
@@ -108,3 +117,17 @@ class StorageTestCase(unittest.TestCase):
         self.assertTrue(store.delete('plop'))
         self.assertRaises(KeyError, lambda: store.delete('plop'))
         self.assertRaises(KeyError, lambda: store.get('plop'))
+
+    def _do_store_test_nofolder(self, store_cls):
+        ext = store_cls.__name__.lower()[:4]
+        path = join(
+            dirname(abspath(__file__)),
+            '__i_dont_exist__',
+            'test.' + ext
+        )
+        with self.assertRaises(IOError):
+            store = store_cls(path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix that prevents issues like #5259 from raising again. Currently if the file doesn't exist we create it, but the behavior breaks when the folder doesn't.

There's also a `PermissionError` which might get raised, however that one should be rather obvious to get even if it's raised after the instance is created and `put()` called.