### PR TITLE
_text_sdl2.pyx: Don't clear pixel memory twice

### DIFF
--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -8,7 +8,6 @@ TODO:
 
 include '../../lib/sdl2.pxi'
 
-from libc.string cimport memset
 from kivy.core.image import ImageData
 from kivy.compat import PY2
 
@@ -40,7 +39,6 @@ cdef class _SurfaceContainer:
         self.surface = SDL_CreateRGBSurface(0,
             w, h, 32,
             0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000)
-        memset(self.surface.pixels, 0, w * h * 4)
 
     def __dealloc__(self):
         if self.surface != NULL:


### PR DESCRIPTION
[SDL2 does this already](https://github.com/SDL-mirror/SDL/blob/release-2.0.0/src/video/SDL_surface.c#L97-L98)