### PR TITLE
Don t drop SDL_Dropfile event while in pause #5388

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -465,7 +465,15 @@ class WindowSDL(WindowBase):
             self._win.wait_event()
             if not self._pause_loop:
                 break
-            self._win.poll()
+            event = self._win.poll()
+            if event is None:
+                continue
+            # As dropfile is send was the app is still in pause.loop
+            # we need to dispatch it
+            action, args = event[0], event[1:]
+            if action == 'dropfile':
+                dropfile = args
+                self.dispatch('on_dropfile', dropfile[0])
 
         while True:
             event = self._win.poll()
@@ -545,7 +553,6 @@ class WindowSDL(WindowBase):
 
             elif action == 'dropfile':
                 dropfile = args
-                print('WE GOT A DROPFILE ACTION')
                 self.dispatch('on_dropfile', dropfile[0])
             # video resize
             elif action == 'windowresized':

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -545,6 +545,7 @@ class WindowSDL(WindowBase):
 
             elif action == 'dropfile':
                 dropfile = args
+                print('WE GOT A DROPFILE ACTION')
                 self.dispatch('on_dropfile', dropfile[0])
             # video resize
             elif action == 'windowresized':


### PR DESCRIPTION
We need to catch the dropfile event sent by SDL even in Pause for inter app communication with scheme URI (qrcode from camera from example on iOS) #5388 