### PR TITLE
Fix setup.py under python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,11 @@ def get_version(filename='kivy/version.py'):
         GIT_REVISION = check_output(
             ['git', 'rev-parse', 'HEAD']
         ).strip().decode('ascii')
-    except (CalledProcessError, OSError):
+    except (CalledProcessError, OSError, IOError) as e:
+        # CalledProcessError has no errno
+        errno = getattr(e, 'errno', None)
+        if errno != 2 and 'CalledProcessError' not in repr(e):
+            raise
         GIT_REVISION = "Unknown"
 
     cnt = (

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_version(filename='kivy/version.py'):
         GIT_REVISION = check_output(
             ['git', 'rev-parse', 'HEAD']
         ).strip().decode('ascii')
-    except (CalledProcessError, FileNotFoundError):
+    except (CalledProcessError, OSError):
         GIT_REVISION = "Unknown"
 
     cnt = (


### PR DESCRIPTION
The setup.py currently has an `except FileNotFoundError`, but if an exception does occur then this crashes because FileNotFoundError was introduced only in Python 3. Using OSError instead seems to be the right way to catch the error in both versions.