### PR TITLE
Specify segments=10 and get 5 segments on picture

### DIFF
--- a/examples/canvas/lines_extended.py
+++ b/examples/canvas/lines_extended.py
@@ -45,7 +45,7 @@ Builder.load_string('''
             ellipse: (self.x, self.y, self.width, self.height, 90, 720, 10)
     Label:
         center: root.center
-        text: 'Ellipse from 90 to 720\\n10 segments'
+        text: 'Ellipse from 90 to 720\\n5 segments'
         halign: 'center'
 
 <LineCircle1>:


### PR DESCRIPTION
This is more of a comment than a real patch to apply.

Parameter "segments" should be two times larger than expected:
- segments = 4 gives you 2 parts (sectors, portions)
- segments = 6 gives you 3 parts (sectors, portions)
- segments = 8 gives you 4 parts (sectors, portions)
- segments = 10 gives you 5 parts (sectors, portions)
and so on...

If you specify:
width = height = 30
angle_start = 0
angle_end = 360

then you will get (for even number of segments):
- triangle for segments=6
- square for segments=8
- pentagon for segments=10

There is nothing drawn on the screen for odd number of segments.

So the name "segments" is misleading, you should specify
twice as much segments to get the expected result.

That's why I propose to change the description from "10 segments" to "5 segments" because you see only 5 parts on the picture:
https://github.com/kivy/kivy/blob/master/doc/sources/images/examples/canvas__lines_extended__py.png
in the place titled "Ellipse from 90 to 720 10 segments".