### PR TITLE
Fixes for Cython 0.27

### DIFF
--- a/kivy/factory.py
+++ b/kivy/factory.py
@@ -136,7 +136,11 @@ class FactoryBase(object):
         # No class to return, import the module
         if cls is None:
             if item['module']:
-                module = __import__(name=item['module'], fromlist='.')
+                module = __import__(
+                    name=item['module'],
+                    fromlist='*',
+                    level=0  # force absolute
+                )
                 if not hasattr(module, name):
                     raise FactoryException(
                         'No class named <%s> in module <%s>' % (

--- a/kivy/graphics/fbo.pxd
+++ b/kivy/graphics/fbo.pxd
@@ -27,4 +27,4 @@ cdef class Fbo(RenderContext):
     cdef int apply(self) except -1
     cdef void raise_exception(self, str message, int status=?)
     cdef str resolve_status(self, int status)
-    cdef void reload(self)
+    cdef void reload(self) except *

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -360,7 +360,7 @@ cdef class Fbo(RenderContext):
             self.flag_update_done()
         return 0
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         # recreate the framebuffer, without deleting it. the deletion is not
         # handled by us.
         self.create_fbo()

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -223,7 +223,7 @@ cdef class InstructionGroup(Instruction):
         cdef Instruction c
         return [c for c in self.children if c.group == groupname]
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         Instruction.reload(self)
         cdef Instruction c
         for c in self.children:
@@ -574,7 +574,7 @@ cdef class Canvas(CanvasBase):
         self._before = None
         self._after = None
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         return
         '''
         # XXX ensure it's not needed anymore.
@@ -868,7 +868,7 @@ cdef class RenderContext(Canvas):
 
         return 0
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         pushActiveContext(self)
         reset_gl_context()
         Canvas.reload(self)

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -95,7 +95,7 @@ cdef class Instruction(ObjectWithUid):
     cdef void set_parent(self, Instruction parent):
         self.parent = parent
 
-    cdef void reload(self):
+    cdef void reload(self) except *:
         self.flags |= GI_NEEDS_UPDATE
         self.flags &= ~GI_NO_APPLY_ONCE
         self.flags &= ~GI_IGNORE


### PR DESCRIPTION
Based on #5390 and trying to fix remaining issues. While it seems to be ok on py2, py3 for whatever reason tries to say `kivy.graphics.instructions` isn't available ([it is actually ô_ô](https://travis-ci.org/KeyWeeUsr/kivy/jobs/279673529#L1201)). Perhaps [the error](https://travis-ci.org/KeyWeeUsr/kivy/jobs/279673529#L2500) means I'm not on the right track?