### PR TITLE
Downgrade Cython to 0.26.1 for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
         sudo apt-get -y install python-dev libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff4-dev libX11-dev libmtdev-dev;
         sudo apt-get -y install python-setuptools build-essential libgl1-mesa-dev libgles2-mesa-dev;
         sudo apt-get -y install xvfb pulseaudio;
-        pip install --upgrade cython pillow nose coveralls;
+        pip install --upgrade cython==0.26.1 pillow nose coveralls;
       fi;
       if [ "${RUN}" == "docs" ]; then
         pip install --upgrade sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag;
@@ -74,9 +74,9 @@ install:
       if [ "${PY}" == "3" ]; then
          curl -O -L https://www.python.org/ftp/python/3.5.2/python-3.5.2-macosx10.6.pkg;
          sudo installer -package python-3.5.2-macosx10.6.pkg -target /;
-         pip3 install --upgrade --user cython pillow nose mock;
+         pip3 install --upgrade --user cython==0.26.1 pillow nose mock;
       else
-         pip install --upgrade --user cython pillow nose mock;
+         pip install --upgrade --user cython==0.26.1 pillow nose mock;
       fi;
     fi;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -153,7 +153,7 @@ build_script:
       Check-Error
     }
 
-    pip install mock cython pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
+    pip install mock cython==0.26.1 pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
 
     pip --no-cache-dir install kivy.deps.gstreamer
 


### PR DESCRIPTION
Until #5390/#5406 fixes the stuff for the newest stable version of Cython we need to use the previous version (it won't compile) otherwise we can't really run the tests.