### PR TITLE
Don't pass touch to children when outside the sv.

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -722,17 +722,22 @@ class ScrollView(StencilView):
 
     def on_touch_move(self, touch):
         if self._touch is not touch:
-            # touch is in parent
-            touch.push()
-            touch.apply_transform_2d(self.to_local)
-            super(ScrollView, self).on_touch_move(touch)
-            touch.pop()
+            # don't pass on touch to children if outside the sv
+            if self.collide_point(*touch.pos):
+                # touch is in parent
+                touch.push()
+                touch.apply_transform_2d(self.to_local)
+                super(ScrollView, self).on_touch_move(touch)
+                touch.pop()
             return self._get_uid() in touch.ud
         if touch.grab_current is not self:
             return True
 
         if touch.ud.get(self._get_uid()) is None:
-            return super(ScrollView, self).on_touch_move(touch)
+            # don't pass on touch to children if outside the sv
+            if self.collide_point(*touch.pos):
+                return super(ScrollView, self).on_touch_move(touch)
+            return False
 
         touch.ud['sv.handled'] = {'x': False, 'y': False}
         if self.dispatch('on_scroll_move', touch):
@@ -818,13 +823,15 @@ class ScrollView(StencilView):
     def on_touch_up(self, touch):
         uid = self._get_uid('svavoid')
         if self._touch is not touch and uid not in touch.ud:
-            # touch is in parents
-            touch.push()
-            touch.apply_transform_2d(self.to_local)
-            if super(ScrollView, self).on_touch_up(touch):
+            # don't pass on touch to children if outside the sv
+            if self.collide_point(*touch.pos):
+                # touch is in parents
+                touch.push()
+                touch.apply_transform_2d(self.to_local)
+                if super(ScrollView, self).on_touch_up(touch):
+                    touch.pop()
+                    return True
                 touch.pop()
-                return True
-            touch.pop()
             return False
 
         if self.dispatch('on_scroll_stop', touch):


### PR DESCRIPTION
Scrollview used to pass on a touch to its children in `on_touch_move/up` even if the touch was outside the sv. This resulted in children processing touches that was outside their area, thinking that it was inside.

That's because when you do a collide test in a sv child widget, part of the widget is obscured if the sv is smaller than the widget, but the child doesn't know this. So it thinks the touch was meant for it even though it isn't. All because the sv passed it on to its children unconditionally.