### PR TITLE
[RFC] KivyWM

### DIFF
--- a/examples/windowmanager/main.py
+++ b/examples/windowmanager/main.py
@@ -1,0 +1,22 @@
+from kivy.uix.windowmanager import KivyWindowManager
+from kivy.app import App
+from kivy.uix.gridlayout import GridLayout
+from kivy.uix.label import Label
+
+class WindowManagerApp(KivyWindowManager):
+    def __init__(self, *args):
+        super(WindowManagerApp, self).__init__(*args)
+
+        self.add_window_callback(self.add_window, name='glxgears')
+
+    def add_window(self, window):
+        self.root.add_widget(window)
+
+    def build(self):
+        layout = GridLayout(cols=2)
+        layout.add_widget(Label(text='Kivy Window Manager'))
+        return layout
+
+if __name__ == '__main__':
+    WindowManagerApp().run()
+

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -195,9 +195,14 @@ class WindowX11(WindowBase):
         if 'KIVY_WINDOW_X11_CWOR' in environ:
             CWOR = True
 
+        if isinstance(self.title, bytes):
+            title = self.title
+        else:
+            title = self.title.encode('utf-8')
+
         if x11_create_window(size[0], size[1], pos[0], pos[1],
                 resizable, fullscreen, border, above, CWOR,
-                <char *><bytes>self.title) < 0:
+                <char *><bytes>title) < 0:
             Logger.critical('WinX11: Unable to create the window')
             return
 
@@ -232,7 +237,12 @@ class WindowX11(WindowBase):
         super(WindowX11, self).flip()
 
     def on_title(self, *kwargs):
-        x11_set_title(<char *><bytes>self.title)
+        if isinstance(self.title, bytes):
+            title = self.title
+        else:
+            title = self.title.encode('utf-8')
+
+        x11_set_title(<char *><bytes>title)
 
     def on_keyboard(self, key,
         scancode=None, codepoint=None, modifier=None, **kwargs):

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -15,6 +15,10 @@ from kivy.base import stopTouchApp, EventLoop, ExceptionManager
 from kivy.utils import platform
 from os import environ
 
+from libc.stdint cimport uintptr_t
+
+from kivy.graphics.cgl cimport Display, Window
+
 # force include the file
 cdef extern from "window_x11_core.c":
     pass
@@ -64,6 +68,8 @@ cdef extern void x11_set_title(char *title)
 cdef extern int x11_idle()
 cdef extern int x11_get_width()
 cdef extern int x11_get_height()
+cdef extern Display *x11_get_display()
+cdef extern Window x11_get_window()
 
 ctypedef int (*event_cb_t)(XEvent *event)
 cdef extern void x11_set_event_callback(event_cb_t callback)
@@ -258,4 +264,10 @@ class WindowX11(WindowBase):
                 return True
         super(WindowX11, self).on_keyboard(key, scancode,
             codepoint=codepoint, modifier=modifier)
+
+    def get_xdisplay(self):
+        return <uintptr_t>x11_get_display()
+
+    def get_xwindow(self):
+        return <uintptr_t>x11_get_window()
 

--- a/kivy/core/window/window_x11_core.c
+++ b/kivy/core/window/window_x11_core.c
@@ -454,6 +454,14 @@ int x11_idle(void) {
 	return updateTheMessageQueue();
 }
 
+Display *x11_get_display(void) {
+	return Xdisplay;
+}
+
+Window x11_get_window(void) {
+	return window_handle;
+}
+
 #include "window_x11_keytab.c"
 
 long x11_keycode_to_keysym(unsigned int keycode, int shiftDown) {

--- a/kivy/graphics/cgl.pxd
+++ b/kivy/graphics/cgl.pxd
@@ -22,10 +22,33 @@ cdef extern from "gl_redirect.h":
     ctypedef signed long int    GLintptr
     ctypedef signed long int    GLsizeiptr
 
+    # X11
     cdef struct _XDisplay:
         pass
 
     ctypedef _XDisplay Display
+
+    cdef struct XVisualInfo:
+        pass
+
+    ctypedef int XID
+    ctypedef XID Bool
+    ctypedef XID Window
+    ctypedef XID Drawable
+    ctypedef XID Pixmap
+
+    # GLX
+    cdef struct __GLXFBConfigRec:
+        pass
+
+    ctypedef __GLXFBConfigRec GLXFBConfig
+
+    cdef struct __GLXcontextRec:
+        pass
+
+    ctypedef __GLXcontextRec *GLXContext
+    ctypedef XID GLXPixmap
+    ctypedef XID GLXDrawable
 
     int GL_DEPTH_BUFFER_BIT
     int GL_STENCIL_BUFFER_BIT

--- a/kivy/graphics/cgl.pxd
+++ b/kivy/graphics/cgl.pxd
@@ -22,6 +22,10 @@ cdef extern from "gl_redirect.h":
     ctypedef signed long int    GLintptr
     ctypedef signed long int    GLsizeiptr
 
+    cdef struct _XDisplay:
+        pass
+
+    ctypedef _XDisplay Display
 
     int GL_DEPTH_BUFFER_BIT
     int GL_STENCIL_BUFFER_BIT
@@ -378,6 +382,7 @@ cdef extern from "gl_redirect.h":
 
     int GL_FRAMEBUFFER_UNDEFINED_OES
 
+# GL
 ctypedef const GLubyte* (__stdcall *GLGETSTRINGPTR)(GLenum) nogil
 ctypedef GLboolean (__stdcall *GLISBUFFERPTR)(GLuint buffer) nogil
 ctypedef GLboolean (__stdcall *GLISENABLEDPTR)(GLenum cap) nogil
@@ -507,6 +512,14 @@ ctypedef void (__stdcall *GLVERTEXATTRIB3FPTR)(GLuint indx, GLfloat x, GLfloat y
 ctypedef void (__stdcall *GLVERTEXATTRIB4FPTR)(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w) nogil
 ctypedef void (__stdcall *GLVERTEXATTRIBPOINTERPTR)(GLuint, GLint, GLenum, GLboolean, GLsizei, const void *) nogil
 ctypedef void (__stdcall *GLVIEWPORTPTR)(GLint, GLint, GLsizei, GLsizei) nogil
+
+# GLX
+ctypedef void (*PFNGLXBINDTEXIMAGEEXTPROC)(Display *, GLXDrawable, const int, int *) nogil
+ctypedef void (*PFNGLXRELEASETEXIMAGEEXTPROC)(Display *, GLXDrawable, const int) nogil
+
+ctypedef struct GLX_Context:
+    void (*glXBindTexImageEXT)(Display *, GLXDrawable, const int, int *)
+    void (*glXReleaseTexImageEXT)(Display *, GLXDrawable, const int)
 
 ctypedef struct GLES2_Context:
     const GLubyte* (__stdcall *glGetString)(GLenum) nogil
@@ -638,6 +651,8 @@ ctypedef struct GLES2_Context:
     void (__stdcall *glVertexAttrib4f)(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w) nogil
     void (__stdcall *glVertexAttribPointer)(GLuint, GLint, GLenum, GLboolean, GLsizei, const void *) nogil
     void (__stdcall *glViewport)(GLint, GLint, GLsizei, GLsizei) nogil
+
+    GLX_Context *glx
 
 cdef GLES2_Context *cgl
 cdef int kivy_opengl_es2

--- a/kivy/graphics/cgl_backend/cgl_sdl2.pyx
+++ b/kivy/graphics/cgl_backend/cgl_sdl2.pyx
@@ -150,3 +150,4 @@ def init_backend():
         cgl.glVertexAttrib4f = <GLVERTEXATTRIB4FPTR>SDL_GL_GetProcAddress("glVertexAttrib4f")
         cgl.glVertexAttribPointer = <GLVERTEXATTRIBPOINTERPTR>SDL_GL_GetProcAddress("glVertexAttribPointer")
         cgl.glViewport = <GLVIEWPORTPTR>SDL_GL_GetProcAddress("glViewport")
+

--- a/kivy/graphics/texture.pxd
+++ b/kivy/graphics/texture.pxd
@@ -27,6 +27,7 @@ cdef class Texture:
     cdef list observers
     cdef object _proxyimage
     cdef object _callback
+    cdef object _pixmap
 
     cdef void update_tex_coords(self)
     cdef void set_min_filter(self, x)

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -563,6 +563,28 @@ def texture_create(size=None, colorfmt=None, bufferfmt=None, mipmap=False,
     return _texture_create(width, height, colorfmt, bufferfmt, mipmap,
             allocate, callback, icolorfmt)
 
+from libc.stdint cimport uintptr_t
+from kivy.graphics.tfp cimport bindTexImage, releaseTexImage
+def texture_create_from_pixmap(pixmap, size):
+    cdef GLuint target = GL_TEXTURE_2D
+    cdef int allocate = 0, mipmap = 0
+    callback = None
+    colorfmt = 'rgba'
+    bufferfmt = 'ubyte'
+    icolorfmt = colorfmt
+
+    cdef Texture texture = Texture(size[0], size[1], target,
+          colorfmt=colorfmt, bufferfmt=bufferfmt, mipmap=mipmap,
+          callback=callback, icolorfmt=icolorfmt)
+
+    texture.min_filter = 'linear'
+    texture.mag_filter = 'linear'
+
+    texture.bind()
+    bindTexImage(pixmap)
+    texture.flip_vertical()
+
+    return texture
 
 def texture_create_from_data(im, mipmap=False):
     '''Create a texture from an ImageData class.
@@ -613,6 +635,7 @@ cdef class Texture:
     '''
     create = staticmethod(texture_create)
     create_from_data = staticmethod(texture_create_from_data)
+    create_from_pixmap = staticmethod(texture_create_from_pixmap)
 
     def __init__(self, width, height, target, texid=0, colorfmt='rgb',
             bufferfmt='ubyte', mipmap=False, source=None, callback=None,

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -581,8 +581,9 @@ def texture_create_from_pixmap(pixmap, size):
     texture.mag_filter = 'linear'
 
     texture.bind()
-    bindTexImage(pixmap)
+    glxpixmap = bindTexImage(pixmap)
     texture.flip_vertical()
+    texture._pixmap = glxpixmap
 
     return texture
 
@@ -660,6 +661,7 @@ cdef class Texture:
         self._source        = source
         self._nofree        = 0
         self._callback      = callback
+        self._pixmap        = None
 
         if texid == 0:
             self.flags |= TI_NEED_GEN
@@ -706,6 +708,10 @@ cdef class Texture:
             if cb.is_dead() or cb() is callback:
                 self.observers.remove(cb)
                 continue
+
+    def release_pixmap(self):
+        if self._pixmap:
+            releaseTexImage(self._pixmap)
 
     cdef void allocate(self):
         cdef int iglfmt, glfmt, iglbufferfmt, datasize, dataerr = 0

--- a/kivy/graphics/tfp.pxd
+++ b/kivy/graphics/tfp.pxd
@@ -1,0 +1,5 @@
+include "common.pxi"
+from kivy.graphics.cgl cimport *
+
+cdef GLXPixmap bindTexImage(Pixmap pixmap)
+cdef void releaseTexImage(GLXDrawable drawable)

--- a/kivy/graphics/tfp.pyx
+++ b/kivy/graphics/tfp.pyx
@@ -1,0 +1,102 @@
+'''
+texture_from_pixmap
+'''
+
+from kivy.graphics.cgl cimport XID, Window, GLXDrawable
+from libc.stdint cimport uintptr_t
+from libc.stdio cimport fprintf, stderr
+from libc.string cimport strlen
+
+DEF GLX_BIND_TO_TEXTURE_RGBA_EXT = 0x20D1
+DEF GLX_DRAWABLE_TYPE = 0x8010
+DEF GLX_PIXMAP_BIT = 0x00000002
+DEF GLX_RGBA = 4
+DEF GLX_DEPTH_SIZE = 12
+DEF GLX_BIND_TO_TEXTURE_TARGETS_EXT = 0x20D3
+DEF GLX_TEXTURE_2D_BIT_EXT = 0x00000002
+DEF GLX_DOUBLEBUFFER = 5
+DEF GLX_Y_INVERTED_EXT = 0x20D4
+DEF GLX_DONT_CARE = 0xFFFFFFFF
+DEF GLX_TEXTURE_TARGET_EXT = 0x20D6
+DEF GLX_TEXTURE_2D_EXT = 0x20DC
+DEF GLX_TEXTURE_FORMAT_EXT = 0x20D5
+DEF GLX_TEXTURE_FORMAT_RGB_EXT = 0x20D9
+DEF GLX_TEXTURE_FORMAT_RGBA_EXT = 0x20DA
+DEF GLX_FRONT_EXT = 0x20DE
+
+cdef extern from "X11/Xlib.h":
+    ctypedef struct XErrorEvent:
+        Display *display
+        XID resourceid
+        unsigned long serial
+        unsigned char error_code
+        unsigned char request_code
+        unsigned char minor_code
+
+    cdef void XFree(void *data)
+
+    ctypedef int (*XErrorHandler)(Display *d, XErrorEvent *e)
+    cdef XErrorHandler XSetErrorHandler(XErrorHandler)
+    cdef void XGetErrorText(Display *, unsigned char, char *, int)
+
+cdef extern from "GL/glx.h":
+    GLXPixmap glXCreatePixmap(Display *, GLXFBConfig, Pixmap, const int *);
+    GLXFBConfig *glXChooseFBConfig(Display *, int , const int *, int *);
+    XVisualInfo *glXChooseVisual( Display *, int , int *);
+    GLXContext glXCreateContext( Display *, XVisualInfo *, GLXContext, Bool);
+
+
+cdef int error_handler(Display *d, XErrorEvent *e):
+    print(f'ERROR: error_code: {e.error_code}, request_code: {e.request_code}, minor_code: {e.minor_code}')
+
+    cdef char buf[255]
+    XGetErrorText(d, e.error_code, buf, 255)
+    print(f'ERROR Message: {buf}')
+
+XSetErrorHandler(error_handler)
+
+cdef GLXPixmap bindTexImage(Pixmap pixmap):
+    from kivy.core.window import Window as KivyWindow
+
+    _disp = <uintptr_t>KivyWindow.get_xdisplay()
+    cdef Display *xdisplay = <Display *>_disp
+
+    _win = <uintptr_t>KivyWindow.get_xwindow()
+    cdef unsigned long xwindow = <Window>_win
+
+    cdef int *pixmap_config = [
+        GLX_BIND_TO_TEXTURE_RGBA_EXT, True,
+        GLX_DRAWABLE_TYPE, GLX_PIXMAP_BIT,
+        GLX_BIND_TO_TEXTURE_TARGETS_EXT, GLX_TEXTURE_2D_BIT_EXT,
+        GLX_DOUBLEBUFFER, False,
+        GLX_Y_INVERTED_EXT, GLX_DONT_CARE,
+        0x8000
+    ]
+
+    cdef int c = 0
+    cdef GLXFBConfig *configs = glXChooseFBConfig(xdisplay, 0, pixmap_config, &c);
+
+    if not configs:
+        print('No appropriate GLX FBConfig available!')
+
+    cdef int *pixmap_attribs = [
+        GLX_TEXTURE_TARGET_EXT, GLX_TEXTURE_2D_EXT,
+        GLX_TEXTURE_FORMAT_EXT, GLX_TEXTURE_FORMAT_RGBA_EXT,
+        0x8000
+    ]
+
+    glxpixmap = glXCreatePixmap(xdisplay, configs[0], pixmap, pixmap_attribs)
+
+    XFree(configs)
+
+    cgl.glx.glXBindTexImageEXT(xdisplay, glxpixmap, GLX_FRONT_EXT, NULL)
+    return glxpixmap
+
+cdef void releaseTexImage(GLXPixmap pixmap):
+    from kivy.core.window import Window as KivyWindow
+    from kivy.core.window.window_x11 import WindowX11
+
+    _disp = <uintptr_t>KivyWindow.get_xdisplay()
+    cdef Display *xdisplay = <Display *>_disp
+
+    cgl.glx.glXReleaseTexImageEXT(xdisplay, pixmap, GLX_FRONT_EXT)

--- a/kivy/include/gl_redirect.h
+++ b/kivy/include/gl_redirect.h
@@ -62,7 +62,9 @@
 #		else
 #			define GL_GLEXT_PROTOTYPES
 #			include <GL/gl.h>
+#           include <GL/glx.h>
 #			include <GL/glext.h>
+#           include <GL/glxext.h>
 #		endif
 #		define GL_SHADER_BINARY_FORMATS					0x8DF8
 #		define GL_RGB565								0x8D62

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -91,6 +91,11 @@ cdef extern from "SDL2/SDL.h":
         SDL_FALSE = 0
         SDL_TRUE = 1
 
+    cdef struct SDL_version:
+        Uint8 major
+        Uint8 minor
+        Uint8 patch
+
     cdef struct SDL_Rect:
         int x, y
         int w, h
@@ -447,6 +452,7 @@ cdef extern from "SDL2/SDL.h":
     cdef int SDL_INIT_EVENTS         = 0x00004000
     cdef int SDL_INIT_NOPARACHUTE    = 0x00100000  # Don't catch fatal signals */
 
+    cdef void SDL_GetVersion(SDL_version * ver)
     cdef SDL_Renderer * SDL_CreateRenderer(SDL_Window * window, int index, Uint32 flags)
     cdef void SDL_DestroyRenderer (SDL_Renderer * renderer)
     cdef SDL_Texture * SDL_CreateTexture(SDL_Renderer * renderer, Uint32 format, int access, int w, int h)
@@ -967,3 +973,34 @@ cdef extern from "SDL2/SDL_mixer.h":
     cdef Mix_Chunk *  Mix_GetChunk(int channel)
     cdef void  Mix_CloseAudio()
     cdef char * Mix_GetError()
+
+from kivy.graphics.cgl cimport Display, Window
+
+cdef extern from "SDL2/SDL_syswm.h":
+    cdef enum SDL_SYSWM_TYPE:
+        SDL_SYSWM_UNKNOWN
+        SDL_SYSWM_WINDOWS
+        SDL_SYSWM_X11
+        SDL_SYSWM_DIRECTFB
+        SDL_SYSWM_COCOA
+        SDL_SYSWM_UIKIT
+        SDL_SYSWM_WAYLAND
+        SDL_SYSWM_MIR
+        SDL_SYSWM_WINRT
+        SDL_SYSWM_ANDROID
+        SDL_SYSWM_VIVANTE
+        SDL_SYSWM_OS2
+
+    cdef struct _wm_info_x11:
+        Display *display
+        Window window
+
+    cdef union _wm_info:
+        _wm_info_x11 x11
+
+    cdef struct SDL_SysWMinfo:
+        SDL_version version
+        SDL_SYSWM_TYPE subsystem
+        _wm_info info
+
+    cdef SDL_bool SDL_GetWindowWMInfo(SDL_Window *window, SDL_SysWMinfo *info)

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -4,7 +4,7 @@
 #whose terms are available in the LICENSE file or at http://www.ignifuga.org/license
 
 
-cdef extern from "SDL_joystick.h":
+cdef extern from "SDL2/SDL_joystick.h":
     cdef struct SDL_Joystick
     cdef int SDL_HAT_CENTERED = 0x00
     cdef int SDL_HAT_UP = 0x01
@@ -12,7 +12,7 @@ cdef extern from "SDL_joystick.h":
     cdef int SDL_HAT_DOWN = 0x04
     cdef int SDL_HAT_LEFT = 0x08
 
-cdef extern from "SDL.h":
+cdef extern from "SDL2/SDL.h":
     ctypedef unsigned char Uint8
     ctypedef unsigned long Uint32
     ctypedef signed long Sint32
@@ -620,7 +620,7 @@ cdef extern from "SDL.h":
     Uint16 AUDIO_F32MSB #0x9120  /**< As above, but big-endian byte order */
     Uint16 AUDIO_F32    #AUDIO_F32LSB
 
-cdef extern from "SDL_shape.h":
+cdef extern from "SDL2/SDL_shape.h":
     cdef SDL_Window * SDL_CreateShapedWindow(
         char *title,
         unsigned int x,
@@ -659,7 +659,7 @@ cdef extern from "SDL_shape.h":
         SDL_WindowShapeMode * shape_mode
     )
 
-cdef extern from "SDL_image.h":
+cdef extern from "SDL2/SDL_image.h":
     ctypedef enum IMG_InitFlags:
         IMG_INIT_JPG
         IMG_INIT_PNG
@@ -673,7 +673,7 @@ cdef extern from "SDL_image.h":
     cdef int *IMG_SavePNG(SDL_Surface *src, char *file)
 
 
-cdef extern from "SDL_ttf.h":
+cdef extern from "SDL2/SDL_ttf.h":
     ctypedef struct TTF_Font
     cdef int TTF_Init()
     cdef TTF_Font *  TTF_OpenFont( char *file, int ptsize)
@@ -828,7 +828,7 @@ cdef extern from "SDL_ttf.h":
     # Get the kerning size of two glyphs */
     cdef int TTF_GetFontKerningSize(TTF_Font *font, int prev_index, int index)
 
-cdef extern from "SDL_audio.h":
+cdef extern from "SDL2/SDL_audio.h":
     cdef int AUDIO_S16SYS
     ctypedef struct SDL_AudioFilter:
         pass
@@ -855,7 +855,7 @@ cdef extern from "SDL_audio.h":
     )
     cdef int SDL_ConvertAudio(SDL_AudioCVT *cvt)
 
-cdef extern from "SDL_mixer.h":
+cdef extern from "SDL2/SDL_mixer.h":
     cdef struct Mix_Chunk:
         int allocated
         Uint8 *abuf

--- a/kivy/uix/windowmanager.py
+++ b/kivy/uix/windowmanager.py
@@ -1,0 +1,132 @@
+'''
+Window manager
+==============
+
+The kivy window manager is a compositing window manager that exposes an
+interface for creating Kivy widgets from X windows, which can be sized and
+positioned according to kivy layouts.
+
+'''
+
+from kivy.app import App
+from kivy.graphics import Color, Rectangle
+from kivy.logger import Logger
+from kivy.event import EventDispatcher
+from kivy.properties import DictProperty, ObjectProperty
+from kivy.uix.widget import Widget
+from kivy.graphics.texture import Texture
+from kivy.clock import Clock
+from kivy.core.window import Window as KivyWindow
+
+import select
+
+try:
+    import Xlib.display
+    import Xlib.error
+    import Xlib.protocol.event
+    import Xlib.X
+except ModuleNotFoundError:
+    Logger.warning('WindowMgr: Unable to import Xlib, please install it with "pip install python-xlib"')
+
+
+class Window(Widget):
+    def on_size(self):
+        pass
+
+    def on_pos(self):
+        pass
+
+
+class BaseWindowManager(EventDispatcher):
+    windows = ListProperty([])
+
+    event_mapping = {
+            'CreateNotify': 'on_create_notify',
+            'DestroyNotify': 'on_destroy_notify',
+            'UnmapNotify': 'on_unmap_notify',
+            'MapNotify': 'on_map_notify',
+            'MapRequest': 'on_map_request',
+            'ReparentNotify': 'on_reparent_notify',
+            'ConfigureNotify': 'on_configure_notify',
+            'ConfigureRequest': 'on_configure_request',
+        }
+
+    def __init__(self, **kwargs):
+        super(BaseWindowManager, self).__init__()
+
+        # Convert event strings to X protocol values
+        self.event_mapping = {
+            getattr(Xlib.X, event): handler
+            for event, handler in self.event_mapping.items()
+        }
+
+        [self.register_event_type(event)
+            for event in self.event_mapping.values()]
+
+        self.connect()
+
+        self.bind(on_start=self.setup_wm)
+
+        Clock.schedule_interval(lambda dt: self.poll_events(), 0)
+
+    def connect(self):
+        try:
+            self.display = Xlib.display.Display()
+        except Xlib.error.DisplayConnectionError:
+            Logger.error('WindowMgr: Unable to connect to X server')
+            raise
+
+    def setup_wm(self, *args):
+        self.root_win = self.display.screen().root
+
+        event_mask = Xlib.X.SubstructureNotifyMask \
+                   | Xlib.X.SubstructureRedirectMask
+
+        ec = Xlib.error.CatchError(Xlib.error.BadAccess)
+        self.root_win.change_attributes(event_mask=event_mask, onerror=ec)
+        self.display.sync()
+
+        if ec.get_error():
+            Logger.error('WindowMgr: Unable to create window manager, another one is running')
+
+    def poll_events(self):
+        readable, w, e = select.select([self.display], [], [], 0)
+
+        if not readable:
+            return
+        elif self.display in readable:
+            num_events = self.display.pending_events()
+            Logger.info
+            for i in range(num_events):
+                self.handle_event(self.display.next_event())
+
+    def handle_event(self, event):
+        try:
+            self.dispatch(self.event_mapping[event.type], event)
+        except Xlib.error.BadWindow:
+            # TODO: Handle BadWindow
+            pass
+
+    def on_create_notify(self, event):
+        pass
+
+    def on_destroy_notify(self, event):
+        pass
+
+    def on_unmap_notify(self, event):
+        pass
+
+    def on_map_notify(self, event):
+        pass
+
+    def on_map_request(self, event):
+        pass
+
+    def on_reparent_notify(self, event):
+        pass
+
+    def on_configure_notify(self, event):
+        pass
+
+    def on_configure_request(self, event):
+        pass

--- a/kivy/uix/windowmanager.py
+++ b/kivy/uix/windowmanager.py
@@ -25,21 +25,75 @@ try:
     import Xlib.error
     import Xlib.protocol.event
     import Xlib.X
+    from Xlib.ext.composite import RedirectAutomatic
 except ModuleNotFoundError:
     Logger.warning('WindowMgr: Unable to import Xlib, please install it with "pip install python-xlib"')
 
 
-class Window(Widget):
-    def on_size(self):
-        pass
+class XWindow(Widget):
+    texture = ObjectProperty(None)
 
-    def on_pos(self):
-        pass
+    def __init__(self, manager, window, **kwargs):
+        super(XWindow, self).__init__(**kwargs)
 
+        self.manager = manager
 
-class BaseWindowManager(EventDispatcher):
-    windows = ListProperty([])
+        self.pixmap = None
+        self._window = window
 
+        with self.canvas:
+            Color(1, 1, 1, 1)
+            self.rect = Rectangle(size=self.size, pos=self.pos)
+
+        # HACK: invalidate the pixmap every couple of seconds to update the
+        # texture. This is simply to ease development before adding support for
+        # damage and fixes
+        Clock.schedule_interval(lambda dt: self.on_window_map(), 2)
+
+        self.register_event_type('on_window_map')
+        self.register_event_type('on_window_resize')
+
+    @property
+    def name(self):
+        return self._window.get_wm_name()
+
+    def on_window_map(self):
+        self.invalidate_pixmap()
+
+    def on_window_resize(self):
+        self.invalidate_pixmap()
+
+    def invalidate_pixmap(self):
+        self.bind_texture()
+        self.redraw()
+
+    def bind_texture(self):
+        if self.pixmap:
+            self.pixmap.free()
+
+        self.pixmap = self._window.composite_name_window_pixmap()
+        self.manager.display.sync()
+
+        if self.texture:
+            self.texture.release_pixmap()
+
+        # TODO: Get window geometry, and create a texture based on the actual
+        # window size. There appears to be an issue with displaying NPOT
+        # textures.
+        self.texture = Texture.create_from_pixmap(self._window.id, (256, 256))
+
+    def redraw(self, *args):
+        self.rect.texture = self.texture
+        self.rect.size = self.texture.size
+        self.rect.pos = self.pos
+
+    def on_parent(self, *args):
+        if self.parent:
+            self._window.map()
+        else:
+            self._window.unmap()
+
+class BaseWindowManager(App):
     event_mapping = {
             'CreateNotify': 'on_create_notify',
             'DestroyNotify': 'on_destroy_notify',
@@ -157,3 +211,105 @@ class CompositingWindowManager(BaseWindowManager):
                 window.map()
                 self.display.sync()
                 break
+
+
+class KivyWindowManager(CompositingWindowManager):
+    windows = DictProperty([])
+    window_callbacks = DictProperty({'name': {}, 'id': {}})
+
+    def _add_child(self, window):
+        ''' Creates an XWindow object that can be retrieved and used as a widget by the main app
+        '''
+        if window.id not in self.windows:
+            self.windows[window.id] = XWindow(self, window)
+            print(f'Created XWindow from <{window.get_wm_name()}>')
+
+        default_window_callback = self.window_callbacks.get(None)
+        if default_window_callback:
+            default_window_callback(self.windows[window.id])
+            print('Executed default callback')
+
+        id_callback = self.window_callbacks['id'].get(window.id)
+        if id_callback:
+            id_callback(self.windows[window.id])
+            print('Executed id callback')
+
+        name_callback = self.window_callbacks['name'].get(window.get_wm_name())
+        if name_callback:
+            name_callback(self.windows[window.id])
+            print('Executed named callback')
+
+    def _remove_child(self, window):
+        ''' Remove a child window
+        '''
+        if window.id in self.windows:
+            del self.windows[window.id]
+
+    def add_window_callback(self, cb, name=None, id=None):
+        if name:
+            self.window_callbacks['name'][name] = cb
+        elif id:
+            self.window_callbacks['id'][id] = cb
+        else:
+            self.window_callbacks[None] = cb
+
+    def get_window_by_name(self, name):
+        for xid, window in self.windows.items():
+            if window.get_wm_name() == name:
+                return window
+        return None
+
+    def get_window_by_xid(self, xid):
+        return self.windows.get(xid)
+
+    def on_create_notify(self, event):
+        app = App.get_running_app()
+
+        # Don't create a child for the Kivy window
+        if event.window.id == KivyWindow.get_xwindow():
+            return
+
+        self._add_child(event.window)
+
+        Logger.info(f'Created window: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_create_notify(event)
+
+    def on_destroy_notify(self, event):
+        Logger.info(f'Destroyed window: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_destroy_notify(event)
+
+    def on_unmap_notify(self, event):
+        Logger.info(f'Unmap notify: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_unmap_notify(event)
+
+    def on_map_notify(self, event):
+        if event.window.id in self.windows:
+            self.windows[event.window.id].dispatch('on_window_map')
+
+        Logger.info(f'Map notify: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_map_notify(event)
+
+    def on_map_request(self, event):
+        Logger.info(f'Map request: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_map_request(event)
+
+    def on_reparent_notify(self, event):
+        Logger.info(f'Reparented window: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_reparent_notify(event)
+
+    def on_reparent_request(self, event):
+        Logger.info(f'Reparent request: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_reparent_request(event)
+
+    def on_configure_notify(self):
+        if event.window.id in self.windows:
+            # TODO: Check if the window was actually resized
+            self.windows[event.window.id].dispatch('on_window_resize')
+
+        Logger.info(f'Configure notify: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_configure_notify(event)
+
+    def on_configure_request(self, event):
+        Logger.info(f'Configure request: {event}, name: {event.window.get_wm_name()}')
+        super(KivyWindowManager, self).on_configure_request(event)
+

--- a/kivy/uix/windowmanager.py
+++ b/kivy/uix/windowmanager.py
@@ -19,6 +19,7 @@ from kivy.clock import Clock
 from kivy.core.window import Window as KivyWindow
 
 import select
+import sys
 
 try:
     import Xlib.display
@@ -29,6 +30,11 @@ try:
 except ModuleNotFoundError:
     Logger.warning('WindowMgr: Unable to import Xlib, please install it with "pip install python-xlib"')
 
+SUPPORTED_WINDOW_PROVIDERS = ['WindowX11']
+
+if KivyWindow.__class__.__name__ not in SUPPORTED_WINDOW_PROVIDERS:
+    Logger.error('WindowMgr: Unsupported window provider')
+    sys.exit(1)
 
 class XWindow(Widget):
     texture = ObjectProperty(None)

--- a/setup.py
+++ b/setup.py
@@ -575,7 +575,7 @@ def determine_base_flags():
 def determine_gl_flags():
     kivy_graphics_include = join(src_path, 'kivy', 'include')
     flags = {'include_dirs': [kivy_graphics_include], 'libraries': []}
-    base_flags = {'include_dirs': [kivy_graphics_include], 'libraries': []}
+    base_flags = {'include_dirs': [kivy_graphics_include], 'libraries': ['GL', 'GLX', 'X11']}
     if c_options['use_opengl_mock']:
         return flags, base_flags
     if platform == 'win32':

--- a/setup.py
+++ b/setup.py
@@ -623,7 +623,7 @@ def determine_gl_flags():
         c_options['use_x11'] = True
         c_options['use_egl'] = True
     else:
-        flags['libraries'] = ['GL']
+        flags['libraries'] = ['GL', 'GLX']
     return flags, base_flags
 
 


### PR DESCRIPTION
This pull request is a work-in-progress demonstration of Kivy adapted to function as a compositing X11 window manager. The intent is to create a channel of communication with the Kivy development team and users, to evaluate the utility of the feature, as well as shape design choices going forward.

Below is a screenshot of Kivy running in Xephyr, with a GridLayout for the root widget. Added to the GridLayout is a Label widget, and an XWindow widget displaying glxgears.

![screenshot from 2017-10-04 16-09-21](https://user-images.githubusercontent.com/40163/31239423-e16e08e0-a9b1-11e7-80d0-8d2545afb827.png)

Here is a video demonstration: https://www.youtube.com/video_id=tkuvaVhVNus

Currently, the only supported window provider is X11, so Kivy must be built with `USE_X11=1`, and the example program must be run with `KIVY_WINDOW=x11`.

There's been some initial work on making the SDL2 window provider work with KivyWM, but it's unfinished.

Areas that need improvement:

- Input handling
- Scaling windows based on widget size
- Extension loading (TFP)
- Xfixes/XDamage for updating textures
- Documentation
- Compatibility with window providers other than X11 (SDL2)
- Compatibility with display servers other than X
- Window/Display server agnostic method of binding a texture to a pixmap
    (May be worth considering integrating a UI toolkit that supports this natively, such as COGL, or Clutter)