### PR TITLE
Add probesysfs option to include devices that offer core pointer functionality

### DIFF
--- a/kivy/input/providers/probesysfs.py
+++ b/kivy/input/providers/probesysfs.py
@@ -33,7 +33,8 @@ Here is an example of auto creation::
 By default, ProbeSysfs module will enumerate hardware from the /sys/class/input
 device, and configure hardware with ABS_MT_POSITION_X capability. But for
 example, the wacom screen doesn't support this capability. You can prevent this
-behavior by putting select_all=1 in your config line.
+behavior by putting select_all=1 in your config line. Add use_mouse=1 to also
+include touchscreen hardware that offers core pointer functionality.
 '''
 
 __all__ = ('ProbeSysfsHardwareProbe', )
@@ -160,6 +161,7 @@ else:
             self.match = None
             self.input_path = '/sys/class/input'
             self.select_all = True if _is_rpi else False
+            self.use_mouse = False
             self.use_regex = False
             self.args = []
 
@@ -183,6 +185,8 @@ else:
                     self.use_regex = bool(int(value))
                 elif key == 'select_all':
                     self.select_all = bool(int(value))
+                elif key == 'use_mouse':
+                    self.use_mouse = bool(int(value))
                 elif key == 'param':
                     self.args.append(value)
                 else:
@@ -192,8 +196,9 @@ else:
             self.probe()
 
         def should_use_mouse(self):
-            return not any(p for p in EventLoop.input_providers
-                           if isinstance(p, MouseMotionEventProvider))
+            return (self.use_mouse or
+                    not any(p for p in EventLoop.input_providers
+                            if isinstance(p, MouseMotionEventProvider)))
 
         def probe(self):
             global EventLoop

--- a/kivy/input/providers/probesysfs.py
+++ b/kivy/input/providers/probesysfs.py
@@ -180,9 +180,9 @@ else:
                 elif key == 'provider':
                     self.provider = value
                 elif key == 'use_regex':
-                    self.use_regex = bool(value)
+                    self.use_regex = bool(int(value))
                 elif key == 'select_all':
-                    self.select_all = bool(value)
+                    self.select_all = bool(int(value))
                 elif key == 'param':
                     self.args.append(value)
                 else:


### PR DESCRIPTION
By default, touchscreen drives exposing core pointer functionality to xinput are skipped by probesysfs (introduced as should_use_mouse method in 6bd989fb0d42190e8186afd492972fa7c3d27c2c, for whatever reason). With that behaviour, a touchscreen that is also recognized as core pointer is not usable.
```
$ xinput list
⎡ Virtual core pointer                          id=2    [master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer                id=4    [slave  pointer  (2)]
⎜   ↳ AFO Co., Ltd. AFO TCM10J-32V HID          id=8    [slave  pointer  (2)]
⎜   ↳ Microsoft Wired Keyboard 600              id=10   [slave  pointer  (2)]
⎜   ↳ Logitech USB Optical Mouse                id=11   [slave  pointer  (2)]
⎣ Virtual core keyboard                         id=3    [master keyboard (2)]
...
```

Setting probesysfs parameter `select_all=1` circumvents this problem, but is much more intrusive. I've added an option `use_mouse=1` which also considers these touch devices as valid input devices.

As separate commit, but also affecting these code lines, I've added a fix for the interpretation of the other numerical parameters, e.g. `select_all=1`: Since their values are strings, `select_all=0` does not actually deactivate the the option, but still enables it - which I find fairly confusing. Converting to integer before fixes this.