### PR TITLE
Changed Logger.error to Logger.warning on android import

### DIFF
--- a/kivy/base.py
+++ b/kivy/base.py
@@ -208,7 +208,7 @@ class EventLoopBase(EventDispatcher):
             from android import remove_presplash
             remove_presplash()
         except ImportError:
-            Logger.error(
+            Logger.warning(
                 'Base: Failed to import "android" module. '
                 'Could not remove android presplash.')
             return


### PR DESCRIPTION
It doesn't actually matter if the android module can't be imported (I deliberately don't include it, for instance), but I've seen multiple users worried about the error. Changing it to a warning should be an improvement.