### PR TITLE
Purge KV lang TRACE logs on demand with environment variable

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -66,12 +66,12 @@ def custom_callback(__kvlang__, idmap, *largs, **kwargs):
 
 def call_fn(args, instance, v):
     element, key, value, rule, idmap = args
-    if __debug__:
+    if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
         trace('Lang: call_fn %s, key=%s, value=%r, %r' % (
             element, key, value, rule.value))
     rule.count += 1
     e_value = eval(value, idmap)
-    if __debug__:
+    if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
         trace('Lang: call_fn => value=%r' % (e_value, ))
     setattr(element, key, e_value)
 
@@ -283,7 +283,7 @@ class BuilderBase(object):
                 widget inside the definition.
         '''
         filename = resource_find(filename) or filename
-        if __debug__:
+        if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
             trace('Lang: load file %s' % filename)
         with open(filename, 'r') as fd:
             kwargs['filename'] = filename
@@ -427,7 +427,7 @@ class BuilderBase(object):
         constant rules that overwrite a value initialized in python.
         '''
         rules = self.match_rule_name(rule_name)
-        if __debug__:
+        if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
             trace('Lang: Found %d rules for %s' % (len(rules), rule_name))
         if not rules:
             return
@@ -443,7 +443,7 @@ class BuilderBase(object):
         constant rules that overwrite a value initialized in python.
         '''
         rules = self.match(widget)
-        if __debug__:
+        if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
             trace('Lang: Found %d rules for %s' % (len(rules), widget))
         if not rules:
             return

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import traceback
+from os import environ
 from re import sub, findall
 from types import CodeType
 from functools import partial
@@ -302,7 +303,7 @@ class ParserRule(object):
 
     def _build_rule(self):
         name = self.name
-        if __debug__:
+        if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
             trace('Builder: build rule for %s' % name)
         if name[0] != '<' or name[-1] != '>':
             raise ParserException(self.ctx, self.line,
@@ -347,7 +348,7 @@ class ParserRule(object):
 
     def _build_template(self):
         name = self.name
-        if __debug__:
+        if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
             trace('Builder: build template for %s' % name)
         if name[0] != '[' or name[-1] != ']':
             raise ParserException(self.ctx, self.line,
@@ -395,7 +396,7 @@ class Parser(object):
         global __KV_INCLUDES__
         for ln, cmd in self.directives:
             cmd = cmd.strip()
-            if __debug__:
+            if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
                 trace('Parser: got directive <%s>' % cmd)
             if cmd[:5] == 'kivy ':
                 version = cmd[5:].strip()
@@ -488,7 +489,7 @@ class Parser(object):
         lines = list(zip(list(range(num_lines)), lines))
         self.sourcecode = lines[:]
 
-        if __debug__:
+        if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
             trace('Parser: parsing %d lines' % num_lines)
 
         # Strip all comments

--- a/kivy/tests/test_module_inspector.py
+++ b/kivy/tests/test_module_inspector.py
@@ -1,6 +1,7 @@
 from kivy.tests.common import GraphicUnitTest, UnitTestTouch
 
 from kivy.base import EventLoop
+from kivy.lang import Builder
 from kivy.modules import inspector
 from kivy.factory import Factory
 
@@ -72,7 +73,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = self.builder.Builder.load_string(KV)
+        self.root = Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -110,7 +111,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = self.builder.Builder.load_string(KV)
+        self.root = Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -150,7 +151,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = self.builder.Builder.load_string(KV)
+        self.root = Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -209,7 +210,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = self.builder.Builder.load_string(KV)
+        self.root = Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -291,7 +292,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = self.builder.Builder.load_string(KV)
+        self.root = Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 

--- a/kivy/tests/test_module_inspector.py
+++ b/kivy/tests/test_module_inspector.py
@@ -50,21 +50,15 @@ class InspectorTestCase(GraphicUnitTest):
     framecount = 0
 
     def setUp(self):
-        # kill KV lang logging (too long test)
-        import kivy.lang.builder as builder
-
-        if not hasattr(self, '_trace'):
-            self._trace = builder.trace
-
-        self.builder = builder
-        builder.trace = lambda *_, **__: None
-        super(InspectorTestCase, self).setUp()
+        from os import environ
+        environ['KIVY_UNITTEST_NOBUILDERTRACE'] = '1'
+        environ['KIVY_UNITTEST_NOPARSERTRACE'] = '1'
+        super(self.__class__, self).setUp()
 
     def tearDown(self):
-        # add the logging back
-        import kivy.lang.builder as builder
-        builder.trace = self._trace
-        super(InspectorTestCase, self).tearDown()
+        from os import environ
+        del environ['KIVY_UNITTEST_NOBUILDERTRACE']
+        del environ['KIVY_UNITTEST_NOPARSERTRACE']
 
     def clean_garbage(self, *args):
         for child in self._win.children[:]:

--- a/kivy/tests/test_uix_actionbar.py
+++ b/kivy/tests/test_uix_actionbar.py
@@ -84,6 +84,17 @@ class ActionBarTestCase(GraphicUnitTest):
         for i in range(t):
             EventLoop.idle()
 
+    def setUp(self):
+        from os import environ
+        environ['KIVY_UNITTEST_NOBUILDERTRACE'] = '1'
+        environ['KIVY_UNITTEST_NOPARSERTRACE'] = '1'
+        super(self.__class__, self).setUp()
+
+    def tearDown(self):
+        from os import environ
+        del environ['KIVY_UNITTEST_NOBUILDERTRACE']
+        del environ['KIVY_UNITTEST_NOPARSERTRACE']
+
     def clean_garbage(self, *args):
         for child in self._win.children[:]:
             self._win.remove_widget(child)

--- a/kivy/tests/test_uix_slider.py
+++ b/kivy/tests/test_uix_slider.py
@@ -30,9 +30,16 @@ class TestSliderAll(Slider):
 class SliderMoveTestCase(GraphicUnitTest):
     framecount = 0
 
-    # debug with
-    # def tearDown(self, *a): pass
-    # def setUp(self): pass
+    def setUp(self):
+        from os import environ
+        environ['KIVY_UNITTEST_NOBUILDERTRACE'] = '1'
+        environ['KIVY_UNITTEST_NOPARSERTRACE'] = '1'
+        super(self.__class__, self).setUp()
+
+    def tearDown(self):
+        from os import environ
+        del environ['KIVY_UNITTEST_NOBUILDERTRACE']
+        del environ['KIVY_UNITTEST_NOPARSERTRACE']
 
     def test_slider_move(self):
         EventLoop.ensure_window()


### PR DESCRIPTION
The amount of KV lang logs is rather getting out of hands if testing some more complex cases such as clicking everywhere, playing with dropdowns, etc. Travis has a limit of 4MB for the logs. That + distro setup + our copiling + unittests make the build crash with the silly-ish log >4MB error because of the lines like:
https://github.com/kivy/kivy/blob/79bf5ef40497cf1d09854ceae000adefa4045351/kivy/lang/builder.py#L75

While the lines help if the error isn't too obvious and is e.g. related to positions of the widgets, I made a new env variable to disable them on demand, so that it doesn't clutter & kill the build in those more complex cases. If something happens to the complex tests, there's always the option to turn the trace logs on.

Note: If building a test case with this behavior, always put the trace back on, so that only the specific complex cases are handled differently and not the entire test suite. :)