### PR TITLE
OSX Install Instruction Update - Cython explicit version

### DIFF
--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -19,7 +19,7 @@ You can install Kivy with Homebrew and pip using the following steps:
 
     2. Install Cython and Kivy using pip::
 
-        $ pip install -U Cython
+        $ pip install Cython==0.26
         $ pip install kivy
 
     - To install the development version, use this in the second step::
@@ -55,7 +55,7 @@ You can install Kivy with Macports and pip using the following steps:
 
     5. Install Cython and Kivy using pip::
 
-        $ pip install -U Cython
+        $ pip install Cython==0.26
         $ pip install kivy
 
     - To install the development version, use this in the second step::


### PR DESCRIPTION
- kivy does not compile with the recent Cython 0.27.x in OSX, there is compilation failure
- Added instruction to install the latest supported version which is 0.26.x