### PR TITLE
Resize treeview collapse. closes #5426

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -231,7 +231,7 @@
             rgba: 1, 1, 1, int(not self.is_leaf)
         Rectangle:
             source: 'atlas://data/images/defaulttheme/tree_%s' % ('opened' if self.is_open else 'closed')
-            size: 16, 16
+            size: self.height / 2.0, self.height / 2.0
             pos: self.x - 20, self.center_y - 8
     canvas.after:
         Color:


### PR DESCRIPTION
Sizing the collapse button dynamically does make more sense.

https://github.com/kivy/kivy/issues/5426