### PR TITLE
Add TextInput cursor blinking control

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -184,7 +184,10 @@
             size: self.size
             source: self.background_active if self.focus else (self.background_disabled_normal if self.disabled else self.background_normal)
         Color:
-            rgba: (self.cursor_color if self.focus and not self.cursor_blink else (0, 0, 0, 0))
+            rgba:
+                (self.cursor_color
+                if self.focus and not self._cursor_blink
+                else (0, 0, 0, 0))
         Rectangle:
             pos: [int(x) for x in self.cursor_pos]
             size: root.cursor_width, -self.line_height

--- a/kivy/tests/test_uix_textinput.py
+++ b/kivy/tests/test_uix_textinput.py
@@ -7,6 +7,7 @@ import unittest
 
 from kivy.tests.common import GraphicUnitTest
 from kivy.uix.textinput import TextInput
+from kivy.clock import Clock
 
 
 class TextInputTest(unittest.TestCase):
@@ -321,6 +322,36 @@ class TextInputGraphicTest(GraphicUnitTest):
             self.assertEqual(ti.cursor, pos)
 
             ti._key_up((None, None, 'ctrl_L', 1), repeat=False)
+
+    def test_cursor_blink(self):
+        ti = TextInput(cursor_blink=True)
+        ti.focus = True
+
+        # overwrite blinking event, because too long delay
+        ti._do_blink_cursor_ev = Clock.create_trigger(
+            ti._do_blink_cursor, 0.01, interval=True
+        )
+
+        self.render(ti)
+
+        # from kwargs cursor_blink == True
+        self.assertTrue(ti.cursor_blink)
+        self.assertTrue(ti._do_blink_cursor_ev.is_triggered)
+
+        # set whether to blink & check if resets
+        ti.cursor_blink = False
+        for i in range(30):
+            self.advance_frames(int(0.01 * Clock._max_fps) + 1)
+            self.assertFalse(ti._do_blink_cursor_ev.is_triggered)
+
+            # no blinking, cursor visible
+            self.assertFalse(ti._cursor_blink)
+
+        ti.cursor_blink = True
+        self.assertTrue(ti.cursor_blink)
+        for i in range(30):
+            self.advance_frames(int(0.01 * Clock._max_fps) + 1)
+            self.assertTrue(ti._do_blink_cursor_ev.is_triggered)
 
 
 if __name__ == '__main__':

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2574,6 +2574,12 @@ class TextInput(FocusBehavior, Widget):
     '''This property is used to set whether the graphic cursor should blink
     or not.
 
+    .. versionchanged:: 1.10.1
+        `cursor_blink` has been refactored to enable switching the blinking
+        on/off and the previous behavior has been moved to a private
+        `_cursor_blink` property. The previous default value `False` has been
+        changed to `True`.
+
     :attr:`cursor_blink` is a :class:`~kivy.properties.BooleanProperty` and
     defaults to True.
     '''

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1767,11 +1767,13 @@ class TextInput(FocusBehavior, Widget):
 
     def _do_blink_cursor(self, dt):
         # Callback for blinking the cursor.
-        self.cursor_blink = not self.cursor_blink
+        self._cursor_blink = not self._cursor_blink
 
     def _reset_cursor_blink(self, *args):
+        if not self.cursor_blink:
+            return
         self._do_blink_cursor_ev.cancel()
-        self.cursor_blink = 0
+        self._cursor_blink = False
         self._do_blink_cursor_ev()
 
     def on_cursor(self, instance, value):
@@ -2496,6 +2498,7 @@ class TextInput(FocusBehavior, Widget):
     _editable = BooleanProperty(True)
     _insert_int_pat = re.compile(u'^-?[0-9]*$')
     _insert_float_pat = re.compile(u'^-?[0-9]*\\.?[0-9]*$')
+    _cursor_blink = BooleanProperty(False)
 
     readonly = BooleanProperty(False)
     '''If True, the user will not be able to change the content of a textinput.
@@ -2556,13 +2559,12 @@ class TextInput(FocusBehavior, Widget):
     and defaults to True.
     '''
 
-    cursor_blink = BooleanProperty(False)
-    '''This property is used to blink the cursor graphic. The value of
-    :attr:`cursor_blink` is automatically computed. Setting a value on it will
-    have no impact.
+    cursor_blink = BooleanProperty(True)
+    '''This property is used to set whether the graphic cursor should blink
+    or not.
 
     :attr:`cursor_blink` is a :class:`~kivy.properties.BooleanProperty` and
-    defaults to False.
+    defaults to True.
     '''
 
     def _get_cursor(self):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1765,13 +1765,24 @@ class TextInput(FocusBehavior, Widget):
         Cache_append('textinput.width', cid, width)
         return width
 
+    def on_cursor_blink(self, instance, value):
+        # trigger blink event reset to switch blinking while focused
+        self._reset_cursor_blink()
+
     def _do_blink_cursor(self, dt):
+        if not self.cursor_blink:
+            # ignore event if not triggered,
+            # stop if cursor_blink value changed right now
+            if self._do_blink_cursor_ev.is_triggered:
+                self._do_blink_cursor_ev.cancel()
+            # don't blink, make cursor visible
+            self._cursor_blink = False
+            return
+
         # Callback for blinking the cursor.
         self._cursor_blink = not self._cursor_blink
 
     def _reset_cursor_blink(self, *args):
-        if not self.cursor_blink:
-            return
         self._do_blink_cursor_ev.cancel()
         self._cursor_blink = False
         self._do_blink_cursor_ev()


### PR DESCRIPTION
Moves the original functionality of `cursor_blink` to `_cursor_blink`. Perhaps if we should preserve the "public" property, we might rename it to something more obvious such as `cursor_invisible` or something similar.

"invisible" just because of the current behavior, otherwise we might invert it and use `cursor_visible` instead.

Closes #5449 