### PR TITLE
Introduce no support for Cython 0.27 - 0.27.2

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -224,10 +224,10 @@ from kivy import setupconfig
 replacements = {
     'cython_install': 'Cython==' + setupconfig.CYTHON_MAX,
     'cython_note': (
-        'This version of **Kivy requires at least Cython version {0}**, '
-        'and has been tested through {1}. Later versions may work, '
+        'Kivy {0} **requires at least Cython version {1}**, '
+        'and has been tested through {2}. Later versions may work, '
         'but as they have not been tested there is no guarantee.'
-    ).format(setupconfig.CYTHON_MIN, setupconfig.CYTHON_MAX)
+    ).format(version, setupconfig.CYTHON_MIN, setupconfig.CYTHON_MAX)
 }
 
 if setupconfig.CYTHON_BAD:

--- a/doc/sources/installation/deps-cython.rst
+++ b/doc/sources/installation/deps-cython.rst
@@ -1,0 +1,19 @@
+.. _deps_cython:
+
+Cython
+======
+
+|cython_note|
+
+Known issues
+------------
+
+* 0.27 -> Kivy Cython declaration bug in 1.10.0 causes failing compilation
+
+Unsupported
+-----------
+
+* 0.27 - 0.27.2 -> Kivy doesn't compile on Python 3.4 with `MinGWPy
+  <http://mingwpy.github.io>`_ because of a used unexported symbol
+  during the compilation. For more details see `this issue.
+  <https://github.com/cython/cython/issues/1968>`_

--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -6,29 +6,30 @@ Installation
 We try not to reinvent the wheel, but to bring something innovative to the
 market. As a consequence, we're focused on our own code and use pre-existing,
 high quality third-party libraries where possible.
-To support the full, rich set of features that Kivy offers, several other libraries are
-required. If you do not use a specific feature (e.g. video playback), you
-don't need the corresponding dependency.
+
+To support the full, rich set of features that Kivy offers, several other
+libraries are required. If you do not use a specific feature (e.g. video
+playback), you don't need the corresponding dependency.
+
 That said, there is one dependency that Kivy **does** require:
 `Cython <http://cython.org>`_.
 
-|cython_note|
-
 In addition, you need a `Python <http://python.org/>`_ 2.x (2.7 <= x < 3.0)
-or 3.x (3.3 <= x)
-interpreter. If you want to enable features like windowing (i.e. open a Window),
-audio/video playback or spelling correction, additional dependencies must
-be available. For these, we recommend `SDL2 <https://www.libsdl.org/download-2.0.php>`_, `Gstreamer 1.x
-<http://www.gstreamer.net/>`_ and `PyEnchant
-<https://pythonhosted.org/pyenchant/>`_, respectively.
-
+or 3.x (3.3 <= x) interpreter. If you want to enable features like windowing
+(i.e. open a Window), audio/video playback or spelling correction, additional
+dependencies must be available. For these, we recommend
+`SDL2 <https://www.libsdl.org/download-2.0.php>`_,
+`Gstreamer 1.x <http://www.gstreamer.net/>`_ and
+`PyEnchant <https://pythonhosted.org/pyenchant/>`_ respectively.
 
 Other optional libraries (mutually independent) are:
 
-    * `OpenCV 2.0 <http://sourceforge.net/projects/opencvlibrary/>`_ -- Camera input.
-    * `Pillow <https://python-pillow.github.io/>`_ -- Image and text display.
-    * `PyEnchant <https://pythonhosted.org/pyenchant/>`_ -- Spelling correction.
-
+* `OpenCV 2.0 <http://sourceforge.net/projects/opencvlibrary/>`_
+  -- Camera input,
+* `Pillow <https://python-pillow.github.io/>`_
+  -- Image and text display,
+* `PyEnchant <https://pythonhosted.org/pyenchant/>`_
+  -- Spelling correction.
 
 That said, **DON'T PANIC**!
 
@@ -37,6 +38,21 @@ Instead, we have created nice portable packages that you can use directly,
 and they already contain the necessary packages for your platform.
 We just want you to know that there are alternatives to the defaults and give
 you an overview of the things Kivy uses internally.
+
+
+.. _installation_deps:
+
+Dependencies
+------------
+
+Here are listed dependencies required for Kivy to run and have/had issues
+in specific versions that broke our core functionality and Kivy either
+doesn't compile or can throw errors:
+
+.. toctree::
+    :maxdepth: 2
+
+    deps-cython
 
 
 Stable Version

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,12 @@ def get_version(filename='kivy/version.py'):
 
 MIN_CYTHON_STRING = '0.23'
 MIN_CYTHON_VERSION = LooseVersion(MIN_CYTHON_STRING)
-MAX_CYTHON_STRING = '0.25.2'
+MAX_CYTHON_STRING = '0.27.3'
 MAX_CYTHON_VERSION = LooseVersion(MAX_CYTHON_STRING)
-CYTHON_UNSUPPORTED = ()
+CYTHON_UNSUPPORTED = (
+    # ref https://github.com/cython/cython/issues/1968
+    '0.27', '0.27.2'
+)
 
 
 def getoutput(cmd, env=None):


### PR DESCRIPTION
Resolved in https://github.com/cython/cython/issues/1968, however we probably shouldn't support those versions directly as they contain the unpatched `Coroutine.c` which doesn't build Kivy with MinGWPy/MinGW (GCC) for Python 3.4 on Windows.

Trying temporarily with Cython's master branch now and hopefully there will be a release soon.

Also, I think we might move [this chapter](https://kivy.org/docs/installation/installation-linux.html#cython)(or section or...) out from the linux installation page to let's say a separate page e.g.:

    https://kivy.org/docs/installation/cython.html
    https://kivy.org/docs/installation/cython_support.html
    https://kivy.org/docs/installation/deps/cython.html

The last alternative seems even nice and we might go with this URL style even for other deps e.g. SDL2 (mixer issue(s) currently), GStreamer or the recent RPi drivers. I think it'd make it easier for editing for the users such as:

##### cython.html

    * 0.28 yay for Kivy X.Y.Z
    * 0.27.2 nope with 3.4 + mingw + win for Kivy X.Y.Z (#issue)
    * -- || --
    * ...