### PR TITLE
shape_mode set to default initially when window is created

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1197,6 +1197,8 @@ class WindowBase(EventDispatcher):
             self.render_context = RenderContext()
             self.canvas = Canvas()
             self.render_context.add(self.canvas)
+            if self.shaped:
+                self.shape_mode = 'default'
 
         else:
             # if we get initialized more than once, then reload opengl state


### PR DESCRIPTION
shape_mode set to "default" initially when window is created. Otherwise it had to be manually triggered (set). See this issue: #5454 