### PR TITLE
Textinput - _key_down() method now more readable, separated deletion and insertion / action keys handling

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2247,9 +2247,22 @@ class TextInput(FocusBehavior, Widget):
 
     def _key_down(self, key, repeat=False):
         displayed_str, internal_str, internal_action, scale = key
+
+        # handle deletion
+        if self._selection and internal_action in (None, 'del', 'backspace', 'enter'):
+            self.delete_selection()
+        elif internal_action == 'del':
+            # Move cursor one char to the right. If that was successful,
+            # do a backspace (effectively deleting char right of cursor)
+            cursor = self.cursor
+            self.do_cursor_movement('cursor_right')
+            if cursor != self.cursor:
+                self.do_backspace(mode='del')
+        elif internal_action == 'backspace':
+            self.do_backspace()
+
+        # handle action keys and text insertion
         if internal_action is None:
-            if self._selection:
-                self.delete_selection()
             self.insert_text(displayed_str)
         elif internal_action in ('shift', 'shift_L', 'shift_R'):
             if not self._selection:
@@ -2274,22 +2287,8 @@ class TextInput(FocusBehavior, Widget):
                 self._update_selection()
             else:
                 self.cancel_selection()
-        elif self._selection and internal_action in ('del', 'backspace'):
-            self.delete_selection()
-        elif internal_action == 'del':
-            # Move cursor one char to the right. If that was successful,
-            # do a backspace (effectively deleting char right of cursor)
-            cursor = self.cursor
-            self.do_cursor_movement('cursor_right')
-            if cursor != self.cursor:
-                self.do_backspace(mode='del')
-        elif internal_action == 'backspace':
-            self.do_backspace()
         elif internal_action == 'enter':
-            if self.multiline and self._selection:
-                self.delete_selection()
-                self.insert_text(u'\n')
-            elif self.multiline:
+            if self.multiline:
                 self.insert_text(u'\n')
             else:
                 self.dispatch('on_text_validate')
@@ -2297,9 +2296,8 @@ class TextInput(FocusBehavior, Widget):
                     self.focus = False
         elif internal_action == 'escape':
             self.focus = False
-        if internal_action != 'escape':
-            # self._recalc_size()
-            pass
+
+
 
     def _key_up(self, key, repeat=False):
         displayed_str, internal_str, internal_action, scale = key

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2297,8 +2297,6 @@ class TextInput(FocusBehavior, Widget):
         elif internal_action == 'escape':
             self.focus = False
 
-
-
     def _key_up(self, key, repeat=False):
         displayed_str, internal_str, internal_action, scale = key
         if internal_action in ('shift', 'shift_L', 'shift_R'):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2249,7 +2249,8 @@ class TextInput(FocusBehavior, Widget):
         displayed_str, internal_str, internal_action, scale = key
 
         # handle deletion
-        if self._selection and internal_action in (None, 'del', 'backspace', 'enter'):
+        if (self._selection and
+                internal_action in (None, 'del', 'backspace', 'enter')):
             self.delete_selection()
         elif internal_action == 'del':
             # Move cursor one char to the right. If that was successful,

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2251,7 +2251,8 @@ class TextInput(FocusBehavior, Widget):
         # handle deletion
         if (self._selection and
                 internal_action in (None, 'del', 'backspace', 'enter')):
-            self.delete_selection()
+            if internal_action != 'enter' or self.multiline:
+                self.delete_selection()
         elif internal_action == 'del':
             # Move cursor one char to the right. If that was successful,
             # do a backspace (effectively deleting char right of cursor)


### PR DESCRIPTION
As we fixed issue #5469 with @emomicrowave, we noticed the _key_down() method needs some refactoring (because of repetitive self.delete_selection() calls) so we tried to make a clearer separation between deleting text when selected and other key handling.