### PR TITLE
Explain units and datatype of dt in kivy.clock

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -5,7 +5,8 @@ Clock object
 The :class:`Clock` object allows you to schedule a function call in the
 future; once or repeatedly at specified intervals. You can get the time
 elapsed between the scheduling and the calling of the callback via the
-`dt` argument::
+`dt` argument, which is a `float` containing the number of seconds
+since the last event::
 
     # dt means delta-time
     def my_callback(dt):


### PR DESCRIPTION
The callback is documented as returning the time since the last callback, but it's not actually documented anywhere what datatype or units this comes in. Update the docs to explain that.