### PR TITLE
Switch to manual KV trace purging

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -66,12 +66,12 @@ def custom_callback(__kvlang__, idmap, *largs, **kwargs):
 
 def call_fn(args, instance, v):
     element, key, value, rule, idmap = args
-    if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
+    if __debug__:
         trace('Lang: call_fn %s, key=%s, value=%r, %r' % (
             element, key, value, rule.value))
     rule.count += 1
     e_value = eval(value, idmap)
-    if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
+    if __debug__:
         trace('Lang: call_fn => value=%r' % (e_value, ))
     setattr(element, key, e_value)
 
@@ -283,7 +283,7 @@ class BuilderBase(object):
                 widget inside the definition.
         '''
         filename = resource_find(filename) or filename
-        if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
+        if __debug__:
             trace('Lang: load file %s' % filename)
         with open(filename, 'r') as fd:
             kwargs['filename'] = filename
@@ -427,7 +427,7 @@ class BuilderBase(object):
         constant rules that overwrite a value initialized in python.
         '''
         rules = self.match_rule_name(rule_name)
-        if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
+        if __debug__:
             trace('Lang: Found %d rules for %s' % (len(rules), rule_name))
         if not rules:
             return
@@ -443,7 +443,7 @@ class BuilderBase(object):
         constant rules that overwrite a value initialized in python.
         '''
         rules = self.match(widget)
-        if __debug__ and not environ.get('KIVY_UNITTEST_NOBUILDERTRACE'):
+        if __debug__:
             trace('Lang: Found %d rules for %s' % (len(rules), widget))
         if not rules:
             return

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 import traceback
-from os import environ
 from re import sub, findall
 from types import CodeType
 from functools import partial
@@ -303,7 +302,7 @@ class ParserRule(object):
 
     def _build_rule(self):
         name = self.name
-        if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
+        if __debug__:
             trace('Builder: build rule for %s' % name)
         if name[0] != '<' or name[-1] != '>':
             raise ParserException(self.ctx, self.line,
@@ -348,7 +347,7 @@ class ParserRule(object):
 
     def _build_template(self):
         name = self.name
-        if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
+        if __debug__:
             trace('Builder: build template for %s' % name)
         if name[0] != '[' or name[-1] != ']':
             raise ParserException(self.ctx, self.line,
@@ -396,7 +395,7 @@ class Parser(object):
         global __KV_INCLUDES__
         for ln, cmd in self.directives:
             cmd = cmd.strip()
-            if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
+            if __debug__:
                 trace('Parser: got directive <%s>' % cmd)
             if cmd[:5] == 'kivy ':
                 version = cmd[5:].strip()
@@ -489,7 +488,7 @@ class Parser(object):
         lines = list(zip(list(range(num_lines)), lines))
         self.sourcecode = lines[:]
 
-        if __debug__ and not environ.get('KIVY_UNITTEST_NOPARSERTRACE'):
+        if __debug__:
             trace('Parser: parsing %d lines' % num_lines)
 
         # Strip all comments

--- a/kivy/tests/test_module_inspector.py
+++ b/kivy/tests/test_module_inspector.py
@@ -51,15 +51,21 @@ class InspectorTestCase(GraphicUnitTest):
     framecount = 0
 
     def setUp(self):
-        from os import environ
-        environ['KIVY_UNITTEST_NOBUILDERTRACE'] = '1'
-        environ['KIVY_UNITTEST_NOPARSERTRACE'] = '1'
-        super(self.__class__, self).setUp()
+        # kill KV lang logging (too long test)
+        import kivy.lang.builder as builder
+
+        if not hasattr(self, '_trace'):
+            self._trace = builder.trace
+
+        self.builder = builder
+        builder.trace = lambda *_, **__: None
+        super(InspectorTestCase, self).setUp()
 
     def tearDown(self):
-        from os import environ
-        del environ['KIVY_UNITTEST_NOBUILDERTRACE']
-        del environ['KIVY_UNITTEST_NOPARSERTRACE']
+        # add the logging back
+        import kivy.lang.builder as builder
+        builder.trace = self._trace
+        super(InspectorTestCase, self).tearDown()
 
     def clean_garbage(self, *args):
         for child in self._win.children[:]:

--- a/kivy/tests/test_module_inspector.py
+++ b/kivy/tests/test_module_inspector.py
@@ -1,7 +1,6 @@
 from kivy.tests.common import GraphicUnitTest, UnitTestTouch
 
 from kivy.base import EventLoop
-from kivy.lang import Builder
 from kivy.modules import inspector
 from kivy.factory import Factory
 
@@ -79,7 +78,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = Builder.load_string(KV)
+        self.root = self.builder.Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -117,7 +116,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = Builder.load_string(KV)
+        self.root = self.builder.Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -157,7 +156,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = Builder.load_string(KV)
+        self.root = self.builder.Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -216,7 +215,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = Builder.load_string(KV)
+        self.root = self.builder.Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 
@@ -298,7 +297,7 @@ class InspectorTestCase(GraphicUnitTest):
         self.clean_garbage()
 
         # build the widget tree & add Window as the main EL
-        self.root = Builder.load_string(KV)
+        self.root = self.builder.Builder.load_string(KV)
         self.render(self.root)
         self.assertLess(len(self._win.children), 2)
 

--- a/kivy/tests/test_uix_actionbar.py
+++ b/kivy/tests/test_uix_actionbar.py
@@ -80,6 +80,23 @@ class TouchPoint(UTMotionEvent):
 class ActionBarTestCase(GraphicUnitTest):
     framecount = 0
 
+    def setUp(self):
+        # kill KV lang logging (too long test)
+        import kivy.lang.builder as builder
+
+        if not hasattr(self, '_trace'):
+            self._trace = builder.trace
+
+        self.builder = builder
+        builder.trace = lambda *_, **__: None
+        super(ActionBarTestCase, self).setUp()
+
+    def tearDown(self):
+        # add the logging back
+        import kivy.lang.builder as builder
+        builder.trace = self._trace
+        super(ActionBarTestCase, self).tearDown()
+
     def move_frames(self, t):
         for i in range(t):
             EventLoop.idle()

--- a/kivy/tests/test_uix_actionbar.py
+++ b/kivy/tests/test_uix_actionbar.py
@@ -84,17 +84,6 @@ class ActionBarTestCase(GraphicUnitTest):
         for i in range(t):
             EventLoop.idle()
 
-    def setUp(self):
-        from os import environ
-        environ['KIVY_UNITTEST_NOBUILDERTRACE'] = '1'
-        environ['KIVY_UNITTEST_NOPARSERTRACE'] = '1'
-        super(self.__class__, self).setUp()
-
-    def tearDown(self):
-        from os import environ
-        del environ['KIVY_UNITTEST_NOBUILDERTRACE']
-        del environ['KIVY_UNITTEST_NOPARSERTRACE']
-
     def clean_garbage(self, *args):
         for child in self._win.children[:]:
             self._win.remove_widget(child)

--- a/kivy/tests/test_uix_slider.py
+++ b/kivy/tests/test_uix_slider.py
@@ -30,9 +30,22 @@ class TestSliderAll(Slider):
 class SliderMoveTestCase(GraphicUnitTest):
     framecount = 0
 
-    # debug with
-    # def tearDown(self, *a): pass
-    # def setUp(self): pass
+    def setUp(self):
+        # kill KV lang logging (too long test)
+        import kivy.lang.builder as builder
+
+        if not hasattr(self, '_trace'):
+            self._trace = builder.trace
+
+        self.builder = builder
+        builder.trace = lambda *_, **__: None
+        super(SliderMoveTestCase, self).setUp()
+
+    def tearDown(self):
+        # add the logging back
+        import kivy.lang.builder as builder
+        builder.trace = self._trace
+        super(SliderMoveTestCase, self).tearDown()
 
     def test_slider_move(self):
         EventLoop.ensure_window()

--- a/kivy/tests/test_uix_slider.py
+++ b/kivy/tests/test_uix_slider.py
@@ -30,16 +30,9 @@ class TestSliderAll(Slider):
 class SliderMoveTestCase(GraphicUnitTest):
     framecount = 0
 
-    def setUp(self):
-        from os import environ
-        environ['KIVY_UNITTEST_NOBUILDERTRACE'] = '1'
-        environ['KIVY_UNITTEST_NOPARSERTRACE'] = '1'
-        super(self.__class__, self).setUp()
-
-    def tearDown(self):
-        from os import environ
-        del environ['KIVY_UNITTEST_NOBUILDERTRACE']
-        del environ['KIVY_UNITTEST_NOPARSERTRACE']
+    # debug with
+    # def tearDown(self, *a): pass
+    # def setUp(self): pass
 
     def test_slider_move(self):
         EventLoop.ensure_window()


### PR DESCRIPTION
Partially reverting #5437 due to performance reasons. The logs are purged the way I did before the env variables i.e. with replacing the `trace` value in the module and reverting it after the test ends.

Can't really choose other way because the `trace = Logger.trace` and `call_fn` are global therefore if I create an env variable and set it once, it'll kill the trace logs for the whole testing (with `nose` at least), therefore I do switching the logs manually per test instead of removing it for all.