### PR TITLE
Fix FileNotFoundError when sys path doesn't exist

### DIFF
--- a/kivy/input/providers/probesysfs.py
+++ b/kivy/input/providers/probesysfs.py
@@ -82,7 +82,12 @@ else:
 
         def get_capabilities(self):
             path = os.path.join(self.path, "device", "capabilities", "abs")
-            line = read_line(path)
+            line = "0"
+            try:
+                line = read_line(path)
+            except OSError:
+                return []
+
             capabilities = []
             long_bit = getconf("LONG_BIT")
             for i, word in enumerate(line.split(" ")):


### PR DESCRIPTION
This is intended to fix https://github.com/kivy/kivy/issues/5534

You get a FileNotFoundError when trying to access  '/sys/class/input/event<some integer>/device/capabilities/abs' when the full path doesn't exist. 

This may be an input device, but capabilities aren't listed so the fix just defaults "0".