### PR TITLE
Window info

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -131,6 +131,9 @@ class Keyboard(EventDispatcher):
         #: VKeyboard widget, if allowed by the configuration
         self.widget = kwargs.get('widget', None)
 
+    def get_window_info():
+        pass
+
     def on_key_down(self, keycode, text, modifiers):
         pass
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -10,8 +10,11 @@ from kivy.graphics.cgl import cgl_get_backend_name
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 
-IF UNAME_SYSNAME == 'Linux':
-    from window_info cimport WindowInfoX11, WindowInfoWayland
+IF USE_WAYLAND:
+    from window_info cimport WindowInfoWayland
+
+IF USE_X11:
+    from window_info cimport WindowInfoX11
 
 IF UNAME_SYSNAME == 'Windows':
     from window_info cimport WindowInfoWindows
@@ -347,9 +350,8 @@ cdef class _WindowSDL2Storage:
         if not success:
             return
 
-        IF UNAME_SYSNAME == 'Linux':
+        IF USE_WAYLAND:
             cdef WindowInfoWayland wayland_info
-            cdef WindowInfoX11 x11_info
 
             if wm_info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_WAYLAND:
                 wayland_info = WindowInfoWayland()
@@ -357,11 +359,16 @@ cdef class _WindowSDL2Storage:
                 wayland_info.surface = wm_info.info.wl.surface
                 wayland_info.shell_surface = wm_info.info.wl.shell_surface
                 return wayland_info
-            elif wm_info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_X11:
+
+        IF USE_X11:
+            cdef WindowInfoX11 x11_info
+
+            if wm_info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_X11:
                 x11_info = WindowInfoX11()
                 x11_info.display = wm_info.info.x11.display
                 x11_info.window = wm_info.info.x11.window
                 return x11_info
+
         IF UNAME_SYSNAME == 'Windows':
             cdef WindowInfoWindows windows_info
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -376,7 +376,6 @@ cdef class _WindowSDL2Storage:
                 windows_info = WindowInfoWindows()
                 windows_info.window = wm_info.info.win.window
                 windows_info.hdc = wm_info.info.win.hdc
-                windows_info.hinstance = wm_info.info.win.hinstance
 
     # Transparent Window background
     def is_window_shaped(self):

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -374,7 +374,7 @@ cdef class _WindowSDL2Storage:
 
             if wm_info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_WINDOWS:
                 windows_info = WindowInfoWindows()
-                windows_info.hwnd = wm_info.info.win.hwnd
+                windows_info.window = wm_info.info.win.window
                 windows_info.hdc = wm_info.info.win.hdc
                 windows_info.hinstance = wm_info.info.win.hinstance
 

--- a/kivy/core/window/window_attrs.pxi
+++ b/kivy/core/window/window_attrs.pxi
@@ -1,22 +1,6 @@
-IF UNAME_SYSNAME == 'Windows':
-    cdef extern from "WinNT.h":
-        ctypedef void *HANDLE
+include "../../include/config.pxi"
 
-    cdef extern from "WinDef.h":
-        ctypedef HANDLE HWND
-        ctypedef HANDLE HDC
-        ctypedef HANDLE HINSTANCE
-
-IF UNAME_SYSNAME == 'Linux':
-    cdef extern from "X11/Xlib.h":
-        cdef struct _XDisplay:
-            pass
-
-        ctypedef _XDisplay Display
-
-        ctypedef int XID
-        ctypedef XID Window
-
+IF USE_WAYLAND:
     cdef extern from "wayland-client-protocol.h":
         cdef struct wl_display:
             pass
@@ -27,4 +11,21 @@ IF UNAME_SYSNAME == 'Linux':
         cdef struct wl_shell_surface:
             pass
 
+IF USE_X11:
+    cdef extern from "X11/Xlib.h":
+        cdef struct _XDisplay:
+            pass
 
+        ctypedef _XDisplay Display
+
+        ctypedef int XID
+        ctypedef XID Window
+
+IF UNAME_SYSNAME == 'Windows':
+    cdef extern from "WinNT.h":
+        ctypedef void *HANDLE
+
+    cdef extern from "WinDef.h":
+        ctypedef HANDLE HWND
+        ctypedef HANDLE HDC
+        ctypedef HANDLE HINSTANCE

--- a/kivy/core/window/window_attrs.pxi
+++ b/kivy/core/window/window_attrs.pxi
@@ -22,10 +22,9 @@ IF USE_X11:
         ctypedef XID Window
 
 IF UNAME_SYSNAME == 'Windows':
-    cdef extern from "WinNT.h":
+    cdef extern from "windows.h":
         ctypedef void *HANDLE
 
-    cdef extern from "WinDef.h":
         ctypedef HANDLE HWND
         ctypedef HANDLE HDC
         ctypedef HANDLE HINSTANCE

--- a/kivy/core/window/window_attrs.pxi
+++ b/kivy/core/window/window_attrs.pxi
@@ -1,0 +1,30 @@
+IF UNAME_SYSNAME == 'Windows':
+    cdef extern from "WinNT.h":
+        ctypedef void *HANDLE
+
+    cdef extern from "WinDef.h":
+        ctypedef HANDLE HWND
+        ctypedef HANDLE HDC
+        ctypedef HANDLE HINSTANCE
+
+IF UNAME_SYSNAME == 'Linux':
+    cdef extern from "X11/Xlib.h":
+        cdef struct _XDisplay:
+            pass
+
+        ctypedef _XDisplay Display
+
+        ctypedef int XID
+        ctypedef XID Window
+
+    cdef extern from "wayland-client-protocol.h":
+        cdef struct wl_display:
+            pass
+
+        cdef struct wl_surface:
+            pass
+
+        cdef struct wl_shell_surface:
+            pass
+
+

--- a/kivy/core/window/window_info.pxd
+++ b/kivy/core/window/window_info.pxd
@@ -15,6 +15,6 @@ IF USE_X11:
 
 IF UNAME_SYSNAME == 'Windows':
     cdef class WindowInfoWindows:
-        cdef HWND hwnd
+        cdef HWND window
         cdef HDC hdc
         cdef HINSTANCE hinstance

--- a/kivy/core/window/window_info.pxd
+++ b/kivy/core/window/window_info.pxd
@@ -17,4 +17,3 @@ IF UNAME_SYSNAME == 'Windows':
     cdef class WindowInfoWindows:
         cdef HWND window
         cdef HDC hdc
-        cdef HINSTANCE hinstance

--- a/kivy/core/window/window_info.pxd
+++ b/kivy/core/window/window_info.pxd
@@ -1,13 +1,14 @@
-include 'window_attrs.pxi'
+include "window_attrs.pxi"
 
 from libc.stdint cimport uintptr_t
 
-IF UNAME_SYSNAME == 'Linux':
+IF USE_WAYLAND:
     cdef class WindowInfoWayland:
         cdef wl_display *display
         cdef wl_surface *surface
         cdef wl_shell_surface *shell_surface
 
+IF USE_X11:
     cdef class WindowInfoX11:
         cdef Display *display
         cdef Window window

--- a/kivy/core/window/window_info.pxd
+++ b/kivy/core/window/window_info.pxd
@@ -1,0 +1,19 @@
+include 'window_attrs.pxi'
+
+from libc.stdint cimport uintptr_t
+
+IF UNAME_SYSNAME == 'Linux':
+    cdef class WindowInfoWayland:
+        cdef wl_display *display
+        cdef wl_surface *surface
+        cdef wl_shell_surface *shell_surface
+
+    cdef class WindowInfoX11:
+        cdef Display *display
+        cdef Window window
+
+IF UNAME_SYSNAME == 'Windows':
+    cdef class WindowInfoWindows:
+        cdef HWND hwnd
+        cdef HDC hdc
+        cdef HINSTANCE hinstance

--- a/kivy/core/window/window_info.pyx
+++ b/kivy/core/window/window_info.pyx
@@ -34,7 +34,3 @@ IF UNAME_SYSNAME == 'Windows':
         @property
         def hdc(self):
             return <uintptr_t>self.hdc
-
-        @property
-        def hinstance(self):
-            return <uintptr_t>self.hinstance

--- a/kivy/core/window/window_info.pyx
+++ b/kivy/core/window/window_info.pyx
@@ -28,8 +28,8 @@ IF USE_X11:
 IF UNAME_SYSNAME == 'Windows':
     cdef class WindowInfoWindows:
         @property
-        def hwnd(self):
-            return <uintptr_t>self.hwnd
+        def window(self):
+            return <uintptr_t>self.window
 
         @property
         def hdc(self):

--- a/kivy/core/window/window_info.pyx
+++ b/kivy/core/window/window_info.pyx
@@ -1,0 +1,37 @@
+IF UNAME_SYSNAME == 'Linux':
+    cdef class WindowInfoWayland:
+        @property
+        def display(self):
+            return <uintptr_t>self.display
+
+        @property
+        def surface(self):
+            return <uintptr_t>self.surface
+
+        @property
+        def shell_surface(self):
+            return <uintptr_t>self.shell_surface
+
+
+    cdef class WindowInfoX11:
+        @property
+        def display(self):
+            return <uintptr_t>self.display
+
+        @property
+        def window(self):
+            return <uintptr_t>self.window
+
+IF UNAME_SYSNAME == 'Windows':
+    cdef class WindowInfoWindows:
+        @property
+        def hwnd(self):
+            return <uintptr_t>self.hwnd
+
+        @property
+        def hdc(self):
+            return <uintptr_t>self.hdc
+
+        @property
+        def hinstance(self):
+            return <uintptr_t>self.hinstance

--- a/kivy/core/window/window_info.pyx
+++ b/kivy/core/window/window_info.pyx
@@ -1,4 +1,6 @@
-IF UNAME_SYSNAME == 'Linux':
+include "../../include/config.pxi"
+
+IF USE_WAYLAND:
     cdef class WindowInfoWayland:
         @property
         def display(self):
@@ -13,6 +15,7 @@ IF UNAME_SYSNAME == 'Linux':
             return <uintptr_t>self.shell_surface
 
 
+IF USE_X11:
     cdef class WindowInfoX11:
         @property
         def display(self):

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -188,6 +188,9 @@ class WindowSDL(WindowBase):
 
         self.bind(allow_screensaver=self._set_allow_screensaver)
 
+    def get_window_info(self):
+        return self._win.get_window_info()
+
     def _set_minimum_size(self, *args):
         minimum_width = self.minimum_width
         minimum_height = self.minimum_height

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -3,6 +3,7 @@
 #Permission to use this file is granted under the conditions of the Ignifuga Game Engine License
 #whose terms are available in the LICENSE file or at http://www.ignifuga.org/license
 
+include "../include/config.pxi"
 
 cdef extern from "SDL_joystick.h":
     cdef struct SDL_Joystick
@@ -995,25 +996,31 @@ cdef extern from "SDL_syswm.h":
             HWND window
             HDC hdc
             HINSTANCE hinstance
+    ELSE:
+        cdef struct _wm_info_win:
+            int dummy
 
-    IF UNAME_SYSNAME == 'Linux':
+    IF USE_WAYLAND:
         cdef struct _wm_info_wl:
             wl_display *display
             wl_surface *surface
             wl_shell_surface *shell_surface
+    ELSE:
+        cdef struct _wm_info_wl:
+            int dummy
 
+    IF USE_X11:
         cdef struct _wm_info_x11:
             Display *display
             Window window
+    ELSE:
+       cdef struct _wm_info_x11:
+           int dummy
 
-    IF UNAME_SYSNAME == 'Windows':
-        cdef union _wm_info:
-            _wm_info_win win
-
-    IF UNAME_SYSNAME == 'Linux':
-        cdef union _wm_info:
-            _wm_info_wl wl
-            _wm_info_x11 x11
+    cdef union _wm_info:
+        _wm_info_win win
+        _wm_info_wl wl
+        _wm_info_x11 x11
 
     cdef struct SDL_SysWMinfo:
         SDL_version version

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -91,6 +91,11 @@ cdef extern from "SDL.h":
         SDL_FALSE = 0
         SDL_TRUE = 1
 
+    cdef struct SDL_version:
+        Uint8 major
+        Uint8 minor
+        Uint8 patch
+
     cdef struct SDL_Rect:
         int x, y
         int w, h
@@ -447,6 +452,7 @@ cdef extern from "SDL.h":
     cdef int SDL_INIT_EVENTS         = 0x00004000
     cdef int SDL_INIT_NOPARACHUTE    = 0x00100000  # Don't catch fatal signals */
 
+    cdef void SDL_GetVersion(SDL_version * ver)
     cdef SDL_Renderer * SDL_CreateRenderer(SDL_Window * window, int index, Uint32 flags)
     cdef void SDL_DestroyRenderer (SDL_Renderer * renderer)
     cdef SDL_Texture * SDL_CreateTexture(SDL_Renderer * renderer, Uint32 format, int access, int w, int h)
@@ -967,3 +973,51 @@ cdef extern from "SDL_mixer.h":
     cdef Mix_Chunk *  Mix_GetChunk(int channel)
     cdef void  Mix_CloseAudio()
     cdef char * Mix_GetError()
+
+include '../core/window/window_attrs.pxi'
+cdef extern from "SDL_syswm.h":
+    cdef enum SDL_SYSWM_TYPE:
+        SDL_SYSWM_UNKNOWN
+        SDL_SYSWM_WINDOWS
+        SDL_SYSWM_X11
+        SDL_SYSWM_DIRECTFB
+        SDL_SYSWM_COCOA
+        SDL_SYSWM_UIKIT
+        SDL_SYSWM_WAYLAND
+        SDL_SYSWM_MIR
+        SDL_SYSWM_WINRT
+        SDL_SYSWM_ANDROID
+        SDL_SYSWM_VIVANTE
+        SDL_SYSWM_OS2
+
+    IF UNAME_SYSNAME == 'Windows':
+        cdef struct _wm_info_win:
+            HWND window
+            HDC hdc
+            HINSTANCE hinstance
+
+    IF UNAME_SYSNAME == 'Linux':
+        cdef struct _wm_info_wl:
+            wl_display *display
+            wl_surface *surface
+            wl_shell_surface *shell_surface
+
+        cdef struct _wm_info_x11:
+            Display *display
+            Window window
+
+    IF UNAME_SYSNAME == 'Windows':
+        cdef union _wm_info:
+            _wm_info_win win
+
+    IF UNAME_SYSNAME == 'Linux':
+        cdef union _wm_info:
+            _wm_info_wl wl
+            _wm_info_x11 x11
+
+    cdef struct SDL_SysWMinfo:
+        SDL_version version
+        SDL_SYSWM_TYPE subsystem
+        _wm_info info
+
+    cdef SDL_bool SDL_GetWindowWMInfo(SDL_Window *window, SDL_SysWMinfo *info)

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -995,7 +995,6 @@ cdef extern from "SDL_syswm.h":
         cdef struct _wm_info_win:
             HWND window
             HDC hdc
-            HINSTANCE hinstance
     ELSE:
         cdef struct _wm_info_win:
             int dummy

--- a/kivy/tests/test_window_info.py
+++ b/kivy/tests/test_window_info.py
@@ -1,0 +1,29 @@
+from kivy.tests.common import GraphicUnitTest
+from kivy import setupconfig
+
+class WindowInfoTest(GraphicUnitTest):
+    def test_window_info_nonzero(self):
+        from kivy.core.window import Window
+        window_info = Window.get_window_info()
+        if window_info is None:
+            return
+
+        if setupconfig.USE_X11:
+            from kivy.core.window.window_info import WindowInfoX11
+            if isinstance(window_info, WindowInfoX11):
+                self.assertNotEqual(window_info.display, 0)
+                self.assertNotEqual(window_info.window, 0)
+
+        if setupconfig.USE_WAYLAND:
+            from kivy.core.window.window_info import WindowInfoWayland
+            if isinstance(window_info, WindowInfoWayland):
+                self.assertNotEqual(window_info.display, 0)
+                self.assertNotEqual(window_info.surface, 0)
+                self.assertNotEqual(window_info.shell_surface, 0)
+
+        if setupconfig.PLATFORM == 'win32':
+            from kivy.core.window.window_info import WindowInfoWindows
+            if isinstance(window_info, WindowInfoWindows):
+                self.assertNotEqual(window_info.HWND, 0)
+                self.assertNotEqual(window_info.HDC, 0)
+

--- a/setup.py
+++ b/setup.py
@@ -779,6 +779,7 @@ sources = {
     'graphics/cgl_backend/cgl_sdl2.pyx': merge(base_flags, gl_flags_base),
     'graphics/cgl_backend/cgl_debug.pyx': merge(base_flags, gl_flags_base),
     'core/text/text_layout.pyx': base_flags,
+    'core/window/window_info.pyx': base_flags,
     'graphics/tesselator.pyx': merge(base_flags, {
         'include_dirs': ['kivy/lib/libtess2/Include'],
         'c_depends': [
@@ -1021,6 +1022,8 @@ if not build_examples:
             '*.pxi',
             'core/text/*.pxd',
             'core/text/*.pxi',
+            'core/window/*.pxi',
+            'core/window/*.pxd',
             'graphics/*.pxd',
             'graphics/*.pxi',
             'graphics/*.h',

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ c_options['use_sdl2'] = None
 c_options['use_ios'] = False
 c_options['use_mesagl'] = False
 c_options['use_x11'] = False
+c_options['use_wayland'] = False
 c_options['use_gstreamer'] = None
 c_options['use_avfoundation'] = platform == 'darwin'
 c_options['use_osx_frameworks'] = platform == 'darwin'


### PR DESCRIPTION
This PR implements a method for getting platform specific window
information from Kivy window providers.

Platform specific window system information is useful for
programatically acquiring a handle to the Kivy window.

When unable to retrieve windowing subsystem information, the function
returns `None`. Currently, only the SDL2 window provider actually
implements the function, using `SDL_GetWindowWMInfo`. The implementation
only returns information for Linux (X11/Wayland) and Windows.

Window system info is encapsulated in the `core.window.window_info` module, allowing other providers to create and return window info objects as necessary, using a standard interface.