### PR TITLE
Allow custom comparator in properties

### DIFF
--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -21,6 +21,7 @@ cdef class Property:
     cdef str _name
     cdef int allownone
     cdef int force_dispatch
+    cdef object comparator
     cdef object errorvalue
     cdef object errorhandler
     cdef int errorvalue_set


### PR DESCRIPTION
This adds a property option that allows to specify a custom comparator rather than the default `a == b` used in properties. This should also resolve some of the issues e.g. when using different type objects that need special comparison, like numpy arrays.

Here's some code example:

```py
class A(EventDispatcher):
    a = ObjectProperty(None)
    b = ObjectProperty(None, comparator=lambda x, y: x is y)
    
    def on_a(self, *largs):
        print('a', largs)
    
    def on_b(self, *largs):
        print('b', largs)
>>> val = A()
>>> val.a = [1, 2]
a (<__main__.A object at 0x000002817CEB1C10>, [1, 2])
>>> val.a = [1, 2]
>>> val.b = [1, 2]
b (<__main__.A object at 0x000002817CEB1C10>, [1, 2])
>>> val.b = [1, 2]
b (<__main__.A object at 0x000002817CEB1C10>, [1, 2])
```