### PR TITLE
Correct typo 'setdefaults' to 'setdefault'

### DIFF
--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -585,7 +585,7 @@ class EffectFbo(Fbo):
     attempts to set a new shader. See :meth:`set_fs`.
     '''
     def __init__(self, *args, **kwargs):
-        kwargs.setdefaults("with_stencilbuffer", True)
+        kwargs.setdefault("with_stencilbuffer", True)
         super(EffectFbo, self).__init__(*args, **kwargs)
         self.texture_rectangle = None
 


### PR DESCRIPTION
In file `/kivy/uix/effectwidget.py`, there is this line:
  `kwargs.setdefaults("with_stencilbuffer", True)`
which throws an AttributeError `('dict' object has no attribute 'setdefaults')`

This PR corrects the method `setdefaults `to `setdefault`.