### PR TITLE
Fix Ctypes Clipboard error with embeded null character

### DIFF
--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -4,6 +4,7 @@ Clipboard windows: an implementation of the Clipboard using ctypes.
 
 __all__ = ('ClipboardWindows', )
 
+import sys
 from kivy.utils import platform
 from kivy.core.clipboard import ClipboardBase
 
@@ -56,7 +57,18 @@ class ClipboardWindows(ClipboardBase):
         user32.OpenClipboard(user32.GetActiveWindow())
         user32.EmptyClipboard()
         hCd = GlobalAlloc(0, len(text) * ctypes.sizeof(ctypes.c_wchar))
-        msvcrt.wcscpy_s(c_wchar_p(hCd), len(text), c_wchar_p(text))
+
+        # ignore null character if >= 3.6.3
+        # ! change in CPython internals !
+        msvcrt.wcscpy_s(
+            c_wchar_p(hCd),
+            len(text),
+            c_wchar_p(
+                text[:-1]
+                if sys.version_info >= (3, 6, 3)
+                else text
+            )
+        )
         SetClipboardData(CF_UNICODETEXT, hCd)
         user32.CloseClipboard()
 

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -4,7 +4,6 @@ Clipboard windows: an implementation of the Clipboard using ctypes.
 
 __all__ = ('ClipboardWindows', )
 
-import sys
 from kivy.utils import platform
 from kivy.core.clipboard import ClipboardBase
 
@@ -58,12 +57,8 @@ class ClipboardWindows(ClipboardBase):
         user32.EmptyClipboard()
         hCd = GlobalAlloc(0, len(text) * ctypes.sizeof(ctypes.c_wchar))
 
-        # ignore null character if >= 3.6.3, 3.5.4
-        # ! change in CPython internals !
-        ver = sys.version_info
-        if ver >= (3, 6, 3) or ver >= (3, 5, 4):
-            pytext = text[:-1]
-        msvcrt.wcscpy_s(c_wchar_p(hCd), len(text), c_wchar_p(pytext))
+        # ignore null character for strSource pointer
+        msvcrt.wcscpy_s(c_wchar_p(hCd), len(text), c_wchar_p(text[:-1]))
         SetClipboardData(CF_UNICODETEXT, hCd)
         user32.CloseClipboard()
 

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -58,17 +58,12 @@ class ClipboardWindows(ClipboardBase):
         user32.EmptyClipboard()
         hCd = GlobalAlloc(0, len(text) * ctypes.sizeof(ctypes.c_wchar))
 
-        # ignore null character if >= 3.6.3
+        # ignore null character if >= 3.6.3, 3.5.4
         # ! change in CPython internals !
-        msvcrt.wcscpy_s(
-            c_wchar_p(hCd),
-            len(text),
-            c_wchar_p(
-                text[:-1]
-                if sys.version_info >= (3, 6, 3)
-                else text
-            )
-        )
+        ver = sys.version_info
+        if ver >= (3, 6, 3) or ver >= (3, 5, 4):
+            pytext = text[:-1]
+        msvcrt.wcscpy_s(c_wchar_p(hCd), len(text), c_wchar_p(pytext))
         SetClipboardData(CF_UNICODETEXT, hCd)
         user32.CloseClipboard()
 


### PR DESCRIPTION
I believe I've found the issue in this commit https://github.com/python/cpython/commit/0834905d9b61291b1fc5e05a1ffbc69de9c9379f, however I'm not sure if I'm right with this specific one (didn't do bisect...). The description of `_PyUnicode_AsUnicode` vs `PyUnicode_AsUnicode` matches though.

I reproduced the issue locally with `3.6.3` (commit isn't present in older ones) and since [`wcspy_s`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strcpy-s-wcscpy-s-mbscpy-s) 's third parameter actualy **expects** a null terminated buffer/string/... and doesn't fail, this means that the null character is appended elsewhere. Or the original length used here actually creates a null character in the `wcspy_s` call (more likely I guess):

    msvcrt.wcscpy_s(c_wchar_p(hCd), len(text), c_wchar_p(text[:-1]))
                                     ↑ here

Resolves also 3.6 failed builds on Appveyor.

Closes #5569, ref https://github.com/python/cpython/pull/2302