### PR TITLE
Fixed one letter documentation typo (in example)

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -117,7 +117,7 @@ example, this can be accomplished like so::
             Button:
                 text: 'Quit'
 
-    <SettingScreen>:
+    <SettingsScreen>:
         BoxLayout:
             Button:
                 text: 'My settings button'


### PR DESCRIPTION
Lettering used in second kv snippet doesn't match the code that's supposed to run it in example from docstring.