### PR TITLE
typo fix in docs example

### DIFF
--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -140,7 +140,7 @@ escape them. We created a simple syntax::
 
 Then you can write::
 
-    "[size=24]Hello &bl;World&bt;[/size]"
+    "[size=24]Hello &bl;World&br;[/size]"
 
 Interactive zone in text
 ------------------------


### PR DESCRIPTION
A typo in a code example. I assume info in lines just above my fix is correct:
`    [   -> &bl;
    ]   -> &br;
    &   -> &amp;`
