### PR TITLE
do not use the clock in __dealloc__ to prevent deadlock

### DIFF
--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -84,6 +84,7 @@ cdef class CyClockBase(object):
 
     cpdef get_resolution(self)
     cpdef create_trigger(self, callback, timeout=*, interval=*)
+    cpdef schedule_del_safe(self, callback)
     cpdef schedule_once(self, callback, timeout=*)
     cpdef schedule_interval(self, callback, timeout)
     cpdef unschedule(self, callback, all=*)

--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -22,6 +22,7 @@ cdef class ClockEvent(object):
     '''
     cdef public double _last_dt
     cdef public double _dt
+    cdef public list _del_queue
 
     cpdef get_callback(self)
     cpdef cancel(self)

--- a/kivy/graphics/context.pyx
+++ b/kivy/graphics/context.pyx
@@ -47,7 +47,9 @@ cdef class Context:
         self.l_canvas = []
         self.l_fbo = []
         self.flush()
-        self.trigger_gl_dealloc = Clock.create_trigger(self.gl_dealloc, 0)
+
+    def trigger_gl_dealloc(self):
+        Clock.schedule_del_safe(self.gl_dealloc)
 
     cdef void flush(self):
         gc.collect()


### PR DESCRIPTION
Prevents hangs such as in #5605
In 1.10 the Clock always hold a lock when registering or unregistering callbacks. So if garbage collection occurs while the clock holds the lock in the same thread (such as in #5605) the process will deadlock. This PR changes the behavior in `__dealloc__` to perform the work synchronously without using the clock to prevent this issue.