### PR TITLE
Fix typo in docs.

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -37,7 +37,7 @@ The Logger can be controlled via the Kivy configuration file::
     log_enable = 1
     log_dir = logs
     log_name = kivy_%y-%m-%d_%_.txt
-    log_maxfile = 100
+    log_maxfiles = 100
 
 More information about the allowed values are described in the
 :mod:`kivy.config` module.


### PR DESCRIPTION
`log_maxfiles` is [correct](https://github.com/kivy/kivy/blob/97d675e0669f600f62b074a6cc9efb409091ced0/kivy/logger.py#L120)