### PR TITLE
Add setupconfig.py to packagedata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1019,6 +1019,7 @@ if not build_examples:
         ],
         package_dir={'kivy': 'kivy'},
         package_data={'kivy': [
+            'setupconfig.py'
             '*.pxd',
             '*.pxi',
             'core/text/*.pxd',


### PR DESCRIPTION
When installing from PyPI it was possible for the generated setupconfig module not to be included. This PR adds it to the packagedata, so that it will always be included.

Fixes #4350. Tested on test.pypi.org