### PR TITLE
Don't use fork() in kivy.lib.osc (forking a multithreaded process hangs)

### DIFF
--- a/kivy/lib/osc/oscAPI.py
+++ b/kivy/lib/osc/oscAPI.py
@@ -40,6 +40,8 @@ try:
     use_multiprocessing = True
     from multiprocessing import Process, Queue, Value
     import multiprocessing.synchronize
+    # Don't use fork as it is a bad idea with threaded processes
+    multiprocessing.set_start_method('spawn')
     Logger.info('OSC: using <multiprocessing> for socket')
 except:
     use_multiprocessing = False


### PR DESCRIPTION
Hello!

Multiprocessing seems to hang OSC on Linux, and after a LOT of digging I finally found why:

https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

It basically says forking a multithreaded process is a bad idea, and Kivy is multithreaded, and on Unix the default multiprocessing method is fork.

You might try to reproduce the issue yourself with parts of my game code: https://gist.github.com/anonymous/cb3f116fa46ccd7f4c2bd78807d083b8 (this is two files, one server one client, and requires multiosc PR #5635 )

Thanks!