### PR TITLE
Fix LabelBase.register() to behave as documented

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -249,7 +249,7 @@ class LabelBase(object):
                 else:
                     fonts.append(font)
             else:
-                fonts.append(fonts[-1])  # add regular font to list again
+                fonts.append(fonts[0])  # add regular font to list again
 
         LabelBase._fonts[name] = tuple(fonts)
 


### PR DESCRIPTION
I stumbled on this looking at the code, -1 here will only load the regular font in some circumstances. For example if `fn_italic` is set, both `fn_bold` and `fn_bolditalic` will incorrectly fall back to italic