### PR TITLE
Disable welcome message for new issues

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,8 +1,8 @@
 # Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
 
 # Comment to be posted to on first time issues
-newIssueWelcomeComment: |
-  👋 Thanks for opening your first issue here! Be sure to follow the issue template!
+# newIssueWelcomeComment: |
+#  👋 Thanks for opening your first issue here! Be sure to follow the issue template!
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 


### PR DESCRIPTION
I find this annoying and propose to disable it. I just don't think this adds any value at all.

The bot's auto-response doesn't make up for lacking human resources to respond to and deal with issues. I'd argue that it makes it worse.

Every message lands in repository watcher's inbox, including mine, I'd rather not have it.

Again feel free to close, just voicing my opinion.