### PR TITLE
Remove widget from pre-existing parent. references #5508, #5612, #5645

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1241,11 +1241,7 @@ class WindowBase(EventDispatcher):
     def add_widget(self, widget, canvas=None):
         '''Add a widget to a window'''
         if widget.parent:
-            from kivy.uix.widget import WidgetException
-            raise WidgetException(
-                'Cannot add %r to window, it already has a parent %r' %
-                (widget, widget.parent)
-            )
+            widget.parent.remove_widget(widget)
 
         widget.parent = self
         self.children.insert(0, widget)


### PR DESCRIPTION
To my mind, this approach makes more sense the throwing the error. 

a. It fixes/avoids this issue, which does seem relatively artificial in the first place: https://github.com/kivy/kivy/issues/5508

b. More often  than not, this will be desired behavior. i.e. it just works.

c. It should fix various other issues. e.g. https://github.com/kivy/kivy/issues/5645, https://github.com/kivy/kivy/issues/5646

d. I can't really see many downsides?
