### PR TITLE
Prevent inspector from adding itself to the window

### DIFF
--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -375,7 +375,7 @@ class Inspector(FloatLayout):
         return ret
 
     def on_window_children(self, win, children):
-        if self.avoid_bring_to_top:
+        if self.avoid_bring_to_top or not self.activated:
             return
         self.avoid_bring_to_top = True
         win.remove_widget(self)


### PR DESCRIPTION
Based on https://github.com/kivy/kivy/issues/5645, I managed to reproduce
the Inspector "already has a parent" error but it happens immediately I pres "Ctrl + e" to open
the inspector but only when a popup has been created.
To debug this, I monitored the 'on_parent' event of the inspector. It turns
our the Inspector binds to the 'children' event of the window and then tries
to add itself when whenever th 'children' Window event` fires. 

As the ModalView adds itself directly to the Window, the event fires and the 
Inspector adds itself even when it has not been activated. This is clearly
not desired behavior.

THe PR adds a check to the Inpector to detect that it does indeed want to 
re-insert itself into the children.

@bionid. Please confirm it fixes https://github.com/kivy/kivy/issues/5645 as I
could only reproduce this when creating the popup, not on closing the
inspector as your ticket indicates.  It also seems to fix the error in the travis builds, so those should pass if this is merged :-)

