### PR TITLE
Fixes renderbuffer leaking when creating Fbo

### DIFF
--- a/kivy/graphics/context.pyx
+++ b/kivy/graphics/context.pyx
@@ -111,13 +111,14 @@ cdef class Context:
     cdef void dealloc_fbo(self, Fbo fbo):
         cdef array arr_fb
         cdef array arr_rb
+        cdef int gl_id
         if fbo.buffer_id != 0:
             arr_fb = self.lr_fbo_fb
             arr_fb.append(fbo.buffer_id)
             self.trigger_gl_dealloc()
-        if fbo.depthbuffer_id != 0:
+        if fbo.depthbuffer_id != 0 or fbo.stencilbuffer_id != 0:
             arr_rb = self.lr_fbo_rb
-            arr_rb.append(fbo.depthbuffer_id)
+            arr_rb.append(fbo.depthbuffer_id or fbo.stencilbuffer_id)
             # no need to trigger, depthbuffer required absolutely a buffer.
 
     def add_reload_observer(self, callback, before=False):

--- a/kivy/graphics/context.pyx
+++ b/kivy/graphics/context.pyx
@@ -111,7 +111,6 @@ cdef class Context:
     cdef void dealloc_fbo(self, Fbo fbo):
         cdef array arr_fb
         cdef array arr_rb
-        cdef int gl_id
         if fbo.buffer_id != 0:
             arr_fb = self.lr_fbo_fb
             arr_fb.append(fbo.buffer_id)


### PR DESCRIPTION
If a FBO was created with stencil buffer but no depth buffer (like what ShaderTransition does today), it doesn't release the Renderbuffer created for the stencil.

The same renderbuffer is used for both stencil and depth, but only the depth id was checked for the release. This PR fixes the leak.

Ref #5581 