### PR TITLE
Fix TypeError when Trackball devices are used

### DIFF
--- a/examples/miscellaneous/joystick.py
+++ b/examples/miscellaneous/joystick.py
@@ -61,8 +61,8 @@ class Listener(Widget):
     def on_joy_axis(self, win, stickid, axisid, value):
         self.joy_motion('axis', stickid, axisid, value)
 
-    def on_joy_ball(self, win, stickid, ballid, value):
-        self.joy_motion('ball', ballid, axisid, value)
+    def on_joy_ball(self, win, stickid, ballid, xvalue, yvalue):
+        self.joy_motion('ball', stickid, ballid, (xvalue, yvalue))
 
     def on_joy_hat(self, win, stickid, hatid, value):
         self.joy_motion('hat', stickid, hatid, value)

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1634,7 +1634,7 @@ class WindowBase(EventDispatcher):
         .. versionadded:: 1.9.0'''
         pass
 
-    def on_joy_ball(self, stickid, ballid, value):
+    def on_joy_ball(self, stickid, ballid, xvalue, yvalue):
         '''Event called when a joystick has a ball moved.
 
         .. versionadded:: 1.9.0'''


### PR DESCRIPTION
Fixes crashes whenever a ``pygame.JOYBALLMOTION`` or ``SDL_JOYBALLMOTION`` event happens. Both window_pygame.py https://github.com/kivy/kivy/blob/3a2a86ce71c6c2806b9d3c2ee39f95ef4131ffa1/kivy/core/window/window_pygame.py#L349-L350 and window_sdl2.py https://github.com/kivy/kivy/blob/3a2a86ce71c6c2806b9d3c2ee39f95ef4131ffa1/kivy/core/window/window_sdl2.py#L539 call this method with two position values