### PR TITLE
Re-enable `gi` camera provider.

### DIFF
--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -141,6 +141,8 @@ if platform == 'macosx':
                    'CameraAVFoundation'), )
 elif platform == 'android':
     providers += (('android', 'camera_android', 'CameraAndroid'), )
+else:
+    providers += (('gi', 'camera_gi', 'CameraGi'), )
 
 providers += (('opencv', 'camera_opencv', 'CameraOpenCV'), )
 


### PR DESCRIPTION
The `gi` camera provider was disabled along with the `pygst` provider in [this commit](https://github.com/kivy/kivy/commit/61fd64d98854804a8af1d893d5a5ac69b63fd210#diff-bbcc00f86b3569f5d3d96a183f4193f0) but the implementation is still there. This change re-adds it to the list of available providers.