### PR TITLE
Docs: Add warning about using Texture before application start

### DIFF
--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -37,6 +37,10 @@ You can use your texture in almost all vertex instructions with the
 your texture in kv lang, you can save it in an
 :class:`~kivy.properties.ObjectProperty` inside your widget.
 
+.. warning::
+    Using Texture before OpenGL has been initialized will lead to a crash. If
+    you need to create textures before the application has started, import
+    Window first: `from kivy.core.window import Window`
 
 Blitting custom data
 --------------------


### PR DESCRIPTION
Maybe there is a practical way to fix this instead of the warning?

```python
from kivy.graphics.texture import Texture
Texture.create(size=(64, 64))
```

```
(gdb) r
Starting program: /home/kivy/.pyenv/versions/3.6.4/bin/python3 crash.py
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[INFO   ] [Logger      ] Record log in /home/kivy/.kivy/logs/kivy_18-04-11_24.txt
[INFO   ] [Kivy        ] v1.10.1.dev0, git-9ddbdd0, 20180411
[INFO   ] [Python      ] v3.6.4 (default, Mar  1 2018, 19:29:51)
[GCC 6.3.0 20170516]
[INFO   ] [Image       ] Providers: img_tex, img_dds, img_sdl2, img_pil, img_gif (img_ffpyplayer ignored)

Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00007fffe62d6aa5 in __pyx_f_4kivy_8graphics_12opengl_utils_gl_get_version (__pyx_skip_dispatch=__pyx_skip_dispatch@entry=0) at kivy/graphics/opengl_utils.c:5084
#2  0x00007fffe62d865b in __pyx_f_4kivy_8graphics_12opengl_utils_gl_get_version_major (__pyx_skip_dispatch=<optimized out>) at kivy/graphics/opengl_utils.c:5551
#3  0x00007ffff21c4c80 in __pyx_f_4kivy_8graphics_7texture__texture_create (__pyx_v_width=__pyx_v_width@entry=64, __pyx_v_height=64, __pyx_v_colorfmt=__pyx_v_colorfmt@entry=0x7ffff5fb3298,
    __pyx_v_bufferfmt=__pyx_v_bufferfmt@entry=0x7ffff34dfd50, __pyx_v_mipmap=0, __pyx_v_allocate=1, __pyx_v_callback=0x555555a1a900 <_Py_NoneStruct>, __pyx_v_icolorfmt=0x7ffff5fb3298) at kivy/graphics/texture.c:8339
#4  0x00007ffff21e478e in __pyx_pf_4kivy_8graphics_7texture_texture_create (__pyx_self=<optimized out>, __pyx_v_icolorfmt=0x7ffff5fb3298, __pyx_v_callback=<optimized out>, __pyx_v_mipmap=<optimized out>,
    __pyx_v_bufferfmt=0x7ffff34dfd50, __pyx_v_colorfmt=0x7ffff5fb3298, __pyx_v_size=<optimized out>) at kivy/graphics/texture.c:9129
#5  __pyx_pw_4kivy_8graphics_7texture_1texture_create (__pyx_self=<optimized out>, __pyx_args=<optimized out>, __pyx_kwds=<optimized out>) at kivy/graphics/texture.c:8870
#6  0x0000555555647537 in _PyCFunction_FastCallDict (kwargs=0x7ffff708a558, nargs=<optimized out>, args=0x555555ae6c68, func_obj=0x7fffe6dce3f0) at Objects/methodobject.c:231
#7  _PyCFunction_FastCallKeywords (func=func@entry=0x7fffe6dce3f0, stack=stack@entry=0x555555ae6c68, nargs=<optimized out>, kwnames=kwnames@entry=0x7ffff7079898) at Objects/methodobject.c:294
#8  0x00005555556d8b7e in call_function (pp_stack=pp_stack@entry=0x7fffffffda68, oparg=oparg@entry=1, kwnames=kwnames@entry=0x7ffff7079898) at Python/ceval.c:4824
#9  0x00005555556db9cd in _PyEval_EvalFrameDefault (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:3338
#10 0x00005555556d87cd in PyEval_EvalFrameEx (throwflag=0, f=0x555555ae6ae8) at Python/ceval.c:753
#11 _PyEval_EvalCodeWithName (_co=_co@entry=0x7ffff7086ae0, globals=globals@entry=0x7ffff70e3168, locals=locals@entry=0x7ffff7086ae0, args=args@entry=0x0, argcount=argcount@entry=0, kwnames=kwnames@entry=0x0, kwargs=0x0,
    kwcount=0, kwstep=2, defs=0x0, defcount=0, kwdefs=0x0, closure=0x0, name=0x0, qualname=0x0) at Python/ceval.c:4153
#12 0x00005555556d9663 in PyEval_EvalCodeEx (closure=0x0, kwdefs=0x0, defcount=0, defs=0x0, kwcount=0, kws=0x0, argcount=0, args=0x0, locals=locals@entry=0x7ffff7086ae0, globals=globals@entry=0x7ffff70e3168,
    _co=_co@entry=0x7ffff7086ae0) at Python/ceval.c:4174
#13 PyEval_EvalCode (co=co@entry=0x7ffff7086ae0, globals=globals@entry=0x7ffff70c91b0, locals=locals@entry=0x7ffff70c91b0) at Python/ceval.c:730
#14 0x00005555555b3619 in run_mod (arena=0x7ffff70e3168, flags=0x7fffffffdd5c, locals=0x7ffff70c91b0, globals=0x7ffff70c91b0, filename=0x7ffff70077f0, mod=0x555555ad1098) at Python/pythonrun.c:1025
#15 PyRun_FileExFlags (fp=0x555555ac84f0, filename_str=<optimized out>, start=<optimized out>, globals=0x7ffff70c91b0, locals=0x7ffff70c91b0, closeit=1, flags=0x7fffffffdd5c) at Python/pythonrun.c:978
#16 0x00005555555b3835 in PyRun_SimpleFileExFlags (fp=0x555555ac84f0, filename=<optimized out>, closeit=1, flags=0x7fffffffdd5c) at Python/pythonrun.c:420
#17 0x00005555555c90be in run_file (p_cf=0x7fffffffdd5c, filename=0x555555a912f0 L"crash.py", fp=0x555555ac84f0) at Modules/main.c:338
#18 Py_Main (argc=<optimized out>, argv=<optimized out>) at Modules/main.c:809
#19 0x00005555555a99c1 in main (argc=2, argv=<optimized out>) at ./Programs/python.c:69
```
