### PR TITLE
add layout.add_widgets()

### DIFF
--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -95,6 +95,10 @@ class Layout(Widget):
         fbind('size_hint_max', self._trigger_layout)
         fbind('size_hint_min', self._trigger_layout)
         return super(Layout, self).add_widget(widget, index)
+    
+    def add_widgets(self, *args):
+        for widget in args:
+            self.add_widget(widget)
 
     def remove_widget(self, widget):
         funbind = widget.funbind


### PR DESCRIPTION
added layout.add_widgets() so you can add many widgets to the layout at once
```
layout = BoxLayout(orientation='vertical')
lbl0 = Label(text = "Foo")
lbl1 = Label(text = "Bar")
layout.add_widgets(lbl0, lbl1)
```