### PR TITLE
Fixed format string mistake in Error Message

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -245,7 +245,7 @@ class LabelBase(object):
                 font = resource_find(font_type)
 
                 if font is None:
-                    raise IOError('File {0}s not found'.format(font_type))
+                    raise IOError('File {0} not found'.format(font_type))
                 else:
                     fonts.append(font)
             else:


### PR DESCRIPTION
While debugging a issue with creating a Kivy exe using PyInstaller I found this bug where it adds the 's' to file names in the error message. Just a small bug, but annoying.