### PR TITLE
Let Layout.add_widget use the ``canvas`` argument

### DIFF
--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -88,13 +88,13 @@ class Layout(Widget):
         '''
         raise NotImplementedError('Must be implemented in subclasses.')
 
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         fbind = widget.fbind
         fbind('size', self._trigger_layout)
         fbind('size_hint', self._trigger_layout)
         fbind('size_hint_max', self._trigger_layout)
         fbind('size_hint_min', self._trigger_layout)
-        return super(Layout, self).add_widget(widget, index)
+        return super(Layout, self).add_widget(widget, index, canvas)
 
     def remove_widget(self, widget):
         funbind = widget.funbind


### PR DESCRIPTION
I had occasion to turn a Widget subclass of mine into a Layout, which caused TypeError as Layout's add_widget never got the ``canvas`` argument that base Widget has. Layout.add_widget isn't that different from Widget.add_widget though, so I just added it. Might help somebody?