### PR TITLE
input: probesysfs: remove getconf dependency

### DIFF
--- a/kivy/input/providers/probesysfs.py
+++ b/kivy/input/providers/probesysfs.py
@@ -47,6 +47,7 @@ if 'KIVY_DOC' in os.environ:
     ProbeSysfsHardwareProbe = None
 
 else:
+    import ctypes
     from re import match, IGNORECASE
     from glob import glob
     from subprocess import Popen, PIPE
@@ -89,7 +90,7 @@ else:
                 return []
 
             capabilities = []
-            long_bit = getconf("LONG_BIT")
+            long_bit = ctypes.sizeof(ctypes.c_long) * 8
             for i, word in enumerate(line.split(" ")):
                 word = int(word, 16)
                 subcapabilities = [bool(word & 1 << i)
@@ -111,10 +112,6 @@ else:
             return Popen(args, stdout=PIPE).communicate()[0]
         except OSError:
             return ''
-
-    def getconf(var):
-        output = getout("getconf", var)
-        return int(output)
 
     def query_xinput():
         global _cache_xinput


### PR DESCRIPTION
Remove the dependency on getconf to get LONG_BIT value, in order to
improve portability to Linux systems without Glibc and/or getconf.

My testing with this patch is, so far, limited to the existing unit tests, and using a mouse with the upstream examples. I have not tried a touchscreen, or different architectures with this patch yet, and I'm marking it WIP until I can get more testing data with it.

This closes #5598 