### PR TITLE
 Let BoxLayout.add_widget use the ``canvas`` argument

### DIFF
--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -308,9 +308,9 @@ class BoxLayout(Layout):
                 else:
                     c.size = (w, h)
 
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         widget.fbind('pos_hint', self._trigger_layout)
-        return super(BoxLayout, self).add_widget(widget, index)
+        return super(BoxLayout, self).add_widget(widget, index, canvas)
 
     def remove_widget(self, widget):
         widget.funbind('pos_hint', self._trigger_layout)


### PR DESCRIPTION
This is pretty much the same as #5715 but for ``BoxLayout``.
    
I looked through the other Layout subclasses apart from in the examples and this seems like the only remaining one with a custom ``add_widget`` that didn't take ``canvas``.
