### PR TITLE
hotfix: Stop AccordionItem collapse animation

### DIFF
--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -282,13 +282,14 @@ class AccordionItem(FloatLayout):
             self.accordion.select(self)
         collapse_alpha = float(value)
         if self._anim_collapse:
-            self._anim_collapse.stop()
+            self._anim_collapse.stop(self)
             self._anim_collapse = None
         if self.collapse_alpha != collapse_alpha:
             self._anim_collapse = Animation(
                 collapse_alpha=collapse_alpha,
                 t=accordion.anim_func,
-                d=accordion.anim_duration).start(self)
+                d=accordion.anim_duration)
+            self._anim_collapse.start(self)
 
     def on_collapse_alpha(self, instance, value):
         self.accordion._trigger_layout()


### PR DESCRIPTION
This commit addresses the problem of not being able to stop AccordionItem collapse_alpha animation which reads multiple AccordionItem being expanded simultaneously on specific situation. 

How to reproduce.
1. Tap on some accordion item.
2. Status of the item has changed to 'collapse = False' and collapse animation has fired
3. Tap on another accordion item before the animation reaches it's first step (when collapse_alpha is still 1.0)
4. Status of the first accordion item has reverted to 'collapse = True' by Accordion but the animation never get stopped because 'self._anim_collapse' is always 'None'

Normally, first expanding animation fired has overridden by secondly followed collapsing animation in similar situation so that is seemed work as intended but in the situation above, unchanged 'collapse_alpha' in step 3 prevented second following animation being fired and ended up two accordion item expanded at the same time.

The fact that original code 'self._anim_collapse.stop()' on line 285 must have complained about missing arguments but never did is strong clue on this bug.
