### PR TITLE
Add decorator for Clock.create_trigger()

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -803,7 +803,7 @@ def mainthread(func):
     return delayed_func
 
 
-def triggered(timeout, interval=False):
+def triggered(timeout=0, interval=False):
     '''Decorator that will trigger the call of the function at the specified
     timeout, through the method :meth:`CyClockBase.create_trigger`. A new call
     to the function before the timeout will interrupt the previous call and
@@ -816,7 +816,7 @@ def triggered(timeout, interval=False):
         callback(id=1)
         callback(id=2)
 
-        @triggered(timeout, interval=False)
+        @triggered(timeout=0, interval=False)
         def callback(self, id):
             print('The callback has been called with id=%d' % id)
 

--- a/kivy/tests/test_clock.py
+++ b/kivy/tests/test_clock.py
@@ -80,3 +80,40 @@ class ClockTestCase(unittest.TestCase):
         Clock.unschedule(callback)
         Clock.tick()
         self.assertEqual(counter, 0)
+
+    def test_trigger_create(self):
+        from kivy.clock import Clock
+        trigger = Clock.create_trigger(callback, 0)
+        trigger()
+        self.assertEqual(counter, 0)
+        Clock.tick()
+        self.assertEqual(counter, 1)
+
+    def test_trigger_cancel(self):
+        from kivy.clock import Clock
+        trigger = Clock.create_trigger(callback, 5.)
+        trigger()
+        trigger.cancel()
+        Clock.tick()
+        self.assertEqual(counter, 0)
+
+    def test_trigger_interval(self):
+        from kivy.clock import Clock
+        trigger = Clock.create_trigger(callback, 0, interval=True)
+        trigger()
+        Clock.tick()
+        self.assertEqual(counter, 1)
+        Clock.tick()
+        self.assertEqual(counter, 2)
+
+    def test_trigger_decorator(self):
+        from kivy.clock import Clock, triggered
+
+        @triggered()
+        def triggered_callback():
+            callback(dt=0)
+
+        triggered_callback()
+        self.assertEqual(counter, 0)
+        Clock.tick()
+        self.assertEqual(counter, 1)


### PR DESCRIPTION
This PR adds the decorator `@triggered` to `Clock`. It schedules the given function through `Clock.create_trigger()`, the same way that `@mainthread` uses `Clock.schedule_once()`, but with the ability to set the `timeout` and `interval` parameters.

It simplifies the use of triggered events on regular methods, without complicating the code using dt, lambda, partial, etc. The decorated method can be called several times within the timeout, even with different arguments, but only the last one will be triggered.

It can be very helpful when in a complex system, you have several events or functions calling an expensive method with an updating parameter, but only the last one is needed.
