### PR TITLE
Deprecate the Widget's id property

### DIFF
--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -175,6 +175,8 @@ the value can use the values of other properties using reserved keywords.
             TextInput:
                 on_focus: self.insert_text("Focus" if args[1] else "No focus")
 
+.. kv-lang-ids:
+
 ids
 ~~~
 

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -1026,15 +1026,20 @@ class Widget(WidgetBase):
     '''
 
     id = StringProperty(None, allownone=True)
-    '''Unique identifier of the widget in the tree.
+    '''Identifier of the widget in the tree.
 
     :attr:`id` is a :class:`~kivy.properties.StringProperty` and defaults to
     None.
 
+    .. note::
+
+        The :attr:`id` is not the same as ``id`` in the kv language. For the
+        latter, see :attr:`ids` and :ref:`Kivy Language: ids <kv-lang-ids>`.
+
     .. warning::
 
-        If the :attr:`id` is already used in the tree, an exception will
-        be raised.
+        The :attr:`id` property has been deprecated and will be removed
+        completely in future versions.
     '''
 
     children = ListProperty([])


### PR DESCRIPTION
The id property is easily confused with the kv language's id mechanism.
Deprecate and make it clear that it should not be used.

PR for #4001.