### PR TITLE
@triggered decorator: add cancel method

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -813,12 +813,17 @@ def triggered(timeout=0, interval=False):
     triggered by different methods. Setting a proper timeout will delay the
     calling and only one of them wil be triggered.
 
-        callback(id=1)
-        callback(id=2)
-
-        @triggered(timeout=0, interval=False)
+        @triggered(timeout, interval=False)
         def callback(self, id):
             print('The callback has been called with id=%d' % id)
+
+        >> callback(id=1)
+        >> callback(id=2)
+        The callback has been called with id=2
+
+    The decorated callback can also be unscheduled using:
+
+        >> callback.cancel()
 
     .. versionadded:: 1.10.1
     '''
@@ -843,6 +848,11 @@ def triggered(timeout=0, interval=False):
             _kwargs.clear()
             _kwargs.update(kwargs)
             cb_trigger()
+
+        def trigger_cancel():
+            cb_trigger.cancel()
+
+        setattr(trigger_function, 'cancel', trigger_cancel)
 
         return trigger_function
 

--- a/kivy/tests/test_clock.py
+++ b/kivy/tests/test_clock.py
@@ -117,3 +117,15 @@ class ClockTestCase(unittest.TestCase):
         self.assertEqual(counter, 0)
         Clock.tick()
         self.assertEqual(counter, 1)
+
+    def test_trigger_decorator_cancel(self):
+        from kivy.clock import Clock, triggered
+
+        @triggered()
+        def triggered_callback():
+            callback(dt=0)
+
+        triggered_callback()
+        triggered_callback.cancel()
+        Clock.tick()
+        self.assertEqual(counter, 0)


### PR DESCRIPTION
Last minute addition to PR #5749.

I realized that a function triggered using the decorator might not be easily unscheduled, since the clock event is hidden inside the decorator internals, so I added a cancel method that can be called directly from the callback funcion.

```
triggered_callback.cancel()
```

_Sorry for the bad timing with the PR._