### PR TITLE
Add build requirements file according to PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["Cython==0.28.2", "setuptools", "wheel"]


### PR DESCRIPTION
**Note:** Should probably not be merged before v1.10.1 so we can see what effect this has.
It shouldn't cause any problems in any case, but you never know.

[PEP 518](https://www.python.org/dev/peps/pep-0518/) specifies a way to add build requirements to a project with a new file `pyproject.toml`. Pip from v10 on knows how to handle this.

