### PR TITLE
Fix osc typetag detection

### DIFF
--- a/kivy/lib/osc/OSC.py
+++ b/kivy/lib/osc/OSC.py
@@ -300,9 +300,9 @@ def decodeOSC(data):
             typetags, rest = readString(rest)
             decoded.append(address)
             decoded.append(typetags)
-            if typetags[0] == b",":
+            if typetags[0] == ord(","):
                 for tag in typetags[1:]:
-                    value, rest = table[tag](rest)
+                    value, rest = table[chr(tag)](rest)
                     decoded.append(value)
             else:
                 print("Oops, typetag lacks the magic ,")


### PR DESCRIPTION
The comma at the beginning of the osc typetag is now correctly detected. Also the type conversion function is now selected.