### PR TITLE
Update Cython to 0.28.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def get_version(filename='kivy/version.py'):
 
 MIN_CYTHON_STRING = '0.23'
 MIN_CYTHON_VERSION = LooseVersion(MIN_CYTHON_STRING)
-MAX_CYTHON_STRING = '0.28.2'
+MAX_CYTHON_STRING = '0.28.3'
 MAX_CYTHON_VERSION = LooseVersion(MAX_CYTHON_STRING)
 CYTHON_UNSUPPORTED = (
     # ref https://github.com/cython/cython/issues/1968


### PR DESCRIPTION
[Cython 0.28.3 is a bugfix release](https://github.com/cython/cython/blob/0.28.x/CHANGES.rst) with 3 fixes. Risk is low.

I've run tests with this version of Cython with current master (b19d755) on the following systems:
- Ubuntu: 16.04, 17.10, 18.04; py2, py3
- Debian 9.4: py2, py3
- Fedora 28: py2, py3
- OpenSUSE Tumbleweed: py2, py3
- Windows: mingw py27, msvc py36

The only real error I got was on Windows py27 and is unrelated:
```
======================================================================
ERROR: test_reload_asyncimage (kivy.tests.test_uix_asyncimage.AsyncImageTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\kivy-test\mingw\py27\kivy\kivy\tests\test_uix_asyncimage.py", line 113, in test_reload_asyncimage
    from os import symlink, unlink
ImportError: cannot import name symlink
```