### PR TITLE
[WIP] Remove SDL image dependence from SDL2 Window

### DIFF
--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -94,7 +94,7 @@ class ImageLoaderPygame(ImageLoaderBase):
                 fmt, data, source=filename)]
 
     @staticmethod
-    def save(filename, width, height, fmt, pixels, flipped):
+    def save(filename, width, height, fmt, pixels, flipped=False):
         surface = pygame.image.fromstring(
             pixels, (width, height), fmt.upper(), flipped)
         pygame.image.save(surface, filename)

--- a/kivy/core/image/img_sdl2.py
+++ b/kivy/core/image/img_sdl2.py
@@ -50,7 +50,7 @@ class ImageLoaderSDL2(ImageLoaderBase):
             rowlength=rowlength)]
 
     @staticmethod
-    def save(filename, width, height, fmt, pixels, flipped):
+    def save(filename, width, height, fmt, pixels, flipped=False):
         _img_sdl2.save(filename, width, height, fmt, pixels, flipped)
         return True
 


### PR DESCRIPTION
**WIP**, or rather, proof of concept. Needs review.

SDL2 currently depends on the SDL image project, even when PIL is used as the image provider. There are 3 API calls in `_window_sdl2.py` which make this a necessity.

This is to remove that dependency by replacing those calls with the `core.image` API.

The `surface_from_core_image()` is adapted from `_img_sdl2.pyx`. I've been able to test both the icon code and the screenshot code, but I'm unable to enable a shaped window (with or without my modifications). Also, I'm not sure if the `SDL_FreeSurface()` is required there.

Second commit fixes a minor API inconsistency.