### PR TITLE
Removed checkbox doc info about colours outside 0-1 range

### DIFF
--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -146,9 +146,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
     '''Color is used for tinting the default graphical representation
     of checkbox and radio button (images).
 
-    Color is in the format (r, g, b, a). Use alpha greater than 1 for
-    brighter colors. Alpha greater than 4 causes blending border and check
-    mark together.
+    Color is in the format (r, g, b, a).
 
     .. versionadded:: 1.10.0
 


### PR DESCRIPTION
I think this is just confusing, and nothing special to CheckBox (it could have more of a place in a general discussion about what Kivy colours mean). Also, the number 4 seems to be an arbitrary value that isn't actually especially meaningful.