### PR TITLE
Improve Makefile debug configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ IOSPATH := $(PATH):/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin
 
 BUILD_OPTS       = build_ext --inplace
 BUILD_OPTS_FORCE = $(BUILD_OPTS) -f
-BUILD_OPTS_DEBUG = $(BUILD_OPTS_FORCE) -g
+BUILD_OPTS_DEBUG = $(BUILD_OPTS_FORCE) -g --cython-gdb
 
 INSTALL_OPTIONS  = install
 INSTALL_ROOT     =
@@ -38,7 +38,7 @@ force:
 	$(PYTHON) setup.py $(BUILD_OPTS_FORCE)
 
 debug:
-	$(PYTHON) setup.py $(BUILD_OPTS_DEBUG)
+	env CFLAGS="-Og" $(PYTHON) setup.py $(BUILD_OPTS_DEBUG)
 
 mesabuild:
 	env USE_MESAGL=1 $(PYTHON) setup.py $(BUILD_OPTS)


### PR DESCRIPTION
<dl>
  <dt>--cython-gdb</dt><dd>enables the <code>cygdb</code> command</dd>
  <dt>-Og</dt><dd>recommended optimisation flag for debugging</dd>
</dl>

see:
- http://docs.cython.org/en/latest/src/userguide/debugging.html
- https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-Ofast