### PR TITLE
fix syntax table for emacs kivy-mode

### DIFF
--- a/kivy/tools/highlight/kivy-mode.el
+++ b/kivy/tools/highlight/kivy-mode.el
@@ -142,6 +142,9 @@
   (modify-syntax-entry ?\\ "\\" kivy-mode-syntax-table)
   (modify-syntax-entry ?- "_" kivy-mode-syntax-table)
   (modify-syntax-entry ?_ "w" kivy-mode-syntax-table)
+  (modify-syntax-entry ?< "." kivy-mode-syntax-table)
+  (modify-syntax-entry ?> "." kivy-mode-syntax-table)
+  (modify-syntax-entry ?_ "_" kivy-mode-syntax-table)
   )
 
 


### PR DESCRIPTION
"<" and ">" were considered part of symbols, but are now punctuation. This means
selecting the symbol-at-point will now correctly select "Foo" instead of "\<Foo\>".

"_" was part of a word, but is now part of a symbol. This means you can move by
word inside of snake_case symbols, like in other emacs modes.