### PR TITLE
Drop support for py3.3, which is EOL

### DIFF
--- a/doc/sources/faq.rst
+++ b/doc/sources/faq.rst
@@ -159,10 +159,10 @@ Does Kivy support Python 3.x?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Yes! As of version 1.8.0 Kivy supports both Python >= 2.7 and Python
->= 3.3 with the same codebase. Python 3 is also now supported by
+>= 3.4 with the same codebase. Python 3 is also now supported by
 python-for-android.
 
-However, be aware that while Kivy will run in Python 3.3+, our iOS
+However, be aware that while Kivy will run in Python 3.4+, our iOS
 build tools still require Python 2.7.
 
 

--- a/doc/sources/guide/packaging-ios.rst
+++ b/doc/sources/guide/packaging-ios.rst
@@ -6,7 +6,7 @@ Create a package for IOS
 .. note::
 
     Currently, packages for iOS can only be generated with Python 2.7. Python
-    3.3+ support is on the way.
+    3.4+ support is on the way.
 
 The overall process for creating a package for IOS can be explained in 4 steps:
 

--- a/doc/sources/installation/installation.rst
+++ b/doc/sources/installation/installation.rst
@@ -15,7 +15,7 @@ That said, there is one dependency that Kivy **does** require:
 `Cython <http://cython.org>`_.
 
 In addition, you need a `Python <http://python.org/>`_ 2.x (2.7 <= x < 3.0)
-or 3.x (3.3 <= x) interpreter. If you want to enable features like windowing
+or 3.x (3.4 <= x) interpreter. If you want to enable features like windowing
 (i.e. open a Window), audio/video playback or spelling correction, additional
 dependencies must be available. For these, we recommend
 `SDL2 <https://www.libsdl.org/download-2.0.php>`_,

--- a/kivy/compat.py
+++ b/kivy/compat.py
@@ -1,6 +1,6 @@
 '''
-Compatibility module for Python 2.7 and > 3.3
-=============================================
+Compatibility module for Python 2.7 and >= 3.4
+==============================================
 
 This module provides a set of utility types and functions for optimization and
 to aid in writing Python 2/3 compatibile code.

--- a/setup.py
+++ b/setup.py
@@ -1084,7 +1084,6 @@ if not build_examples:
             'Operating System :: POSIX :: BSD :: FreeBSD',
             'Operating System :: POSIX :: Linux',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python 3.3 has reached end of life (since 2017-09-29).

See:
- [Python 3.3.0 Release | Python.org](https://www.python.org/download/releases/3.3.0/)
- [Python Insider: Python 3.3.7rc1 is now available prior to Python 3.3.x end-of-life](https://blog.python.org/2017/09/python-337rc1-is-now-available-prior-to.html)