### PR TITLE
Fix missing requirements for Python 3.6 64bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,9 +135,7 @@ build_script:
 
     Check-Error
 
-    pip install mock cython pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
-
-    pip --no-cache-dir install kivy.deps.gstreamer
+    pip install cython
 
     Check-Error
 
@@ -147,6 +145,12 @@ build_script:
       python setup.py sdist --formats=gztar -d "$env:WHEEL_DIR"
       Check-Error
     }
+    
+    pip install mock cython pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
+
+    pip --no-cache-dir install kivy.deps.gstreamer
+
+    Check-Error
 
     if ($env:COMPILER -ne "msvc") {
       python -c "with open(r'$PYTHON_ROOT\Lib\distutils\distutils.cfg', 'wb') as fh: fh.write(b'[build]\ncompiler = mingw32\n')"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,6 +135,12 @@ build_script:
 
     Check-Error
 
+    pip install mock cython pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
+
+    pip --no-cache-dir install kivy.deps.gstreamer
+
+    Check-Error
+
     # sdist must happen before anything else
 
     if ($DO_WHEEL -eq "True" -and $env:BITTNESS -eq "64" -and $env:PYVER -eq "36") {
@@ -148,12 +154,6 @@ build_script:
       pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy
       Check-Error
     }
-
-    pip install mock cython pygments docutils nose kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
-
-    pip --no-cache-dir install kivy.deps.gstreamer
-
-    Check-Error
 
     if ($env:COMPILER -eq "msvc") {
       pip install kivy.deps.angle


### PR DESCRIPTION
sdist might need to be first, but without deps it will fail on missing Cython, thus no wheels for 3.6 64b

ref: https://ci.appveyor.com/project/KivyOrg/kivy/build/1.0.2460/job/u6bsnlrwwe5n5yy2#L202

Perhaps `kivy.deps.*` might need to be moved to the original place, I'm not sure.