### PR TITLE
carousel - update add_widget with 'canvas' parameter

### DIFF
--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -615,10 +615,10 @@ class Carousel(StencilView):
             super(Carousel, self).on_touch_down(touch)
             return
 
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         slide = RelativeLayout(size=self.size, x=self.x - self.width, y=self.y)
         slide.add_widget(widget)
-        super(Carousel, self).add_widget(slide, index)
+        super(Carousel, self).add_widget(slide, index, canvas)
         if index != 0:
             self.slides.insert(index - len(self.slides), widget)
         else:


### PR DESCRIPTION
Update `carousel.py`'s `add_widget()` to allow the canvas input parameter