### PR TITLE
Docs: Update for Python 3.7

### DIFF
--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -30,17 +30,6 @@ specific platform:
     :target: ../installation/installation-rpi.html
     :class: gs-osimage gs-osimage-last
 
-.. note::
-
-   `Python 3.7 <https://www.python.org/downloads/>`_ has recently been
-   released, but for technical reasons we can't provide binary Kivy packages
-   yet.
-
-   For the time being, please use one of the supported versions up to and
-   including Python 3.6. Alternatively, it's also possible to compile it
-   yourself, for example by following the instructions for the development
-   version below.
-
 Development Version
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -110,6 +110,10 @@ Nightly wheel installation
 .. _cp36_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp36-cp36m-win32.whl
 .. |cp36_amd64| replace:: Python 3.6, 64bit
 .. _cp36_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp36-cp36m-win_amd64.whl
+.. |cp37_win32| replace:: Python 3.7, 32bit
+.. _cp37_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp37-cp37m-win32.whl
+.. |cp37_amd64| replace:: Python 3.7, 64bit
+.. _cp37_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp37-cp37m-win_amd64.whl
 .. |examples_whl| replace:: Kivy examples
 .. _examples_whl: https://kivy.org/downloads/appveyor/kivy/Kivy_examples-1.11.0.dev0-py2.py3-none-any.whl
 
@@ -127,10 +131,12 @@ follows.
 + |cp27_win32|_
 + |cp35_win32|_
 + |cp36_win32|_
++ |cp37_win32|_
 
 - |cp27_amd64|_
 - |cp35_amd64|_
 - |cp36_amd64|_
+- |cp37_amd64|_
 
 #. Perform steps 1 and 2 of the above Installation section.
 #. Download the appropriate wheel for your system.


### PR DESCRIPTION
- Installation: Remove temporary Python 3.7 notice
- Installation Windows: Add links to the Python 3.7 nightly wheels