### PR TITLE
add missing mapping for `numpaddecimal`

### DIFF
--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -299,6 +299,7 @@ else:
         'numpadmul': '*',
         'numpaddivide': '/',
         'numpadadd': '+',
+        'numpaddecimal': '.',
         'numpadsubstract': '-',
     }
 


### PR DESCRIPTION
A mapping for `numpaddecimal` is missing, so when I press `.` on a numeric keyboard attached to a Raspberry Pi, the string `numpaddecimal` appears.

This one-liner simply adds the missing mapping.