### PR TITLE
Fixed PEP8 in Pong examples

### DIFF
--- a/examples/tutorials/pong/main.py
+++ b/examples/tutorials/pong/main.py
@@ -3,8 +3,9 @@ kivy.require('1.1.1')
 
 from kivy.app import App
 from kivy.uix.widget import Widget
-from kivy.properties import NumericProperty, ReferenceListProperty,\
-    ObjectProperty
+from kivy.properties import (
+    NumericProperty, ReferenceListProperty, ObjectProperty
+)
 from kivy.vector import Vector
 from kivy.clock import Clock
 

--- a/examples/tutorials/pong/pong.kv
+++ b/examples/tutorials/pong/pong.kv
@@ -21,7 +21,7 @@
     
     canvas:
         Rectangle:
-            pos: self.center_x-5, 0
+            pos: self.center_x - 5, 0
             size: 10, self.height
     
     Label:
@@ -47,7 +47,7 @@
         
     PongPaddle:
         id: player_right
-        x: root.width-self.width
+        x: root.width - self.width
         center_y: root.center_y
         
 

--- a/examples/tutorials/pong/steps/step3/pong.kv
+++ b/examples/tutorials/pong/steps/step3/pong.kv
@@ -10,7 +10,7 @@
 <PongGame>:
     canvas:
         Rectangle:
-            pos: self.center_x-5, 0
+            pos: self.center_x - 5, 0
             size: 10, self.height
     
     Label:

--- a/examples/tutorials/pong/steps/step4/main.py
+++ b/examples/tutorials/pong/steps/step4/main.py
@@ -1,7 +1,8 @@
 from kivy.app import App
 from kivy.uix.widget import Widget
-from kivy.properties import NumericProperty, ReferenceListProperty,\
-    ObjectProperty
+from kivy.properties import (
+    NumericProperty, ReferenceListProperty, ObjectProperty
+)
 from kivy.vector import Vector
 from kivy.clock import Clock
 from random import randint

--- a/examples/tutorials/pong/steps/step4/pong.kv
+++ b/examples/tutorials/pong/steps/step4/pong.kv
@@ -12,7 +12,7 @@
     
     canvas:
         Rectangle:
-            pos: self.center_x-5, 0
+            pos: self.center_x - 5, 0
             size: 10, self.height
     
     Label:

--- a/examples/tutorials/pong/steps/step5/main.py
+++ b/examples/tutorials/pong/steps/step5/main.py
@@ -1,7 +1,8 @@
 from kivy.app import App
 from kivy.uix.widget import Widget
-from kivy.properties import NumericProperty, ReferenceListProperty,\
-    ObjectProperty
+from kivy.properties import (
+    NumericProperty, ReferenceListProperty, ObjectProperty
+)
 from kivy.vector import Vector
 from kivy.clock import Clock
 

--- a/examples/tutorials/pong/steps/step5/pong.kv
+++ b/examples/tutorials/pong/steps/step5/pong.kv
@@ -21,7 +21,7 @@
     
     canvas:
         Rectangle:
-            pos: self.center_x-5, 0
+            pos: self.center_x - 5, 0
             size: 10, self.height
     
     Label:
@@ -47,7 +47,7 @@
         
     PongPaddle:
         id: player_right
-        x: root.width-self.width
+        x: root.width - self.width
         center_y: root.center_y
         
 


### PR DESCRIPTION
In short:

- fixed pep8 in previous step files.
- Added a bounce controller as step6
- Added step6 to docs as "Improved bouncing"

I found that when you hit the ball with upper or lower side of the paddle, the bounce gets called many many times, creating a undesired behavior. Enabling/disabling bounce ability like this solves the problem.

I hope this time pass checks.