### PR TITLE
Provider matching for input postproc calibration

### DIFF
--- a/kivy/input/postproc/calibration.py
+++ b/kivy/input/postproc/calibration.py
@@ -26,6 +26,22 @@ Then, you can use the calibration postproc module::
 Now, the touches from the left screen will be within 0-0.3333 range, and the
 touches from the middle screen will be within 0.3333-0.6666 range.
 
+You can also match calibration rules to devices based on their provider type.
+This is useful when probesysfs is used to match devices. For example::
+
+    [input]
+    mtdev_%(name)s = probesysfs,provider=mtdev
+
+To apply calibration to these devices, you can match with the provider name
+enclosed by parentheses::
+
+    [postproc:calibration]
+    (mtdev) = xratio=0.3333,xoffset=0.3333
+
+Matching devices like this means the device's path doesn't need to be
+configured ahead of time. Note that with this method, all mtdev inputs will
+have the same calibration applied to them. For this reason, matching by
+provider will typically be useful only when expecting one input device.
 '''
 
 __all__ = ('InputPostprocCalibration', )
@@ -41,9 +57,13 @@ class InputPostprocCalibration(object):
     '''Recalibrate the inputs.
 
     The configuration must go within a section named `postproc:calibration`.
-    Within the section, you must have line like::
+    Within the section, you must have a line like::
 
         devicename = param=value,param=value
+
+    If you wish to match by provider, you must have a line like::
+
+        (provider) = param=value,param=value
 
     :Parameters:
         `xratio`: float

--- a/kivy/input/postproc/calibration.py
+++ b/kivy/input/postproc/calibration.py
@@ -100,8 +100,8 @@ class InputPostprocCalibration(object):
 
     def _get_provider_map(self):
         """Iterates through all registered input provider names and finds the
-        respective MotionEvent subclass for each. Returns a dict of provider
-        names mapped to their MotionEvent subclass.
+        respective MotionEvent subclass for each. Returns a dict of MotionEvent
+        subclasses mapped to their provider name.
         """
         provider_map = {}
         for input_provider in MotionEventFactory.list():
@@ -109,24 +109,21 @@ class InputPostprocCalibration(object):
                 continue
 
             p = getattr(providers, input_provider)
-            events = []
             for m in p.__all__:
-                attr = getattr(p, m)
-                if issubclass(attr, MotionEvent):
-                    events.append(attr)
-            if events:
-                provider_map[input_provider] = events
+                event = getattr(p, m)
+                if issubclass(event, MotionEvent):
+                    provider_map[event] = input_provider
+
         return provider_map
 
     def _get_provider_key(self, event):
-        """Idenitifes the provider name of a MotionEvent and returns the
-        corresponding key in self.devices if it exists.
+        """Returns the provider key for the event if the provider is configured
+        for calibration.
         """
-        for input_type, ev_class in self.provider_map.items():
-            key = '({})'.format(input_type)
-            for ec in ev_class:
-                if isinstance(event, ec) and key in self.devices:
-                    return key
+        input_type = self.provider_map.get(event.__class__)
+        key = '({})'.format(input_type)
+        if input_type and key in self.devices:
+            return key
 
     def process(self, events):
         # avoid doing any processing if there is no device to calibrate at all.


### PR DESCRIPTION
Allows users to match calibration rules to any and all devices of a particular input provider. This is useful when the name of the device is not known in advance. For example, if probesysfs is used to match an mtdev touchscreen:

`[input]`
`mtdev_%(name)s = probesysfs,provider=mtdev`

then the touchscreen can be calibrated using:

`[postproc:calibration]`
`(mtdev) = xratio=0.3333,xoffset=0.3333`

The new convention is to use parentheses to denote a provider name instead of a device.

I mainly made this change to work with https://github.com/kivy/kivy/pull/5659 to apply auto calibration to a resizable app no matter what device it is installed on.

I have only tested this PR with an mtdev touchscreen, but it should work for any input that might need calibrating.