### PR TITLE
[WIP] Make kivy.graphics.Callback available from within Kv language

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -24,6 +24,7 @@ from kivy.compat import PY2, iteritems, iterkeys
 from kivy.context import register_context
 from kivy.resources import resource_find
 from kivy._event import Observable, EventDispatcher
+from kivy.graphics import Callback as CallbackInstruction
 
 __all__ = ('Observable', 'Builder', 'BuilderBase', 'BuilderException')
 
@@ -828,6 +829,10 @@ class BuilderBase(object):
             if name == 'Clear':
                 canvas.clear()
                 continue
+            if name == 'Callback':
+                for handler in crule.handlers:
+                    _create_callback_instruction(widget, handler, idmap)
+                continue
             instr = Factory.get(name)()
             if not isinstance(instr, Instruction):
                 raise BuilderException(
@@ -916,3 +921,10 @@ if 'KIVY_PROFILE_LANG' in environ:
         print('Profiling written at builder_stats.html')
 
     atexit.register(dump_builder_stats)
+
+
+def _create_callback_instruction(widget, prule, idmap):
+    idmap = copy(idmap)
+    idmap.update(global_idmap)
+    idmap['self'] = widget.proxy_ref
+    return CallbackInstruction(partial(custom_callback, prule, idmap))


### PR DESCRIPTION
This PR is progrees of #5711. I re-created the repository so I re-create the PR. Sorry I'm bad at git command.

Hi, currently `kivy.graphics.Callback` is not available from within KvLanguage. This PR allows you to do like this:

```python3
from kivy.lang import Builder
from kivy.app import App


KV_STRING = r'''
#:import random random
#:set MESSAGE 'Kivy'

BoxLayout:
    Widget:
        canvas:
            Callback:
                on_call:  # any name that starts with 'on_' is OK
                    print('-----------------------------------')
                    print(app)
                    print(self)
                    print(root)
                    print(args)
                    print(cm)
                    print(random.random())
                    print(MESSAGE)
                    print(label)  # Can't use other widget's id. That's why this PR is WIP.
    Label:
        id: label
        text: 'Hello Kivy'
'''



class TestApp(App):
    def build(self):
        return Builder.load_string(KV_STRING)

TestApp().run()
```

```text
-----------------------------------
<__main__.TestApp object at 0x7f1777effb40>
<kivy.uix.widget.Widget object at 0x7f177855d868>
<kivy.uix.boxlayout.BoxLayout object at 0x7f1777effba8>
(<kivy.graphics.instructions.Callback object at 0x7f97505ff228>,)
<function cm at 0x7f17851d8ea0>
0.5298193401683202
Kivy
 Traceback (most recent call last):
   File "kivy/graphics/compiler.pyx", line 143, in kivy.graphics.compiler.GraphicsCompiler.compile
   File "kivy/graphics/instructions.pyx", line 482, in kivy.graphics.instructions.Callback.apply
   File "/tmp/firefox/kivy/kivy/lang/builder.py", line 65, in custom_callback
     exec(__kvlang__.co_value, idmap)
   File "<string>", line 12, in <module>
 NameError: name 'label' is not defined
 Exception ignored in: 'kivy.graphics.instructions.InstructionGroup.build'
 Traceback (most recent call last):
   File "kivy/graphics/compiler.pyx", line 143, in kivy.graphics.compiler.GraphicsCompiler.compile
   File "kivy/graphics/instructions.pyx", line 482, in kivy.graphics.instructions.Callback.apply
   File "/tmp/firefox/kivy/kivy/lang/builder.py", line 65, in custom_callback
     exec(__kvlang__.co_value, idmap)
   File "<string>", line 12, in <module>
 NameError: name 'label' is not defined
```

#2636