### PR TITLE
Added pass in build_config method of App class

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -511,7 +511,7 @@ class App(EventDispatcher):
                 Use this to add default section / key / value items
 
         '''
-	pass
+        pass
 
     def build_settings(self, settings):
         '''.. versionadded:: 1.0.7

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -511,6 +511,7 @@ class App(EventDispatcher):
                 Use this to add default section / key / value items
 
         '''
+	pass
 
     def build_settings(self, settings):
         '''.. versionadded:: 1.0.7


### PR DESCRIPTION
In _app.py_ build_config method is empty. Adding **pass** will remove the error if method is called.