### PR TITLE
[WIP] GPIOInputProvider and DialBehavior for rotary knobs

### DIFF
--- a/examples/demo/dialpong/__main__.py
+++ b/examples/demo/dialpong/__main__.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+
+from kivy.app import App
+from kivy.uix.widget import Widget
+from kivy.properties import NumericProperty, ReferenceListProperty,\
+    ObjectProperty
+from kivy.vector import Vector
+from kivy.clock import Clock
+
+from dialbehavior import DialBehavior
+
+
+def _constraint(x, min, max):
+    return min if x < min else max if x > max else x
+
+
+class PongPaddle(DialBehavior, Widget):
+    score = NumericProperty(0)
+
+    def bounce_ball(self, ball):
+        if self.collide_widget(ball):
+            vx, vy = ball.velocity
+            offset = (ball.center_y - self.center_y) / (self.height / 2)
+            bounced = Vector(-1 * vx, vy)
+            vel = bounced * 1.1
+            ball.velocity = vel.x, vel.y + offset
+
+    def on_dial(self, value):
+        self.center_y = _constraint (self.center_y + value,
+            min=self.parent.y, 
+            max=self.parent.top)
+
+class PongBall(Widget):
+    velocity_x = NumericProperty(0)
+    velocity_y = NumericProperty(0)
+    velocity = ReferenceListProperty(velocity_x, velocity_y)
+
+    def move(self):
+        self.pos = Vector(*self.velocity) + self.pos
+
+
+class PongGame(Widget):
+    ball = ObjectProperty(None)
+    player1 = ObjectProperty(None)
+    player2 = ObjectProperty(None)
+
+    def serve_ball(self, vel=(4, 0)):
+        self.ball.center = self.center
+        self.ball.velocity = vel
+
+    def update(self, dt):
+        self.ball.move()
+
+        # bounce of paddles
+        self.player1.bounce_ball(self.ball)
+        self.player2.bounce_ball(self.ball)
+
+        # bounce ball off bottom or top
+        if (self.ball.y < self.y) or (self.ball.top > self.top):
+            self.ball.velocity_y *= -1
+
+        # went of to a side to score point?
+        if self.ball.x < self.x:
+            self.player2.score += 1
+            self.serve_ball(vel=(4, 0))
+        if self.ball.x > self.width:
+            self.player1.score += 1
+            self.serve_ball(vel=(-4, 0))
+
+    def on_touch_move(self, touch):
+        if touch.x < self.width / 3:
+            self.player1.center_y = touch.y
+        if touch.x > self.width - self.width / 3:
+            self.player2.center_y = touch.y
+
+
+class PongApp(App):
+    def build(self):
+        game = PongGame()
+        game.serve_ball()
+        Clock.schedule_interval(game.update, 1.0 / 60.0)
+        return game
+
+
+def __main__():
+    PongApp().run()
+
+
+if __name__ == '__main__':
+    __main__()
+

--- a/examples/demo/dialpong/dialbehavior.py
+++ b/examples/demo/dialpong/dialbehavior.py
@@ -1,0 +1,1 @@
+/home/pi/rockberry-player/rockberry_player/widgets/dialbehavior.py

--- a/examples/demo/dialpong/pong.kv
+++ b/examples/demo/dialpong/pong.kv
@@ -1,0 +1,56 @@
+#:kivy 1.0.9
+
+<PongBall>:
+    size: 50, 50
+    canvas:
+        Ellipse:
+            pos: self.pos
+            size: self.size
+
+<PongPaddle>:
+    size: 25, 200
+    canvas:
+        Rectangle:
+            pos:self.pos
+            size:self.size
+
+<PongGame>:
+    ball: pong_ball
+    player1: player_left
+    player2: player_right
+
+    canvas:
+        Rectangle:
+            pos: self.center_x-5, 0
+            size: 10, self.height
+
+    Label:
+        font_size: 70
+        center_x: root.width / 4
+        top: root.top - 50
+        text: str(root.player1.score)
+
+    Label:
+        font_size: 70
+        center_x: root.width * 3 / 4
+        top: root.top - 50
+        text: str(root.player2.score)
+
+    PongBall:
+        id: pong_ball
+        center: self.parent.center
+
+    PongPaddle:
+        id: player_left
+        x: root.x
+        dial_step: 5
+        dial_axis: 'x'
+        center_y: root.center_y
+
+    PongPaddle:
+        id: player_right
+        x: root.width-self.width
+        dial_step: 5
+        dial_axis: 'y'
+        center_y: root.center_y
+

--- a/kivy/input/providers/__init__.py
+++ b/kivy/input/providers/__init__.py
@@ -52,6 +52,11 @@ if platform == 'linux' or 'KIVY_DOC' in os.environ:
     except:
         err = 'Input: LinuxWacom is not supported by your version of linux'
         Logger.exception(err)
+    try:
+        import kivy.input.providers.gpioinput
+    except:
+        err = 'Input: GPIOInput is not supported by your version of linux'
+        Logger.exception(err)
 
 if (platform == 'android' and not USE_SDL2) or 'KIVY_DOC' in os.environ:
     try:

--- a/kivy/input/providers/gpioinput.py
+++ b/kivy/input/providers/gpioinput.py
@@ -1,0 +1,270 @@
+# coding utf-8
+from __future__ import print_function, division
+
+'''
+Support for GPIO input from the linux kernel using gpio devtree
+==================================================
+
+To configure GPIOInput, add this to your configuration::
+
+    [input]
+    # devicename = gpioinput,/dev/input/eventXX,[accel_time=xx(ms)]
+    # example with Rotary Encoder for volume
+    volume = gpioinput,/dev/input/event2
+
+.. note::
+    You must have read access to the input event.
+
+.. versionadded:: NOT RELEASED
+
+'''
+
+__all__ = ('GPIOEventProvider', 'GPIOEvent')
+
+import os
+from collections import defaultdict
+
+from kivy.input.motionevent import MotionEvent
+from kivy.input.shape import ShapeRect
+Window = None
+
+
+class GPIOEvent(MotionEvent):
+
+    def depack(self, args):
+        super(GPIOEvent, self).depack(args)
+        for k, v in args.items():
+            self.__dict__[k] = v
+        if getattr(self, 'is_rotary', False):
+            self.profile.append('dial')
+
+    def __str__(self):
+        return '<%s id=%d device=%s>' \
+            % (self.__class__.__name__, self.id, self.device)
+
+
+if 'KIVY_DOC' in os.environ:
+    # documentation hack
+    GPIOEventProvider = None
+
+else:
+    import threading
+    import collections
+    import struct
+    import fcntl
+    from kivy.input.provider import MotionEventProvider
+    from kivy.input.factory import MotionEventFactory
+    from kivy.logger import Logger
+
+    #
+    # This part is taken from linux-source-2.6.32/include/linux/input.h
+    #
+
+    # Event types
+    EV_SYN = 0x00
+    EV_KEY = 0x01
+    EV_REL = 0x02
+    EV_ABS = 0x03
+    EV_MSC = 0x04
+    EV_SW = 0x05
+    EV_LED = 0x11
+    EV_SND = 0x12
+    EV_REP = 0x14
+    EV_FF = 0x15
+    EV_PWR = 0x16
+    EV_FF_STATUS = 0x17
+    EV_MAX = 0x1f
+    EV_CNT = (EV_MAX + 1)
+
+    KEY_MAX = 0x2ff
+
+    # Synchronization events
+    SYN_REPORT = 0
+    SYN_CONFIG = 1
+    SYN_MT_REPORT = 2
+
+    # Misc events
+    MSC_SERIAL = 0x00
+    MSC_PULSELED = 0x01
+    MSC_GESTURE = 0x02
+    MSC_RAW = 0x03
+    MSC_SCAN = 0x04
+    MSC_MAX = 0x07
+    MSC_CNT = (MSC_MAX + 1)
+
+    # Relative axis events
+    REL_X = 0x00
+    REL_Y = 0x01
+    REL_Z = 0x02
+    REL_RX = 0x03
+    REL_RY = 0x04
+    REL_RZ = 0x05
+    REL_HWHEEL = 0x06
+    REL_DIAL = 0x07
+    REL_WHEEL = 0x08
+    REL_MISC = 0x09
+    REL_MAX = 0x0f
+    REL_CNT = (REL_MAX + 1)
+
+    # some ioctl base (with 0 value)
+    EVIOCGNAME = 2147501318
+    EVIOCGBIT = 2147501344
+    EVIOCGABS = 2149074240
+
+    # Relation between rel ev_codes and axis coordinates
+    AXIS_COORDS = {
+        REL_X: 'x',
+        REL_Y: 'y',
+        REL_Z: 'z',
+        REL_RX: 'rx',
+        REL_RY: 'ry',
+        REL_RZ: 'rz',
+        REL_HWHEEL: 'hwheel',
+        REL_DIAL: 'dial',
+        REL_WHEEL: 'wheel',
+    }
+
+    # sizeof(struct input_event)
+    struct_input_event_sz = struct.calcsize('LLHHi')
+    struct_input_absinfo_sz = struct.calcsize('iiiiii')
+    sz_l = struct.calcsize('Q')
+
+    class GPIOEventProvider(MotionEventProvider):
+
+        options = {
+        }
+
+        def __init__(self, device, args):
+            super(GPIOEventProvider, self).__init__(device, args)
+            global Window
+            if Window is None:
+                from kivy.core.window import Window
+
+            self.input_fn = None
+            self.device_name = None
+
+            # Accumulated info for any axis
+            # TODO: Get REL codes from device capabilities
+            self._axis_info = {AXIS_COORDS[ev_code]: 0
+                               for ev_code in AXIS_COORDS.keys()}
+            self._pending_axis = set()
+
+            # split arguments
+            args = args.split(',')
+
+            # read filename
+            self.input_fn = args[0]
+            Logger.info('GPIOInput: Read event from <%s>' % self.input_fn)
+
+            options = dict(self.options)
+            for arg in args[1:]:
+                try:
+                    arg_name, arg_value = arg.split('=')
+                except ValueError:
+                    Logger.warning(
+                        "GPIOInput: <%s> Wrong option '%s'."
+                        % (self.device, arg))
+                    continue
+
+                if arg_name in self.options.keys():
+                    Logger.info(
+                        "GPIOInput: <%s> Set option %s to %s"
+                        % (self.device, arg_name, arg_value))
+                    options[arg_name] = arg_value
+                else:
+                    Logger.warning("GPIOInput: <%s> Option '%s' not available."
+                                   % (self.device_name, arg_name))
+                    continue
+
+            for op_name, op_value in options.iteritems():
+                self.__dict__[op_name] = op_value
+
+        def start(self):
+            if self.input_fn is None:
+                return
+            self.uid = 0
+            self.dispatch_queue = []
+            self.thread = threading.Thread(
+                target=self._thread_run,
+                kwargs=dict(
+                    input_fn=self.input_fn,
+                    device=self.device))
+            self.thread.daemon = True
+            self.thread.start()
+
+        def _thread_run(self, **kwargs):
+
+            def process_as_rotary(tv_sec, tv_usec, ev_type, ev_code, ev_value):
+
+                tv_msec = tv_sec * 1000 + tv_usec / 1000
+
+                if ev_type == EV_SYN:
+                    if ev_code == SYN_REPORT:
+                        if not self._pending_axis:
+                            return
+
+                        ev_props = {'push_attrs': list(self._pending_axis),
+                                    'is_touch': False,
+                                    'is_rotary': True}
+                        for ax_coord in self._pending_axis:
+                            ev_props[ax_coord] = self._axis_info[ax_coord]
+                            self._axis_info[ax_coord] = 0
+
+                        Logger.trace(
+                            "GPIOInput:(%0.3f) <%s>[<EV_SYN>,<SYN_REPORT>] %s"
+                            % (tv_msec / 1000, self.device, ev_props))
+
+                        self.dispatch_queue.append(
+                            GPIOEvent(self.device,
+                                      'GPIOEvent_%d' % tv_msec,
+                                      ev_props))
+                        self._pending_axis.clear()
+
+                elif ev_type == EV_REL:
+                    ax_coord = AXIS_COORDS[ev_code]
+                    self._axis_info[ax_coord] += ev_value
+                    self._pending_axis.add(ax_coord)
+
+                    Logger.trace(
+                        "GPIOInput:(%0.3f)<%s>[<EV_REL>,AXIS %d(%s),VALUE %d]"
+                        % (tv_msec / 1000, self.device, ev_code, ax_coord,
+                           ev_value))
+
+            # open the input
+            fd = open(self.input_fn, 'rb')
+
+            # get the controller name (EVIOCGNAME)
+            self.device_name = str(fcntl.ioctl(fd,
+                                               EVIOCGNAME + (256 << 16),
+                                               " " * 256)
+                                   ).split('\x00')[0]
+
+            Logger.info('GPIOEvent: using <%s> as <%s>' %
+                        (self.device_name, self.device))
+
+            # read until the end
+            while fd:
+
+                data = fd.read(struct_input_event_sz)
+                if len(data) < struct_input_event_sz:
+                    break
+
+                # extract each event
+                for i in range(int(len(data) / struct_input_event_sz)):
+                    ev = data[i * struct_input_event_sz:]
+                    # extract timeval + event infos
+                    infos = struct.unpack('LLHHi', ev[:struct_input_event_sz])
+                    process_as_rotary(*infos)
+
+        def update(self, dispatch_fn):
+            # dispatch all events from threads
+
+            try:
+                while True:
+                    me = self.dispatch_queue.pop(0)
+                    Window.dispatch('on_motion', 'begin', me)
+                    Logger.trace('GPIOEvent: dispatching %r' % me)
+            except IndexError:
+                pass
+
+    MotionEventFactory.register('gpioinput', GPIOEventProvider)

--- a/kivy/input/providers/gpioinput.py
+++ b/kivy/input/providers/gpioinput.py
@@ -24,9 +24,90 @@ __all__ = ('GPIOEventProvider', 'GPIOEvent')
 import os
 from collections import defaultdict
 
+import threading
+import collections
+import struct
+import fcntl
+from kivy.input.provider import MotionEventProvider
+from kivy.input.factory import MotionEventFactory
 from kivy.input.motionevent import MotionEvent
 from kivy.input.shape import ShapeRect
+from kivy.logger import Logger
+
 Window = None
+
+#
+# This part is taken from linux-source-2.6.32/include/linux/input.h
+#
+
+# Event types
+EV_SYN = 0x00
+EV_KEY = 0x01
+EV_REL = 0x02
+EV_ABS = 0x03
+EV_MSC = 0x04
+EV_SW = 0x05
+EV_LED = 0x11
+EV_SND = 0x12
+EV_REP = 0x14
+EV_FF = 0x15
+EV_PWR = 0x16
+EV_FF_STATUS = 0x17
+EV_MAX = 0x1f
+EV_CNT = (EV_MAX + 1)
+
+KEY_MAX = 0x2ff
+
+# Synchronization events
+SYN_REPORT = 0
+SYN_CONFIG = 1
+SYN_MT_REPORT = 2
+
+# Misc events
+MSC_SERIAL = 0x00
+MSC_PULSELED = 0x01
+MSC_GESTURE = 0x02
+MSC_RAW = 0x03
+MSC_SCAN = 0x04
+MSC_MAX = 0x07
+MSC_CNT = (MSC_MAX + 1)
+
+# Relative axis events
+REL_X = 0x00
+REL_Y = 0x01
+REL_Z = 0x02
+REL_RX = 0x03
+REL_RY = 0x04
+REL_RZ = 0x05
+REL_HWHEEL = 0x06
+REL_DIAL = 0x07
+REL_WHEEL = 0x08
+REL_MISC = 0x09
+REL_MAX = 0x0f
+REL_CNT = (REL_MAX + 1)
+
+# some ioctl base (with 0 value)
+EVIOCGNAME = 2147501318
+EVIOCGBIT = 2147501344
+EVIOCGABS = 2149074240
+
+# Relation between rel ev_codes and axis coordinates
+AXIS_COORDS = {
+    REL_X: 'x',
+    REL_Y: 'y',
+    REL_Z: 'z',
+    REL_RX: 'rx',
+    REL_RY: 'ry',
+    REL_RZ: 'rz',
+    REL_HWHEEL: 'hwheel',
+    REL_DIAL: 'dial',
+    REL_WHEEL: 'wheel',
+}
+
+# sizeof(struct input_event)
+struct_input_event_sz = struct.calcsize('LLHHi')
+struct_input_absinfo_sz = struct.calcsize('iiiiii')
+sz_l = struct.calcsize('Q')
 
 
 class GPIOEvent(MotionEvent):
@@ -43,228 +124,147 @@ class GPIOEvent(MotionEvent):
             % (self.__class__.__name__, self.id, self.device)
 
 
+class GPIOEventProvider(MotionEventProvider):
+
+    options = {
+    }
+
+    def __init__(self, device, args):
+        super(GPIOEventProvider, self).__init__(device, args)
+        global Window
+        if Window is None:
+            from kivy.core.window import Window
+
+        self.input_fn = None
+        self.device_name = None
+
+        # Accumulated info for any axis
+        # TODO: Get REL codes from device capabilities
+        self._axis_info = {AXIS_COORDS[ev_code]: 0
+                           for ev_code in AXIS_COORDS.keys()}
+        self._pending_axis = set()
+
+        # split arguments
+        args = args.split(',')
+
+        # read filename
+        self.input_fn = args[0]
+        Logger.info('GPIOInput: Read event from <%s>' % self.input_fn)
+
+        options = dict(self.options)
+        for arg in args[1:]:
+            try:
+                arg_name, arg_value = arg.split('=')
+            except ValueError:
+                Logger.warning(
+                    "GPIOInput: <%s> Wrong option '%s'."
+                    % (self.device, arg))
+                continue
+
+            if arg_name in self.options.keys():
+                Logger.info(
+                    "GPIOInput: <%s> Set option %s to %s"
+                    % (self.device, arg_name, arg_value))
+                options[arg_name] = arg_value
+            else:
+                Logger.warning("GPIOInput: <%s> Option '%s' not available."
+                               % (self.device_name, arg_name))
+                continue
+
+        for op_name, op_value in options.iteritems():
+            self.__dict__[op_name] = op_value
+
+    def start(self):
+        if self.input_fn is None:
+            return
+        self.uid = 0
+        self.dispatch_queue = []
+        self.thread = threading.Thread(
+            target=self._thread_run,
+            kwargs=dict(
+                input_fn=self.input_fn,
+                device=self.device))
+        self.thread.daemon = True
+        self.thread.start()
+
+    def _thread_run(self, **kwargs):
+
+        def process_as_rotary(tv_sec, tv_usec, ev_type, ev_code, ev_value):
+
+            tv_msec = tv_sec * 1000 + tv_usec / 1000
+
+            if ev_type == EV_SYN:
+                if ev_code == SYN_REPORT:
+                    if not self._pending_axis:
+                        return
+
+                    ev_props = {'push_attrs': list(self._pending_axis),
+                                'is_touch': False,
+                                'is_rotary': True}
+                    for ax_coord in self._pending_axis:
+                        ev_props[ax_coord] = self._axis_info[ax_coord]
+                        self._axis_info[ax_coord] = 0
+
+                    Logger.trace(
+                        "GPIOInput:(%0.3f) <%s>[<EV_SYN>,<SYN_REPORT>] %s"
+                        % (tv_msec / 1000, self.device, ev_props))
+
+                    self.dispatch_queue.append(
+                        GPIOEvent(self.device,
+                                  'GPIOEvent_%d' % tv_msec,
+                                  ev_props))
+                    self._pending_axis.clear()
+
+            elif ev_type == EV_REL:
+                ax_coord = AXIS_COORDS[ev_code]
+                self._axis_info[ax_coord] += ev_value
+                self._pending_axis.add(ax_coord)
+
+                Logger.trace(
+                    "GPIOInput:(%0.3f)<%s>[<EV_REL>,AXIS %d(%s),VALUE %d]"
+                    % (tv_msec / 1000, self.device, ev_code, ax_coord,
+                       ev_value))
+
+        # open the input
+        fd = open(self.input_fn, 'rb')
+
+        # get the controller name (EVIOCGNAME)
+        self.device_name = str(fcntl.ioctl(fd,
+                                           EVIOCGNAME + (256 << 16),
+                                           " " * 256)
+                               ).split('\x00')[0]
+
+        Logger.info('GPIOEvent: using <%s> as <%s>' %
+                    (self.device_name, self.device))
+
+        # read until the end
+        while fd:
+
+            data = fd.read(struct_input_event_sz)
+            if len(data) < struct_input_event_sz:
+                break
+
+            # extract each event
+            for i in range(int(len(data) / struct_input_event_sz)):
+                ev = data[i * struct_input_event_sz:]
+                # extract timeval + event infos
+                infos = struct.unpack('LLHHi', ev[:struct_input_event_sz])
+                process_as_rotary(*infos)
+
+    def update(self, dispatch_fn):
+        # dispatch all events from threads
+
+        try:
+            while True:
+                me = self.dispatch_queue.pop(0)
+                Window.dispatch('on_motion', 'begin', me)
+                Logger.trace('GPIOEvent: dispatching %r' % me)
+        except IndexError:
+            pass
+
+
 if 'KIVY_DOC' in os.environ:
     # documentation hack
     GPIOEventProvider = None
-
 else:
-    import threading
-    import collections
-    import struct
-    import fcntl
-    from kivy.input.provider import MotionEventProvider
-    from kivy.input.factory import MotionEventFactory
-    from kivy.logger import Logger
-
-    #
-    # This part is taken from linux-source-2.6.32/include/linux/input.h
-    #
-
-    # Event types
-    EV_SYN = 0x00
-    EV_KEY = 0x01
-    EV_REL = 0x02
-    EV_ABS = 0x03
-    EV_MSC = 0x04
-    EV_SW = 0x05
-    EV_LED = 0x11
-    EV_SND = 0x12
-    EV_REP = 0x14
-    EV_FF = 0x15
-    EV_PWR = 0x16
-    EV_FF_STATUS = 0x17
-    EV_MAX = 0x1f
-    EV_CNT = (EV_MAX + 1)
-
-    KEY_MAX = 0x2ff
-
-    # Synchronization events
-    SYN_REPORT = 0
-    SYN_CONFIG = 1
-    SYN_MT_REPORT = 2
-
-    # Misc events
-    MSC_SERIAL = 0x00
-    MSC_PULSELED = 0x01
-    MSC_GESTURE = 0x02
-    MSC_RAW = 0x03
-    MSC_SCAN = 0x04
-    MSC_MAX = 0x07
-    MSC_CNT = (MSC_MAX + 1)
-
-    # Relative axis events
-    REL_X = 0x00
-    REL_Y = 0x01
-    REL_Z = 0x02
-    REL_RX = 0x03
-    REL_RY = 0x04
-    REL_RZ = 0x05
-    REL_HWHEEL = 0x06
-    REL_DIAL = 0x07
-    REL_WHEEL = 0x08
-    REL_MISC = 0x09
-    REL_MAX = 0x0f
-    REL_CNT = (REL_MAX + 1)
-
-    # some ioctl base (with 0 value)
-    EVIOCGNAME = 2147501318
-    EVIOCGBIT = 2147501344
-    EVIOCGABS = 2149074240
-
-    # Relation between rel ev_codes and axis coordinates
-    AXIS_COORDS = {
-        REL_X: 'x',
-        REL_Y: 'y',
-        REL_Z: 'z',
-        REL_RX: 'rx',
-        REL_RY: 'ry',
-        REL_RZ: 'rz',
-        REL_HWHEEL: 'hwheel',
-        REL_DIAL: 'dial',
-        REL_WHEEL: 'wheel',
-    }
-
-    # sizeof(struct input_event)
-    struct_input_event_sz = struct.calcsize('LLHHi')
-    struct_input_absinfo_sz = struct.calcsize('iiiiii')
-    sz_l = struct.calcsize('Q')
-
-    class GPIOEventProvider(MotionEventProvider):
-
-        options = {
-        }
-
-        def __init__(self, device, args):
-            super(GPIOEventProvider, self).__init__(device, args)
-            global Window
-            if Window is None:
-                from kivy.core.window import Window
-
-            self.input_fn = None
-            self.device_name = None
-
-            # Accumulated info for any axis
-            # TODO: Get REL codes from device capabilities
-            self._axis_info = {AXIS_COORDS[ev_code]: 0
-                               for ev_code in AXIS_COORDS.keys()}
-            self._pending_axis = set()
-
-            # split arguments
-            args = args.split(',')
-
-            # read filename
-            self.input_fn = args[0]
-            Logger.info('GPIOInput: Read event from <%s>' % self.input_fn)
-
-            options = dict(self.options)
-            for arg in args[1:]:
-                try:
-                    arg_name, arg_value = arg.split('=')
-                except ValueError:
-                    Logger.warning(
-                        "GPIOInput: <%s> Wrong option '%s'."
-                        % (self.device, arg))
-                    continue
-
-                if arg_name in self.options.keys():
-                    Logger.info(
-                        "GPIOInput: <%s> Set option %s to %s"
-                        % (self.device, arg_name, arg_value))
-                    options[arg_name] = arg_value
-                else:
-                    Logger.warning("GPIOInput: <%s> Option '%s' not available."
-                                   % (self.device_name, arg_name))
-                    continue
-
-            for op_name, op_value in options.iteritems():
-                self.__dict__[op_name] = op_value
-
-        def start(self):
-            if self.input_fn is None:
-                return
-            self.uid = 0
-            self.dispatch_queue = []
-            self.thread = threading.Thread(
-                target=self._thread_run,
-                kwargs=dict(
-                    input_fn=self.input_fn,
-                    device=self.device))
-            self.thread.daemon = True
-            self.thread.start()
-
-        def _thread_run(self, **kwargs):
-
-            def process_as_rotary(tv_sec, tv_usec, ev_type, ev_code, ev_value):
-
-                tv_msec = tv_sec * 1000 + tv_usec / 1000
-
-                if ev_type == EV_SYN:
-                    if ev_code == SYN_REPORT:
-                        if not self._pending_axis:
-                            return
-
-                        ev_props = {'push_attrs': list(self._pending_axis),
-                                    'is_touch': False,
-                                    'is_rotary': True}
-                        for ax_coord in self._pending_axis:
-                            ev_props[ax_coord] = self._axis_info[ax_coord]
-                            self._axis_info[ax_coord] = 0
-
-                        Logger.trace(
-                            "GPIOInput:(%0.3f) <%s>[<EV_SYN>,<SYN_REPORT>] %s"
-                            % (tv_msec / 1000, self.device, ev_props))
-
-                        self.dispatch_queue.append(
-                            GPIOEvent(self.device,
-                                      'GPIOEvent_%d' % tv_msec,
-                                      ev_props))
-                        self._pending_axis.clear()
-
-                elif ev_type == EV_REL:
-                    ax_coord = AXIS_COORDS[ev_code]
-                    self._axis_info[ax_coord] += ev_value
-                    self._pending_axis.add(ax_coord)
-
-                    Logger.trace(
-                        "GPIOInput:(%0.3f)<%s>[<EV_REL>,AXIS %d(%s),VALUE %d]"
-                        % (tv_msec / 1000, self.device, ev_code, ax_coord,
-                           ev_value))
-
-            # open the input
-            fd = open(self.input_fn, 'rb')
-
-            # get the controller name (EVIOCGNAME)
-            self.device_name = str(fcntl.ioctl(fd,
-                                               EVIOCGNAME + (256 << 16),
-                                               " " * 256)
-                                   ).split('\x00')[0]
-
-            Logger.info('GPIOEvent: using <%s> as <%s>' %
-                        (self.device_name, self.device))
-
-            # read until the end
-            while fd:
-
-                data = fd.read(struct_input_event_sz)
-                if len(data) < struct_input_event_sz:
-                    break
-
-                # extract each event
-                for i in range(int(len(data) / struct_input_event_sz)):
-                    ev = data[i * struct_input_event_sz:]
-                    # extract timeval + event infos
-                    infos = struct.unpack('LLHHi', ev[:struct_input_event_sz])
-                    process_as_rotary(*infos)
-
-        def update(self, dispatch_fn):
-            # dispatch all events from threads
-
-            try:
-                while True:
-                    me = self.dispatch_queue.pop(0)
-                    Window.dispatch('on_motion', 'begin', me)
-                    Logger.trace('GPIOEvent: dispatching %r' % me)
-            except IndexError:
-                pass
-
     MotionEventFactory.register('gpioinput', GPIOEventProvider)

--- a/kivy/uix/behaviors/dialbehavior.py
+++ b/kivy/uix/behaviors/dialbehavior.py
@@ -1,0 +1,106 @@
+from __future__ import division
+
+from kivy.core.window import Window
+from kivy.event import EventDispatcher
+from kivy.uix.slider import Slider
+from kivy.properties import NumericProperty, OptionProperty, StringProperty
+from kivy.logger import Logger
+
+# Compatibility HACK: If GPIOInputProvider is not available
+# launch warning instead of exception
+try:
+    from kivy.input.providers.gpioinput import GPIOEvent, AXIS_COORDS
+except ImportError:
+    Logger.warning(
+        'GPIOInput: Module not found: DialBehavior is not available')
+    AXIS_COORDS = {'x': 'x', 'y': 'y'}
+
+    class GPIOEvent(object):
+        pass
+
+
+class DialBehavior(EventDispatcher):
+
+    AXIS = AXIS_COORDS.values()
+
+    dial_device = StringProperty(None, allownone=True)
+    dial_axis = OptionProperty(AXIS[0], options=AXIS)
+    dial_step = NumericProperty(1)
+    dial_accelms = NumericProperty(200)
+
+    def __init__(self, *args, **kwargs):
+        self._last_update = 0
+        self._dial_acc_value = 0
+        super(DialBehavior, self).__init__(*args, **kwargs)
+        self.register_event_type('on_dial')
+        Window.bind(on_motion=self.on_motion)
+
+    def on_motion(self, instance, evtype, event):
+        if not isinstance(event, GPIOEvent):
+            return False
+
+        Logger.trace('%s: on_motion: evtype=%r event=%r' %
+                     (self.__class__.__name__, evtype, event))
+
+        # Filter on event conditions
+        if ('dial' not in event.profile or
+                (self.dial_device and self.dial_device != event.device) or
+                (self.dial_axis and self.dial_axis not in event.push_attrs)):
+            return False
+
+        # Dial value received on the event for axis 'dial_axis' (+1/-1)
+        dial_raw_value = getattr(event, self.dial_axis)
+
+        # Reset accumulated value if direction changed or accel timeout
+        if ((self._dial_acc_value * dial_raw_value < 0) or
+                (event.time_update - self._last_update >
+                    self.dial_accelms / 1000)):
+            self._dial_acc_value = 0
+
+        self._dial_acc_value += dial_raw_value
+        self._last_update = event.time_update
+
+        dial_value = self._dial_acc_value * self.dial_step
+
+        Logger.debug(
+            '%s: on_motion: dispatching on_dial(axis=%s, value=%d)' %
+            (self.__class__.__name__, self.dial_axis, dial_value))
+        self.dispatch('on_dial', dial_value)
+
+        return False
+
+    def on_dial(self, value):
+        pass
+
+    @staticmethod
+    def constraint(x, min, max):
+        return min if x < min else max if x > max else x
+
+
+class DialSlider(DialBehavior, Slider):
+
+    def on_dial(self, dial):
+        self.value = self.constraint(
+            self.value + dial,
+            self.min,
+            self.max)
+
+
+if __name__ == '__main__':
+    import kivy
+    kivy.require('1.9.2')
+    from kivy.base import runTouchApp
+    from kivy.lang import Builder
+
+    Builder.load_string("""
+
+<DialSlider>:
+    dial_axis: 'x'
+    size_hint_y: 0.1
+    min: 0
+    max: 200
+    value: 100
+
+    """)
+
+    runTouchApp(widget=DialSlider())


### PR DESCRIPTION
The purpose of this PR is to discuss about the expansion of HIDInputProvider (or new provider) to handle REL events produced by a discrete knob (through the linux rotary-encoder driver).

There's an ongoing conversation on [kivy-dev mailing list](https://groups.google.com/forum/#!topic/kivy-dev/dg8HG2ap6dM) about how to better integrate it on current kivy input system.

Of course names of objects, properties and events are provisional.
I've added a use case into 'examples/demo/dialpong' which adds knob control to the popular pong tutorial example (knob with axis 'x' for player1 and knob with axis 'y' for player 2)