### PR TITLE
Let the Inspector browse into WeakProxy'd widgets

### DIFF
--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -82,6 +82,7 @@ from kivy.properties import ObjectProperty, BooleanProperty, ListProperty, \
 from kivy.graphics.texture import Texture
 from kivy.clock import Clock
 from kivy.lang import Builder
+from kivy.weakproxy import WeakProxy
 
 
 Builder.load_string('''
@@ -530,7 +531,11 @@ class Inspector(FloatLayout):
         keys = list(widget.properties().keys())
         keys.sort()
         node = None
-        wk_widget = weakref.ref(widget)
+        if type(widget) is WeakProxy:
+            wk_widget = widget.__ref__
+            widget = wk_widget()
+        else:
+            wk_widget = weakref.ref(widget)
         for key in keys:
             node = TreeViewProperty(key=key, widget_ref=wk_widget)
             node.bind(is_selected=self.show_property)

--- a/kivy/modules/inspector.py
+++ b/kivy/modules/inspector.py
@@ -533,7 +533,6 @@ class Inspector(FloatLayout):
         node = None
         if type(widget) is WeakProxy:
             wk_widget = widget.__ref__
-            widget = wk_widget()
         else:
             wk_widget = weakref.ref(widget)
         for key in keys:


### PR DESCRIPTION
When a widget has an ObjectProperty and it's filled with another widget in kv-lang, this actually results in a ``kivy.weakproxy.WeakProxy`` to the object being created. The inspector doesn't quite know how to handle those, and will crash if you try to browse them directly. This PR changes the behavior of the inspector so that instead of inspecting the ``WeakProxy``, it will inspect the underlying widget, although it will still show up as a ``WeakProxy`` in the ``TreeView``.