### PR TITLE
Updated camera_opencv.py to use reshape(-1) instead of tostring()

### DIFF
--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -138,9 +138,11 @@ class CameraOpenCV(CameraBase):
             try:
                 self._buffer = frame.imageData
             except AttributeError:
-                # On OSX there is no imageData attribute but a tostring()
+                # On OSX/Linux there is no imageData attribute but a tostring()
                 # method.
-                self._buffer = frame.tostring()
+                # frame is already of type ndarray which can be reshaped to 1-d.
+                # Either frame.tostring() or frame.tobytes() is slow.
+                self._buffer = frame.reshape(-1)
             self._copy_to_gpu()
         except:
             Logger.exception('OpenCV: Couldn\'t get image from Camera')

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -138,10 +138,7 @@ class CameraOpenCV(CameraBase):
             try:
                 self._buffer = frame.imageData
             except AttributeError:
-                # On OSX/Linux there is no imageData attribute but a tostring()
-                # method.
                 # frame is already of type ndarray which can be reshaped to 1-d.
-                # Either frame.tostring() or frame.tobytes() is slow.
                 self._buffer = frame.reshape(-1)
             self._copy_to_gpu()
         except:


### PR DESCRIPTION
Replaced frame.tostring() with frame.reshape(-1) to remove unnecessary overhead.
The following simple benchmark shows the overhead of tostring()/tobytes() are significant compared with reshape(-1).
```python
from time import time
import cv2 

cap = cv2.VideoCapture(0)
ret, frame = cap.read()

tic = time()
for _ in range(1000):
    string = frame.tostring()

toc = time()
print(f"frame.tostring() takes {toc - tic:.3f}s")


tic = time()
for _ in range(1000):
    bytes = frame.tobytes()

toc = time()
print(f"frame.tobytes() takes {toc - tic:.3f}s")


tic = time()
for _ in range(1000):
    string = frame.reshape(-1)

toc = time()
print(f"frame.reshape(-1) takes {toc - tic:.3f}s")
```

On a 6-core machine (i7-6850K/Ubuntu 16.04), the output results are as follows:
```
frame.tostring() takes 0.088s
frame.tobytes() takes 0.059s
frame.reshape(-1) takes 0.001s
```