### PR TITLE
Fix odd behaviour while kivy.modules.touchring is active

### DIFF
--- a/kivy/modules/touchring.py
+++ b/kivy/modules/touchring.py
@@ -91,8 +91,8 @@ def start(win, ctx):
         window=win,
         pointer_scale=float(config_get('scale', 1.0)),
         pointer_alpha=float(config_get('alpha', 1.0)),
-        pointer_image=Image(config_get('image',
-                                       'atlas://data/images/defaulttheme/ring')),
+        pointer_image=Image(
+            config_get('image', 'atlas://data/images/defaulttheme/ring')),
     )
     win.bind(on_touch_down=widget.on_touch_down_window,
              on_touch_move=widget.on_touch_move_window)

--- a/kivy/modules/touchring.py
+++ b/kivy/modules/touchring.py
@@ -31,67 +31,75 @@ __all__ = ('start', 'stop')
 
 from kivy.core.image import Image
 from kivy.graphics import Color, Rectangle
-from kivy import kivy_data_dir
-from os.path import join
-
-pointer_image = None
-pointer_scale = 1.0
-pointer_alpha = 0.7
+from kivy.uix.widget import Widget
+from kivy.properties import ObjectProperty, NumericProperty
 
 
-def _touch_down(win, touch):
-    ud = touch.ud
-    with win.canvas.after:
-        ud['tr.color'] = Color(1, 1, 1, pointer_alpha)
-        iw, ih = pointer_image.size
-        ud['tr.rect'] = Rectangle(
-            pos=(
-                touch.x - (pointer_image.width / 2. * pointer_scale),
-                touch.y - (pointer_image.height / 2. * pointer_scale)),
-            size=(iw * pointer_scale, ih * pointer_scale),
-            texture=pointer_image.texture)
+class TouchRingWidget(Widget):
+    '''This widget will not be added to the widget tree. Only using for touch
+    handler'''
+    window = ObjectProperty()
+    pointer_image = ObjectProperty()
+    pointer_alpha = NumericProperty()
+    pointer_scale = NumericProperty()
 
-    if not ud.get('tr.grab', False):
-        ud['tr.grab'] = True
-        touch.grab(win)
-
-
-def _touch_move(win, touch):
-    ud = touch.ud
-    if not ud.get('tr.rect', False):
-        _touch_down(win, touch)
-    ud['tr.rect'].pos = (
-        touch.x - (pointer_image.width / 2. * pointer_scale),
-        touch.y - (pointer_image.height / 2. * pointer_scale))
-
-
-def _touch_up(win, touch):
-    if touch.grab_current is win:
+    def on_touch_down_window(self, window, touch):
         ud = touch.ud
-        win.canvas.after.remove(ud['tr.color'])
-        win.canvas.after.remove(ud['tr.rect'])
+        pointer_image = self.pointer_image
+        pointer_scale = self.pointer_scale
+        with window.canvas.after:
+            ud['tr.color'] = Color(1, 1, 1, self.pointer_alpha)
+            iw, ih = pointer_image.size
+            ud['tr.rect'] = Rectangle(
+                pos=(
+                    touch.x - (pointer_image.width / 2. * pointer_scale),
+                    touch.y - (pointer_image.height / 2. * pointer_scale)),
+                size=(iw * pointer_scale, ih * pointer_scale),
+                texture=pointer_image.texture)
+
+        if not ud.get('tr.grab', False):
+            ud['tr.grab'] = True
+            touch.grab(self)
+
+    def on_touch_move_window(self, window, touch):
+        if not touch.ud.get('tr.rect', False):
+            self.on_touch_down_window(window, touch)
+
+    def on_touch_move(self, touch):
+        assert touch.grab_current is self
+        pointer_image = self.pointer_image
+        pointer_scale = self.pointer_scale
+        touch.ud['tr.rect'].pos = (
+            touch.x - (pointer_image.width / 2. * pointer_scale),
+            touch.y - (pointer_image.height / 2. * pointer_scale))
+
+    def on_touch_up(self, touch):
+        assert touch.grab_current is self
+        ud = touch.ud
+        remove = self.window.canvas.after.remove
+        remove(ud['tr.color'])
+        remove(ud['tr.rect'])
 
         if ud.get('tr.grab') is True:
-            touch.ungrab(win)
+            touch.ungrab(self)
             ud['tr.grab'] = False
 
 
 def start(win, ctx):
-    # XXX use ctx !
-    global pointer_image, pointer_scale, pointer_alpha
-
-    pointer_fn = ctx.config.get('image',
-                                'atlas://data/images/defaulttheme/ring')
-    pointer_scale = float(ctx.config.get('scale', 1.0))
-    pointer_alpha = float(ctx.config.get('alpha', 1.0))
-    pointer_image = Image(pointer_fn)
-
-    win.bind(on_touch_down=_touch_down,
-             on_touch_move=_touch_move,
-             on_touch_up=_touch_up)
+    config_get = ctx.config.get
+    widget = TouchRingWidget(
+        window=win,
+        pointer_scale=float(config_get('scale', 1.0)),
+        pointer_alpha=float(config_get('alpha', 1.0)),
+        pointer_image=Image(config_get('image',
+                                       'atlas://data/images/defaulttheme/ring')),
+    )
+    win.bind(on_touch_down=widget.on_touch_down_window,
+             on_touch_move=widget.on_touch_move_window)
+    ctx.widget = widget
 
 
 def stop(win, ctx):
-    win.unbind(on_touch_down=_touch_down,
-               on_touch_move=_touch_move,
-               on_touch_up=_touch_up)
+    widget = ctx.widget
+    win.unbind(on_touch_down=widget.on_touch_down_window,
+               on_touch_move=widget.on_touch_move_window)

--- a/kivy/modules/touchring.py
+++ b/kivy/modules/touchring.py
@@ -66,7 +66,6 @@ class TouchRingWidget(Widget):
             self.on_touch_down_window(window, touch)
 
     def on_touch_move(self, touch):
-        assert touch.grab_current is self
         pointer_image = self.pointer_image
         pointer_scale = self.pointer_scale
         touch.ud['tr.rect'].pos = (
@@ -74,7 +73,6 @@ class TouchRingWidget(Widget):
             touch.y - (pointer_image.height / 2. * pointer_scale))
 
     def on_touch_up(self, touch):
-        assert touch.grab_current is self
         ud = touch.ud
         remove = self.window.canvas.after.remove
         remove(ud['tr.color'])

--- a/kivy/tests/test_module_touchring.py
+++ b/kivy/tests/test_module_touchring.py
@@ -1,0 +1,90 @@
+import unittest
+from kivy.config import Config
+Config.set('modules', 'touchring', '')
+from kivy.app import runTouchApp, stopTouchApp
+from kivy.clock import Clock
+from kivy.factory import Factory
+from kivy.tests.common import UnitTestTouch
+
+
+class TouchCounter(Factory.Widget):
+
+    def __init__(self, **kwargs):
+        super(TouchCounter, self).__init__(**kwargs)
+        self.n_down = 0
+        self.n_move = 0
+        self.n_up = 0
+
+    def on_touch_down(self, touch):
+        self.n_down += 1
+        return super(TouchCounter, self).on_touch_down(touch)
+
+    def on_touch_move(self, touch):
+        self.n_move += 1
+        return super(TouchCounter, self).on_touch_move(touch)
+
+    def on_touch_up(self, touch):
+        self.n_up += 1
+        return super(TouchCounter, self).on_touch_up(touch)
+
+
+class TouchCountTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.root = TouchCounter()
+
+    def tearDown(self):
+        root = self.root
+        root.parent.remove_widget(root)
+
+    def assertTouchCount(self, touchcounter, n_down, n_move, n_up):
+        self.assertEqual(touchcounter.n_down, n_down)
+        self.assertEqual(touchcounter.n_move, n_move)
+        self.assertEqual(touchcounter.n_up, n_up)
+
+    def test_single_touch(self):
+        root = self.root
+
+        def func(dt):
+            self.assertTouchCount(root, 0, 0, 0)
+            touch = UnitTestTouch(0, 0)
+
+            touch.touch_down()
+            self.assertTouchCount(root, 1, 0, 0)
+            touch.touch_move(20, 20)
+            self.assertTouchCount(root, 1, 1, 0)
+            touch.touch_up()
+            self.assertTouchCount(root, 1, 1, 1)
+
+            stopTouchApp()
+
+        Clock.schedule_once(func, 0)
+        runTouchApp(root)
+
+    def test_multiple_touch(self):
+        root = self.root
+
+        def func(dt):
+            self.assertTouchCount(root, 0, 0, 0)
+            touch1 = UnitTestTouch(0, 0)
+            touch2 = UnitTestTouch(100, 100)
+
+            touch1.touch_down()
+            self.assertTouchCount(root, 1, 0, 0)
+            touch2.touch_down()
+            self.assertTouchCount(root, 2, 0, 0)
+            touch2.touch_move(30, 30)
+            self.assertTouchCount(root, 2, 1, 0)
+            touch1.touch_move(20, 20)
+            self.assertTouchCount(root, 2, 2, 0)
+            touch2.touch_move(200, 200)
+            self.assertTouchCount(root, 2, 3, 0)
+            touch2.touch_up()
+            self.assertTouchCount(root, 2, 3, 1)
+            touch1.touch_up()
+            self.assertTouchCount(root, 2, 3, 2)
+
+            stopTouchApp()
+
+        Clock.schedule_once(func, 0)
+        runTouchApp(root)


### PR DESCRIPTION
Hi, I think `kivy.modules.touchring` has some issues.

# Issue 1
While `TouchRing` is active, `on_touch_move` and `on_touch_up` are doubled.

```python3
from kivy.config import Config
Config.set('modules', 'touchring', '')
from kivy.app import runTouchApp
from kivy.factory import Factory
from kivy.clock import Clock
from kivy.tests.common import UnitTestTouch


def simulate_touch(dt):
    touch = UnitTestTouch(0, 0)
    touch.touch_down()
    touch.touch_move(1, 1)
    touch.touch_up()


Clock.schedule_once(simulate_touch, 0)


runTouchApp(Factory.Widget(
    on_touch_down=lambda __, touch: print('on_touch_down', touch.grab_current),
    on_touch_move=lambda __, touch: print('on_touch_move', touch.grab_current),
    on_touch_up=lambda __, touch: print('on_touch_up', touch.grab_current),
))

```

```text
on_touch_down None
on_touch_move None
on_touch_move <kivy.core.window.window_sdl2.WindowSDL object at 0x7f40f578ece0>
on_touch_up None
on_touch_up <kivy.core.window.window_sdl2.WindowSDL object at 0x7f40f578ece0>
```

This is because `_touch_move()` and `touch_up()` in the code below do not return True when `touch.grab_current is win`

https://github.com/kivy/kivy/blob/267da41decb49b1eb43f15050719b418581980f7/kivy/modules/touchring.py#L59-L76

# Issue 2

If there is another module that does `touch.grab(window)` at the same time, the program behave unexpectedly. 

```python
from kivy.config import Config
Config.set('modules', 'touchring', '')
from kivy.app import runTouchApp
from kivy.lang import Builder
from kivy.core.window import Window


def _touch_down(window, touch):
    ud = touch.ud
    if not ud.get('another_grab', False):
        ud['another_grab'] = True
        touch.grab(window)


def _touch_move(window, touch):
    if touch.grab_current is window:
        return True


def _touch_up(window, touch):
    if touch.grab_current is window:
        ud = touch.ud
        if ud.get('another_grab', False):
            touch.ungrab(window)
            ud['another_grab'] = False
        return True


def on_active_changed(switch, active):
    window = switch.get_root_window()
    if active:
        window.bind(
            on_touch_down=_touch_down,
            on_touch_move=_touch_move,
            on_touch_up=_touch_up,
        )
    else:
        window.unbind(
            on_touch_down=_touch_down,
            on_touch_move=_touch_move,
            on_touch_up=_touch_up,
        )


root = Builder.load_string('''
Widget:
    Switch:
        id: switch
''')
switch = root.ids.switch
switch.bind(active=on_active_changed)
runTouchApp(root)
```

Rings don't disappear while switch is active.

![screenshot at 2018-08-30 07-32-16](https://user-images.githubusercontent.com/26050135/44819249-22a8f400-ac27-11e8-9350-a185cdcf9f13.png)

In the first place, is `touch.grab(window)` safe? I don't think so because there is no guarantee that `touchring` is the only one who does `touch.grab(window)`. The argument of `touch.grab()` should be your own widget instance.