### PR TITLE
Fix Doc 'Input Management'

### DIFF
--- a/doc/sources/guide/inputs.rst
+++ b/doc/sources/guide/inputs.rst
@@ -241,9 +241,6 @@ are some limitations to grabbing:
     - You might receive an event with a grabbed touch, but not from you: it can be
       because the parent has sent the touch to its children while it was in
       the grabbed state.
-    - The touch coordinate is not translated to your widget space because the
-      touch is coming directly from the Window. It's your job to convert the
-      coordinate to your local space.
 
 Here is an example of how to use grabbing::
 


### PR DESCRIPTION
Hi, the documentation says:

> The touch coordinate is not translated to your widget space because the touch is coming directly from the Window. It's your job to convert the coordinate to your local space.

but that's not correct.

https://github.com/kivy/kivy/blob/267da41decb49b1eb43f15050719b418581980f7/kivy/base.py#L254-L261

```python
from kivy.lang import Builder
from kivy.factory import Factory
from kivy.app import runTouchApp


class Grabber(Factory.Widget):

    def on_touch_down(self, touch):
        touch.grab(self)
        return True

    def on_touch_move(self, touch):
        if touch.grab_current is self:
            print('on_touch_move()', touch.pos, 'grab')
            return True
        else:
            print('on_touch_move()', touch.pos)

    def on_touch_up(self, touch):
        if touch.grab_current is self:
            print('on_touch_up()', touch.pos, 'grab')
            touch.ungrab(self)
            return True
        else:
            print('on_touch_up():', touch.pos)


root = Builder.load_string('''
BoxLayout:
    Widget:
    RelativeLayout:
        Grabber:
''')

runTouchApp(root)
```

```text
on_touch_move() (72.0, 345.0)
on_touch_move() (72.0, 345.0) grab
on_touch_move() (70.0, 343.99999999999994)
on_touch_move() (70.0, 343.99999999999994) grab
on_touch_up(): (70.0, 343.99999999999994)
on_touch_up() (70.0, 343.99999999999994) grab
```

The coordinates of grab-touch is same as non-grabbed-touch.