### PR TITLE
Repair power consumption on android

### DIFF
--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -116,4 +116,7 @@ class Camera(Image):
         if value:
             self._camera.start()
         else:
-            self._camera._release_camera() 
+            if hasattr(self._camera,"_release_camera")
+                self._camera._release_camera()
+            else:
+                self._camera.stop()

--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -116,4 +116,4 @@ class Camera(Image):
         if value:
             self._camera.start()
         else:
-            self._camera.stop()
+            self._camera._release_camera() 

--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -116,7 +116,7 @@ class Camera(Image):
         if value:
             self._camera.start()
         else:
-            if hasattr(self._camera,"_release_camera")
+            if hasattr(self._camera,"_release_camera"):
                 self._camera._release_camera()
             else:
                 self._camera.stop()


### PR DESCRIPTION
set play to False Can not reduce power consumption，i found self._camera.stop() doesn't release the camera object，the camera object still running in the background and consume a lot of power，change stop() to _release_camera()  can repair it.