### PR TITLE
Set android camera to autofocus

### DIFF
--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -67,6 +67,7 @@ class CameraAndroid(CameraBase):
         self._android_camera.setPreviewTexture(self._surface_texture)
 
         self._fbo = Fbo(size=self._resolution)
+        self._fbo['resolution'] = (float(width),float(height))
         self._fbo.shader.fs = '''
             #extension GL_OES_EGL_image_external : require
             #ifdef GL_ES
@@ -80,9 +81,11 @@ class CameraAndroid(CameraBase):
             /* uniform texture samplers */
             uniform sampler2D texture0;
             uniform samplerExternalOES texture1;
+            uniform vec2 resolution;
 
             void main()
             {
+                vec2 coord = vec2(tex_coord0.y*(resolution.y/resolution.x),1.-tex_coord0.x);
                 gl_FragColor = texture2D(texture1, tex_coord0);
             }
         '''

--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -50,6 +50,7 @@ class CameraAndroid(CameraBase):
         params = self._android_camera.getParameters()
         width, height = self._resolution
         params.setPreviewSize(width, height)
+        params.setFocusMode('continuous-picture')
         self._android_camera.setParameters(params)
         # self._android_camera.setDisplayOrientation()
         self.fps = 30.


### PR DESCRIPTION
This change makes the Camera widget on Android to autofocus. This avoids the blurry images that appear when using this widget.