### PR TITLE
Change order of CGL backend to prefer dynamic GL symbol loading

### DIFF
--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -56,7 +56,7 @@ cpdef cgl_get_backend_name():
     if name:
         return name.lower()
 
-    for name in ('glew', 'gl', 'sdl2', 'mock'):
+    for name in ('glew', 'sdl2', 'gl', 'mock'):
         mod = importlib.import_module("kivy.graphics.cgl_backend.cgl_{}".format(name))
         if mod.is_backend_supported():
             return name


### PR DESCRIPTION
Some issues are due to bad or old OpenGL drivers that misses few GL symbol (like glGetFramebufferAttachmentParameteriv on #5348).

Symbol like that are not used directly by Kivy, so it is safe not to required them. Our static compilation failed at the loading time if GL symbol is missing.

By switching to dynamic GL loader (cgl_sdl2), it will break if the symbol is used. That's actually better, as you can in the app check if the symbol is not NULL (that's what is done in game engine usually).

Closes #5348 
Closes #4459