### PR TITLE
Fix 5783 carousel looping

### DIFF
--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -438,27 +438,21 @@ class Carousel(StencilView):
         if self._skip_slide is not None or index is None:
             return
 
-        if direction[0] == 'r':
-            if _offset <= -width:
-                index += 1
-            if _offset >= width:
-                index -= 1
-        if direction[0] == 'l':
-            if _offset <= -width:
-                index -= 1
-            if _offset >= width:
-                index += 1
-        if direction[0] == 't':
-            if _offset <= - height:
-                index += 1
-            if _offset >= height:
-                index -= 1
-        if direction[0] == 'b':
-            if _offset <= -height:
-                index -= 1
-            if _offset >= height:
-                index += 1
-        self.index = index
+        # Move to next slide?
+        if (direction[0] == 'r' and _offset <= -width) or \
+                (direction[0] == 'l' and _offset >= width) or \
+                (direction[0] == 't' and _offset <= - height) or \
+                (direction[0] == 'b' and _offset >= height):
+            if self.next_slide:
+                self.index += 1
+
+        # Move to previous slide?
+        if (direction[0] == 'r' and _offset >= width) or \
+                (direction[0] == 'l' and _offset <= -width) or \
+                (direction[0] == 't' and _offset >= height) or \
+                (direction[0] == 'b' and _offset <= -height):
+            if self.previous_slide:
+                self.index -= 1
 
     def _start_animation(self, *args, **kwargs):
         # compute target offset for ease back, next or prev


### PR DESCRIPTION
Fix for issue https://github.com/kivy/kivy/issues/5783

When dragging a slide (e.g. when direction is 'right')

1.  (in _position_visible_slides) If too far left, check if the next slide should be shown on the right. If so, show it
2.  (in on__offset) If too far left, check if we should switch to the next slide. If so, change the index

The first test, already checked for _loop. The second test didn't check for _loop, so always switches

self.previous_slide and self.next_slide will only be set if there is a prev/next slide, and already takes looping into account. So that's what I used to check whether we can switch