### PR TITLE
Issue 5945

### DIFF
--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -37,7 +37,7 @@ class VideoBase(EventDispatcher):
             Action to take when EOS is hit. Can be one of 'pause', 'stop' or
             'loop'.
 
-            .. versionchanged:: unknown
+            .. versionchanged:: 1.4.0
                 added 'pause'
 
         `async`: bool, defaults to True

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -201,7 +201,6 @@ class Video(Image):
             if self.eos:
                 self._video.stop()
                 self._video.position = 0.
-                self._video.eos = False
             self.eos = False
             self._video.play()
         elif value == 'pause':
@@ -209,7 +208,6 @@ class Video(Image):
         else:
             self._video.stop()
             self._video.position = 0
-            self._video.eos = False
 
     def _on_video_frame(self, *largs):
         video = self._video


### PR DESCRIPTION
This fixes the management of the "eos" setting of the underlying CoreVideo object, that was previously set to `False`, whenever the video was stopped.