### PR TITLE
Fix Cython properties syntax

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,4 +1,4 @@
-Cython>=0.23
+Cython>=0.24
 # Frozen Sphinx requirements for easier pip installation
 sphinxcontrib-actdiag
 sphinxcontrib-blockdiag

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -145,9 +145,9 @@ cdef class Observable(ObjectWithUid):
             except KeyError:
                 pass
 
-    property proxy_ref:
-        def __get__(self):
-            return self
+    @property
+    def proxy_ref(self):
+        return self
 
 
 cdef class EventDispatcher(ObjectWithUid):
@@ -888,12 +888,12 @@ cdef class EventDispatcher(ObjectWithUid):
             self.__properties[name] = prop
             setattr(self.__class__, name, prop)
 
-    property proxy_ref:
+    @property
+    def proxy_ref(self):
         '''Default implementation of proxy_ref, returns self.
         .. versionadded:: 1.9.0
         '''
-        def __get__(self):
-            return self
+        return self
 
 
 cdef class BoundCallback:

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -649,11 +649,11 @@ cdef class _WindowSDL2Storage:
     def grab_mouse(self, grab):
         SDL_SetWindowGrab(self.win, SDL_TRUE if grab else SDL_FALSE)
 
-    property window_size:
-        def __get__(self):
-            cdef int w, h
-            SDL_GetWindowSize(self.win, &w, &h)
-            return [w, h]
+    @property
+    def window_size(self):
+        cdef int w, h
+        SDL_GetWindowSize(self.win, &w, &h)
+        return [w, h]
 
 
 # Based on the example at

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -111,17 +111,21 @@ cdef class PushState(ContextInstruction):
         ContextInstruction.__init__(self, **kwargs)
         self.context_push = list(args)
 
-    property state:
-        def __get__(self):
-            return ','.join(self.context_push)
-        def __set__(self, value):
-            self.context_push = value.split(',')
+    @property
+    def state(self):
+        return ','.join(self.context_push)
 
-    property states:
-        def __get__(self):
-            return self.context_push
-        def __set__(self, value):
-            self.context_push = list(value)
+    @state.setter
+    def state(self, value):
+        self.context_push = value.split(',')
+
+    @property
+    def states(self):
+        return self.context_push
+
+    @states.setter
+    def states(self, value):
+        self.context_push = list(value)
 
 
 cdef class ChangeState(ContextInstruction):
@@ -134,11 +138,13 @@ cdef class ChangeState(ContextInstruction):
         ContextInstruction.__init__(self, **kwargs)
         self.context_state.update(**kwargs)
 
-    property changes:
-        def __get__(self):
-            return self.context_state
-        def __set__(self, value):
-            self.context_state = dict(value)
+    @property
+    def changes(self):
+        return self.context_state
+
+    @changes.setter
+    def changes(self, value):
+        self.context_state = dict(value)
 
 
 cdef class PopState(ContextInstruction):
@@ -151,17 +157,21 @@ cdef class PopState(ContextInstruction):
         ContextInstruction.__init__(self, **kwargs)
         self.context_pop = list(args)
 
-    property state:
-        def __get__(self):
-            return ','.join(self.context_pop)
-        def __set__(self, value):
-            self.context_pop = value.split(',')
+    @property
+    def state(self):
+        return ','.join(self.context_pop)
 
-    property states:
-        def __get__(self):
-            return self.context_pop
-        def __set__(self, value):
-            self.context_pop = list(value)
+    @state.setter
+    def state(self, value):
+        self.context_pop = value.split(',')
+
+    @property
+    def states(self):
+        return self.context_pop
+
+    @states.setter
+    def states(self, value):
+        self.context_pop = list(value)
 
 
 cdef class Color(ContextInstruction):
@@ -253,76 +263,105 @@ cdef class Color(ContextInstruction):
             if property_name in kwargs:
                 setattr(self, property_name, kwargs[property_name])
 
-    property rgba:
+    @property
+    def rgba(self):
         '''RGBA color, list of 4 values in 0-1 range.
         '''
-        def __get__(self):
-            return self.context_state['color']
-        def __set__(self, rgba):
-            self.set_state('color', [float(x) for x in rgba])
-    property rgb:
+        return self.context_state['color']
+
+    @rgba.setter
+    def rgba(self, rgba):
+        self.set_state('color', [float(x) for x in rgba])
+
+    @property
+    def rgb(self):
         '''RGB color, list of 3 values in 0-1 range. The alpha will be 1.
         '''
-        def __get__(self):
-            return self.rgba[:-1]
-        def __set__(self, rgb):
-            self.rgba = (rgb[0], rgb[1], rgb[2], 1.0)
-    property r:
+        return self.rgba[:-1]
+
+    @rgb.setter
+    def rgb(self, rgb):
+        self.rgba = (rgb[0], rgb[1], rgb[2], 1.0)
+
+    @property
+    def r(self):
         '''Red component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.rgba[0]
-        def __set__(self, r):
-            self.rgba = [r, self.g, self.b, self.a]
-    property g:
+        return self.rgba[0]
+
+    @r.setter
+    def r(self, r):
+        self.rgba = [r, self.g, self.b, self.a]
+
+    @property
+    def g(self):
         '''Green component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.rgba[1]
-        def __set__(self, g):
-            self.rgba = [self.r, g, self.b, self.a]
-    property b:
+        return self.rgba[1]
+
+    @g.setter
+    def g(self, g):
+        self.rgba = [self.r, g, self.b, self.a]
+
+    @property
+    def b(self):
         '''Blue component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.rgba[2]
-        def __set__(self, b):
-            self.rgba = [self.r, self.g, b, self.a]
-    property a:
+        return self.rgba[2]
+
+    @b.setter
+    def b(self, b):
+        self.rgba = [self.r, self.g, b, self.a]
+
+    @property
+    def a(self):
         '''Alpha component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.rgba[3]
-        def __set__(self, a):
-            self.rgba = [self.r, self.g, self.b, a]
-    property hsv:
+        return self.rgba[3]
+
+    @a.setter
+    def a(self, a):
+        self.rgba = [self.r, self.g, self.b, a]
+
+    @property
+    def hsv(self):
         '''HSV color, list of 3 values in 0-1 range, alpha will be 1.
         '''
-        def __get__(self):
-            return rgb_to_hsv(self.r, self.g, self.b)
-        def __set__(self, x):
-            self.rgb = hsv_to_rgb(x[0], x[1], x[2])
-    property h:
+        return rgb_to_hsv(self.r, self.g, self.b)
+
+    @hsv.setter
+    def hsv(self, x):
+        self.rgb = hsv_to_rgb(x[0], x[1], x[2])
+
+    @property
+    def h(self):
         '''Hue component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.hsv[0]
-        def __set__(self, x):
-            self.hsv = [x, self.s, self.v]
-    property s:
+        return self.hsv[0]
+
+    @h.setter
+    def h(self, x):
+        self.hsv = [x, self.s, self.v]
+
+    @property
+    def s(self):
         '''Saturation component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.hsv[1]
-        def __set__(self, x):
-            self.hsv = [self.h, x, self.v]
-    property v:
+        return self.hsv[1]
+
+    @s.setter
+    def s(self, x):
+        self.hsv = [self.h, x, self.v]
+
+    @property
+    def v(self):
         '''Value component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.hsv[2]
-        def __set__(self, x):
-            self.hsv = [self.h, self.s, x]
+        return self.hsv[2]
+
+    @v.setter
+    def v(self, x):
+        self.hsv = [self.h, self.s, x]
 
 
 cdef class BindTexture(ContextInstruction):
@@ -351,41 +390,47 @@ cdef class BindTexture(ContextInstruction):
         cdef RenderContext context = self.get_context()
         context.set_texture(self._index, self._texture)
 
-    property texture:
-        def __get__(self):
-            return self._texture
-        def __set__(self, object texture):
-            if texture is None:
-                texture = get_default_texture()
-            if self._texture is texture:
-                return
-            self._texture = texture
-            self.flag_update()
+    @property
+    def texture(self):
+        return self._texture
 
-    property index:
-        def __get__(self):
-            return self._index
-        def __set__(self, int index):
-            if self._index == index:
-                return
-            self._index = index
-            self.flag_update()
+    @texture.setter
+    def texture(self, object texture):
+        if texture is None:
+            texture = get_default_texture()
+        if self._texture is texture:
+            return
+        self._texture = texture
+        self.flag_update()
 
-    property source:
+    @property
+    def index(self):
+        return self._index
+
+    @index.setter
+    def index(self, int index):
+        if self._index == index:
+            return
+        self._index = index
+        self.flag_update()
+
+    @property
+    def source(self):
         '''Set/get the source (filename) to load for the texture.
         '''
-        def __get__(self):
-            return self._source
-        def __set__(self, filename):
-            self._source = resource_find(filename)
-            if self._source:
-                tex = Cache.get('kv.texture', filename)
-                if not tex:
-                    tex = Image(self._source).texture
-                    Cache.append('kv.texture', filename, tex)
-                self.texture = tex
-            else:
-                self.texture = None
+        return self._source
+
+    @source.setter
+    def source(self, filename):
+        self._source = resource_find(filename)
+        if self._source:
+            tex = Cache.get('kv.texture', filename)
+            if not tex:
+                tex = Image(self._source).texture
+                Cache.append('kv.texture', filename, tex)
+            self.texture = tex
+        else:
+            self.texture = None
 
 
 cdef double radians(double degrees):
@@ -401,17 +446,19 @@ cdef class LoadIdentity(ContextInstruction):
     def __init__(self, **kwargs):
         self.stack = kwargs.get('stack', 'modelview_mat')
 
-    property stack:
+    @property
+    def stack(self):
         '''Name of the matrix stack to use. Can be 'modelview_mat',
         'projection_mat' or 'frag_modelview_mat'.
         '''
-        def __get__(self):
-            if PY2:
-                return self.context_state.keys()[0]
-            else:
-                return list(self.context_state.keys())[0]
-        def __set__(self, value):
-            self.context_state = {value: Matrix()}
+        if PY2:
+            return self.context_state.keys()[0]
+        else:
+            return list(self.context_state.keys())[0]
+
+    @stack.setter
+    def stack(self, value):
+        self.context_state = {value: Matrix()}
 
 
 cdef class PushMatrix(ContextInstruction):
@@ -421,17 +468,19 @@ cdef class PushMatrix(ContextInstruction):
         ContextInstruction.__init__(self, **kwargs)
         self.stack = kwargs.get('stack', 'modelview_mat')
 
-    property stack:
+    @property
+    def stack(self):
         '''Name of the matrix stack to use. Can be 'modelview_mat',
         'projection_mat' or 'frag_modelview_mat'.
 
         .. versionadded:: 1.6.0
         '''
-        def __get__(self):
-            return self.context_push[0]
-        def __set__(self, value):
-            value = value or 'modelview_mat'
-            self.context_push = [value]
+        return self.context_push[0]
+
+    @stack.setter
+    def stack(self, value):
+        value = value or 'modelview_mat'
+        self.context_push = [value]
 
 
 cdef class PopMatrix(ContextInstruction):
@@ -441,17 +490,19 @@ cdef class PopMatrix(ContextInstruction):
         ContextInstruction.__init__(self, **kwargs)
         self.stack = kwargs.get('stack', 'modelview_mat')
 
-    property stack:
+    @property
+    def stack(self):
         '''Name of the matrix stack to use. Can be 'modelview_mat',
         'projection_mat' or 'frag_modelview_mat'.
 
         .. versionadded:: 1.6.0
         '''
-        def __get__(self):
-            return self.context_push[0]
-        def __set__(self, value):
-            value = value or 'modelview_mat'
-            self.context_pop = [value]
+        return self.context_push[0]
+
+    @stack.setter
+    def stack(self, value):
+        value = value or 'modelview_mat'
+        self.context_pop = [value]
 
 
 cdef class ApplyContextMatrix(ContextInstruction):
@@ -470,27 +521,31 @@ cdef class ApplyContextMatrix(ContextInstruction):
         m = m.multiply(context.get_state(self._source_stack))
         context.set_state(self._target_stack, m)
 
-    property target_stack:
+    @property
+    def target_stack(self):
         '''Name of the matrix stack to use as a target.
         Can be 'modelview_mat', 'projection_mat' or 'frag_modelview_mat'.
 
         .. versionadded:: 1.6.0
         '''
-        def __get__(self):
-            return self._target_stack
-        def __set__(self, value):
-            self._target_stack = value or 'modelview_mat'
+        return self._target_stack
 
-    property source_stack:
+    @target_stack.setter
+    def target_stack(self, value):
+        self._target_stack = value or 'modelview_mat'
+
+    @property
+    def source_stack(self):
         '''Name of the matrix stack to use as a source.
         Can be 'modelview_mat', 'projection_mat' or 'frag_modelview_mat'.
 
         .. versionadded:: 1.6.0
         '''
-        def __get__(self):
-            return self._source_stack
-        def __set__(self, value):
-            self._source_stack = value or 'modelview_mat'
+        return self._source_stack
+
+    @source_stack.setter
+    def source_stack(self, value):
+        self._source_stack = value or 'modelview_mat'
 
 
 cdef class UpdateNormalMatrix(ContextInstruction):
@@ -524,30 +579,34 @@ cdef class MatrixInstruction(ContextInstruction):
         mvm = context.get_state(self._stack)
         context.set_state(self._stack, mvm.multiply(self.matrix))
 
-    property matrix:
+    @property
+    def matrix(self):
         ''' Matrix property. Matrix from the transformation module.
         Setting the matrix using this property when a change is made
         is important because it will notify the context about the update.
         '''
-        def __get__(self):
-            if self._matrix == None:
-                self._matrix = Matrix()
-            return self._matrix
-        def __set__(self, x):
-            self._matrix = x
-            self.flag_update()
+        if self._matrix == None:
+            self._matrix = Matrix()
+        return self._matrix
 
-    property stack:
+    @matrix.setter
+    def matrix(self, x):
+        self._matrix = x
+        self.flag_update()
+
+    @property
+    def stack(self):
         '''Name of the matrix stack to use. Can be 'modelview_mat',
         'projection_mat' or 'frag_modelview_mat'.
 
         .. versionadded:: 1.6.0
         '''
-        def __get__(self):
-            return self._stack
-        def __set__(self, value):
-            value = value or "modelview_mat"
-            self._stack = value
+        return self._stack
+
+    @stack.setter
+    def stack(self, value):
+        value = value or "modelview_mat"
+        self._stack = value
 
 
 cdef class Transform(MatrixInstruction):
@@ -647,43 +706,49 @@ cdef class Rotate(Transform):
         matrix = matrix.multiply(Matrix().translate(-ox, -oy, -oz))
         self.matrix = matrix
 
-    property angle:
+    @property
+    def angle(self):
         '''Property for getting/setting the angle of the rotation.
         '''
-        def __get__(self):
-            return self._angle
-        def __set__(self, a):
-            self._angle = a
-            self.compute()
+        return self._angle
 
-    property axis:
+    @angle.setter
+    def angle(self, a):
+        self._angle = a
+        self.compute()
+
+    @property
+    def axis(self):
         '''Property for getting/setting the axis of the rotation.
 
         The format of the axis is (x, y, z).
         '''
-        def __get__(self):
-            return self._axis
-        def __set__(self, axis):
-            self._axis = axis
-            self.compute()
+        return self._axis
 
-    property origin:
+    @axis.setter
+    def axis(self, axis):
+        self._axis = axis
+        self.compute()
+
+    @property
+    def origin(self):
         '''Origin of the rotation.
 
         .. versionadded:: 1.7.0
 
         The format of the origin can be either (x, y) or (x, y, z).
         '''
-        def __get__(self):
-            return self._origin
-        def __set__(self, origin):
-            if len(origin) == 3:
-                self._origin = tuple(origin)
-            elif len(origin) == 2:
-                self._origin = (origin[0], origin[1], 0.)
-            else:
-                raise Exception('invalid number of components in origin')
-            self.compute()
+        return self._origin
+
+    @origin.setter
+    def origin(self, origin):
+        if len(origin) == 3:
+            self._origin = tuple(origin)
+        elif len(origin) == 2:
+            self._origin = (origin[0], origin[1], 0.)
+        else:
+            raise Exception('invalid number of components in origin')
+        self.compute()
 
 
 cdef class Scale(Transform):
@@ -733,83 +798,95 @@ cdef class Scale(Transform):
         matrix = matrix.multiply(Matrix().translate(-ox, -oy, -oz))
         self.matrix = matrix
 
-    property scale:
+    @property
+    def scale(self):
         '''Property for getting/setting the scale.
 
         .. deprecated:: 1.6.0
             Deprecated in favor of per axis scale properties x,y,z, xyz, etc.
         '''
-        def __get__(self):
-            if self._x == self._y == self._z:
-                Logger.warning("scale property is deprecated, use xyz, x, " +\
-                    "y, z, etc properties to get scale factor based on axis.")
-                return self._x
-            else:
-                raise Exception("trying to access deprecated property" +\
-                    " 'scale' on Scale instruction with non uniform scaling!")
-
-        def __set__(self, s):
+        if self._x == self._y == self._z:
             Logger.warning("scale property is deprecated, use xyz, x, " +\
                 "y, z, etc properties to get scale factor based on axis.")
-            self.set_scale(s,s,s)
+            return self._x
+        else:
+            raise Exception("trying to access deprecated property" +\
+                " 'scale' on Scale instruction with non uniform scaling!")
 
-    property x:
+
+    @scale.setter
+    def scale(self, s):
+        Logger.warning("scale property is deprecated, use xyz, x, " +\
+            "y, z, etc properties to get scale factor based on axis.")
+        self.set_scale(s,s,s)
+
+    @property
+    def x(self):
         '''Property for getting/setting the scale on the X axis.
 
         .. versionchanged:: 1.6.0
         '''
-        def __get__(self):
-            return self._x
-        def __set__(self, double x):
-            self.set_scale(x, self._y, self._z)
+        return self._x
 
-    property y:
+    @x.setter
+    def x(self, double x):
+        self.set_scale(x, self._y, self._z)
+
+    @property
+    def y(self):
         '''Property for getting/setting the scale on the Y axis.
 
         .. versionchanged:: 1.6.0
         '''
-        def __get__(self):
-            return self._y
-        def __set__(self, double y):
-            self.set_scale(self._x, y, self._z)
+        return self._y
 
-    property z:
+    @y.setter
+    def y(self, double y):
+        self.set_scale(self._x, y, self._z)
+
+    @property
+    def z(self):
         '''Property for getting/setting the scale on Z axis.
 
         .. versionchanged:: 1.6.0
         '''
-        def __get__(self):
-            return self._z
-        def __set__(self, double z):
-            self.set_scale(self._x, self._y, z)
+        return self._z
 
-    property xyz:
+    @z.setter
+    def z(self, double z):
+        self.set_scale(self._x, self._y, z)
+
+    @property
+    def xyz(self):
         '''3 tuple scale vector in 3D in x, y, and z axis.
 
         .. versionchanged:: 1.6.0
         '''
-        def __get__(self):
-            return self._x, self._y, self._z
-        def __set__(self, c):
-            self.set_scale(c[0], c[1], c[2])
+        return self._x, self._y, self._z
 
-    property origin:
+    @xyz.setter
+    def xyz(self, c):
+        self.set_scale(c[0], c[1], c[2])
+
+    @property
+    def origin(self):
         '''Origin of the scale.
 
         .. versionadded:: 1.9.0
 
         The format of the origin can be either (x, y) or (x, y, z).
         '''
-        def __get__(self):
-            return self._origin
-        def __set__(self, origin):
-            if len(origin) == 3:
-                self._origin = tuple(origin)
-            elif len(origin) == 2:
-                self._origin = (origin[0], origin[1], 0.)
-            else:
-                raise Exception('invalid number of components in origin')
-            self.set_scale(self._x, self._y, self._z)
+        return self._origin
+
+    @origin.setter
+    def origin(self, origin):
+        if len(origin) == 3:
+            self._origin = tuple(origin)
+        elif len(origin) == 2:
+            self._origin = (origin[0], origin[1], 0.)
+        else:
+            raise Exception('invalid number of components in origin')
+        self.set_scale(self._x, self._y, self._z)
 
 
 cdef class Translate(Transform):
@@ -836,44 +913,54 @@ cdef class Translate(Transform):
         self._y = y
         self._z = z
 
-    property x:
+    @property
+    def x(self):
         '''Property for getting/setting the translation on the X axis.
         '''
-        def __get__(self):
-            return self._x
-        def __set__(self, double x):
-            self.set_translate(x, self._y, self._z)
+        return self._x
 
-    property y:
+    @x.setter
+    def x(self, double x):
+        self.set_translate(x, self._y, self._z)
+
+    @property
+    def y(self):
         '''Property for getting/setting the translation on the Y axis.
         '''
-        def __get__(self):
-            return self._y
-        def __set__(self, double y):
-            self.set_translate(self._x, y, self._z)
+        return self._y
 
-    property z:
+    @y.setter
+    def y(self, double y):
+        self.set_translate(self._x, y, self._z)
+
+    @property
+    def z(self):
         '''Property for getting/setting the translation on the Z axis.
         '''
-        def __get__(self):
-            return self._z
-        def __set__(self, double z):
-            self.set_translate(self._x, self._y, z)
+        return self._z
 
-    property xy:
+    @z.setter
+    def z(self, double z):
+        self.set_translate(self._x, self._y, z)
+
+    @property
+    def xy(self):
         '''2 tuple with translation vector in 2D for x and y axis.
         '''
-        def __get__(self):
-            return self._x, self._y
-        def __set__(self, c):
-            self.set_translate(c[0], c[1], self._z)
+        return self._x, self._y
 
-    property xyz:
+    @xy.setter
+    def xy(self, c):
+        self.set_translate(c[0], c[1], self._z)
+
+    @property
+    def xyz(self):
         '''3 tuple translation vector in 3D in x, y, and z axis.
         '''
-        def __get__(self):
-            return self._x, self._y, self._z
-        def __set__(self, c):
-            self.set_translate(c[0], c[1], c[2])
+        return self._x, self._y, self._z
+
+    @xyz.setter
+    def xyz(self, c):
+        self.set_translate(c[0], c[1], c[2])
 
 

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -406,58 +406,62 @@ cdef class Fbo(RenderContext):
                 continue
 
 
-    property size:
+    @property
+    def size(self):
         '''Size of the framebuffer, in (width, height) format.
 
         If you change the size, the framebuffer content will be lost.
         '''
-        def __get__(self):
-            return (self._width, self._height)
-        def __set__(self, x):
-            cdef int w, h
-            w, h = x
-            if w == self._width and h == self._height:
-                return
-            self._width, self._height = x
-            self.delete_fbo()
-            self.create_fbo()
-            self.flag_update()
+        return (self._width, self._height)
 
-    property clear_color:
+    @size.setter
+    def size(self, x):
+        cdef int w, h
+        w, h = x
+        if w == self._width and h == self._height:
+            return
+        self._width, self._height = x
+        self.delete_fbo()
+        self.create_fbo()
+        self.flag_update()
+
+    @property
+    def clear_color(self):
         '''Clear color in (red, green, blue, alpha) format.
         '''
-        def __get__(self):
-            return (self._clear_color[0],
-                    self._clear_color[1],
-                    self._clear_color[2],
-                    self._clear_color[3])
-        def __set__(self, x):
-            x = list(x)
-            if len(x) != 4:
-                raise Exception('clear_color must be a list/tuple of 4 entry.')
-            self._clear_color[0] = x[0]
-            self._clear_color[1] = x[1]
-            self._clear_color[2] = x[2]
-            self._clear_color[3] = x[3]
+        return (self._clear_color[0],
+                self._clear_color[1],
+                self._clear_color[2],
+                self._clear_color[3])
 
-    property texture:
+    @clear_color.setter
+    def clear_color(self, x):
+        x = list(x)
+        if len(x) != 4:
+            raise Exception('clear_color must be a list/tuple of 4 entry.')
+        self._clear_color[0] = x[0]
+        self._clear_color[1] = x[1]
+        self._clear_color[2] = x[2]
+        self._clear_color[3] = x[3]
+
+    @property
+    def texture(self):
         '''Return the framebuffer texture
         '''
-        def __get__(self):
-            return self._texture
+        return self._texture
 
-    property pixels:
+    @property
+    def pixels(self):
         '''Get the pixels texture, in RGBA format only, unsigned byte. The
         origin of the image is at bottom left.
 
         .. versionadded:: 1.7.0
         '''
-        def __get__(self):
-            w, h = self._width, self._height
-            self.bind()
-            data = py_glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE)
-            self.release()
-            return data
+        w, h = self._width, self._height
+        self.bind()
+        data = py_glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE)
+        self.release()
+        return data
 
     cpdef get_pixel_color(self, int wx, int wy):
         """Get the color of the pixel with specified window

--- a/kivy/graphics/gl_instructions.pyx
+++ b/kivy/graphics/gl_instructions.pyx
@@ -52,68 +52,80 @@ cdef class ClearColor(Instruction):
         cgl.glClearColor(self.r, self.g, self.b, self.a)
         return 0
 
-    property rgba:
+    @property
+    def rgba(self):
         '''RGBA color used for the clear color, a list of 4 values in the 0-1
         range.
         '''
-        def __get__(self):
-            return [self.r, self.b, self.g, self.a]
-        def __set__(self, rgba):
-            cdef list clear_color = [float(x) for x in rgba]
-            self.r = clear_color[0]
-            self.g = clear_color[1]
-            self.b = clear_color[2]
-            self.a = clear_color[3]
-            self.flag_update()
+        return [self.r, self.b, self.g, self.a]
 
-    property rgb:
+    @rgba.setter
+    def rgba(self, rgba):
+        cdef list clear_color = [float(x) for x in rgba]
+        self.r = clear_color[0]
+        self.g = clear_color[1]
+        self.b = clear_color[2]
+        self.a = clear_color[3]
+        self.flag_update()
+
+    @property
+    def rgb(self):
         '''RGB color, a list of 3 values in 0-1 range where alpha will be 1.
         '''
-        def __get__(self):
-            return [self.r, self.g, self.b]
-        def __set__(self, rgb):
-            cdef list clear_color = [float(x) for x in rgb]
-            self.r = clear_color[0]
-            self.g = clear_color[1]
-            self.b = clear_color[2]
-            self.a = 1
-            self.flag_update()
+        return [self.r, self.g, self.b]
 
-    property r:
+    @rgb.setter
+    def rgb(self, rgb):
+        cdef list clear_color = [float(x) for x in rgb]
+        self.r = clear_color[0]
+        self.g = clear_color[1]
+        self.b = clear_color[2]
+        self.a = 1
+        self.flag_update()
+
+    @property
+    def r(self):
         '''Red component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.r
-        def __set__(self, r):
-            self.r = r
-            self.flag_update()
+        return self.r
 
-    property g:
+    @r.setter
+    def r(self, r):
+        self.r = r
+        self.flag_update()
+
+    @property
+    def g(self):
         '''Green component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.g
-        def __set__(self, g):
-            self.g = g
-            self.flag_update()
+        return self.g
 
-    property b:
+    @g.setter
+    def g(self, g):
+        self.g = g
+        self.flag_update()
+
+    @property
+    def b(self):
         '''Blue component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.b
-        def __set__(self, b):
-            self.b = b
-            self.flag_update()
+        return self.b
 
-    property a:
+    @b.setter
+    def b(self, b):
+        self.b = b
+        self.flag_update()
+
+    @property
+    def a(self):
         '''Alpha component, between 0 and 1.
         '''
-        def __get__(self):
-            return self.a
-        def __set__(self, a):
-            self.a = a
-            self.flag_update()
+        return self.a
+
+    @a.setter
+    def a(self, a):
+        self.a = a
+        self.flag_update()
 
 
 cdef class ClearBuffers(Instruction):
@@ -146,35 +158,41 @@ cdef class ClearBuffers(Instruction):
         cgl.glClear(mask)
         return 0
 
-    property clear_color:
+    @property
+    def clear_color(self):
         '''If True, the color buffer will be cleared.
         '''
-        def __get__(self):
-            return self.clear_color
-        def __set__(self, value):
-            value = int(value)
-            if value == self.clear_color:
-                return
-            self.clear_color = value
+        return self.clear_color
 
-    property clear_stencil:
+    @clear_color.setter
+    def clear_color(self, value):
+        value = int(value)
+        if value == self.clear_color:
+            return
+        self.clear_color = value
+
+    @property
+    def clear_stencil(self):
         '''If True, the stencil buffer will be cleared.
         '''
-        def __get__(self):
-            return self.clear_stencil
-        def __set__(self, value):
-            value = int(value)
-            if value == self.clear_stencil:
-                return
-            self.clear_stencil = value
+        return self.clear_stencil
 
-    property clear_depth:
+    @clear_stencil.setter
+    def clear_stencil(self, value):
+        value = int(value)
+        if value == self.clear_stencil:
+            return
+        self.clear_stencil = value
+
+    @property
+    def clear_depth(self):
         '''If True, the depth buffer will be cleared.
         '''
-        def __get__(self):
-            return self.clear_depth
-        def __set__(self, value):
-            value = int(value)
-            if value == self.clear_depth:
-                return
-            self.clear_depth = value
+        return self.clear_depth
+
+    @clear_depth.setter
+    def clear_depth(self, value):
+        value = int(value)
+        if value == self.clear_depth:
+            return
+        self.clear_depth = value

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -100,13 +100,14 @@ cdef class Instruction(ObjectWithUid):
         self.flags &= ~GI_NO_APPLY_ONCE
         self.flags &= ~GI_IGNORE
 
-    property needs_redraw:
-        def __get__(self):
-            if (self.flags & GI_NEEDS_UPDATE) > 0:
-                return True
-            return False
+    @property
+    def needs_redraw(self):
+        if (self.flags & GI_NEEDS_UPDATE) > 0:
+            return True
+        return False
 
-    property proxy_ref:
+    @property
+    def proxy_ref(self):
         '''Return a proxy reference to the Instruction i.e. without creating a
         reference of the widget. See `weakref.proxy
         <http://docs.python.org/2/library/weakref.html?highlight=proxy#weakref.proxy>`_
@@ -114,10 +115,9 @@ cdef class Instruction(ObjectWithUid):
 
         .. versionadded:: 1.7.2
         '''
-        def __get__(self):
-            if self.__proxy_ref is None:
-                self.__proxy_ref = proxy(self)
-            return self.__proxy_ref
+        if self.__proxy_ref is None:
+            self.__proxy_ref = proxy(self)
+        return self.__proxy_ref
 
 
 cdef class InstructionGroup(Instruction):
@@ -308,7 +308,8 @@ cdef class VertexInstruction(Instruction):
         instr.set_parent(None)
         self.set_parent(None)
 
-    property texture:
+    @property
+    def texture(self):
         '''Property that represents the texture used for drawing this
         Instruction. You can set a new texture like this::
 
@@ -321,18 +322,20 @@ cdef class VertexInstruction(Instruction):
         Usually, you will use the :attr:`source` attribute instead of the
         texture.
         '''
-        def __get__(self):
-            return self.texture_binding.texture
-        def __set__(self, _tex):
-            cdef Texture tex = _tex
-            self.texture_binding.texture = tex
-            if tex:
-                self.tex_coords = tex.tex_coords
-            else:
-                self.tex_coords = [0.0,0.0, 1.0,0.0, 1.0,1.0, 0.0,1.0]
-            self.flag_update()
+        return self.texture_binding.texture
 
-    property source:
+    @texture.setter
+    def texture(self, _tex):
+        cdef Texture tex = _tex
+        self.texture_binding.texture = tex
+        if tex:
+            self.tex_coords = tex.tex_coords
+        else:
+            self.tex_coords = [0.0,0.0, 1.0,0.0, 1.0,1.0, 0.0,1.0]
+        self.flag_update()
+
+    @property
+    def source(self):
         '''This property represents the filename to load the texture from.
         If you want to use an image as source, do it like this::
 
@@ -356,13 +359,15 @@ cdef class VertexInstruction(Instruction):
             :func:`kivy.resources.resource_find` function.
 
         '''
-        def __get__(self):
-            return self.texture_binding.source
-        def __set__(self, source):
-            self.texture_binding.source = source
-            self.texture = self.texture_binding._texture
+        return self.texture_binding.source
 
-    property tex_coords:
+    @source.setter
+    def source(self, source):
+        self.texture_binding.source = source
+        self.texture = self.texture_binding._texture
+
+    @property
+    def tex_coords(self):
         '''This property represents the texture coordinates used for drawing the
         vertex instruction. The value must be a list of 8 values.
 
@@ -384,21 +389,22 @@ cdef class VertexInstruction(Instruction):
             the texture coordinates to be faster.
 
         '''
-        def __get__(self):
-            return (
-                self._tex_coords[0],
-                self._tex_coords[1],
-                self._tex_coords[2],
-                self._tex_coords[3],
-                self._tex_coords[4],
-                self._tex_coords[5],
-                self._tex_coords[6],
-                self._tex_coords[7])
-        def __set__(self, tc):
-            cdef int index
-            for index in xrange(8):
-                self._tex_coords[index] = tc[index]
-            self.flag_update()
+        return (
+            self._tex_coords[0],
+            self._tex_coords[1],
+            self._tex_coords[2],
+            self._tex_coords[3],
+            self._tex_coords[4],
+            self._tex_coords[5],
+            self._tex_coords[6],
+            self._tex_coords[7])
+
+    @tex_coords.setter
+    def tex_coords(self, tc):
+        cdef int index
+        for index in xrange(8):
+            self._tex_coords[index] = tc[index]
+        self.flag_update()
 
     cdef void build(self):
         pass
@@ -523,29 +529,33 @@ cdef class Callback(Instruction):
         self._shader.use()
         return 0
 
-    property reset_context:
+    @property
+    def reset_context(self):
         '''Set this to True if you want to reset the OpenGL context for Kivy
         after the callback has been called.
         '''
-        def __get__(self):
-            return self._reset_context
-        def __set__(self, value):
-            cdef int ivalue = int(value)
-            if self._reset_context == ivalue:
-                return
-            self._reset_context = ivalue
-            self.flag_update()
+        return self._reset_context
 
-    property callback:
+    @reset_context.setter
+    def reset_context(self, value):
+        cdef int ivalue = int(value)
+        if self._reset_context == ivalue:
+            return
+        self._reset_context = ivalue
+        self.flag_update()
+
+    @property
+    def callback(self):
         '''Property for getting/setting func.
         '''
-        def __get__(self):
-            return self.func
-        def __set__(self, object func):
-            if self.func == func:
-                return
-            self.func = func
-            self.flag_update()
+        return self.func
+
+    @callback.setter
+    def callback(self, object func):
+        if self.func == func:
+            return
+        self.func = func
+        self.flag_update()
 
 
 cdef class CanvasBase(InstructionGroup):
@@ -648,44 +658,45 @@ cdef class Canvas(CanvasBase):
         '''
         self.flag_update()
 
-    property before:
+    @property
+    def before(self):
         '''Property for getting the 'before' group.
         '''
-        def __get__(self):
-            if self._before is None:
-                self._before = CanvasBase()
-                self.insert(0, self._before)
-            return self._before
+        if self._before is None:
+            self._before = CanvasBase()
+            self.insert(0, self._before)
+        return self._before
 
-    property after:
+    @property
+    def after(self):
         '''Property for getting the 'after' group.
         '''
-        def __get__(self):
-            cdef CanvasBase c
-            if self._after is None:
-                c = CanvasBase()
-                self.add(c)
-                self._after = c
-            return self._after
+        cdef CanvasBase c
+        if self._after is None:
+            c = CanvasBase()
+            self.add(c)
+            self._after = c
+        return self._after
 
-    property has_before:
+    @property
+    def has_before(self):
         '''Property to see if the :attr:`before` group has already been created.
 
         .. versionadded:: 1.7.0
         '''
-        def __get__(self):
-            return self._before is not None
+        return self._before is not None
 
-    property has_after:
+    @property
+    def has_after(self):
         '''Property to see if the :attr:`after` group has already been created.
 
         .. versionadded:: 1.7.0
         '''
-        def __get__(self):
-            return self._after is not None
+        return self._after is not None
 
 
-    property opacity:
+    @property
+    def opacity(self):
         '''Property to get/set the opacity value of the canvas.
 
         .. versionadded:: 1.4.1
@@ -703,11 +714,12 @@ cdef class Canvas(CanvasBase):
             frag_color = color * vec4(1.0, 1.0, 1.0, opacity);
 
         '''
-        def __get__(self):
-            return self._opacity
-        def __set__(self, value):
-            self._opacity = value
-            self.flag_update()
+        return self._opacity
+
+    @opacity.setter
+    def opacity(self, value):
+        self._opacity = value
+        self.flag_update()
 
 # Active Canvas and getActiveCanvas function is used
 # by instructions, so they know which canvas to add
@@ -899,13 +911,14 @@ cdef class RenderContext(Canvas):
     def __getitem__(self, key):
         return self._shader.uniform_values[key]
 
-    property shader:
+    @property
+    def shader(self):
         '''Return the shader attached to the render context.
         '''
-        def __get__(self):
-            return self._shader
+        return self._shader
 
-    property use_parent_projection:
+    @property
+    def use_parent_projection(self):
         '''If True, the parent projection matrix will be used.
 
         .. versionadded:: 1.7.0
@@ -918,15 +931,17 @@ cdef class RenderContext(Canvas):
 
             rc = RenderContext(use_parent_projection=True)
         '''
-        def __get__(self):
-            return bool(self._use_parent_projection)
-        def __set__(self, value):
-            cdef cvalue = int(bool(value))
-            if self._use_parent_projection != cvalue:
-                self._use_parent_projection = cvalue
-                self.flag_update()
+        return bool(self._use_parent_projection)
 
-    property use_parent_modelview:
+    @use_parent_projection.setter
+    def use_parent_projection(self, value):
+        cdef cvalue = int(bool(value))
+        if self._use_parent_projection != cvalue:
+            self._use_parent_projection = cvalue
+            self.flag_update()
+
+    @property
+    def use_parent_modelview(self):
         '''If True, the parent modelview matrix will be used.
 
         .. versionadded:: 1.7.0
@@ -939,28 +954,31 @@ cdef class RenderContext(Canvas):
 
             rc = RenderContext(use_parent_modelview=True)
         '''
-        def __get__(self):
-            return bool(self._use_parent_modelview)
-        def __set__(self, value):
-            cdef cvalue = int(bool(value))
-            if self._use_parent_modelview != cvalue:
-                self._use_parent_modelview = cvalue
-                self.flag_update()
+        return bool(self._use_parent_modelview)
 
-    property use_parent_frag_modelview:
+    @use_parent_modelview.setter
+    def use_parent_modelview(self, value):
+        cdef cvalue = int(bool(value))
+        if self._use_parent_modelview != cvalue:
+            self._use_parent_modelview = cvalue
+            self.flag_update()
+
+    @property
+    def use_parent_frag_modelview(self):
         '''If True, the parent fragment modelview matrix will be used.
 
         .. versionadded:: 1.10.1
 
             rc = RenderContext(use_parent_frag_modelview=True)
         '''
-        def __get__(self):
-            return bool(self._use_parent_frag_modelview)
-        def __set__(self, value):
-            cdef cvalue = int(bool(value))
-            if self._use_parent_frag_modelview != cvalue:
-                self._use_parent_frag_modelview = cvalue
-                self.flag_update()
+        return bool(self._use_parent_frag_modelview)
+
+    @use_parent_frag_modelview.setter
+    def use_parent_frag_modelview(self, value):
+        cdef cvalue = int(bool(value))
+        if self._use_parent_frag_modelview != cvalue:
+            self._use_parent_frag_modelview = cvalue
+            self.flag_update()
 
 
 cdef RenderContext ACTIVE_CONTEXT = None

--- a/kivy/graphics/scissor_instructions.pyx
+++ b/kivy/graphics/scissor_instructions.pyx
@@ -77,13 +77,13 @@ cdef class ScissorStack:
     def __init__(self):
         self._stack = []
 
-    property empty:
-        def __get__(self):
-            return True if len(self._stack) is 0 else False
+    @property
+    def empty(self):
+        return True if len(self._stack) is 0 else False
 
-    property back:
-        def __get__(self):
-            return self._stack[-1]
+    @property
+    def back(self):
+        return self._stack[-1]
 
     def push(self, element):
         self._stack.append(element)
@@ -110,53 +110,65 @@ cdef class ScissorPush(Instruction):
     cdef int _height
     cdef Rect _rect
 
-    property x:
-        def __get__(self):
-            return self._x
-        def __set__(self, value):
-            self._x = value
-            self._rect = Rect(self._x, self._y, self._width, self._height)
-            self.flag_update()
+    @property
+    def x(self):
+        return self._x
 
-    property y:
-        def __get__(self):
-            return self._y
-        def __set__(self, value):
-            self._y = value
-            self._rect = Rect(self._x, self._y, self._width, self._height)
-            self.flag_update()
+    @x.setter
+    def x(self, value):
+        self._x = value
+        self._rect = Rect(self._x, self._y, self._width, self._height)
+        self.flag_update()
 
-    property width:
-        def __get__(self):
-            return self._width
-        def __set__(self, value):
-            self._width = value
-            self._rect = Rect(self._x, self._y, self._width, self._height)
-            self.flag_update()
+    @property
+    def y(self):
+        return self._y
 
-    property height:
-        def __get__(self):
-            return self._height
-        def __set__(self, value):
-            self._height = value
-            self._rect = Rect(self._x, self._y, self._width, self._height)
-            self.flag_update()
+    @y.setter
+    def y(self, value):
+        self._y = value
+        self._rect = Rect(self._x, self._y, self._width, self._height)
+        self.flag_update()
 
-    property pos:
-        def __get__(self):
-            return self._x, self._y
-        def __set__(self, value):
-            self._x, self._y = value
-            self._rect = Rect(self._x, self._y, self._width, self._height)
-            self.flag_update()
+    @property
+    def width(self):
+        return self._width
 
-    property size:
-        def __get__(self):
-            return self._width, self._height
-        def __set__(self, value):
-            self._width, self._height = value
-            self._rect = Rect(self._x, self._y, self._width, self._height)
-            self.flag_update()
+    @width.setter
+    def width(self, value):
+        self._width = value
+        self._rect = Rect(self._x, self._y, self._width, self._height)
+        self.flag_update()
+
+    @property
+    def height(self):
+        return self._height
+
+    @height.setter
+    def height(self, value):
+        self._height = value
+        self._rect = Rect(self._x, self._y, self._width, self._height)
+        self.flag_update()
+
+    @property
+    def pos(self):
+        return self._x, self._y
+
+    @pos.setter
+    def pos(self, value):
+        self._x, self._y = value
+        self._rect = Rect(self._x, self._y, self._width, self._height)
+        self.flag_update()
+
+    @property
+    def size(self):
+        return self._width, self._height
+
+    @size.setter
+    def size(self, value):
+        self._width, self._height = value
+        self._rect = Rect(self._x, self._y, self._width, self._height)
+        self.flag_update()
 
     def __init__(self, **kwargs):
         self._x, self._y = kwargs.pop(

--- a/kivy/graphics/shader.pyx
+++ b/kivy/graphics/shader.pyx
@@ -642,7 +642,8 @@ cdef class Shader:
     # Python access
     #
 
-    property source:
+    @property
+    def source(self):
         '''glsl  source code.
 
         source should be the filename of a glsl shader that contains both the
@@ -652,66 +653,71 @@ cdef class Shader:
 
         .. versionadded:: 1.6.0
         '''
-        def __get__(self):
-            return self._source
-        def __set__(self, object source):
-            self._source = source
-            if source is None:
-                self.vs = None
-                self.fs = None
-                return
-            self.vert_src = ""
-            self.frag_src = ""
-            glsl_source = "\n"
-            Logger.info('Shader: Read <{}>'.format(self._source))
-            with open(self._source) as fin:
-                glsl_source += fin.read()
-            sections = glsl_source.split('\n---')
-            for section in sections:
-                lines = section.split('\n')
-                if lines[0].lower().startswith("vertex"):
-                    _vs = '\n'.join(lines[1:])
-                    self.vert_src = _vs.replace('$HEADER$', header_vs)
-                if lines[0].lower().startswith("fragment"):
-                    _fs = '\n'.join(lines[1:])
-                    self.frag_src = _fs.replace('$HEADER$', header_fs)
-            self.build_vertex(0)
-            self.build_fragment(0)
-            self.link_program()
+        return self._source
 
-    property vs:
+    @source.setter
+    def source(self, object source):
+        self._source = source
+        if source is None:
+            self.vs = None
+            self.fs = None
+            return
+        self.vert_src = ""
+        self.frag_src = ""
+        glsl_source = "\n"
+        Logger.info('Shader: Read <{}>'.format(self._source))
+        with open(self._source) as fin:
+            glsl_source += fin.read()
+        sections = glsl_source.split('\n---')
+        for section in sections:
+            lines = section.split('\n')
+            if lines[0].lower().startswith("vertex"):
+                _vs = '\n'.join(lines[1:])
+                self.vert_src = _vs.replace('$HEADER$', header_vs)
+            if lines[0].lower().startswith("fragment"):
+                _fs = '\n'.join(lines[1:])
+                self.frag_src = _fs.replace('$HEADER$', header_fs)
+        self.build_vertex(0)
+        self.build_fragment(0)
+        self.link_program()
+
+    @property
+    def vs(self):
         '''Vertex shader source code.
 
         If you set a new vertex shader code source, it will be automatically
         compiled and will replace the current vertex shader.
         '''
-        def __get__(self):
-            return self.vert_src
-        def __set__(self, object source):
-            if source is None:
-                source = default_vs
-            source = source.replace('$HEADER$', header_vs)
-            self.vert_src = source
-            self.build_vertex()
+        return self.vert_src
 
-    property fs:
+    @vs.setter
+    def vs(self, object source):
+        if source is None:
+            source = default_vs
+        source = source.replace('$HEADER$', header_vs)
+        self.vert_src = source
+        self.build_vertex()
+
+    @property
+    def fs(self):
         '''Fragment shader source code.
 
         If you set a new fragment shader code source, it will be automatically
         compiled and will replace the current fragment shader.
         '''
-        def __get__(self):
-            return self.frag_src
-        def __set__(self, object source):
-            if source is None:
-                source = default_fs
-            source = source.replace('$HEADER$', header_fs)
-            self.frag_src = source
-            self.build_fragment()
+        return self.frag_src
 
-    property success:
+    @fs.setter
+    def fs(self, object source):
+        if source is None:
+            source = default_fs
+        source = source.replace('$HEADER$', header_fs)
+        self.frag_src = source
+        self.build_fragment()
+
+    @property
+    def success(self):
         '''Indicate whether the shader loaded successfully and is ready for
         usage or not.
         '''
-        def __get__(self):
-            return self._success
+        return self._success

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -254,7 +254,8 @@ cdef class StencilUse(Instruction):
         stencil_apply_state(_stencil_state, False)
         return 0
 
-    property func_op:
+    @property
+    def func_op(self):
         '''Determine the stencil operation to use for glStencilFunc(). Can be
         one of 'never', 'less', 'equal', 'lequal', 'greater', 'notequal',
         'gequal' or 'always'.
@@ -264,18 +265,18 @@ cdef class StencilUse(Instruction):
         .. versionadded:: 1.5.0
         '''
 
-        def __get__(self):
-            index = _gl_stencil_op.values().index(self._op)
-            if PY2:
-                return _gl_stencil_op.keys()[index]
-            else:
-                return list(_gl_stencil_op.keys())[index]
+        index = _gl_stencil_op.values().index(self._op)
+        if PY2:
+            return _gl_stencil_op.keys()[index]
+        else:
+            return list(_gl_stencil_op.keys())[index]
 
-        def __set__(self, x):
-            cdef int op = _stencil_op_to_gl(x)
-            if op != self._op:
-                self._op = op
-                self.flag_update()
+    @func_op.setter
+    def func_op(self, x):
+        cdef int op = _stencil_op_to_gl(x)
+        if op != self._op:
+            self._op = op
+            self.flag_update()
 
 
 cdef class StencilUnUse(Instruction):

--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -144,6 +144,10 @@ cdef list kv_color_to_int_color(color):
     c = [int(255*x) for x in color]
     return c if len(c) == 4 else c + [255]
 
+cdef int_color_to_kv_color(color):
+    c = [int(x)/255.0 for x in color]
+    return c if len(c) == 4 else c + [255]
+
 cdef parse_color(c, current_color=None):
     cdef int r, g, b, a
     if c is None or c == 'none':
@@ -411,86 +415,96 @@ cdef class Svg(RenderContext):
                 size=(2, 1), colorfmt="rgba")
         self.line_texture.blit_buffer(
                 b"\xff\xff\xff\xff\xff\xff\xff\x00", colorfmt="rgba")
+
+        self._filename = None
         self.filename = filename
 
-    property anchor_x:
+
+    @property
+    def anchor_x(self):
         '''
         Horizontal anchor position for scaling and rotations. Defaults to 0. The
         symbolic values 'left', 'center' and 'right' are also accepted.
         '''
+        return self._anchor_x
 
-        def __set__(self, anchor_x):
-            self._anchor_x = anchor_x
-            if self._anchor_x == 'left':
-                self._a_x = 0
-            elif self._anchor_x == 'center':
-                self._a_x = self.width * .5
-            elif self._anchor_x == 'right':
-                self._a_x = self.width
-            else:
-                self._a_x = self._anchor_x
+    @x.setter
+    def x(self, anchor_x):
+        self._anchor_x = anchor_x
+        if self._anchor_x == 'left':
+            self._a_x = 0
+        elif self._anchor_x == 'center':
+            self._a_x = self.width * .5
+        elif self._anchor_x == 'right':
+            self._a_x = self.width
+        else:
+            self._a_x = self._anchor_x
 
-        def __get__(self):
-            return self._anchor_x
-
-
-    property anchor_y:
+    @property
+    def anchor_y(self):
         '''
         Vertical anchor position for scaling and rotations. Defaults to 0. The
         symbolic values 'bottom', 'center' and 'top' are also accepted.
         '''
+        return self._anchor_y
 
-        def __set__(self, anchor_y):
-            self._anchor_y = anchor_y
-            if self._anchor_y == 'bottom':
-                self._a_y = 0
-            elif self._anchor_y == 'center':
-                self._a_y = self.height * .5
-            elif self._anchor_y == 'top':
-                self._a_y = self.height
-            else:
-                self._a_y = self.anchor_y
+    @anchor_y.setter
+    def anchor_y(self, anchor_y):
+        self._anchor_y = anchor_y
+        if self._anchor_y == 'bottom':
+            self._a_y = 0
+        elif self._anchor_y == 'center':
+            self._a_y = self.height * .5
+        elif self._anchor_y == 'top':
+            self._a_y = self.height
+        else:
+            self._a_y = self.anchor_y
 
-        def __get__(self):
-            return self._anchor_y
+    @property
+    def color(self):
+        return int_color_to_kv_color(self.current_color)
 
+    @color.setter
+    def color(self, color):
+        '''Set the default color.
 
-    '''Set the default color.
+        Used for SvgElements that specify "currentColor"
 
-    Used for SvgElements that specify "currentColor"
+        .. versionadded:: 1.9.1
 
-    .. versionadded:: 1.9.1
+        '''
+        self.current_color = kv_color_to_int_color(color)
+        self.reload()
 
-    '''
-    property color:
-        def __set__(self, color):
-            self.current_color = kv_color_to_int_color(color)
-            self.reload()
+    @property
+    def filename(self):
+        return self._filename
 
-    property filename:
+    @filename.setter
+    def filename(self, filename):
         '''Filename to load.
 
         The parsing and rendering is done as soon as you set the filename.
         '''
-        def __set__(self, filename):
-            Logger.debug('Svg: Loading {}'.format(filename))
-            # check gzip
-            start = time()
-            with open(filename, 'rb') as fd:
-                header = fd.read(3)
-            if header == '\x1f\x8b\x08':
-                import gzip
-                fd = gzip.open(filename, 'rb')
-            else:
-                fd = open(filename, 'rb')
-            try:
-		#save the tree for later reloading
-                self.tree = parse(fd)
-                self.reload()
-                end = time()
-                Logger.debug("Svg: Loaded {} in {:.2f}s".format(filename, end - start))
-            finally:
-                fd.close()
+        Logger.debug('Svg: Loading {}'.format(filename))
+        # check gzip
+        start = time()
+        with open(filename, 'rb') as fd:
+            header = fd.read(3)
+        if header == '\x1f\x8b\x08':
+            import gzip
+            fd = gzip.open(filename, 'rb')
+        else:
+            fd = open(filename, 'rb')
+        try:
+            #save the tree for later reloading
+            self.tree = parse(fd)
+            self.reload()
+            end = time()
+            Logger.debug("Svg: Loaded {} in {:.2f}s".format(filename, end - start))
+        finally:
+            self._filename = filename
+            fd.close()
 
     cdef void reload(self) except *:
             # parse tree

--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -462,30 +462,36 @@ cdef class Svg(RenderContext):
 
     @property
     def color(self):
+        '''The default color
+
+        Used for SvgElements that specify "currentColor"
+
+        .. versionchanged:: 1.10.3
+
+            The color is gettable and settable
+
+        .. versionadded:: 1.9.1
+        '''
         return int_color_to_kv_color(self.current_color)
 
     @color.setter
     def color(self, color):
-        '''Set the default color.
-
-        Used for SvgElements that specify "currentColor"
-
-        .. versionadded:: 1.9.1
-
-        '''
         self.current_color = kv_color_to_int_color(color)
         self.reload()
 
     @property
     def filename(self):
+        '''filename to load.
+
+        The parsing and rendering is done as soon as you set the filename.
+
+        .. versionchanged:: 1.10.3
+            You can get the used filename
+        '''
         return self._filename
 
     @filename.setter
     def filename(self, filename):
-        '''Filename to load.
-
-        The parsing and rendering is done as soon as you set the filename.
-        '''
         Logger.debug('Svg: Loading {}'.format(filename))
         # check gzip
         start = time()

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -1137,94 +1137,99 @@ cdef class Texture:
             id(self), self._id, self.size, self.colorfmt, self.bufferfmt,
             self._source, len(self.observers))
 
-    property size:
+    @property
+    def size(self):
         '''Return the (width, height) of the texture (readonly).
         '''
-        def __get__(self):
-            return (self.width, self.height)
+        return (self.width, self.height)
 
-    property mipmap:
+    @property
+    def mipmap(self):
         '''Return True if the texture has mipmap enabled (readonly).
         '''
-        def __get__(self):
-            return self._mipmap
+        return self._mipmap
 
-    property id:
+    @property
+    def id(self):
         '''Return the OpenGL ID of the texture (readonly).
         '''
-        def __get__(self):
-            return self._id
+        return self._id
 
-    property target:
+    @property
+    def target(self):
         '''Return the OpenGL target of the texture (readonly).
         '''
-        def __get__(self):
-            return self._target
+        return self._target
 
-    property width:
+    @property
+    def width(self):
         '''Return the width of the texture (readonly).
         '''
-        def __get__(self):
-            return self._width
+        return self._width
 
-    property height:
+    @property
+    def height(self):
         '''Return the height of the texture (readonly).
         '''
-        def __get__(self):
-            return self._height
+        return self._height
 
-    property tex_coords:
+    @property
+    def tex_coords(self):
         '''Return the list of tex_coords (opengl).
         '''
-        def __get__(self):
-            return (
-                self._tex_coords[0],
-                self._tex_coords[1],
-                self._tex_coords[2],
-                self._tex_coords[3],
-                self._tex_coords[4],
-                self._tex_coords[5],
-                self._tex_coords[6],
-                self._tex_coords[7])
+        return (
+            self._tex_coords[0],
+            self._tex_coords[1],
+            self._tex_coords[2],
+            self._tex_coords[3],
+            self._tex_coords[4],
+            self._tex_coords[5],
+            self._tex_coords[6],
+            self._tex_coords[7])
 
-    property uvpos:
+    @property
+    def uvpos(self):
         '''Get/set the UV position inside the texture.
         '''
-        def __get__(self):
-            return (self._uvx, self._uvy)
-        def __set__(self, x):
-            self._uvx, self._uvy = x
-            self.update_tex_coords()
+        return (self._uvx, self._uvy)
 
-    property uvsize:
+    @uvpos.setter
+    def uvpos(self, x):
+        self._uvx, self._uvy = x
+        self.update_tex_coords()
+
+    @property
+    def uvsize(self):
         '''Get/set the UV size inside the texture.
 
         .. warning::
             The size can be negative if the texture is flipped.
         '''
-        def __get__(self):
-            return (self._uvw, self._uvh)
-        def __set__(self, x):
-            self._uvw, self._uvh = x
-            self.update_tex_coords()
+        return (self._uvw, self._uvh)
 
-    property colorfmt:
+    @uvsize.setter
+    def uvsize(self, x):
+        self._uvw, self._uvh = x
+        self.update_tex_coords()
+
+    @property
+    def colorfmt(self):
         '''Return the color format used in this texture (readonly).
 
         .. versionadded:: 1.0.7
         '''
-        def __get__(self):
-            return self._colorfmt
+        return self._colorfmt
 
-    property bufferfmt:
+    @property
+    def bufferfmt(self):
         '''Return the buffer format used in this texture (readonly).
 
         .. versionadded:: 1.2.0
         '''
-        def __get__(self):
-            return self._bufferfmt
+        return self._bufferfmt
 
-    property min_filter:
+    @property
+    def min_filter(self):
         '''Get/set the min filter texture. Available values:
 
         - linear
@@ -1238,12 +1243,14 @@ cdef class Texture:
         of these values :
         http://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml.
         '''
-        def __get__(self):
-            return self._min_filter
-        def __set__(self, x):
-            self.set_min_filter(x)
+        return self._min_filter
 
-    property mag_filter:
+    @min_filter.setter
+    def min_filter(self, x):
+        self.set_min_filter(x)
+
+    @property
+    def mag_filter(self):
         '''Get/set the mag filter texture. Available values:
 
         - linear
@@ -1253,12 +1260,14 @@ cdef class Texture:
         of these values :
         http://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml.
         '''
-        def __get__(self):
-            return self._mag_filter
-        def __set__(self, x):
-            self.set_mag_filter(x)
+        return self._mag_filter
 
-    property wrap:
+    @mag_filter.setter
+    def mag_filter(self, x):
+        self.set_mag_filter(x)
+
+    @property
+    def wrap(self):
         '''Get/set the wrap texture. Available values:
 
         - repeat
@@ -1269,20 +1278,21 @@ cdef class Texture:
         of these values :
         http://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml.
         '''
-        def __get__(self):
-            return self._wrap
-        def __set__(self, wrap):
-            self.set_wrap(wrap)
+        return self._wrap
 
-    property pixels:
+    @wrap.setter
+    def wrap(self, wrap):
+        self.set_wrap(wrap)
+
+    @property
+    def pixels(self):
         '''Get the pixels texture, in RGBA format only, unsigned byte. The
         origin of the image is at bottom left.
 
         .. versionadded:: 1.7.0
         '''
-        def __get__(self):
-            from kivy.graphics.fbo import Fbo
-            return Fbo(size=self.size, texture=self).pixels
+        from kivy.graphics.fbo import Fbo
+        return Fbo(size=self.size, texture=self).pixels
 
 
 cdef class TextureRegion(Texture):
@@ -1338,17 +1348,17 @@ cdef class TextureRegion(Texture):
     cpdef bind(self):
         self.owner.bind()
 
-    property pixels:
-        def __get__(self):
-            from kivy.graphics.fbo import Fbo
-            from kivy.graphics import Color, Rectangle
-            fbo = Fbo(size=self.size)
-            fbo.clear()
-            self.flip_vertical()
-            with fbo:
-                Color(1, 1, 1)
-                Rectangle(size=self.size, texture=self,
-                        tex_coords=self.tex_coords)
-            fbo.draw()
-            self.flip_vertical()
-            return fbo.pixels
+    @property
+    def pixels(self):
+        from kivy.graphics.fbo import Fbo
+        from kivy.graphics import Color, Rectangle
+        fbo = Fbo(size=self.size)
+        fbo.clear()
+        self.flip_vertical()
+        with fbo:
+            Color(1, 1, 1)
+            Rectangle(size=self.size, texture=self,
+                    tex_coords=self.tex_coords)
+        fbo.draw()
+        self.flip_vertical()
+        return fbo.pixels

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -209,7 +209,8 @@ cdef class Bezier(VertexInstruction):
         free(vertices)
         free(indices)
 
-    property points:
+    @property
+    def points(self):
         '''Property for getting/settings the points of the triangle.
 
         .. warning::
@@ -217,49 +218,56 @@ cdef class Bezier(VertexInstruction):
             This will always reconstruct the whole graphic from the new points
             list. It can be very CPU intensive.
         '''
-        def __get__(self):
-            return self._points
-        def __set__(self, points):
-            self._points = list(points)
-            if self._loop:
-                self._points.extend(points[:2])
-            self.flag_update()
+        return self._points
 
-    property segments:
+    @points.setter
+    def points(self, points):
+        self._points = list(points)
+        if self._loop:
+            self._points.extend(points[:2])
+        self.flag_update()
+
+    @property
+    def segments(self):
         '''Property for getting/setting the number of segments of the curve.
         '''
-        def __get__(self):
-            return self._segments
-        def __set__(self, value):
-            if value <= 1:
-                raise GraphicException('Invalid segments value, must be >= 2')
-            self._segments = value
-            self.flag_update()
+        return self._segments
 
-    property dash_length:
+    @segments.setter
+    def segments(self, value):
+        if value <= 1:
+            raise GraphicException('Invalid segments value, must be >= 2')
+        self._segments = value
+        self.flag_update()
+
+    @property
+    def dash_length(self):
         '''Property for getting/setting the length of the dashes in the curve.
         '''
-        def __get__(self):
-            return self._dash_length
+        return self._dash_length
 
-        def __set__(self, value):
-            if value < 0:
-                raise GraphicException('Invalid dash_length value, must be >= 0')
-            self._dash_length = value
-            self.flag_update()
 
-    property dash_offset:
+    @dash_length.setter
+    def dash_length(self, value):
+        if value < 0:
+            raise GraphicException('Invalid dash_length value, must be >= 0')
+        self._dash_length = value
+        self.flag_update()
+
+    @property
+    def dash_offset(self):
         '''Property for getting/setting the offset between the dashes in the
         curve.
         '''
-        def __get__(self):
-            return self._dash_offset
+        return self._dash_offset
 
-        def __set__(self, value):
-            if value < 0:
-                raise GraphicException('Invalid dash_offset value, must be >= 0')
-            self._dash_offset = value
-            self.flag_update()
+
+    @dash_offset.setter
+    def dash_offset(self, value):
+        if value < 0:
+            raise GraphicException('Invalid dash_offset value, must be >= 0')
+        self._dash_offset = value
+        self.flag_update()
 
 
 cdef class StripMesh(VertexInstruction):
@@ -452,44 +460,50 @@ cdef class Mesh(VertexInstruction):
         self.batch.set_data(&self._pvertices[0], <int>(self.vcount / vsize),
                             &self._pindices[0], <int>self.icount)
 
-    property vertices:
+    @property
+    def vertices(self):
         '''List of x, y, u, v coordinates used to construct the Mesh. Right now,
         the Mesh instruction doesn't allow you to change the format of the
         vertices, which means it's only x, y + one texture coordinate.
         '''
-        def __get__(self):
-            return self._vertices
-        def __set__(self, value):
-            self._vertices, self._fvertices = _ensure_float_view(value,
-                &self._pvertices)
-            self.vcount = len(self._vertices)
-            self.flag_update()
+        return self._vertices
 
-    property indices:
+    @vertices.setter
+    def vertices(self, value):
+        self._vertices, self._fvertices = _ensure_float_view(value,
+            &self._pvertices)
+        self.vcount = len(self._vertices)
+        self.flag_update()
+
+    @property
+    def indices(self):
         '''Vertex indices used to specify the order when drawing the
         mesh.
         '''
-        def __get__(self):
-            return self._indices
-        def __set__(self, value):
-            if gles_limts and len(value) > 65535:
-                raise GraphicException(
-                    'Cannot upload more than 65535 indices (OpenGL ES 2'
-                    ' limitation - consider setting KIVY_GLES_LIMITS)')
-            self._indices, self._lindices = _ensure_ushort_view(value,
-                &self._pindices)
-            self.icount = len(self._indices)
-            self.flag_update()
+        return self._indices
 
-    property mode:
+    @indices.setter
+    def indices(self, value):
+        if gles_limts and len(value) > 65535:
+            raise GraphicException(
+                'Cannot upload more than 65535 indices (OpenGL ES 2'
+                ' limitation - consider setting KIVY_GLES_LIMITS)')
+        self._indices, self._lindices = _ensure_ushort_view(value,
+            &self._pindices)
+        self.icount = len(self._indices)
+        self.flag_update()
+
+    @property
+    def mode(self):
         '''VBO Mode used for drawing vertices/indices. Can be one of 'points',
         'line_strip', 'line_loop', 'lines', 'triangles', 'triangle_strip' or
         'triangle_fan'.
         '''
-        def __get__(self):
-            return self.batch.get_mode()
-        def __set__(self, mode):
-            self.batch.set_mode(mode)
+        return self.batch.get_mode()
+
+    @mode.setter
+    def mode(self, mode):
+        self.batch.set_mode(mode)
 
 
 
@@ -630,33 +644,37 @@ cdef class Point(VertexInstruction):
         if self.parent is not None:
             self.parent.flag_update()
 
-    property points:
+    @property
+    def points(self):
         '''Property for getting/settings the center points in the points list.
         Each pair of coordinates specifies the center of a new point.
         '''
-        def __get__(self):
-            return self._points
-        def __set__(self, points):
-            if self._points == points:
-                return
-            cdef list _points = list(points)
-            if len(_points) > 2**15-2:
-                raise GraphicException('Too many elements (limit is 2^15-2)')
-            self._points = list(points)
-            self.flag_update()
+        return self._points
 
-    property pointsize:
+    @points.setter
+    def points(self, points):
+        if self._points == points:
+            return
+        cdef list _points = list(points)
+        if len(_points) > 2**15-2:
+            raise GraphicException('Too many elements (limit is 2^15-2)')
+        self._points = list(points)
+        self.flag_update()
+
+    @property
+    def pointsize(self):
         '''Property for getting/setting point size.
         The size is measured from the center to the edge, so a value of 1.0
         means the real size will be 2.0 x 2.0.
         '''
-        def __get__(self):
-            return self._pointsize
-        def __set__(self, float pointsize):
-            if self._pointsize == pointsize:
-                return
-            self._pointsize = pointsize
-            self.flag_update()
+        return self._pointsize
+
+    @pointsize.setter
+    def pointsize(self, float pointsize):
+        if self._pointsize == pointsize:
+            return
+        self._pointsize = pointsize
+        self.flag_update()
 
 
 cdef class Triangle(VertexInstruction):
@@ -698,14 +716,16 @@ cdef class Triangle(VertexInstruction):
 
         self.batch.set_data(vertices, 3, indices, 3)
 
-    property points:
+    @property
+    def points(self):
         '''Property for getting/settings points of the triangle.
         '''
-        def __get__(self):
-            return self._points
-        def __set__(self, points):
-            self._points = list(points)
-            self.flag_update()
+        return self._points
+
+    @points.setter
+    def points(self, points):
+        self._points = list(points)
+        self.flag_update()
 
 
 cdef class Quad(VertexInstruction):
@@ -752,18 +772,20 @@ cdef class Quad(VertexInstruction):
 
         self.batch.set_data(vertices, 4, indices, 6)
 
-    property points:
+    @property
+    def points(self):
         '''Property for getting/settings points of the quad.
         '''
-        def __get__(self):
-            return self._points
-        def __set__(self, points):
-            self._points = list(points)
-            if len(self._points) != 8:
-                raise GraphicException(
-                    'Quad: invalid number of points (%d instead of 8)' % len(
-                    self._points))
-            self.flag_update()
+        return self._points
+
+    @points.setter
+    def points(self, points):
+        self._points = list(points)
+        if len(self._points) != 8:
+            raise GraphicException(
+                'Quad: invalid number of points (%d instead of 8)' % len(
+                self._points))
+        self.flag_update()
 
 
 cdef class Rectangle(VertexInstruction):
@@ -812,33 +834,37 @@ cdef class Rectangle(VertexInstruction):
 
         self.batch.set_data(vertices, 4, indices, 6)
 
-    property pos:
+    @property
+    def pos(self):
         '''Property for getting/settings the position of the rectangle.
         '''
-        def __get__(self):
-            return (self.x, self.y)
-        def __set__(self, pos):
-            cdef float x, y
-            x, y = pos
-            if self.x == x and self.y == y:
-                return
-            self.x = x
-            self.y = y
-            self.flag_update()
+        return (self.x, self.y)
 
-    property size:
+    @pos.setter
+    def pos(self, pos):
+        cdef float x, y
+        x, y = pos
+        if self.x == x and self.y == y:
+            return
+        self.x = x
+        self.y = y
+        self.flag_update()
+
+    @property
+    def size(self):
         '''Property for getting/settings the size of the rectangle.
         '''
-        def __get__(self):
-            return (self.w, self.h)
-        def __set__(self, size):
-            cdef float w, h
-            w, h = size
-            if self.w == w and self.h == h:
-                return
-            self.w = w
-            self.h = h
-            self.flag_update()
+        return (self.w, self.h)
+
+    @size.setter
+    def size(self, size):
+        cdef float w, h
+        w, h = size
+        if self.w == w and self.h == h:
+            return
+        self.w = w
+        self.h = h
+        self.flag_update()
 
 
 
@@ -1052,34 +1078,40 @@ cdef class BorderImage(Rectangle):
         self.batch.set_data(<vertex_t *>vertices, 16, indices, 54)
 
 
-    property border:
+    @property
+    def border(self):
         '''Property for getting/setting the border of the class.
         '''
-        def __get__(self):
-            return self._border
-        def __set__(self, b):
-            self._border = list(b)
-            self.flag_update()
+        return self._border
 
-    property auto_scale:
+    @border.setter
+    def border(self, b):
+        self._border = list(b)
+        self.flag_update()
+
+    @property
+    def auto_scale(self):
         '''Property for setting if the corners are automatically scaled
         when the BorderImage is too small.
         '''
-        def __get__(self):
-            return self._auto_scale
+        return self._auto_scale
 
-        def __set__(self, str value):
-            self._auto_scale = value
-            self.flag_update()
 
-    property display_border:
+    @auto_scale.setter
+    def auto_scale(self, str value):
+        self._auto_scale = value
+        self.flag_update()
+
+    @property
+    def display_border(self):
         '''Property for getting/setting the border display size.
         '''
-        def __get__(self):
-            return self._display_border
-        def __set__(self, b):
-            self._display_border = list(b)
-            self.flag_update()
+        return self._display_border
+
+    @display_border.setter
+    def display_border(self, b):
+        self._display_border = list(b)
+        self.flag_update()
 
 cdef class Ellipse(Rectangle):
     '''A 2D ellipse.
@@ -1196,32 +1228,38 @@ cdef class Ellipse(Rectangle):
         free(vertices)
         free(indices)
 
-    property segments:
+    @property
+    def segments(self):
         '''Property for getting/setting the number of segments of the ellipse.
         '''
-        def __get__(self):
-            return self._segments
-        def __set__(self, value):
-            self._segments = value
-            self.flag_update()
+        return self._segments
 
-    property angle_start:
+    @segments.setter
+    def segments(self, value):
+        self._segments = value
+        self.flag_update()
+
+    @property
+    def angle_start(self):
         '''Start angle of the ellipse in degrees, defaults to 0.
         '''
-        def __get__(self):
-            return self._angle_start
-        def __set__(self, value):
-            self._angle_start = value
-            self.flag_update()
+        return self._angle_start
 
-    property angle_end:
+    @angle_start.setter
+    def angle_start(self, value):
+        self._angle_start = value
+        self.flag_update()
+
+    @property
+    def angle_end(self):
         '''End angle of the ellipse in degrees, defaults to 360.
         '''
-        def __get__(self):
-            return self._angle_end
-        def __set__(self, value):
-            self._angle_end = value
-            self.flag_update()
+        return self._angle_end
+
+    @angle_end.setter
+    def angle_end(self, value):
+        self._angle_end = value
+        self.flag_update()
 
 
 cdef class RoundedRectangle(Rectangle):
@@ -1514,20 +1552,24 @@ cdef class RoundedRectangle(Rectangle):
 
         return points
 
-    property segments:
+    @property
+    def segments(self):
         '''Property for getting/setting the number of segments for each corner.
         '''
-        def __get__(self):
-            return self._segments
-        def __set__(self, value):
-            self._segments = self._check_segments(value)
-            self.flag_update()
+        return self._segments
 
-    property radius:
+    @segments.setter
+    def segments(self, value):
+        self._segments = self._check_segments(value)
+        self.flag_update()
+
+    @property
+    def radius(self):
         '''Corner radii of the rounded rectangle, defaults to [10,].
         '''
-        def __get__(self):
-            return self._radius
-        def __set__(self, value):
-            self._radius = self._check_radius(value)
-            self.flag_update()
+        return self._radius
+
+    @radius.setter
+    def radius(self, value):
+        self._radius = self._check_radius(value)
+        self.flag_update()

--- a/kivy/lib/vidcore_lite/bcm.pyx
+++ b/kivy/lib/vidcore_lite/bcm.pyx
@@ -9,33 +9,37 @@ cdef class Rect:
         self._vc_rect.width = width
         self._vc_rect.height = height
         
-    property x:
-        def __get__(self):
-            return self._vc_rect.x
+    @property
+    def x(self):
+        return self._vc_rect.x
             
-        def __set__(self, int32_t x):
-            self._vc_rect.x = x
+    @x.setter
+    def x(self, int32_t x):
+        self._vc_rect.x = x
             
-    property y:
-        def __get__(self):
-            return self._vc_rect.y
+    @property
+    def y(self):
+        return self._vc_rect.y
             
-        def __set__(self, int32_t y):
-            self._vc_rect.y = y
+    @y.setter
+    def y(self, int32_t y):
+        self._vc_rect.y = y
             
-    property width:
-        def __get__(self):
-            return self._vc_rect.width
+    @property
+    def width(self):
+        return self._vc_rect.width
             
-        def __set__(self, int32_t width):
-            self._vc_rect.width = width
+    @width.setter
+    def width(self, int32_t width):
+        self._vc_rect.width = width
             
-    property height:
-        def __get__(self):
-            return self._vc_rect.height
+    @property
+    def height(self):
+        return self._vc_rect.height
             
-        def __set__(self, int32_t h):
-            self._vc_rect.height = h
+    @height.setter
+    def height(self, int32_t h):
+        self._vc_rect.height = h
             
             
 cdef class DisplayHandle:

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -395,9 +395,9 @@ cdef class Property:
         if 'errorhandler' in kw and not callable(self.errorhandler):
             raise ValueError('errorhandler %s not callable' % self.errorhandler)
 
-    property name:
-        def __get__(self):
-            return self._name
+    @property
+    def name(self):
+        return self._name
 
     def __repr__(self):
         return '<{} name={}>'.format(self.__class__.__name__, self._name)
@@ -1166,28 +1166,27 @@ cdef class BoundedNumericProperty(Property):
                     self.name, _f_max))
         return True
 
-    property bounds:
+    @property
+    def bounds(self):
         '''Return min/max of the value.
 
         .. versionadded:: 1.0.9
         '''
+        if self.use_min == 1:
+            _min = self.min
+        elif self.use_min == 2:
+            _min = self.f_min
+        else:
+            _min = None
 
-        def __get__(self):
-            if self.use_min == 1:
-                _min = self.min
-            elif self.use_min == 2:
-                _min = self.f_min
-            else:
-                _min = None
+        if self.use_max == 1:
+            _max = self.max
+        elif self.use_max == 2:
+            _max = self.f_max
+        else:
+            _max = None
 
-            if self.use_max == 1:
-                _max = self.max
-            elif self.use_max == 2:
-                _max = self.f_max
-            else:
-                _max = None
-
-            return _min, _max
+        return _min, _max
 
 
 cdef class OptionProperty(Property):
@@ -1232,14 +1231,13 @@ cdef class OptionProperty(Property):
                              self.name,
                              value, ps.options))
 
-    property options:
+    @property
+    def options(self):
         '''Return the options available.
 
         .. versionadded:: 1.0.9
         '''
-
-        def __get__(self):
-            return self.options
+        return self.options
 
 class ObservableReferenceList(ObservableList):
     def __setitem__(self, key, value, update_properties=True):

--- a/kivy/weakproxy.pyx
+++ b/kivy/weakproxy.pyx
@@ -35,9 +35,9 @@ cdef class WeakProxy(object):
     def __delattr__(self, name):
         delattr(self.__ref__(), name)
 
-    property __class__:
-        def __get__(self):
-            return self.__ref__().__class__
+    @property
+    def __class__(self):
+        return self.__ref__().__class__
 
     def __dir__(self):
         r = self.__ref()

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def get_version(filename='kivy/version.py'):
     return VERSION
 
 
-MIN_CYTHON_STRING = '0.23'
+MIN_CYTHON_STRING = '0.24'
 MIN_CYTHON_VERSION = LooseVersion(MIN_CYTHON_STRING)
 MAX_CYTHON_STRING = '0.28.3'
 MAX_CYTHON_VERSION = LooseVersion(MAX_CYTHON_STRING)


### PR DESCRIPTION
Kivy is using deprecated Cython syntax for properties, this PR use the latest one.

Fixes #5766
