### PR TITLE
ColorPicker refactor to prevent multiples event firing

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -1177,7 +1177,7 @@
     _radius: 0.45 * min(self.size)
 
 <ColorPicker>:
-    foreground_color: (1, 1, 1, 1) if self.hsv[2] * wheel.a < .5 else (0, 0, 0, 1)
+    foreground_color: (1, 1, 1, 1) if self.hsv[2] * root.color[3] < .5 else (0, 0, 0, 1)
     wheel: wheel
     BoxLayout:
         orientation: 'vertical' if root.width < root.height else 'horizontal'
@@ -1197,7 +1197,7 @@
                 mroot: root
                 text: 'R'
                 clr_idx: 0
-                color: wheel.r
+                color: root.color[0]
                 foreground_color: root.foreground_color
                 size_hint_y: None if root.width < root.height else 0.125
                 size_hint_x: .5 if root.width < root.height else 1
@@ -1207,7 +1207,7 @@
                 mroot: root
                 text: 'G'
                 clr_idx: 1
-                color: wheel.g
+                color: root.color[1]
                 foreground_color: root.foreground_color
                 size_hint_y: None if root.width < root.height else 0.125
                 size_hint_x: .5 if root.width < root.height else 1
@@ -1217,7 +1217,7 @@
                 mroot: root
                 text: 'B'
                 clr_idx: 2
-                color: wheel.b
+                color: root.color[2]
                 foreground_color: root.foreground_color
                 size_hint_y: None if root.width < root.height else 0.125
                 size_hint_x: .5 if root.width < root.height else 1
@@ -1288,4 +1288,4 @@
         ColorWheel:
             id: wheel
             color: root.color
-            on_color: root.color[:3] = args[1][:3]
+            on_color: root.set_color(args[1][:3])

--- a/kivy/uix/colorpicker.py
+++ b/kivy/uix/colorpicker.py
@@ -279,16 +279,8 @@ class ColorWheel(Widget):
             # _hsv based on the selected ColorArc
             piece = int((theta / (2 * pi)) * self._pieces_of_pie)
             division = int((r / self._radius) * self._piece_divisions)
-            self._hsv = \
-                self.arcs[self._pieces_of_pie * division + piece].color
-
-    def on__hsv(self, instance, value):
-        c_hsv = Color(*value, mode='hsv')
-        self.r = c_hsv.r
-        self.g = c_hsv.g
-        self.b = c_hsv.b
-        self.a = c_hsv.a
-        self.rgba = (self.r, self.g, self.b, self.a)
+            hsva = list(self.arcs[self._pieces_of_pie * division + piece].color)
+            self.color = list(hsv_to_rgb(*hsva[:3])) + hsva[-1:]
 
     def _get_touch_r(self, pos):
         return distance(pos, self._origin)
@@ -383,7 +375,16 @@ class ColorPicker(RelativeLayout):
     (1, 1, 1, 1).
     '''
 
-    hsv = ListProperty((1, 1, 1))
+    def _get_hsv(self):
+        return rgb_to_hsv(*self.color[:3])
+
+    def _set_hsv(self, value):
+        if self._updating_clr:
+            return
+        self.set_color(value)
+
+    hsv = AliasProperty(_get_hsv, _set_hsv, bind=('color', ))
+    #hsv = ListProperty((1, 1, 1))
     '''The :attr:`hsv` holds the color currently selected in hsv format.
 
     :attr:`hsv` is a :class:`~kivy.properties.ListProperty` and defaults to
@@ -393,7 +394,9 @@ class ColorPicker(RelativeLayout):
         return get_hex_from_color(self.color)
 
     def _set_hex(self, value):
-        self.color = get_color_from_hex(value)[:4]
+        if self._updating_clr:
+            return
+        self.set_color(get_color_from_hex(value)[:4])
 
     hex_color = AliasProperty(_get_hex, _set_hex, bind=('color', ))
     '''The :attr:`hex_color` holds the currently selected color in hex.
@@ -414,19 +417,10 @@ class ColorPicker(RelativeLayout):
     # now used only internally.
     foreground_color = ListProperty((1, 1, 1, 1))
 
-    def on_color(self, instance, value):
-        if not self._updating_clr:
-            self._updating_clr = True
-            self.hsv = rgb_to_hsv(*value[:3])
-            self._updating_clr = False
-
-    def on_hsv(self, instance, value):
-        if not self._updating_clr:
-            self._updating_clr = True
-            self.color[:3] = hsv_to_rgb(*value)
-            self._updating_clr = False
-
     def _trigger_update_clr(self, mode, clr_idx, text):
+        if self._updating_clr:
+            return
+        self._updating_clr = True
         self._upd_clr_list = mode, clr_idx, text
         ev = self._update_clr_ev
         if ev is None:
@@ -434,27 +428,47 @@ class ColorPicker(RelativeLayout):
         ev()
 
     def _update_clr(self, dt):
+        # to prevent interaction between hsv/rgba, we work internaly using rgba
         mode, clr_idx, text = self._upd_clr_list
         try:
             text = min(255, max(0, float(text)))
             if mode == 'rgb':
                 self.color[clr_idx] = float(text) / 255.
             else:
-                self.hsv[clr_idx] = float(text) / 255.
+                hsv = list(self.hsv[:])
+                hsv[clr_idx] = float(text) / 255.
+                self.color[:3] = hsv_to_rgb(*hsv)
         except ValueError:
             Logger.warning('ColorPicker: invalid value : {}'.format(text))
+        finally:
+            self._updating_clr = False
 
     def _update_hex(self, dt):
-        if len(self._upd_hex_list) != 9:
-            return
-        self.hex_color = self._upd_hex_list
+        try:
+            if len(self._upd_hex_list) != 9:
+                return
+            self._updating_clr = False
+            self.hex_color = self._upd_hex_list
+        finally:
+            self._updating_clr = False
 
     def _trigger_update_hex(self, text):
+        if self._updating_clr:
+            return
+        self._updating_clr = True
         self._upd_hex_list = text
         ev = self._update_hex_ev
         if ev is None:
             ev = self._update_hex_ev = Clock.create_trigger(self._update_hex)
         ev()
+
+    def set_color(self, color):
+        self._updating_clr = True
+        if len(color) == 3:
+            self.color[:3] = color
+        else:
+            self.color = color
+        self._updating_clr = False
 
     def __init__(self, **kwargs):
         self._updating_clr = False


### PR DESCRIPTION
The current ColorPicker have multiple source of informations that conflict with each other.
More than that, it is impossible to go from one source (RGBA) to another (HSV) without a loss of information. So all the double-way binding just fail as they keep calling each others until they are "ok".
Some issues with double precision was also re-firing the properties.

So this PR refactor some internals to have only one source: RGBA. it's the `color` property. `hsv` and `hex_color` derivated from it.
The dependencies and update are controlled via the `_updating_clr` attributes.

So far, it is working much better:
- clicking on the wheel change the color only one time
- changing the RGBA or HSV text or slider works as expected
- changing the Hex color text works as expected

Fixes #5831