### PR TITLE
Removed kivy.lib.osc from setup.py packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1018,7 +1018,6 @@ if not build_examples:
             'kivy.input.providers',
             'kivy.lang',
             'kivy.lib',
-            'kivy.lib.osc',
             'kivy.lib.gstplayer',
             'kivy.lib.vidcore_lite',
             'kivy.modules',


### PR DESCRIPTION
Fixes setup.py error
Related to: #5967 