### PR TITLE
add magical load_kv method

### DIFF
--- a/kivy/tools/packaging/bundle_kv.py
+++ b/kivy/tools/packaging/bundle_kv.py
@@ -1,0 +1,62 @@
+# after this is called, all python code that contains the load_kv() call
+# will be edited *in place* to replace that call with
+# Builder.load_string("content of the kv file"), and the kv file *will
+# be deleted*, don't do this if you don't have uncommited code.
+
+from tempfile import mkstemp
+from os.path import join
+from os import walk, unlink, close, write
+from shutil import move
+import sys
+
+if sys.version_major == 2:
+    input = raw_input
+
+
+if len(sys.argv) < 2 or sys.argv[1] not in ('-y', b'-y'):
+    answer = input(
+        'this will edit your python files in place, and remove your kv '
+        'files.\nAre you sure? [y(es)/N(o)]'
+    )
+    if answer.lower() not in ('y', 'yes'):
+        sys.exit()
+
+
+def get_kv_source(fn):
+    kv = fn[:-2] + 'kv'
+    with open(kv, encoding='utf8') as f:
+        source = f.read()
+        res = source.replace('\\', r'\\')
+    unlink(kv)
+    return res
+
+
+for root, dirnames, filenames in walk('src'):
+    for f in filenames:
+        fn = join(root, f)
+        if f.endswith('.py'):
+            tmp, tmpname = mkstemp()
+            with open(fn, encoding='utf8') as source:
+                found = False
+                for line in source:
+                    if line.endswith('load_kv()\n'):
+                        found = True
+                        line = line.replace('load_kv()', '{}')
+                        write(tmp, b'from kivy.lang.builder import Builder\n')
+                        write(
+                            tmp,
+                            line.format('Builder.load_string("""')
+                            .encode('utf8')
+                        )
+                        write(tmp, get_kv_source(fn).encode('utf8'))
+                        write(tmp, b'""")')
+                    else:
+                        write(tmp, line.encode('utf8'))
+            close(tmp)
+            if found:
+                unlink(fn)
+                move(tmpname, fn)
+                print("replaced {fn}".format(fn=fn))
+            else:
+                unlink(tmpname)
+                print("skipped {fn}".format(fn=fn))

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -21,9 +21,12 @@ __all__ = ('intersection', 'difference', 'strtotuple',
            'platform', 'escape_markup', 'reify', 'rgba')
 
 from os import environ
+from os.path import splitext, extsep, exists
 from sys import platform as _sys_platform
 from re import match, split
 from kivy.compat import string_types
+from kivy.lang import Builder
+import inspect
 
 
 def boundary(value, minvalue, maxvalue):
@@ -496,3 +499,13 @@ class reify(object):
         retval = self.func(inst)
         setattr(inst, self.func.__name__, retval)
         return retval
+
+
+def load_kv():
+    '''This magical function lookup module name, and load the kv file
+    with the same name (in the same directory)
+    '''
+    filename = inspect.currentframe().f_back.f_code.co_filename
+    f = extsep.join((splitext(filename)[0], 'kv'))
+    if exists(f) and f not in Builder.files:
+        Builder.load_file(f)


### PR DESCRIPTION
This method looks up the name of the module that calls it, and load the
kv file with the same name but kv extension.

example usage:

in src/widgets/thing.py

    import load_kv
    from kivy.uix.widget import Widget

    class Thing(Widget):
        pass

    load_kv()

in src/widgets/thing.kv

    <Thing>:
        Label:
            text: 'magic!'

This also adds a packaging tool that will inline all such loaded kvlang
in the python code.

    python kivy/tools/packaging/bundle_kv.py -y

after this is called, all python code that contains the load_kv() call
will be edited *in place* to replace that call with
Builder.load_string("content of the kv file"), and the kv file *will be
deleted*, don't do this if you don't have uncommited code.