### PR TITLE
GL: Prevent enabling vertex attribute that are not in the shader

### DIFF
--- a/kivy/graphics/shader.pyx
+++ b/kivy/graphics/shader.pyx
@@ -517,7 +517,8 @@ cdef class Shader:
                 attr = &self._current_vertex_format.vattr[i]
                 if attr.per_vertex == 0:
                     continue
-                cgl.glDisableVertexAttribArray(attr.index)
+                if attr.index != <unsigned int>-1:
+                  cgl.glDisableVertexAttribArray(attr.index)
                 log_gl_error(
                     'Shader.bind_vertex_format-glDisableVertexAttribArray')
 
@@ -530,7 +531,8 @@ cdef class Shader:
                     continue
                 name = <bytes>attr.name
                 attr.index = cgl.glGetAttribLocation(self.program, <char *>name)
-                cgl.glEnableVertexAttribArray(attr.index)
+                if attr.index != <unsigned int>-1:
+                    cgl.glEnableVertexAttribArray(attr.index)
                 log_gl_error(
                     'Shader.bind_vertex_format-glEnableVertexAttribArray')
 

--- a/kivy/graphics/vbo.pyx
+++ b/kivy/graphics/vbo.pyx
@@ -104,6 +104,8 @@ cdef class VBO:
             attr = &self.format[i]
             if attr.per_vertex == 0:
                 continue
+            if attr.index == <unsigned int>-1:
+                continue
             cgl.glVertexAttribPointer(attr.index, attr.size, attr.type,
                     GL_FALSE, <GLsizei>self.format_size, <GLvoid*><long>offset)
             log_gl_error('VBO.bind-glVertexAttribPointer')


### PR DESCRIPTION
By GLSL compiler optimizer or user error, it is possible that some 
attributes are not declared/available in the shader, but we are still 
enabling and assign them.

Let's say in 3D, you have v_pos, v_normal, v_tc0. And in the shader, 
only v_pos/v_normal are declared and used. All the call concerning v_tc0 
will fail.

We cannot use glGetError because it would fully sync the internal GL 
pipeline.
However, we can check that it returned -1, and avoid the call.