### PR TITLE
add modules/showborder

### DIFF
--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -19,6 +19,7 @@ loading of modules is managed by the config file. Currently, we include:
     * :class:`~kivy.modules.webdebugger`: Realtime examination of your app
       internals via a web browser.
     * :class:`~kivy.modules.joycursor`: Navigate in your app with a joystick.
+    * :class:`~kivy.modules.showborder`: Show widget's border.
 
 Modules are automatically loaded from the Kivy path and User path:
 

--- a/kivy/modules/showborder.py
+++ b/kivy/modules/showborder.py
@@ -2,9 +2,9 @@
 Show border
 ===========
 
-Visualize widget's boundary.
+Shows widget's border.
 
-The idea is taken from
+The idea was taken from
 http://robertour.com/2013/10/02/easy-way-debugging-kivy-interfaces/
 '''
 

--- a/kivy/modules/showborder.py
+++ b/kivy/modules/showborder.py
@@ -16,6 +16,8 @@ from kivy.lang import Builder
 KV_CODE = '''
 <Widget>:
     canvas.after:
+        Color:
+            rgba: 1, 1, 1, 1
         Line:
             rectangle: self.x + 1, self.y + 1, self.width - 1, self.height - 1
             dash_offset: 5

--- a/kivy/modules/showborder.py
+++ b/kivy/modules/showborder.py
@@ -1,0 +1,31 @@
+'''
+Show border
+===========
+
+Visualize widget's boundary.
+
+The idea is taken from
+http://robertour.com/2013/10/02/easy-way-debugging-kivy-interfaces/
+'''
+
+__all__ = ('start', 'stop')
+
+from kivy.lang import Builder
+
+
+KV_CODE = '''
+<Widget>:
+    canvas.after:
+        Line:
+            rectangle: self.x + 1, self.y + 1, self.width - 1, self.height - 1
+            dash_offset: 5
+            dash_length: 3
+'''
+
+
+def start(win, ctx):
+    Builder.load_string(KV_CODE, filename=__file__)
+
+
+def stop(win, ctx):
+    Builder.unload_file(__file__)


### PR DESCRIPTION
Shows widget's boundary. This kinda module is helpful for debug/test I think.

```python
from kivy.config import Config
Config.set('modules', 'showborder', '')
from kivy.lang import Builder
from kivy.app import runTouchApp


runTouchApp(Builder.load_string('''
GridLayout:
    padding: 10
    spacing: 10
    cols: 3
    Widget:
    EffectWidget:
    RelativeLayout:
    Scatter:
'''))
```
![screenshot at 2018-10-20 20-05-21](https://user-images.githubusercontent.com/26050135/47254937-963ae500-d4a3-11e8-995e-7657a2b0fe45.png)

~~But it doesn't work with ScrollView.~~ This issue was already fixed.

```python
from kivy.config import Config
Config.set('modules', 'showborder', '')
from kivy.lang import Builder
from kivy.app import runTouchApp


runTouchApp(Builder.load_string('''
GridLayout:
    padding: 10
    spacing: 10
    cols: 3
    Widget:
    Widget:
    ScrollView:
    Widget:
    Widget:
'''))
```

![screenshot at 2018-10-20 20-08-20](https://user-images.githubusercontent.com/26050135/47254957-ea45c980-d4a3-11e8-9a9a-343a654b28dc.png)
