### PR TITLE
Fix HIDMotionEvent log formatting

### DIFF
--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -608,8 +608,8 @@ else:
             fd = open(input_fn, 'rb')
 
             # get the controler name (EVIOCGNAME)
-            device_name = str(fcntl.ioctl(fd, EVIOCGNAME + (256 << 16),
-                                      " " * 256)).split('\x00')[0]
+            device_name = fcntl.ioctl(fd, EVIOCGNAME + (256 << 16),
+                                      " " * 256).decode().strip()
             Logger.info('HIDMotionEvent: using <%s>' % device_name)
 
             # get abs infos


### PR DESCRIPTION
Fixes #3075

Before:

```
[INFO   ] HIDMotionEvent: using <b'eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00\x00                                                                                                                                                                                                                  '>
[INFO   ] HIDMotionEvent: <b'eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00\x00                                                                                                                                                                                                                  '> range ABS X position is 0 - 4095
[INFO   ] HIDMotionEvent: <b'eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00\x00                                                                                                                                                                                                                  '> range ABS Y position is 0 - 4095
[INFO   ] MTD: </dev/input/event0> range position X is 0 - 4095
[INFO   ] HIDMotionEvent: <b'eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00\x00                                                                                                                                                                                                                  '> range position X is 0 - 4095
[INFO   ] MTD: </dev/input/event0> range position Y is 0 - 4095
[INFO   ] HIDMotionEvent: <b'eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00\x00                                                                                                                                                                                                                  '> range position Y is 0 - 4095
```

After:

```
[INFO   ] HIDMotionEvent: using <eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00>
[INFO   ] HIDMotionEvent: <eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00> range ABS X position is 0 - 4095
[INFO   ] MTD: </dev/input/event0> range position X is 0 - 4095
[INFO   ] HIDMotionEvent: <eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00> range ABS Y position is 0 - 4095
[INFO   ] MTD: </dev/input/event0> range position Y is 0 - 4095
[INFO   ] HIDMotionEvent: <eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00> range position X is 0 - 4095
[INFO   ] MTD: </dev/input/event0> range touch major is 0 - 0
[INFO   ] HIDMotionEvent: <eGalax Inc. eGalaxTouch EXC3110-3883-08.00.00> range position Y is 0 - 4095
```

Note that this has __NOT__ been tested with Python 2. I'll do that soon.
