### PR TITLE
ensure floating point math when calculating fps

### DIFF
--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -119,9 +119,9 @@ class CameraOpenCV(CameraBase):
             self.fps = self._device.get(PROPERTY_FPS)
 
         if self.fps == 0 or self.fps == 1:
-            self.fps = 1 / 30
+            self.fps = 1.0 / 30
         elif self.fps > 1:
-            self.fps = 1 / self.fps
+            self.fps = 1.0 / self.fps
 
         if not self.stopped:
             self.start()


### PR DESCRIPTION
This corrects a bug in https://github.com/kivy/kivy/pull/6027 spotted by @pythonic64. Without this fps will by (wrongly) 0 on py27. @tito thanks for the merge, could you take a look at this too?