### PR TITLE
website layout improvement

### DIFF
--- a/doc/sources/.static/fresh.css
+++ b/doc/sources/.static/fresh.css
@@ -143,7 +143,7 @@ a:hover {
 
 
 div.sphinxsidebar {
-	width: 230px;
+	width: 15%;
 	float: left;
 }
 
@@ -214,8 +214,10 @@ div.sphinxsidebar li a:hover {
 }
 
 #content {
-	margin-left: 250px;
-	margin-top: -8px;
+	margin: auto;
+	width: 950px;
+	min-width: 50%;
+	max-width: 95%;
 }
 
 #content pre {
@@ -423,6 +425,7 @@ div.sphinxsidebar .api-index li a {
 
 /** TOC **/
 .toc {
+	width: auto;
 	background-color: #f5f5f5;
 	border: 1px solid #e0e0e0;
 	padding: 10px;
@@ -469,7 +472,6 @@ table.highlighttable td.linenos {
 /** version added in method/class/attribute/module **/
 span.versionadded {
 	font-size: 12px;
-	position: absolute;
 	right: 2.5em;
 }
 

--- a/doc/sources/.static/fresh.css
+++ b/doc/sources/.static/fresh.css
@@ -372,10 +372,10 @@ table.field-list td.field-body dl.docutils dd {
 form.search input {
 	line-height: 2em;
 	border: 1px solid #d0d0d0;
-	width: 211px;
+	width: 100%;
 	display: block;
 	font-size: 1.1em;
-	padding: 5px 8px;
+	padding: 5px 0px;
 }
 
 form.search {
@@ -423,7 +423,6 @@ div.sphinxsidebar .api-index li a {
 
 /** TOC **/
 .toc {
-	width: auto;
 	background-color: #f5f5f5;
 	border: 1px solid #e0e0e0;
 	padding: 10px;

--- a/doc/sources/.static/fresh.css
+++ b/doc/sources/.static/fresh.css
@@ -226,6 +226,10 @@ div.sphinxsidebar li a:hover {
 	font-family: 'Source Code Pro', monospace;
 }
 
+#content h1, h2, h3, h4, h5, h6 {
+	font-weight: bold;
+}
+
 #content h1 {
 	margin-bottom: 25px;
 }
@@ -446,9 +450,20 @@ div.sphinxsidebar .api-index li a {
 	padding: 0px;
 	margin: 0px;
 }
-.toc ul li li li {
+
+.toc ul li li {
 	padding-left: 10px;
 	border-left: 1px solid #e0e0e0;
+}
+
+.toc ul li li li {
+	padding-left: 10px;
+	border-left: 3px double #e0e0e0;
+}
+
+.toc ul li li li li {
+	padding-left: 10px;
+	border-left: 3px double #e0e0e0;
 }
 
 

--- a/doc/sources/.static/kivy.js
+++ b/doc/sources/.static/kivy.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
 		pagename = pagename.substr(4, pagename.length - 9);
 
 		ensure_bodyshortcut();
-		var modulename = $('<div class="left">Module: <a href="#">' + pagename + '</a></div>')
+		var modulename = $('<span class="left">Module: <a href="#">' + pagename + '</a></span>')
 		modulename.appendTo($('div.bodyshortcut'));
 		is_api = true;
 	}
@@ -247,7 +247,7 @@ $(document).ready(function () {
 
 		// get module version
 		var module_version = read_version($('div.body > div.section > div.versionadded'), '1.0.0');
-		var html_version = '<span class="versionadded">Added in <span>' + module_version + '</span></span>';
+		var html_version = '<span class="right versionadded">Added in <span>' + module_version + '</span></span>';
 		$('div.bodyshortcut').append(html_version);
 
 		// resolve class version, default to module if nothing has been found

--- a/doc/sources/.templates/layout.html
+++ b/doc/sources/.templates/layout.html
@@ -174,6 +174,7 @@
 {%- block document %}
 <div id="contentall">
     {%- block sidebar1 %}{{ sidebar() }}{% endblock %}
+    <div class="toc"><h2>{{ _('Table Of Contents') }}</h2>{{ toc }}</div>
     <div id="content">
     <div class="wrapper">
       <div class="documentwrapper">
@@ -181,7 +182,6 @@
         <div class="bodywrapper">
       {%- endif %}{% endif %}
           <div class="body">
-            <div class="toc"><h2>{{ _('Table Of Contents') }}</h2>{{ toc }}</div>
             {% block body %} {% endblock %}
             <div class="footerlinks">
             {%- if prev or next %}


### PR DESCRIPTION
Changes this

![beofre](https://imgur.com/lyeRRBq.png)

to this 

![after](https://imgur.com/8Wr5ngZ.png)

(guides: [before](https://imgur.com/6L7SwXr.png), [after](https://imgur.com/3xo8SlK.png) ).

Research suggest shorter lines improves readability. [[1]](https://en.wikipedia.org/wiki/Line_length). It is said that 75 would be optimal, however I find that a bit drastic. This is about 120.