### PR TITLE
Cythonized a few important widgets, and lang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -800,7 +800,14 @@ sources = {
             'lib/libtess2/Source/tess.c'
         ]
     }),
-    'graphics/svg.pyx': merge(base_flags, gl_flags_base)
+    'graphics/svg.pyx': merge(base_flags, gl_flags_base),
+    'lang/builder.py': {},
+    'lang/parser.py': {},
+    'uix/videoplayer.py': {},
+    'uix/relativelayout.py': {},
+    'uix/floatlayout.py': {},
+    'uix/layout.py': {},
+    'uix/carousel.py': {},
 }
 
 if c_options["use_sdl2"]:


### PR DESCRIPTION
Adding lang package and some widgets to the cythonization in setup.py, improve performances at the cost of making kivy a bit less easy to change (as you now need to rebuild everytime you change any of these, or just to delete the .so files when you are developping).