### PR TITLE
Update camera_android.py; fixes camera for Python 3

### DIFF
--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -126,7 +126,7 @@ class CameraAndroid(CameraBase):
         with self._buflock:
             self._buffer = None
         for k in range(2):  # double buffer
-            buf = '\x00' * self._bufsize
+            buf = b'\x00' * self._bufsize
             self._android_camera.addCallbackBuffer(buf)
         self._android_camera.setPreviewCallbackWithBuffer(self._preview_cb)
 


### PR DESCRIPTION
In Python 3, the buffer needs to an explicit bytestring rather than a string; hence changing:
buf = '\x00' * self._bufsize
to
buf = b'\x00' * self._bufsize

Fixes various issues:
in Kivy https://github.com/kivy/kivy/issues/5939
and in associated garden project ZbarCam https://github.com/kivy-garden/garden.zbarcam/issues/13