### PR TITLE
Add new "canonical" path for binary Mali driver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,8 @@ if exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
 if(
     exists('/usr/lib/arm-linux-gnueabihf/libMali.so')
-    or exists('/usr/local/mali-egi/libmali.so')
+    or exists('/usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so')
+    or exists('/usr/local/mali-egl/libmali.so')
 ):
     platform = 'mali'
 

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,10 @@ if kivy_ios_root is not None:
     platform = 'ios'
 if exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
-if exists('/usr/lib/arm-linux-gnueabihf/libMali.so'):
+if(
+    exists('/usr/lib/arm-linux-gnueabihf/libMali.so')
+    or exists('/usr/local/mali-egi/libmali.so')
+):
     platform = 'mali'
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This improves detection on "standard" setups of the Mali driver for platforms such as the Odroid XU4.