### PR TITLE
Added the ability to stop (kill) the UrlRequest thread

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -117,9 +117,9 @@ class UrlRequest(Thread):
     .. versionchanged:: 1.10.0
 
         Parameters `proxy_host`, `proxy_port` and `proxy_headers` added.
-        
+
     .. versionchanged:: 1.11.0
-    
+
         Parameters `on_cancel` added.
 
     :Parameters:
@@ -596,7 +596,7 @@ class UrlRequest(Thread):
         '''Cancel the current request. It will be aborted, and the result
         will not be dispatched. Once cancelled, the callback on_cancel will
         be called.
-        
+
         .. versionadded:: 1.11.0
         '''
         self._cancel_event.set()

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -62,6 +62,7 @@ from threading import Thread, Event
 from json import loads
 from time import sleep
 from kivy.compat import PY2
+from kivy.config import Config
 
 if PY2:
     from httplib import HTTPConnection

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -180,7 +180,8 @@ class UrlRequest(Thread):
                  req_body=None, req_headers=None, chunk_size=8192,
                  timeout=None, method=None, decode=True, debug=False,
                  file_path=None, ca_file=None, verify=True, proxy_host=None,
-                 proxy_port=None, proxy_headers=None, on_cancel=None):
+                 proxy_port=None, proxy_headers=None, user_agent=None,
+                 on_cancel=None):
         super(UrlRequest, self).__init__()
         self._queue = deque()
         self._trigger_result = Clock.create_trigger(self._dispatch_result, 0)

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -516,7 +516,7 @@ class UrlRequest(Thread):
 
             elif result == 'killed':
                 if self._debug:
-                    Logger.debug('UrlRequest killed by user')
+                    Logger.debug('UrlRequest: killed by user')
                 if self.on_kill:
                     func = self.on_kill()
                     if func:

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -134,9 +134,6 @@ class UrlRequest(Thread):
             download. `total_size` might be -1 if no Content-Length has been
             reported in the http response.
             This callback will be called after each `chunk_size` is read.
-        `on_cancel`: callback(request)
-            Callback function to call if user requested to cancel the download
-            operation via the .cancel() method.
         `req_body`: str, defaults to None
             Data to sent in the request. If it's not None, a POST will be done
             instead of a GET.
@@ -173,14 +170,17 @@ class UrlRequest(Thread):
         `proxy_headers`: dict, defaults to None
             If set, and `proxy_host` is also set, the headers to send to the
             proxy server in the ``CONNECT`` request.
+        `on_cancel`: callback(request)
+            Callback function to call if user requested to cancel the download
+            operation via the .cancel() method.
     '''
 
     def __init__(self, url, on_success=None, on_redirect=None,
                  on_failure=None, on_error=None, on_progress=None,
-                 on_cancel=None, req_body=None, req_headers=None,
-                 chunk_size=8192, timeout=None, method=None, decode=True,
-                 debug=False, file_path=None, ca_file=None, verify=True,
-                 proxy_host=None, proxy_port=None, proxy_headers=None):
+                 req_body=None, req_headers=None, chunk_size=8192,
+                 timeout=None, method=None, decode=True, debug=False,
+                 file_path=None, ca_file=None, verify=True, proxy_host=None,
+                 proxy_port=None, proxy_headers=None, on_cancel=None):
         super(UrlRequest, self).__init__()
         self._queue = deque()
         self._trigger_result = Clock.create_trigger(self._dispatch_result, 0)

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -228,7 +228,13 @@ class UrlRequest(Thread):
         q = self._queue.appendleft
         url = self.url
         req_body = self.req_body
-        req_headers = self.req_headers
+        req_headers = self.req_headers or {}
+        if (
+            Config.has_section('network')
+            and 'useragent' in Config.items('network')
+        ):
+            useragent = Config.get('network', 'useragent')
+            req_headers.setdefault('User-Agent', useragent)
 
         try:
             result, resp = self._fetch_url(url, req_body, req_headers, q)


### PR DESCRIPTION
Now the user can stop the UrlRequest async download by killing the thread.
I've also implemented a on_kill callback.