### PR TITLE
Fix sdl close inconsistencies. closes #4194

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -135,6 +135,7 @@ class WindowSDL(WindowBase):
     _do_resize_ev = None
 
     def __init__(self, **kwargs):
+        Logger.info("window_sdl2.py: instantiating SDL2 window")
         self._pause_loop = False
         self._win = _WindowSDL2Storage()
         super(WindowSDL, self).__init__()
@@ -208,7 +209,6 @@ class WindowSDL(WindowBase):
         from kivy.app import App
         if action == 'app_terminating':
             EventLoop.quit = True
-            self.close()
 
         elif action == 'app_lowmemory':
             self.dispatch('on_memorywarning')
@@ -486,11 +486,13 @@ class WindowSDL(WindowBase):
                 continue
 
             action, args = event[0], event[1:]
+            if "mouse" not in action:
+                Logger.info("window_sdl2.py: _mainloop action = {0}".format(
+                    action))
             if action == 'quit':
                 if self.dispatch('on_request_close'):
                     continue
                 EventLoop.quit = True
-                self.close()
                 break
 
             elif action in ('fingermotion', 'fingerdown', 'fingerup'):
@@ -708,7 +710,6 @@ class WindowSDL(WindowBase):
             action, args = event[0], event[1:]
             if action == 'quit':
                 EventLoop.quit = True
-                self.close()
                 break
             elif action == 'app_willenterforeground':
                 break
@@ -733,6 +734,8 @@ class WindowSDL(WindowBase):
                     raise
                 else:
                     pass
+        Logger.info("window_sdl2.py: exiting mainloop. Calling close")
+        self.close()
 
     #
     # Pygame wrapper

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -135,7 +135,6 @@ class WindowSDL(WindowBase):
     _do_resize_ev = None
 
     def __init__(self, **kwargs):
-        Logger.info("window_sdl2.py: instantiating SDL2 window")
         self._pause_loop = False
         self._win = _WindowSDL2Storage()
         super(WindowSDL, self).__init__()
@@ -486,9 +485,6 @@ class WindowSDL(WindowBase):
                 continue
 
             action, args = event[0], event[1:]
-            if "mouse" not in action:
-                Logger.info("window_sdl2.py: _mainloop action = {0}".format(
-                    action))
             if action == 'quit':
                 if self.dispatch('on_request_close'):
                     continue
@@ -734,7 +730,7 @@ class WindowSDL(WindowBase):
                     raise
                 else:
                     pass
-        Logger.info("window_sdl2.py: exiting mainloop. Calling close")
+        Logger.info("WindowSDL: exiting mainloop and closing.")
         self.close()
 
     #


### PR DESCRIPTION
Was experiencing the crash listed in #4194 and calling self.root_window.close() fixed it.

Further investigation showed that the "close" method was not being called on app.stop(). Looking into the code, the close() is only called on certain events, and even on desktop, resulting on the window teardown not being consistently called.

This PR moves the close() call to a single place which is reliably called under all of the following scenarios:
    Ubuntu desktop: Windows close icon
    Ubuntu desktop: app.stop()
    Android: app.stop()
