### PR TITLE
Support of base64 pictures

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -428,7 +428,7 @@ class Base64Image(Image):
                 image64 = source.split(';base64,')[1]
                 type64 = source.split('data:image/')[1] \
                                 .split(';base64,')[0]
-            except:
+            except IndexError:
                 raise Exception('Wrong type of base64 image.')
             base64l = base64.b64decode(image64)
             self._coreimage = image = CoreImage(
@@ -443,7 +443,7 @@ class Base64Image(Image):
 
     def _on_source_load(self, value):
         image = self._coreimage.image
-        if not image:
+        if image is None:
             return
         self.texture = image.texture
         self.dispatch('on_load')

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -250,6 +250,9 @@ from kivy.context import get_current_context
 from kivy.weakproxy import WeakProxy
 from functools import partial
 from itertools import islice
+from io import BytesIO
+from PIL import Image
+import base64
 
 
 # References to all the widget destructors (partial method with widget uid as
@@ -688,15 +691,8 @@ class Widget(WidgetBase):
 
                 .. versionadded:: 1.11.0
         '''
-        try:
-            from PIL import Image
-        except ImportError as error:
-            raise Exception(error)
-        from io import BytesIO
-
-        import base64
         scale = kwargs.get('scale', 1)
-        
+
         if self.parent is not None:
             canvas_parent_index = self.parent.canvas.indexof(self.canvas)
             if canvas_parent_index > -1:
@@ -704,14 +700,14 @@ class Widget(WidgetBase):
 
         fbo = Fbo(size=(self.width * scale, self.height * scale),
                   with_stencilbuffer=True)
-        
+
         with fbo:
             ClearColor(0, 0, 0, 0)
             ClearBuffers()
             Scale(1, -1, 1)
             Scale(scale, scale, 1)
             Translate(-self.x, -self.y - self.height, 0)
-        
+
         fbo.add(self.canvas)
         fbo.draw()
         bytesio = BytesIO()

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -660,6 +660,73 @@ class Widget(WidgetBase):
 
         return True
 
+    def export_to_base64(self, *args, **kwargs):
+        '''Saves an image of the widget and its children in base64 format saves into memory instead of storing it.
+        Works by removing the widget canvas from its
+        parent, rendering to an :class:`~kivy.graphics.fbo.Fbo`, and calling
+        :meth:`~kivy.graphics.texture.Texture.save`.
+
+        .. note::
+
+            The image includes only this widget and its children. If you want
+            to include widgets elsewhere in the tree, you must call
+            :meth:`~Widget.export_to_base64` from their common parent, or use
+            :meth:`~kivy.core.window.WindowBase.screenshot` to capture the
+            whole window.
+
+        .. note::
+
+            The image will be returned in a base64 format.
+
+        .. versionadded:: 1.9.0
+
+        :Parameters:
+            `method`: str
+                empty or 'web'. Note: None is for returning the image in Kivy and to be shown.
+            `scale`: float
+                The amount by which to scale the saved image, defaults to 1.
+
+                .. versionadded:: 1.11.0
+        '''
+        try:
+            from PIL import Image
+        except ImportError as error:
+            raise Exception(error)
+        from io import BytesIO
+
+        import base64
+        scale = kwargs.get('scale', 1)
+        
+        if self.parent is not None:
+            canvas_parent_index = self.parent.canvas.indexof(self.canvas)
+            if canvas_parent_index > -1:
+                self.parent.canvas.remove(self.canvas)
+
+        fbo = Fbo(size=(self.width * scale, self.height * scale),
+                  with_stencilbuffer=True)
+        
+        with fbo:
+            ClearColor(0, 0, 0, 0)
+            ClearBuffers()
+            Scale(1, -1, 1)
+            Scale(scale, scale, 1)
+            Translate(-self.x, -self.y - self.height, 0)
+        
+        fbo.add(self.canvas)
+        fbo.draw()
+        bytesio = BytesIO()
+        img = Image.frombytes('RGBA',
+                                self.size,
+                                fbo.pixels)
+        img.save(bytesio, 'PNG')
+        img = 'data:image/png;base64,' + base64.b64encode(bytesio.getvalue()).decode('utf-8')
+        fbo.remove(self.canvas)
+
+        if self.parent is not None and canvas_parent_index > -1:
+            self.parent.canvas.insert(canvas_parent_index, self.canvas)
+
+        return img
+
     def get_root_window(self):
         '''Return the root window.
 


### PR DESCRIPTION
My attempt to add support of base64 encoded pictures. Very useful features when you don't want to store locally these pictures. Also good when you work with remote apps in Kivy.

Demo app of examples on how to use it:
https://gist.github.com/kuzeyron/80416dcb10111ea858d03737f1e9423c

kivy.uix.image.Base64Image is ( WIP !! ) as we talked about with André!