### PR TITLE
Fixed fullscreen and orientation handling to work with SDL-2.0.9 on Android

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -76,7 +76,13 @@ cdef class _WindowSDL2Storage:
                 self.win_flags |= SDL_WINDOW_RESIZABLE
             if borderless:
                 self.win_flags |= SDL_WINDOW_BORDERLESS
-            if fullscreen == 'auto':
+
+            if USE_ANDROID:
+                # Android is handled separately because it is important to create the window with
+                # the same fullscreen setting as AndroidManifest.xml.
+                if environ.get('P4A_IS_WINDOWED', 'True') == 'False':
+                    self.win_flags |= SDL_WINDOW_FULLSCREEN
+            elif fullscreen == 'auto':
                 self.win_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP
             elif fullscreen is True:
                 self.win_flags |= SDL_WINDOW_FULLSCREEN
@@ -118,7 +124,6 @@ cdef class _WindowSDL2Storage:
         # var. Note that this takes priority over any other setting.
         orientations = environ.get('KIVY_ORIENTATION', orientations)
 
-        # SDL_SetHint(SDL_HINT_ORIENTATIONS, <bytes>(orientations.encode('utf-8')))
         SDL_SetHint(SDL_HINT_ORIENTATIONS, <bytes>(orientations.encode('utf-8')))
 
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1)

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -95,6 +95,9 @@ cdef class _WindowSDL2Storage:
 
         SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, b'0')
 
+        SDL_SetHintWithPriority(b'SDL_ANDROID_TRAP_BACK_BUTTON', b'1',
+                                SDL_HINT_OVERRIDE)
+
         if SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0:
             self.die()
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -224,6 +224,11 @@ cdef extern from "SDL.h":
         SDL_WINDOWEVENT_CLOSE           #< The window manager requests that the
                                         # window be closed */
 
+    ctypedef enum SDL_HintPriority:
+        SDL_HINT_DEFAULT
+        SDL_HINT_NORMAL
+        SDL_HINT_OVERRIDE
+
     ctypedef enum SDL_RendererFlip:
         SDL_FLIP_NONE = 0x00000000
         SDL_FLIP_HORIZONTAL = 0x00000001
@@ -440,6 +445,7 @@ cdef extern from "SDL.h":
     cdef char *SDL_HINT_ORIENTATIONS
     cdef char *SDL_HINT_VIDEO_WIN_D3DCOMPILER
     cdef char *SDL_HINT_ACCELEROMETER_AS_JOYSTICK
+    cdef char *SDL_HINT_ANDROID_TRAP_BACK_BUTTON
 
     cdef int SDL_QUERY               = -1
     cdef int SDL_IGNORE              =  0
@@ -505,6 +511,7 @@ cdef extern from "SDL.h":
     cdef int SDL_SetTextureAlphaMod(SDL_Texture * texture, Uint8 alpha)
     cdef char * SDL_GetError()
     cdef SDL_bool SDL_SetHint(char *name, char *value)
+    cdef SDL_bool SDL_SetHintWithPriority(char *name, char *value, SDL_HintPriority priority)
     cdef Uint8 SDL_GetMouseState(int* x,int* y)
     cdef SDL_GLContext SDL_GL_CreateContext(SDL_Window* window)
     cdef int SDL_GetNumVideoDisplays()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if "--build_examples" in sys.argv:
 from copy import deepcopy
 import os
 from os.path import join, dirname, sep, exists, basename, isdir
-from os import walk, environ
+from os import walk, environ, makedirs
 from distutils.version import LooseVersion
 from distutils.sysconfig import get_python_inc
 from collections import OrderedDict
@@ -156,6 +156,7 @@ c_options['use_opengl_mock'] = environ.get('READTHEDOCS', None) == 'True'
 c_options['use_sdl2'] = None
 c_options['use_pangoft2'] = None
 c_options['use_ios'] = False
+c_options['use_android'] = False
 c_options['use_mesagl'] = False
 c_options['use_x11'] = False
 c_options['use_wayland'] = False
@@ -328,6 +329,9 @@ class KivyBuildExt(build_ext):
             with open(fn) as fd:
                 need_update = fd.read() != content
         if need_update:
+            directory_name = dirname(fn)
+            if not exists(directory_name):
+                makedirs(directory_name)
             with open(fn, 'w') as fd:
                 fd.write(content)
         return need_update
@@ -403,6 +407,9 @@ if platform == 'ios':
     print('Kivy-IOS project located at {0}'.format(kivy_ios_root))
     c_options['use_ios'] = True
     c_options['use_sdl2'] = True
+
+elif platform == 'android':
+    c_options['use_android'] = True
 
 elif platform == 'darwin':
     if c_options['use_osx_frameworks']:


### PR DESCRIPTION
Makes Kivy compatible with python-for-android after the changes in https://github.com/kivy/python-for-android/pull/1528.

This probably also fixes some bugs in reading the env vars in python2/python3, especially on iOS with python3.

The code here was a bit messy and could do with further improvement, but that's a more general Kivy issue.

There is still some problem with handling the back button. After pressing it so that the app closes, then re-opening the app, I get the following error:

```
01-20 16:49:16.435 18071 18160 I python  : [INFO   ] [Logger      ] Record log in /data/user/0/net.inclem.lzviewer/files/app/.kivy/logs/kivy_19-01-20_1.txt
01-20 16:49:16.435 18071 18160 I python  : [INFO   ] [Kivy        ] v1.11.0.dev0, git-12a8b13, 20190120
01-20 16:49:16.435 18071 18160 I python  : [INFO   ] [Python      ] v3.7.1 (default, Jan 18 2019, 23:21:04) 
01-20 16:49:16.435 18071 18160 I python  : [Clang 6.0.2 (https://android.googlesource.com/toolchain/clang 183abd29fc496f55
01-20 16:49:16.669 18071 18160 I python  :  Traceback (most recent call last):
01-20 16:49:16.669 18071 18160 I python  :    File "main.py", line 14, in <module>
01-20 16:49:16.670 18071 18160 I python  :      from kivy.app import App
01-20 16:49:16.670 18071 18160 I python  :    File "/data/user/0/net.inclem.lzviewer/files/app/_python_bundle/site-packages/kivy/app.py", line 319, in <module>
01-20 16:49:16.671 18071 18160 I python  :      from kivy.base import runTouchApp, stopTouchApp
01-20 16:49:16.672 18071 18160 I python  :    File "/data/user/0/net.inclem.lzviewer/files/app/_python_bundle/site-packages/kivy/base.py", line 26, in <module>
01-20 16:49:16.672 18071 18160 I python  :      from kivy.clock import Clock
01-20 16:49:16.672 18071 18160 I python  :    File "/data/user/0/net.inclem.lzviewer/files/app/_python_bundle/site-packages/kivy/clock.py", line 706, in <module>
01-20 16:49:16.674 18071 18160 I python  :      class ClockBase(ClockBaseBehavior, CyClockBase):
01-20 16:49:16.675 18071 18160 I python  :  TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
01-20 16:49:16.861 18071 18160 I python  : Python for android ended.
```
I haven't yet checked if this is related to the SDL_ANDROID_TRAP_BACK_BUTTON hint, which I don't think I have set. It's a weird error though, the Python thread appears to finish and close just fine so I don't see what state is hanging around to cause this problem. The issue goes away if the app is completely closed by swiping it away in the app list.