### PR TITLE
declare `_filename` in svg.pxd

### DIFF
--- a/kivy/graphics/svg.pxd
+++ b/kivy/graphics/svg.pxd
@@ -57,6 +57,7 @@ cdef class Svg(RenderContext):
     cdef StripMesh last_mesh
     cdef bint closed
     cdef float vbox_x, vbox_y, vbox_width, vbox_height
+    cdef str _filename
 
     cdef void reload(self) except *
     cdef parse_tree(self, tree)


### PR DESCRIPTION
seems cython is not happy anymore if we don't declare that beforehand, so here it is.

fixes #6101 