### PR TITLE
[widgets][VERY WIP] Start to implement themes

### DIFF
--- a/kivy/uix/__init__.py
+++ b/kivy/uix/__init__.py
@@ -54,9 +54,3 @@ Kivy widgets can be categorized as follows:
 
 ----
 '''
-from kivy.config import Config
-
-
-__theme_path = Config.get("kivy", "theme_path")
-if __theme_path != "/":
-    __path__ = [__theme_path]

--- a/kivy/uixc.py
+++ b/kivy/uixc.py
@@ -1,4 +1,9 @@
 from os import getcwd
+from kivy.config import Config
 
 
-__path__ = [getcwd() + "/uix"]
+__theme_path = Config.get("kivy", "theme_path")
+if __theme_path == "/":
+    __path__ = [getcwd() + "/uix"]
+else:
+    __path__ = [__theme_path]


### PR DESCRIPTION
### What is it

This PR creates a new "fake module" called uixc, that will actually point to any other module on your disk, that's what I call of theme, this way you can customize widgets by downloading or creating themes(folders with the widgets kivy.uix has) and importing via `from kivy.uixc.label import Label` for example.

### How do I do it
Okay so my approach to implement themes is by using the `__path__` variable.

If you already know skip this paragraph. Every file that contains a `__path__` variable is already considerated a module, the `__path__` as you have guesses contains the path to the module files inside a list, like: ["/home/heyimcool/mypythonmodule"]. What I do here is detecting if config.ini has an entry called theme_path when loading the uixc module, if it is "/" keep `__path__` to the uix module, if not, set the `__path__` to the theme module.

Here themes would be folders inside ~/.kivy/themes(maybe someone can suggest a better path for putting themes but that one seems okay). Then in the config at section [kivy] you set theme_path = "/home/path/to/your/theme". This way the uixc file will point to your theme folder.

### Extras

For switching themes in runtime (I guess that) you have to import config, set theme_path to your other theme and reimport the uixc widgets.

Also for that a new config version was created, version 21.

Also it is nice for themes to just import the default widgets and customize them, this way if kivy fixes a bug or something in its widgets you don't need to update your code.

UIXC is for UIX Customized :) If you got a better name tell me, I'll gladly accept it.

There is a lot more to do, I'll write docs about it and possibly make theming kivy_garden a thing.

### Pros and Cons

Pros of this solution for theming(I'm not talking about the dillema, but just about overriding uix folders):
- Lightweight compared to some other attempts(like running a for overriding every widget)
- Highly customizable since you can code the widgets

Cons:
- Idk, if you find one please tell me :) I'll happilly add it

### See it yourself :)

If you want to have a quick demo, create a folder, ~~put an __init__.py and~~(the `__init__.py` is not called, don't worry about it) copy the button.py from uix folder, in the end add the line:
```python
text = StringProperty("lalala")
```
Now go to you kivy config and set the theme_path to the path of your folder, then go to kivy/kivy folder and there create a file with this code:
```python
from uix.button import Button as NButton
from uixc.button import Button as CButton


print(NButton().text, CButton().text)
```
You will see that the NButton(Normal button) will print nothing, but the button you imported via uixc will print "lalala".