### PR TITLE
Removed python version specification from buildozer install

### DIFF
--- a/doc/sources/guide/packaging-android.rst
+++ b/doc/sources/guide/packaging-android.rst
@@ -44,7 +44,7 @@ You can get buildozer at `<https://github.com/kivy/buildozer>`_::
 
     git clone https://github.com/kivy/buildozer.git
     cd buildozer
-    sudo python2.7 setup.py install
+    sudo python setup.py install
 
 This will install buildozer in your system. Afterwards, navigate to
 your project directory and run::


### PR DESCRIPTION
Fixes https://github.com/kivy/buildozer/issues/774 (partially).

There is no reason to be specific about the python version.