### PR TITLE
Fix android's sensor orientation

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -117,9 +117,11 @@ cdef class _WindowSDL2Storage:
                 orientations = 'Portrait'
             elif env_orientations == 'landscape':
                 orientations = 'LandscapeLeft'
+            elif env_orientations == 'sensor':
+                orientations = 'sensor'
             else:
                 Logger.warning(('Could not satisfy Android orientation "{}", only '
-                               '{{portrait,landscape}} are currently supported. '
+                               '{{portrait,landscape and sensor}} are currently supported. '
                                 'Defaulting to portrait').format(orientations))
                 orientations = 'Portrait'
 


### PR DESCRIPTION
Due to the recent sdl2 updates we loosed the `sensor` orientation in android platform.

Resolves: kivy/python-for-android#1688 (this was reported in python-for-android's git but it seems that it is a kivy's issue after all)

Note: I made this pull request starting at commit b47f669 of kivy's master branch, because we use that commit as a version in python-for-android's kivy recipe, as this is the last known kivy's version that works for python-for-android (see issue #6136). This way we can test this pr avoiding that issue.