### PR TITLE
Fixes travis FBO tests

### DIFF
--- a/kivy/tests/test_fbo_py2py3.py
+++ b/kivy/tests/test_fbo_py2py3.py
@@ -34,7 +34,6 @@ class FboTest(Widget):
 class FBOPy2Py3TestCase(GraphicUnitTest):
     def test_fbo_get_pixel_color(self):
         fbow = FboTest()
-        self.render(fbow)
         render_error = 2
         values = (
             # out of bounds of FBO


### PR DESCRIPTION
The current FBO tests were calling render() function, but Fbo.draw() was already working. In addition, the render() output potentally the window output to the Fbo, which screw it in the end.

Just fbo.draw() and check the content works as intented.