### PR TITLE
Fix some travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
         sudo apt-get -y install libgstreamer1.0-dev gstreamer1.0-alsa gstreamer1.0-plugins-base;
         sudo apt-get -y install python-dev libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff4-dev libX11-dev libmtdev-dev;
         sudo apt-get -y install python-setuptools build-essential libgl1-mesa-dev libgles2-mesa-dev;
-        sudo apt-get -y install xvfb pulseaudio;
+        sudo apt-get -y install xvfb pulseaudio xsel;
         pip install --upgrade cython pillow nose coveralls docutils;
       fi;
       if [ "${RUN}" == "docs" ]; then

--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -143,7 +143,8 @@ class CameraOpenCV(CameraBase):
             try:
                 self._buffer = frame.imageData
             except AttributeError:
-                # frame is already of type ndarray which can be reshaped to 1-d.
+                # frame is already of type ndarray
+                # which can be reshaped to 1-d.
                 self._buffer = frame.reshape(-1)
             self._copy_to_gpu()
         except:

--- a/kivy/tests/test_fbo_py2py3.py
+++ b/kivy/tests/test_fbo_py2py3.py
@@ -34,7 +34,6 @@ class FboTest(Widget):
 class FBOPy2Py3TestCase(GraphicUnitTest):
     def test_fbo_get_pixel_color(self):
         fbow = FboTest()
-        self.render(fbow)
         render_error = 2
         values = (
             # out of bounds of FBO

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -824,11 +824,13 @@ class FileChooserController(RelativeLayout):
                     new_path += sep
                 pardir = self._create_entry_widget(dict(
                     name=back, size='', path=new_path, controller=ref(self),
-                    isdir=True, parent=None, sep=sep, get_nice_size=lambda: ''))
+                    isdir=True, parent=None, sep=sep,
+                    get_nice_size=lambda: ''))
             else:
                 pardir = self._create_entry_widget(dict(
                     name=back, size='', path=back, controller=ref(self),
-                    isdir=True, parent=None, sep=sep, get_nice_size=lambda: ''))
+                    isdir=True, parent=None, sep=sep,
+                    get_nice_size=lambda: ''))
             yield 0, 1, pardir
 
         # generate all the entries for files

--- a/setup.py
+++ b/setup.py
@@ -146,9 +146,9 @@ if exists('/opt/vc/include/bcm_host.h'):
 if environ.get('VIDEOCOREMESA', None):
     platform = 'vc'
 mali_paths = (
-  '/usr/lib/arm-linux-gnueabihf/libMali.so',
-  '/usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so',
-  '/usr/local/mali-egl/libmali.so')
+    '/usr/lib/arm-linux-gnueabihf/libMali.so',
+    '/usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so',
+    '/usr/local/mali-egl/libmali.so')
 if any((exists(path) for path in mali_paths)):
     platform = 'mali'
 


### PR DESCRIPTION
  - The current `FBO` tests were calling render() function, but `Fbo.draw()` was already working. In addition, the `render()` output potentially the window output to the Fbo, which screw it in the end. Just `fbo.draw()` and check the content works as intended (Thanks @tito).
  - Fix kivy's initialization error on graphics test for linux: `Unable to find any valuable Cutbuffer provider`
    (This is due to a missing dependency for linux `xclip` or `xsel`)
     See also: https://travis-ci.org/kivy/kivy/jobs/490796639
  - Fix pep8 E501: line too long (`filechooser` and `camera_opencv`)
  - Fix pep8 E121: continuation line under-indented for hanging indent (`setup.py`)
