### PR TITLE
Include GStreamer in PyInstaller package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
         sudo apt-get -y install python-dev libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff4-dev libX11-dev libmtdev-dev;
         sudo apt-get -y install python-setuptools build-essential libgl1-mesa-dev libgles2-mesa-dev;
         sudo apt-get -y install xvfb pulseaudio xsel;
-        pip install --upgrade cython pillow nose coveralls docutils;
+        pip install --upgrade cython pillow nose coveralls docutils PyInstaller;
       fi;
       if [ "${RUN}" == "docs" ]; then
         pip install --upgrade sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag;
@@ -115,10 +115,10 @@ install:
            curl -O -L https://www.python.org/ftp/python/3.5.2/python-3.5.2-macosx10.6.pkg;
            sudo installer -package python-3.5.2-macosx10.6.pkg -target /;
            python3 get-pip.py --user;
-           python3 -m pip install --upgrade --user cython pillow nose mock docutils;
+           python3 -m pip install --upgrade --user cython pillow nose mock docutils PyInstaller;
         else
            python get-pip.py --user;
-           python -m pip install --upgrade --user cython pillow nose mock docutils;
+           python -m pip install --upgrade --user cython pillow nose mock docutils PyInstaller;
         fi;
       fi;
     fi;
@@ -227,7 +227,7 @@ script:
           python$pyver_short -m pip install git+http://github.com/tito/osxrelocator --user;
 
           python$pyver_short -m pip install --upgrade --user pip;
-          python$pyver_short -m pip install --upgrade --user cython nose wheel pillow mock docutils;
+          python$pyver_short -m pip install --upgrade --user cython nose wheel pillow mock docutils PyInstaller;
           python$pyver_short -m pip install --upgrade delocate;
 
           USE_SDL2=1 USE_GSTREAMER=1 python$pyver_short setup.py build_ext --inplace>output.txt;

--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -64,10 +64,14 @@ import pkgutil
 import logging
 from os.path import dirname, join
 import importlib
+import subprocess
+import re
+import glob
 
 import kivy
 import kivy.deps
 from kivy.factory import Factory
+from PyInstaller.depend import bindepend
 
 from os import environ
 if 'KIVY_DOC' not in environ:
@@ -163,9 +167,10 @@ def get_deps_minimal(exclude_ignored=True, **kwargs):
 
     :returns:
 
-        A dict with two keys, ``hiddenimports`` and ``excludes``. Their values
-        are a list of the corresponding modules to include/exclude. This can
-        be passed directly to `Analysis`` with e.g. ::
+        A dict with three keys, ``hiddenimports``, ``excludes``, and
+        ``binaries``. Their values are a list of the corresponding modules to
+        include/exclude. This can be passed directly to `Analysis`` with
+        e.g. ::
 
             a = Analysis(['..\\kivy\\examples\\demo\\touchtracer\\main.py'],
                         ...
@@ -229,9 +234,17 @@ def get_deps_minimal(exclude_ignored=True, **kwargs):
 
     mods = sorted(set(mods))
 
-    if exclude_ignored and not any('gstplayer' in m for m in mods):
+    binaries = []
+    if any('gstplayer' in m for m in mods):
+        binaries = _find_gst_binaries()
+    elif exclude_ignored:
         excludes.append('kivy.lib.gstplayer')
-    return {'hiddenimports': mods, 'excludes': excludes}
+
+    return {
+        'hiddenimports': mods,
+        'excludes': excludes,
+        'binaries': binaries,
+    }
 
 
 def get_deps_all():
@@ -245,15 +258,17 @@ def get_deps_all():
 
     :returns:
 
-        A dict with two keys, ``hiddenimports`` and ``excludes``. Their values
-        are a list of the corresponding modules to include/exclude. This can
-        be passed directly to `Analysis`` with e.g. ::
+        A dict with three keys, ``hiddenimports``, ``excludes``, and
+        ``binaries``. Their values are a list of the corresponding modules to
+        include/exclude. This can be passed directly to `Analysis`` with
+        e.g. ::
 
             a = Analysis(['..\\kivy\\examples\\demo\\touchtracer\\main.py'],
                         ...
                          **get_deps_all())
     '''
     return {
+        'binaries': _find_gst_binaries(),
         'hiddenimports': sorted(set(kivy_modules +
                                     collect_submodules('kivy.core'))),
         'excludes': []}
@@ -284,3 +299,54 @@ def add_dep_paths():
         if hasattr(mod, 'dep_bins'):
             paths.extend(mod.dep_bins)
     sys.path.extend(paths)
+
+
+def _find_gst_plugin_path():
+    '''Returns a list of directories to search for GStreamer plugins.
+    '''
+    if 'GST_PLUGIN_PATH' in environ:
+        return [
+            os.path.abspath(os.path.expanduser(path))
+            for path in environ['GST_PLUGIN_PATH'].split(os.pathsep)
+        ]
+
+    try:
+        p = subprocess.Popen(
+            ['gst-inspect-1.0', 'coreelements'],
+            stdout=subprocess.PIPE)
+    except:
+        return []
+    (stdoutdata, stderrdata) = p.communicate()
+
+    match = re.search(r'\s+(\S+libgstcoreelements\.\S+)', stdoutdata)
+
+    if not match:
+        return []
+
+    return [os.path.dirname(match.group(1))]
+
+
+def _find_gst_binaries():
+    '''Returns a list of GStreamer plugins and libraries to pass as the
+    ``binaries`` argument of ``Analysis``.
+    '''
+    gst_plugin_path = _find_gst_plugin_path()
+
+    plugin_filepaths = []
+    for plugin_dir in gst_plugin_path:
+        plugin_filepaths.extend(
+            glob.glob(os.path.join(plugin_dir, 'libgst*')))
+    if len(plugin_filepaths) == 0:
+        logging.warn('Could not find GStreamer plugins. ' +
+                     'Possible solution: set GST_PLUGIN_PATH')
+        return []
+
+    lib_filepaths = set()
+    for plugin_filepath in plugin_filepaths:
+        plugin_deps = bindepend.selectImports(plugin_filepath)
+        lib_filepaths.update([path for _, path in plugin_deps])
+
+    plugin_binaries = [(f, 'gst-plugins') for f in plugin_filepaths]
+    lib_binaries = [(f, '.') for f in lib_filepaths]
+
+    return plugin_binaries + lib_binaries

--- a/kivy/tools/packaging/pyinstaller_hooks/pyi_rth_kivy.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/pyi_rth_kivy.py
@@ -5,8 +5,7 @@ root = os.path.join(sys._MEIPASS, 'kivy_install')
 
 os.environ['KIVY_DATA_DIR'] = os.path.join(root, 'data')
 os.environ['KIVY_MODULES_DIR'] = os.path.join(root, 'modules')
-os.environ['GST_PLUGIN_PATH'] = '{};{}'.format(
-    sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins'))
+os.environ['GST_PLUGIN_PATH'] = os.path.join(sys._MEIPASS, 'gst-plugins')
 os.environ['GST_REGISTRY'] = os.path.join(sys._MEIPASS, 'registry.bin')
 
 sys.path += [os.path.join(root, '_libs')]


### PR DESCRIPTION
Closes #6126.

This changes `get_deps_minimal` in `kivy.tools.packaging.pyinstaller_hooks`  to include GStreamer plugins and libraries when `gstplayer` is given as a provider to include. It also changes `get_deps_all` to always include GStreamer, which seems to match the intent of that function.

Also fixes an issue with `GST_PLUGIN_PATH` in the runtime hook.

Tested only on MacOS with GStreamer installed using homebrew. There are a couple of things I'm not sure about:

- How does the `kivy.deps.gstreamer` package factor in? Seems like it's Windows-only; should we disable this fix on Windows?

- When I `pip install kivy`, the package gets installed with a `.dylibs` directory that includes `libgstreamer-1.0.0.dylib`. I got errors when the plugins were loading about a GST version mismatch. `pip install kivy --no-binary kivy` fixed this issue for me. I'm not sure about the implications of this.

Sample spec file:

```python
# -*- mode: python -*-

block_cipher = None
from kivy.tools.packaging.pyinstaller_hooks import get_deps_all, get_deps_minimal, hookspath, runtime_hooks

kivy_deps = get_deps_minimal(video=None, window=True, audio=['gstplayer'])
# kivy_deps = get_deps_all()

a = Analysis(['../testapp/main.py'],
             pathex=['.'],
             datas=[],
             hookspath=hookspath(),
             runtime_hooks=runtime_hooks(),
             win_no_prefer_redirects=False,
             win_private_assemblies=False,
             cipher=block_cipher,
             noarchive=False,
             **kivy_deps)
pyz = PYZ(a.pure, a.zipped_data,
             cipher=block_cipher)
exe = EXE(pyz,
          a.scripts,
          [],
          exclude_binaries=True,
          name='soundloader-test',
          debug=False,
          bootloader_ignore_signals=False,
          strip=False,
          upx=True,
          console=False )
coll = COLLECT(exe, Tree('../testapp/'),
               a.binaries,
               a.zipfiles,
               a.datas,
               strip=False,
               upx=True,
               name='soundloader-test')
app = BUNDLE(coll,
             name='soundloader-test.app',
             icon=None,
             bundle_identifier=None)
```