### PR TITLE
kivy.utils.rgba function bug fix for python 3 (used to crash)

### DIFF
--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -96,15 +96,16 @@ def rgba(s, *args):
     '''
     if isinstance(s, string_types):
         return get_color_from_hex(s)
-    elif isinstance(s, (list, tuple)):
-        s = map(lambda x: x / 255., s)
+    if isinstance(s, (list, tuple)):
+        s = [x / 255. for x in s]
         if len(s) == 3:
-            return list(s) + [1]
+            s.append(1)
         return s
-    elif isinstance(s, (int, float)):
-        s = map(lambda x: x / 255., [s] + list(args))
+    if isinstance(s, (int, float)):
+        s = [s / 255.]
+        s.extend(x / 255. for x in args)
         if len(s) == 3:
-            return list(s) + [1]
+            s.append(1)
         return s
     raise Exception('Invalid value (not a string / list / tuple)')
 


### PR DESCRIPTION
I am working on a project with kivy on Windows 10 and Python 3.7.2 and I recently noticed that the `rgba` function from `kivy.utils` doesn't work on this version of python. It  simply crashes with this error message:
```
Traceback (most recent call last):
   File "test.py", line 91, in <module>
     print(ut.rgba([255, 255, 255]))
   File "D:\Programs\Python37\lib\site-packages\kivy\utils.py", line 101, in rgba
     if len(s) == 3:
 TypeError: object of type 'map' has no len()
```
When looking at the source code, I found what's the problem:
It's using the `map` function to parse the arguments. This function was changed in Python 3, and now it returns a generator (`map` object to be specific) instead of a `list` so the `len` function fails. I changed this code to use list comprehension instead of `map`, so now it works on both versions of python.