### PR TITLE
Clipboard: fixes for nspaste

### DIFF
--- a/kivy/core/clipboard/clipboard_nspaste.py
+++ b/kivy/core/clipboard/clipboard_nspaste.py
@@ -37,7 +37,8 @@ class ClipboardNSPaste(ClipboardBase):
     def put(self, data, mimetype='text/plain'):
         pb = self._clipboard
         pb.clearContents()
-        pb.writeObjects_([data])
+        utf8 = NSString.alloc().initWithUTF8String_(data)
+        pb.setString_forType_(utf8, 'public.utf8-plain-text')
 
     def get_types(self):
         return list('text/plain',)

--- a/kivy/tests/test_clipboard.py
+++ b/kivy/tests/test_clipboard.py
@@ -1,7 +1,7 @@
-import unittest
+from kivy.tests.common import GraphicUnitTest
 
 
-class ClipboardTestCase(unittest.TestCase):
+class ClipboardTestCase(GraphicUnitTest):
 
     def setUp(self):
         from kivy.core.clipboard import Clipboard
@@ -11,6 +11,7 @@ class ClipboardTestCase(unittest.TestCase):
         if 'UTF8_STRING' in clippy_types:
             cliptype = 'UTF8_STRING'
         self._cliptype = cliptype
+        super(ClipboardTestCase, self).setUp()
 
     def test_clipboard_not_dummy(self):
         clippy = self._clippy
@@ -32,3 +33,10 @@ class ClipboardTestCase(unittest.TestCase):
         except:
             self.fail(
                 'Can not get put data to clipboard')
+
+    def test_clipboard_copy_paste(self):
+        clippy = self._clippy
+        txt1 = u"Hello 1"
+        clippy.copy(txt1)
+        ret = clippy.paste()
+        self.assertEqual(txt1, ret)


### PR DESCRIPTION
Also ncludes fixes for clipboard tests as they weren't working alone, SDL2 requires initialization/Window to work, but not nspaste. This allow also to run the test by itself.

This wasn't seen before because they were no test about testing if the content of the copy() is returned in paste(). Before paste() was just empty.

Fixes #6178