### PR TITLE
window: fix multiple resize sent, and always sent the GL size, never …

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -678,7 +678,7 @@ class WindowSDL(WindowBase):
     def _do_resize(self, dt):
         Logger.debug('Window: Resize window to %s' % str(self.size))
         self._win.resize_window(*self._size)
-        self.dispatch('on_resize', *self.size)
+        self.dispatch('on_pre_resize', *self.size)
 
     def do_pause(self):
         # should go to app pause mode (desktop style)

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -115,7 +115,7 @@ cdef int event_callback(XEvent *event):
     elif event.type == ConfigureNotify:
         if (event.xconfigure.width != _window_object.system_size[0]) or (event.xconfigure.height != _window_object.system_size[1]):
             _window_object._size = event.xconfigure.width, event.xconfigure.height
-            _window_object.dispatch('on_resize', event.xconfigure.width, event.xconfigure.height)
+            _window_object.dispatch('on_pre_resize', event.xconfigure.width, event.xconfigure.height)
 
     # mouse motion
     elif event.type == ButtonPress or event.type == ButtonRelease:


### PR DESCRIPTION
…the system size, otherwise you'll end up with the size sent twice.

Now, because we send the correct size, there is still a code path that make the resize event sent twice. I introduced a pre_resize internal event to debounce it.

Fixes #6082