### PR TITLE
Updated version no. for SDL building

### DIFF
--- a/doc/sources/installation/installation-devel.rst
+++ b/doc/sources/installation/installation-devel.rst
@@ -66,13 +66,13 @@ OS X
 Without using brew you can install the dependencies for kivy by
 manually pasting the following commands in a terminal::
 
-    curl -O -L https://www.libsdl.org/release/SDL2-2.0.4.dmg
+    curl -O -L https://www.libsdl.org/release/SDL2-2.0.9.dmg
     curl -O -L https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1.dmg
     curl -O -L https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.1.dmg
     curl -O -L https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.13.dmg
     curl -O -L http://gstreamer.freedesktop.org/data/pkg/osx/1.7.1/gstreamer-1.0-1.7.1-x86_64.pkg
     curl -O -L http://gstreamer.freedesktop.org/data/pkg/osx/1.7.1/gstreamer-1.0-devel-1.7.1-x86_64.pkg
-    hdiutil attach SDL2-2.0.4.dmg
+    hdiutil attach SDL2-2.0.9.dmg
     sudo cp -a /Volumes/SDL2/SDL2.framework /Library/Frameworks/
 
 This should ask you for your root password, provide it and then paste


### PR DESCRIPTION
Hit an issue today with cython 0.28.2 complaining about redefining certain constants when building against SDL 2.0.4. Using 2.0.9 solved the problems. 