### PR TITLE
Update OSX SDL2/Image/Mixer/TTF to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,20 +81,20 @@ install:
       hdiutil attach aria2-1.29.0-osx-darwin.dmg;
       sudo installer -package "/Volumes/aria2 1.29.0 Intel/aria2.pkg" -target /;
 
-      curl -O -L https://www.libsdl.org/release/SDL2-2.0.5.dmg;
-      curl -O -L https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.1.dmg;
-      curl -O -L https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.1.dmg;
-      curl -O -L https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14.dmg;
+      curl -O -L https://www.libsdl.org/release/SDL2-2.0.9.dmg;
+      curl -O -L https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.4.dmg;
+      curl -O -L https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.dmg;
+      curl -O -L https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.dmg;
       /usr/local/aria2/bin/aria2c -x 10 https://gstreamer.freedesktop.org/data/pkg/osx/1.10.2/gstreamer-1.0-1.10.2-x86_64.pkg;
       /usr/local/aria2/bin/aria2c -x 10 https://gstreamer.freedesktop.org/data/pkg/osx/1.10.2/gstreamer-1.0-devel-1.10.2-x86_64.pkg;
 
-      hdiutil attach SDL2-2.0.5.dmg;
+      hdiutil attach SDL2-2.0.9.dmg;
       sudo cp -a /Volumes/SDL2/SDL2.framework /Library/Frameworks/;
-      hdiutil attach SDL2_image-2.0.1.dmg;
+      hdiutil attach SDL2_image-2.0.4.dmg;
       sudo cp -a /Volumes/SDL2_image/SDL2_image.framework /Library/Frameworks/;
-      hdiutil attach SDL2_ttf-2.0.14.dmg;
+      hdiutil attach SDL2_ttf-2.0.15.dmg;
       sudo cp -a /Volumes/SDL2_ttf/SDL2_ttf.framework /Library/Frameworks/;
-      hdiutil attach SDL2_mixer-2.0.1.dmg;
+      hdiutil attach SDL2_mixer-2.0.4.dmg;
       sudo cp -a /Volumes/SDL2_mixer/SDL2_mixer.framework /Library/Frameworks/;
       sudo installer -package gstreamer-1.0-1.10.2-x86_64.pkg -target /;
       sudo installer -package gstreamer-1.0-devel-1.10.2-x86_64.pkg -target /;

--- a/setup.py
+++ b/setup.py
@@ -367,12 +367,17 @@ class KivyBuildExt(build_ext, object):
 
 
 def _check_and_fix_sdl2_mixer(f_path):
+    # Between SDL_mixer 2.0.1 and 2.0.4, the included frameworks changed
+    # smpeg2 have been replaced with mpg123, but there is no need to fix.
+    smpeg2_path = ("{}/Versions/A/Frameworks/smpeg2.framework"
+                   "/Versions/A/smpeg2").format(f_path)
+    if not exists(smpeg2_path):
+        return
+
     print("Check if SDL2_mixer smpeg2 have an @executable_path")
     rpath_from = ("@executable_path/../Frameworks/SDL2.framework"
                   "/Versions/A/SDL2")
     rpath_to = "@rpath/../../../../SDL2.framework/Versions/A/SDL2"
-    smpeg2_path = ("{}/Versions/A/Frameworks/smpeg2.framework"
-                   "/Versions/A/smpeg2").format(f_path)
     output = getoutput(("otool -L '{}'").format(smpeg2_path)).decode('utf-8')
     if "@executable_path" not in output:
         return


### PR DESCRIPTION
- SDL 2.0.9
- SDL mixer to 2.0.4
- SDL image to 2.0.4
- SDL ttf to 2.0.15