### PR TITLE
Supports live resizing (sdl2 only)

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -47,7 +47,12 @@ cdef class _WindowSDL2Storage:
         cdef str name = None
         if not self.event_filter:
             return 1
-        if event.type == SDL_APP_TERMINATING:
+        if event.type == SDL_WINDOWEVENT:
+            if event.window.event == SDL_WINDOWEVENT_RESIZED:
+                action = ('windowresized',
+                          event.window.data1, event.window.data2)
+                return self.event_filter(*action)
+        elif event.type == SDL_APP_TERMINATING:
             name = 'app_terminating'
         elif event.type == SDL_APP_LOWMEMORY:
             name = 'app_lowmemory'
@@ -523,7 +528,6 @@ cdef class _WindowSDL2Storage:
     def poll(self):
         cdef SDL_Event event
         cdef int rv
-
         with nogil:
             rv = SDL_PollEvent(&event)
         if rv == 0:

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -204,7 +204,7 @@ class WindowSDL(WindowBase):
     def _set_allow_screensaver(self, *args):
         self._win.set_allow_screensaver(self.allow_screensaver)
 
-    def _event_filter(self, action):
+    def _event_filter(self, action, *largs):
         from kivy.app import App
         if action == 'app_terminating':
             EventLoop.quit = True
@@ -236,6 +236,12 @@ class WindowSDL(WindowBase):
                 self._pause_loop = False
                 app = App.get_running_app()
                 app.dispatch('on_resume')
+
+        elif action == 'windowresized':
+            self._size = largs
+            self._win.resize_window(*self._size)
+            # Force kivy to render the frame now, so that the canvas is drawn.
+            EventLoop.idle()
 
         return 0
 


### PR DESCRIPTION
Today, when the window is resized content is black or just partially drawed. This is because poll() is blocked until we release the mouse.
But we can catch the resize event in the event filter. So the idea is to catch and force the window resize, and force drawing. Works like a charm.
Tested on OSX 10.14 with SDL 2.0.5 and retina screen.

Credits goes to @arafangion for the initial code.

Fixes #2844