### PR TITLE
Config: map KCFG_ environ variables to Config

### DIFF
--- a/doc/sources/guide/environment.rst
+++ b/doc/sources/guide/environment.rst
@@ -82,6 +82,27 @@ KIVY_NO_ARGS
 
     .. versionadded:: 1.9.0
 
+KCFG_section_key
+    If a such format environment name is detected, it will be mapped
+    to the Config object. They are loaded only once when `kivy` is
+    imported. The behavior can be disabled using `KIVY_NO_ENV_CONFIG`.
+
+    ::
+
+        import os
+        os.environ["KCFG_KIVY_LOG_LEVEL"] = "warning"
+        import kivy
+        # during import it will map it to:
+        # Config.set("kivy", "log_level", "warning")
+
+    .. versionadded:: 1.11.0
+
+KIVY_NO_ENV_CONFIG
+    If set, no environment key will be mapped to configuration object.
+    If unset, any `KCFG_section_key=value` will be mapped to Config.
+
+    .. versionadded:: 1.11.0
+
 Restrict core to specific implementation
 ----------------------------------------
 

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -288,7 +288,7 @@ if any(name in sys.argv[0] for name in ('sphinx-build', 'autobuild.py')):
     environ['KIVY_DOC'] = '1'
 if 'sphinx-build' in sys.argv[0]:
     environ['KIVY_DOC_INCLUDE'] = '1'
-if any('nosetests' in arg for arg in sys.argv):
+if any(('nosetests' in arg or 'pytest' in arg) for arg in sys.argv):
     environ['KIVY_UNITTEST'] = '1'
 if any('pyinstaller' in arg.lower() for arg in sys.argv):
     environ['KIVY_PACKAGING'] = '1'

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -49,6 +49,31 @@ For information on configuring your :class:`~kivy.app.App`, please see the
     converted from ascii to unicode only when needed. The method get() returns
     utf-8 strings.
 
+Changing configuration with environment variables
+-------------------------------------------------
+
+Since 1.11.0, it is now possible to change the configuration using
+environment variables. They take precedence on the loaded config.ini.
+The format is::
+
+    KCFG_<section>_<key> = <value>
+
+For example:
+
+    KCFG_GRAPHICS_FULLSCREEN=auto ...
+    KCFG_KIVY_LOG_LEVEL=warning ...
+
+Or in your file before any kivy import:
+
+    import os
+    os.environ["KCFG_KIVY_LOG_LEVEL"] = "warning"
+
+If you don't want to map any environment variables, you can disable
+the behavior::
+
+    os.environ["KIVY_NO_ENV_CONFIG"] = "1"
+
+
 .. _configuration-tokens:
 
 Available configuration tokens
@@ -874,3 +899,16 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             Config.write()
         except Exception as e:
             Logger.exception('Core: Error while saving default config file')
+
+    # Load configuration from env
+    if 'KIVY_NO_ENV_CONFIG' not in environ:
+        for key, value in environ.items():
+            if not key.startswith("KCFG_"):
+                continue
+            try:
+                _, section, name = key.split("_", 2)
+            except ValueError:
+                raise
+            section = section.lower()
+            name = name.lower()
+            Config.set(section, name, value)

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -27,6 +27,8 @@ Alternatively, you can save these settings permanently using
 restart the app for the changes to take effect. Note that this approach will
 effect all Kivy apps system wide.
 
+Please note that no underscore (`_`) is allowed in the section name.
+
 Usage of the Config object
 --------------------------
 
@@ -539,6 +541,7 @@ class ConfigParser(PythonConfigParser, object):
     def adddefaultsection(self, section):
         '''Add a section if the section is missing.
         '''
+        assert("_" not in section)
         if self.has_section(section):
             return
         self.add_section(section)

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -926,8 +926,8 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
             # extract and check the option name
             name = name.lower()
-            sections_to_check = (
-                "kivy", "graphics", "widgets", "postproc", "network")
+            sections_to_check = {
+                "kivy", "graphics", "widgets", "postproc", "network"}
             if (section in sections_to_check and
                     not Config.has_option(section, name)):
                 Logger.warning((

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -911,7 +911,30 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             try:
                 _, section, name = key.split("_", 2)
             except ValueError:
-                raise
+                Logger.warning((
+                    "Environ `{}` invalid format, "
+                    "must be KCFG_section_name").format(key))
+                continue
+
+            # extract and check section
             section = section.lower()
+            if not Config.has_section(section):
+                Logger.warning(
+                    "Environ `{}`: unknown section `{}`".format(
+                        key, section))
+                continue
+
+            # extract and check the option name
             name = name.lower()
+            sections_to_check = (
+                "kivy", "graphics", "widgets", "postproc", "network")
+            if (section in sections_to_check and
+                    not Config.has_option(section, name)):
+                Logger.warning((
+                    "Environ `{}` unknown `{}` option in `{}` section.")
+                    .format(key, name, section))
+                # we don't avoid to set an unknown option, because maybe
+                # an external modules or widgets (in garden?) may want to
+                # save its own configuration here.
+
             Config.set(section, name, value)

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -27,7 +27,7 @@ Alternatively, you can save these settings permanently using
 restart the app for the changes to take effect. Note that this approach will
 effect all Kivy apps system wide.
 
-Please note that no underscore (`_`) is allowed in the section name.
+Please note that no underscores (`_`) are allowed in the section name.
 
 Usage of the Config object
 --------------------------

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -912,7 +912,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
                 _, section, name = key.split("_", 2)
             except ValueError:
                 Logger.warning((
-                    "Environ `{}` invalid format, "
+                    "Config: Environ `{}` invalid format, "
                     "must be KCFG_section_name").format(key))
                 continue
 
@@ -920,7 +920,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             section = section.lower()
             if not Config.has_section(section):
                 Logger.warning(
-                    "Environ `{}`: unknown section `{}`".format(
+                    "Config: Environ `{}`: unknown section `{}`".format(
                         key, section))
                 continue
 
@@ -931,8 +931,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             if (section in sections_to_check and
                     not Config.has_option(section, name)):
                 Logger.warning((
-                    "Environ `{}` unknown `{}` option in `{}` section.")
-                    .format(key, name, section))
+                    "Config: Environ `{}` unknown `{}` "
+                    "option in `{}` section.").format(
+                        key, name, section))
                 # we don't avoid to set an unknown option, because maybe
                 # an external modules or widgets (in garden?) may want to
                 # save its own configuration here.


### PR DESCRIPTION
This allow the user to preconfigure kivy before the import, and/or let the final user to configure kivy itself.

Fixes #6190