### PR TITLE
Image: don't force iteration if we reuse the cache

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -741,7 +741,6 @@ class Image(EventDispatcher):
                 self._set_filename(value)
             else:
                 self._texture = None
-                self._img_iterate()
             return
         else:
             # if we already got a texture, it will be automatically reloaded.


### PR DESCRIPTION
The texture will be populated as usual on the first access, no need to force the population through _img_iterate here.

Fixes #6173