### PR TITLE
Replace "it's" with "its" in several places

### DIFF
--- a/doc/sources/guide/widgets.rst
+++ b/doc/sources/guide/widgets.rst
@@ -122,7 +122,7 @@ Widgets Z Index
 
 The order of widget drawing is based on the widget's position in
 the widget tree. The :attr:`~kivy.uix.widget.Widget.add_widget`
-method takes an `index` parameter which can be used to specify it's position in
+method takes an `index` parameter which can be used to specify its position in
 the widget tree::
 
     root.add_widget(widget, index)

--- a/examples/keyboard/main.py
+++ b/examples/keyboard/main.py
@@ -134,7 +134,7 @@ class ModeScreen(Screen):
         p3 = "[b][color=#ff0000]Warning:[/color][/b] This is a system-wide " \
             "setting and will affect all Kivy apps. If you change the\n" \
             " keyboard mode, please use this app" \
-            " to reset this value to it's original one."
+            " to reset this value to its original one."
 
         self.center_label.text = "".join([p1, p2, p3])
 

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -370,7 +370,7 @@ class ImageLoader(object):
                         continue
                     break
                 if im is not None:
-                    # append ImageData to local variable before it's
+                    # append ImageData to local variable before its
                     # overwritten
                     image_data.append(im._data[0])
                     image = im

--- a/kivy/core/text/_text_pango.pyx
+++ b/kivy/core/text/_text_pango.pyx
@@ -421,7 +421,7 @@ cdef ContextContainer _get_or_create_cc(bytes font_context, bytes font_name_r):
     # (it represents an "ideal font", ie what you *want* to draw with)
     cc.fontdesc = pango_font_description_new()
 
-    # Create font map and set it's FcConfig if Pango supports it (v1.38+).
+    # Create font map and set its FcConfig if Pango supports it (v1.38+).
     # Older versions swapping the current FcConfig in _set_cc_options()
     cc.fontmap = pango_ft2_font_map_new()
     if not cc.fontmap:

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -275,7 +275,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
 
     The function is designed to be called many times, each time new text is
     appended to the last line (or first line if appending upwards), unless a
-    newline is present in the text. Each text appended is described by it's own
+    newline is present in the text. Each text appended is described by its own
     options which can change between successive calls. If the text is
     constrained, we stop as soon as the constraint is reached.
 

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -923,7 +923,7 @@ cdef class BorderImage(Rectangle):
             Both X and Y dimensions will be scaled if the BorderImage is
             smaller than the source.
 
-            If the BorderImage's size is less than the sum of it's
+            If the BorderImage's size is less than the sum of its
             borders, horizontally or vertically, and this property is
             set to True, the borders will be rescaled to accommodate for
             the smaller size.

--- a/kivy/interactive.py
+++ b/kivy/interactive.py
@@ -50,7 +50,7 @@ Interactive Development
 -----------------------
 
 IPython provides a fast way to learn the Kivy API. The :class:`App` instance
-and all of it's attributes, including methods and the entire widget tree,
+and all of its attributes, including methods and the entire widget tree,
 can be quickly listed by using the '.' operator and pressing 'tab'. Try this
 code in an Ipython shell. ::
 

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -457,7 +457,7 @@ In Python, you can create an instance of the dynamic class as follows:
 
 .. note::
 
-    Using dynamic classes, a child class can be declared before it's parent.
+    Using dynamic classes, a child class can be declared before its parent.
     This however, leads to the unintuitive situation where the parent
     properties/methods override those of the child. Be careful if you choose
     to do this.

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -149,7 +149,7 @@ class ActionButton(Button, ActionItem):
     and takes care of the padding between elements.
 
     You don't have much control over these properties, so if you want to
-    customize it's appearance, we suggest you create you own button
+    customize its appearance, we suggest you create you own button
     representation. You can do this by creating a class that subclasses an
     existing widget and an :class:`ActionItem`::
 
@@ -500,7 +500,7 @@ class ActionOverflow(ActionGroup):
             self._list_overflow_items.insert(index, action_item)
 
     def show_default_items(self, parent):
-        # display overflow and it's items if widget's directly added to it
+        # display overflow and its items if widget's directly added to it
         if self._list_overflow_items == []:
             return
         self.show_group()

--- a/kivy/uix/behaviors/knspace.py
+++ b/kivy/uix/behaviors/knspace.py
@@ -536,7 +536,7 @@ class KNSpaceBehavior(object):
 
     If that object has a knspace property, then we return its value. Otherwise,
     we go further up, e.g. with `getattr(object, self.knspace_key)` and look
-    for it's `knspace` property.
+    for its `knspace` property.
 
     Finally, if we reach a value of `None`, or :attr:`knspace_key` was `None`,
     the default :attr:`~kivy.uix.behaviors.knspace.knspace` namespace is

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -483,7 +483,7 @@ class FileChooserController(RelativeLayout):
 
     file_encodings = ListProperty(['utf-8', 'latin1', 'cp1252'])
     '''Possible encodings for decoding a filename to unicode. In the case that
-    the user has a non-ascii filename, undecodable without knowing it's
+    the user has a non-ascii filename, undecodable without knowing its
     initial encoding, we have no other choice than to guess it.
 
     Please note that if you encounter an issue because of a missing encoding

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -129,7 +129,7 @@ class GridLayout(Layout):
     '''
 
     padding = VariableListProperty([0, 0, 0, 0])
-    '''Padding between the layout box and it's children: [padding_left,
+    '''Padding between the layout box and its children: [padding_left,
     padding_top, padding_right, padding_bottom].
 
     padding also accepts a two argument form [padding_horizontal,

--- a/kivy/uix/scatter.py
+++ b/kivy/uix/scatter.py
@@ -19,7 +19,7 @@ advantages / constraints that you should consider:
    :mod:`~kivy.uix.relativelayout.RelativeLayout`. So when dragging the
    scatter, the position of the children don't change, only the position of
    the scatter does.
-#. The scatter size has no impact on the size of it's children.
+#. The scatter size has no impact on the size of its children.
 #. If you want to resize the scatter, use scale, not size (read #2). Scale
    transforms both the scatter and its children, but does not change size.
 #. The scatter is not a layout. You must manage the size of the children

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -271,7 +271,7 @@ class Screen(RelativeLayout):
     - 'in' if the transition is going to show your screen
     - 'out' if the transition is going to hide your screen
 
-    After the transition is complete, the state will retain it's last value (in
+    After the transition is complete, the state will retain its last value (in
     or out).
 
     :attr:`transition_state` is an :class:`~kivy.properties.OptionProperty` and

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -6,7 +6,7 @@
 .. image:: images/splitter.jpg
     :align: right
 
-The :class:`Splitter` is a widget that helps you re-size it's child
+The :class:`Splitter` is a widget that helps you re-size its child
 widget/layout by letting you re-size it via dragging the boundary or
 double tapping the boundary. This widget is similar to the
 :class:`~kivy.uix.scrollview.ScrollView` in that it allows only one

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -763,7 +763,7 @@ class TabbedPanel(GridLayout):
 
             lentab_pos = len(tab_pos)
 
-            # Update scatter's top when it's pos changes.
+            # Update scatter's top when its pos changes.
             # Needed for repositioning scatter to the correct place after its
             # added to the parent. Use clock_schedule_once to ensure top is
             # calculated after the parent's pos on canvas has been calculated.

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1078,7 +1078,7 @@ class TextInput(FocusBehavior, Widget):
             self._selection_callback = Clock.schedule_once(cb)
 
     def do_cursor_movement(self, action, control=False, alt=False):
-        '''Move the cursor relative to it's current position.
+        '''Move the cursor relative to its current position.
         Action can be one of :
 
             - cursor_left: move the cursor to the left

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -454,7 +454,7 @@ class VideoPlayer(GridLayout):
 
     .. warning::
 
-        The re-add operation doesn't care about the index position of it's
+        The re-add operation doesn't care about the index position of its
         children within the parent.
 
     :attr:`fullscreen` is a :class:`~kivy.properties.BooleanProperty`


### PR DESCRIPTION
Sorry for these low priority pull requests, I'm reading through your stuff and these jump out at me!  :-)  (Also, I can do this pretty fast and it gives me a good feeling for the code.)

"It's" appears 181 times in the code, and I changed 19 of them to "its" - the possessive.  I've seen worse.  :-D

Rule: if you can't replace "it's" with "it is" or "it has" then it should be "its".  Example sentence: "It's a book with its cover removed."

Again, sorry for the noise here and thanks for this excellent package that I'm making very good use of!
