### PR TITLE
Added pillow as a required python library

### DIFF
--- a/doc/sources/installation/installation-devel.rst
+++ b/doc/sources/installation/installation-devel.rst
@@ -17,9 +17,9 @@ Installing Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 To install Kivy's dependencies, follow the guide below for your platform. You
-might also need these packages for the RST and lexing components::
+will also need these packages for RST, lexing and image handling::
 
-    $ sudo pip install pygments docutils
+    $ sudo pip install pygments docutils pillow
 
 Ubuntu
 ++++++


### PR DESCRIPTION
Without installing pillow, I got the below error. "pip install pillow" solved it.
```
  File "/usr/local/lib/python3.5/dist-packages/kivy/core/image/__init__.py", line 463, in load
    raise Exception('Unknown <%s> type, no loader found.' % ext)

x11 - ImportError: No module named 'kivy.core.window.window_x11'
  File "/usr/local/lib/python3.5/dist-packages/kivy/core/__init__.py", line 59, in core_select_lib
    fromlist=[modulename], level=0)
```