### PR TITLE
[WIP] give the user the opportunity to initialize widget before/after applying kv rules

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -402,7 +402,7 @@ class BuilderBase(object):
                 self._apply_rule(
                     widget, parser.root, parser.root,
                     rule_children=rule_children)
-
+                widget.dispatch('on_kv_applied')
                 for child in rule_children:
                     child.dispatch('on_kv_post', widget)
                 widget.dispatch('on_kv_post', widget)
@@ -595,6 +595,7 @@ class BuilderBase(object):
                 child = cls(__no_builder=True)
                 widget.add_widget(child)
                 self.apply(child, rule_children=rule_children)
+                child.dispatch('on_kv_applied')
                 self._apply_rule(
                     child, crule, rootrule, rule_children=rule_children)
 

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -396,8 +396,9 @@ class BuilderBase(object):
                 self.files.append(fn)
 
             if parser.root:
-                widget = Factory.get(parser.root.name)()
+                widget = Factory.get(parser.root.name)(__rootrule=True)
                 self._apply_rule(widget, parser.root, parser.root)
+                widget._dispatch_on_kv_post_recursively()
                 return widget
         finally:
             self._current_filename = None

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -396,7 +396,8 @@ class BuilderBase(object):
                 self.files.append(fn)
 
             if parser.root:
-                widget = Factory.get(parser.root.name)(__rootrule=True)
+                widget = Factory.get(parser.root.name)(__no_builder=True)
+                self.apply(widget)
                 self._apply_rule(widget, parser.root, parser.root)
                 widget._dispatch_on_kv_post_recursively()
                 return widget

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -29,6 +29,15 @@ class BaseClass(object):
         self.children.append(widget)
         widget.parent = self
 
+    def on_kv_pre(self):
+        pass
+
+    def on_kv_post(self):
+        pass
+
+    def dispatch(self, event_type, *largs, **kwargs):
+        pass
+
     def create_property(self, name, value=None):
         pass
 

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -32,7 +32,7 @@ class BaseClass(object):
     def on_kv_pre(self):
         pass
 
-    def on_kv_post(self):
+    def on_kv_post(self, root_widget):
         pass
 
     def dispatch(self, event_type, *largs, **kwargs):

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -29,12 +29,6 @@ class BaseClass(object):
         self.children.append(widget)
         widget.parent = self
 
-    def on_kv_pre(self):
-        pass
-
-    def on_kv_post(self, root_widget):
-        pass
-
     def dispatch(self, event_type, *largs, **kwargs):
         pass
 

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -50,7 +50,7 @@ class LangTestCase(unittest.TestCase):
                 if not self.there_is_a_rootrule:
                     testcase.fail(
                         "Strange. The handler was called even though "
-                        "the widget doesn't have root rule.")
+                        "there is no root rule.")
                 self._n_post_from_r += 1
                 ae(self._n_pre_from_d, 1)
                 ae(self._n_post_from_r, 1)

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -5,49 +5,6 @@ from kivy.factory import Factory
 from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty
 
 
-KV_CODE = '''
-<EventCounter>:
-    on_kv_pre: self.on_kv_pre_from_c()  # This line won't be excuted
-    on_kv_post: self.on_kv_post_from_c()
-
-<TestBoxLayout>:
-    Label:
-        id: label
-        text: textinput.text
-    TextInput:
-        id: textinput
-    Button:
-        id: button
-        on_press: self.text = 'pressed'
-
-<TestLabel>:
-    text: 'A'
-    on_kv_post: self.text += 'B'
-    Label:
-        text: root.assert_the_text_hasnt_changed_yet() or 'hello'
-<OtherTestLabel@TestLabel>:
-    on_kv_post: self.text += 'C'
-    height: self.assert_the_text_hasnt_changed_yet() or 200
-    Label:
-        text: root.assert_the_text_hasnt_changed_yet() or 'hello2'
-'''
-KV_FILENAME = 'test_kv_filename'
-
-
-def setUpModule():
-    Builder.load_string(KV_CODE, filename=KV_FILENAME)
-
-
-def tearDownModule():
-    Builder.unload_file(KV_FILENAME)
-    u = Factory.unregister
-    u('EventCounter')
-    u('TestWidget')
-    u('TestBoxLayout')
-    u('TestLabel')
-    u('OtherTestLabel')
-
-
 class LangTestCase(unittest.TestCase):
 
     def test_how_may_times_handlers_are_called(self):
@@ -105,6 +62,21 @@ class LangTestCase(unittest.TestCase):
                 ae(self._n_post_from_r, 1 if self.does_have_root_rule else 0)
                 ae(self._n_post_from_c, 1)
                 ae(self._n_post_from_d, 1)
+
+        Builder.load_string(textwrap.dedent('''
+        <EventCounter>:
+            on_kv_pre: self.on_kv_pre_from_c()  # This line won't be excuted
+            on_kv_post: self.on_kv_post_from_c()
+        <TestBoxLayout>:
+            Label:
+                id: label
+                text: textinput.text
+            TextInput:
+                id: textinput
+            Button:
+                id: button
+                on_press: self.text = 'pressed'
+        '''))
 
         # case #1: Without root rule
         root = EventCounter(does_have_root_rule=False)
@@ -193,6 +165,19 @@ class LangTestCase(unittest.TestCase):
 
     def test_property_is_evaluated_before_on_kv_post_is_fired(self):
         ae = self.assertEqual
+
+        Builder.load_string(textwrap.dedent('''
+        <TestLabel>:
+            text: 'A'
+            on_kv_post: self.text += 'B'
+            Label:
+                text: root.assert_the_text_hasnt_changed_yet() or 'hello'
+        <OtherTestLabel@TestLabel>:
+            on_kv_post: self.text += 'C'
+            height: self.assert_the_text_hasnt_changed_yet() or 200
+            Label:
+                text: root.assert_the_text_hasnt_changed_yet() or 'hello2'
+        '''))
 
         class TestLabel(Factory.Label):
             def assert_the_text_hasnt_changed_yet(self):

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -166,31 +166,3 @@ class LangTestCase(unittest.TestCase):
         '''))
         tc.assertTrue(hasattr(root.children[0],
                               '_the_handler_was_actually_called'))
-
-    def test_all_properties_are_evaluated_before_on_kv_post_is_fired(self):
-        ae = self.assertEqual
-
-        Builder.load_string(textwrap.dedent('''
-        <TestLabel>:
-            text: 'A'
-            on_kv_post: self.text += 'B'
-            Label:
-                text: root.assert_the_text_hasnt_changed_yet() or 'hello'
-        <OtherTestLabel@TestLabel>:
-            on_kv_post: self.text += 'C'
-            height: self.assert_the_text_hasnt_changed_yet() or 200
-            Label:
-                text: root.assert_the_text_hasnt_changed_yet() or 'hello2'
-        '''))
-
-        class TestLabel(Factory.Label):
-            def assert_the_text_hasnt_changed_yet(self):
-                ae(self.text, 'A')
-
-        root = Builder.load_string(textwrap.dedent('''
-        BoxLayout:
-            OtherTestLabel:
-                id: label
-                on_kv_post: self.text += 'D'
-        '''))
-        ae(root.ids.label.text, 'ADCB')

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -184,7 +184,7 @@ class LangTestCase(unittest.TestCase):
                 TestBoxLayout:
         '''))
 
-    def test_order(self):  # TODO: need a good method name
+    def test_property_is_evaluated_before_on_kv_post_is_fired(self):
         ae = self.assertEqual
 
         class TestLabel(Factory.Label):

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -1,0 +1,176 @@
+import unittest
+import textwrap
+from kivy.lang import Builder
+from kivy.factory import Factory
+from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty
+
+
+KV_CODE = '''
+<EventCounter>:
+    on_kv_pre: self.on_kv_pre_from_c()  # This line won't be excuted
+    on_kv_post: self.on_kv_post_from_c()
+
+<TestBoxLayout>:
+    Label:
+        id: label
+        text: textinput.text
+    TextInput:
+        id: textinput
+    Button:
+        id: button
+        on_press: self.text = 'pressed'
+
+<TestLabel>:
+    text: 'A'
+    on_kv_post: self.text += 'B'
+    Label:
+        text: root.assert_the_text_hasnt_changed_yet() or 'hello'
+<OtherTestLabel@TestLabel>:
+    on_kv_post: self.text += 'C'
+    height: self.assert_the_text_hasnt_changed_yet() or 200
+    Label:
+        text: root.assert_the_text_hasnt_changed_yet() or 'hello2'
+'''
+KV_FILENAME = 'test_kv_filename'
+
+
+def setUpModule():
+    Builder.load_string(KV_CODE, filename=KV_FILENAME)
+
+
+def tearDownModule():
+    Builder.unload_file(KV_FILENAME)
+    u = Factory.unregister
+    u('EventCounter')
+    u('TestWidget')
+    u('TestBoxLayout')
+    u('TestLabel')
+    u('OtherTestLabel')
+
+
+class LangTestCase(unittest.TestCase):
+
+    def test_how_may_times_handlers_are_called(self):
+        '''NOTE: Event handlers are supposed to be called in the order below:
+                 'root rule' -> 'class rule' -> 'default handler'
+        '''
+        testcase = self
+        ae = self.assertEqual
+        NP = NumericProperty
+
+        class EventCounter(Factory.Widget):
+            does_have_root_rule = BooleanProperty(True)
+            _n_pre_from_d = NP(0)  # 'd' stands for 'default handler'
+            _n_post_from_r = NP(0)  # 'r' stands for 'root rule'
+            _n_post_from_c = NP(0)  # 'c' stands for 'class rule'
+            _n_post_from_d = NP(0)
+
+            def on_kv_pre(self):
+                self._n_pre_from_d += 1
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 0)
+                ae(self._n_post_from_c, 0)
+                ae(self._n_post_from_d, 0)
+
+            def on_kv_pre_from_c(self):
+                testcase.fail('This method is not supposed to be called')
+
+            def on_kv_pre_from_r(self):
+                testcase.fail('This method is not supposed to be called')
+
+            def on_kv_post(self):
+                self._n_post_from_d += 1
+                self.assert_all_handlers_were_called_correctly()
+
+            def on_kv_post_from_c(self):
+                self._n_post_from_c += 1
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 1 if self.does_have_root_rule else 0)
+                ae(self._n_post_from_c, 1)
+                ae(self._n_post_from_d, 0)
+
+            def on_kv_post_from_r(self):
+                if not self.does_have_root_rule:
+                    testcase.fail(
+                        "Strange. The handler was called even though "
+                        "the widget doesn't have root rule.")
+                self._n_post_from_r += 1
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 1)
+                ae(self._n_post_from_c, 0)
+                ae(self._n_post_from_d, 0)
+
+            def assert_all_handlers_were_called_correctly(self):
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 1 if self.does_have_root_rule else 0)
+                ae(self._n_post_from_c, 1)
+                ae(self._n_post_from_d, 1)
+
+        # Test #1: Without root rule
+        root = EventCounter(does_have_root_rule=False)
+        root.assert_all_handlers_were_called_correctly()
+
+        # Test #2: With root rule
+        root = Builder.load_string(textwrap.dedent('''
+        EventCounter:
+            on_kv_pre: self.on_kv_pre_from_r()  # won't be excuted
+            on_kv_post: self.on_kv_post_from_r()
+            EventCounter:
+                id: child
+                on_kv_pre: self.on_kv_pre_from_r()  # won't be excuted
+                on_kv_post: self.on_kv_post_from_r()
+        '''))
+        root.assert_all_handlers_were_called_correctly()
+        root.ids.child.assert_all_handlers_were_called_correctly()
+
+        # Test #3: If the user add a widget during 'on_kv_pre()',
+        #          is 'on_kv_post' still dispatched once on that widget?
+        class TestWidget(Factory.Widget):
+            def on_kv_pre(self):
+                self._ec = EventCounter(does_have_root_rule=False)
+                self.add_widget(self._ec)
+        root = TestWidget()
+        root._ec.assert_all_handlers_were_called_correctly()
+
+    def test_rule_is_applied_on_kv_post(self):
+        tc = self
+
+        class TestBoxLayout(Factory.BoxLayout):
+            def on_kv_post(self):
+                ids = self.ids
+                tc.assertIn('textinput', ids)
+                tc.assertIn('label', ids)
+                tc.assertIn('button', ids)
+
+                textinput = ids.textinput
+                label = ids.label
+                label.text = 'A'
+                textinput.text = 'B'
+                tc.assertEqual(label.text, 'B')
+
+                button = ids.button
+                button.text = ''
+                button.dispatch('on_press')
+                tc.assertEqual(button.text, 'pressed')
+
+                tc.assertTrue(self.parent is not None)
+
+        root = Builder.load_string(textwrap.dedent('''
+        Widget:
+            TestBoxLayout:
+        '''))
+
+    def test_order(self):  # TODO: need a good method name
+        ae = self.assertEqual
+
+        class TestLabel(Factory.Label):
+            def assert_the_text_hasnt_changed_yet(self):
+                ae(self.text, 'A')
+
+        root = Builder.load_string(textwrap.dedent('''
+        BoxLayout:
+            OtherTestLabel:
+                id: label
+                on_kv_post: self.text += 'D'
+        '''))
+        ae(root.ids.label.text, 'ADCB')

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -35,7 +35,7 @@ class LangTestCase(unittest.TestCase):
             def on_kv_pre_from_r(self):
                 testcase.fail('This method is not supposed to be called')
 
-            def on_kv_post(self):
+            def on_kv_post(self, root_widget):
                 self._n_post_from_d += 1
                 self.assert_all_handlers_were_called_correctly()
 
@@ -106,7 +106,7 @@ class LangTestCase(unittest.TestCase):
         tc = self
 
         class TestBoxLayout(Factory.BoxLayout):
-            def on_kv_post(self):
+            def on_kv_post(self, root_widget):
                 self._the_handler_was_actually_called = True
 
                 # ---------------

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -111,7 +111,7 @@ class LangTestCase(unittest.TestCase):
         root._ec1.assert_all_handlers_were_called_correctly()
         root._ec2.assert_all_handlers_were_called_correctly()
 
-    def test_rule_is_applied_on_kv_post(self):
+    def test_all_rules_are_applied_before_on_kv_post_is_fired(self):
         tc = self
 
         class TestBoxLayout(Factory.BoxLayout):
@@ -163,7 +163,7 @@ class LangTestCase(unittest.TestCase):
             on_press: self.height = 123
         '''))
 
-    def test_property_is_evaluated_before_on_kv_post_is_fired(self):
+    def test_all_properties_are_evaluated_before_on_kv_post_is_fired(self):
         ae = self.assertEqual
 
         Builder.load_string(textwrap.dedent('''

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -116,6 +116,7 @@ class LangTestCase(unittest.TestCase):
                 textinput = ids.textinput
                 label = ids.label
                 label.text = 'A'
+                textinput.text = ''
                 textinput.text = 'B'
                 tc.assertEqual(label.text, 'B')
 
@@ -132,10 +133,11 @@ class LangTestCase(unittest.TestCase):
                 assertEqual = tc.assertNotEqual if reverse else tc.assertEqual
 
                 # check 'parent' property
-                assertTrue(parent is not None)
+                tc.assertTrue(parent is not None)
 
                 # check property binding
                 parent.x = 0
+                parent.y = 0
                 parent.y = 50
                 assertEqual(parent.x, 150)
 
@@ -151,10 +153,11 @@ class LangTestCase(unittest.TestCase):
                 assertEqual = tc.assertNotEqual if reverse else tc.assertEqual
 
                 # check 'parent' property
-                assertTrue(parent is not None)
+                tc.assertTrue(parent is not None)
 
                 # check property binding
                 parent.height = 1
+                parent.width = 0
                 parent.width = 50
                 assertEqual(parent.height, 100)
 
@@ -163,8 +166,15 @@ class LangTestCase(unittest.TestCase):
                 parent.dispatch('on_press')
                 assertEqual(parent.height, 123)
 
+            def on_kv_applied(self):
+                self._on_kv_applied_was_actually_fired = True
+                self.assert_my_own_rule_is_applied()
+                self.assert_the_rule_i_participate_in_is_applied(reverse=True)
+                self.assert_the_rule_i_dont_participate_in_is_applied(
+                    reverse=True)
+
             def on_kv_post(self, root_widget):
-                self._the_handler_was_actually_called = True
+                self._on_kv_post_was_actually_fired = True
                 self.assert_my_own_rule_is_applied()
                 self.assert_the_rule_i_participate_in_is_applied()
                 self.assert_the_rule_i_dont_participate_in_is_applied()
@@ -187,4 +197,6 @@ class LangTestCase(unittest.TestCase):
             on_press: self.height = 123
         '''))
         tc.assertTrue(hasattr(root.children[0],
-                              '_the_handler_was_actually_called'))
+                              '_on_kv_applied_was_actually_fired'))
+        tc.assertTrue(hasattr(root.children[0],
+                              '_on_kv_post_was_actually_fired'))

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -16,7 +16,7 @@ class LangTestCase(unittest.TestCase):
         NP = NumericProperty
 
         class EventCounter(Factory.Widget):
-            does_have_root_rule = BooleanProperty(True)
+            there_is_a_rootrule = BooleanProperty(True)
             _n_pre_from_d = NP(0)  # 'd' stands for 'default handler'
             _n_post_from_r = NP(0)  # 'r' stands for 'root rule'
             _n_post_from_c = NP(0)  # 'c' stands for 'class rule'
@@ -42,12 +42,12 @@ class LangTestCase(unittest.TestCase):
             def on_kv_post_from_c(self):
                 self._n_post_from_c += 1
                 ae(self._n_pre_from_d, 1)
-                ae(self._n_post_from_r, 1 if self.does_have_root_rule else 0)
+                ae(self._n_post_from_r, 1 if self.there_is_a_rootrule else 0)
                 ae(self._n_post_from_c, 1)
                 ae(self._n_post_from_d, 0)
 
             def on_kv_post_from_r(self):
-                if not self.does_have_root_rule:
+                if not self.there_is_a_rootrule:
                     testcase.fail(
                         "Strange. The handler was called even though "
                         "the widget doesn't have root rule.")
@@ -59,7 +59,7 @@ class LangTestCase(unittest.TestCase):
 
             def assert_all_handlers_were_called_correctly(self):
                 ae(self._n_pre_from_d, 1)
-                ae(self._n_post_from_r, 1 if self.does_have_root_rule else 0)
+                ae(self._n_post_from_r, 1 if self.there_is_a_rootrule else 0)
                 ae(self._n_post_from_c, 1)
                 ae(self._n_post_from_d, 1)
 
@@ -70,7 +70,7 @@ class LangTestCase(unittest.TestCase):
         '''))
 
         # case #1: Without root rule
-        root = EventCounter(does_have_root_rule=False)
+        root = EventCounter(there_is_a_rootrule=False)
         root.assert_all_handlers_were_called_correctly()
 
         # case #2: With root rule
@@ -92,11 +92,11 @@ class LangTestCase(unittest.TestCase):
         class TestWidget(Factory.Widget):
             def __init__(self, **kwargs):
                 super(TestWidget, self).__init__(**kwargs)
-                self._ec1 = EventCounter(does_have_root_rule=False)
+                self._ec1 = EventCounter(there_is_a_rootrule=False)
                 self.add_widget(self._ec1)
 
             def on_kv_pre(self):
-                self._ec2 = EventCounter(does_have_root_rule=False)
+                self._ec2 = EventCounter(there_is_a_rootrule=False)
                 self.add_widget(self._ec2)
         root = TestWidget()
         root._ec1.assert_all_handlers_were_called_correctly()

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -106,11 +106,11 @@ class LangTestCase(unittest.TestCase):
                 ae(self._n_post_from_c, 1)
                 ae(self._n_post_from_d, 1)
 
-        # Test #1: Without root rule
+        # case #1: Without root rule
         root = EventCounter(does_have_root_rule=False)
         root.assert_all_handlers_were_called_correctly()
 
-        # Test #2: With root rule
+        # case #2: With root rule
         root = Builder.load_string(textwrap.dedent('''
         EventCounter:
             on_kv_pre: self.on_kv_pre_from_r()  # won't be excuted
@@ -123,14 +123,21 @@ class LangTestCase(unittest.TestCase):
         root.assert_all_handlers_were_called_correctly()
         root.ids.child.assert_all_handlers_were_called_correctly()
 
-        # Test #3: If the user add a widget during 'on_kv_pre()',
-        #          is 'on_kv_post' still dispatched once on that widget?
+        # case #3: If the user add a widget during 'on_kv_pre()' and
+        #          '__init__()', is 'on_kv_post' still fired exactly
+        #          once on that widget?
         class TestWidget(Factory.Widget):
+            def __init__(self, **kwargs):
+                super(TestWidget, self).__init__(**kwargs)
+                self._ec1 = EventCounter(does_have_root_rule=False)
+                self.add_widget(self._ec1)
+
             def on_kv_pre(self):
-                self._ec = EventCounter(does_have_root_rule=False)
-                self.add_widget(self._ec)
+                self._ec2 = EventCounter(does_have_root_rule=False)
+                self.add_widget(self._ec2)
         root = TestWidget()
-        root._ec.assert_all_handlers_were_called_correctly()
+        root._ec1.assert_all_handlers_were_called_correctly()
+        root._ec2.assert_all_handlers_were_called_correctly()
 
     def test_rule_is_applied_on_kv_post(self):
         tc = self

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -7,7 +7,7 @@ from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty
 
 class LangTestCase(unittest.TestCase):
 
-    def test_how_may_times_handlers_are_called(self):
+    def test_how_many_times_handlers_are_called(self):
         '''NOTE: Event handlers are supposed to be called in the order below:
                  'root rule' -> 'class rule' -> 'default handler'
         '''

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -137,27 +137,51 @@ class LangTestCase(unittest.TestCase):
 
         class TestBoxLayout(Factory.BoxLayout):
             def on_kv_post(self):
+                # ---------------
+                # test children
+                # ---------------
                 ids = self.ids
                 tc.assertIn('textinput', ids)
                 tc.assertIn('label', ids)
                 tc.assertIn('button', ids)
-
+                
+                # check property binding
                 textinput = ids.textinput
                 label = ids.label
                 label.text = 'A'
                 textinput.text = 'B'
                 tc.assertEqual(label.text, 'B')
 
+                # check event handler
                 button = ids.button
                 button.text = ''
                 button.dispatch('on_press')
                 tc.assertEqual(button.text, 'pressed')
 
-                tc.assertTrue(self.parent is not None)
+                # ---------------
+                # test parent
+                # ---------------
+                parent = self.parent
+
+                # check 'parent' property
+                tc.assertTrue(parent is not None)
+
+                # check property binding
+                parent.height = 1
+                parent.width = 50
+                tc.assertEqual(parent.height, 100)
+
+                # check event handler
+                parent.height = 1
+                parent.dispatch('on_press')
+                tc.assertEqual(parent.height, 123)
 
         root = Builder.load_string(textwrap.dedent('''
         Widget:
-            TestBoxLayout:
+            Button:
+                height: self.width * 2
+                on_press: self.height = 123
+                TestBoxLayout:
         '''))
 
     def test_order(self):  # TODO: need a good method name

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -67,15 +67,6 @@ class LangTestCase(unittest.TestCase):
         <EventCounter>:
             on_kv_pre: self.on_kv_pre_from_c()  # This line won't be excuted
             on_kv_post: self.on_kv_post_from_c()
-        <TestBoxLayout>:
-            Label:
-                id: label
-                text: textinput.text
-            TextInput:
-                id: textinput
-            Button:
-                id: button
-                on_press: self.text = 'pressed'
         '''))
 
         # case #1: Without root rule
@@ -156,6 +147,15 @@ class LangTestCase(unittest.TestCase):
                 tc.assertEqual(parent.height, 123)
 
         root = Builder.load_string(textwrap.dedent('''
+        <TestBoxLayout>:
+            Label:
+                id: label
+                text: textinput.text
+            TextInput:
+                id: textinput
+            Button:
+                id: button
+                on_press: self.text = 'pressed'
         <TestButton@Button>:
             TestBoxLayout:
         TestButton:

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -107,6 +107,8 @@ class LangTestCase(unittest.TestCase):
 
         class TestBoxLayout(Factory.BoxLayout):
             def on_kv_post(self):
+                self._the_handler_was_actually_called = True
+
                 # ---------------
                 # test children
                 # ---------------
@@ -162,6 +164,8 @@ class LangTestCase(unittest.TestCase):
             height: self.width * 2
             on_press: self.height = 123
         '''))
+        tc.assertTrue(hasattr(root.children[0],
+                              '_the_handler_was_actually_called'))
 
     def test_all_properties_are_evaluated_before_on_kv_post_is_fired(self):
         ae = self.assertEqual

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -95,7 +95,7 @@ class LangTestCase(unittest.TestCase):
         root.assert_all_handlers_were_called_correctly()
         root.ids.child.assert_all_handlers_were_called_correctly()
 
-        # case #3: If the user add a widget during 'on_kv_pre()' and
+        # case #3: If the user add a widget during 'on_kv_pre()' or
         #          '__init__()', is 'on_kv_post' still fired exactly
         #          once on that widget?
         class TestWidget(Factory.Widget):

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -144,7 +144,7 @@ class LangTestCase(unittest.TestCase):
                 tc.assertIn('textinput', ids)
                 tc.assertIn('label', ids)
                 tc.assertIn('button', ids)
-                
+
                 # check property binding
                 textinput = ids.textinput
                 label = ids.label

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -184,11 +184,11 @@ class LangTestCase(unittest.TestCase):
                 tc.assertEqual(parent.height, 123)
 
         root = Builder.load_string(textwrap.dedent('''
-        Widget:
-            Button:
-                height: self.width * 2
-                on_press: self.height = 123
-                TestBoxLayout:
+        <TestButton@Button>:
+            TestBoxLayout:
+        TestButton:
+            height: self.width * 2
+            on_press: self.height = 123
         '''))
 
     def test_property_is_evaluated_before_on_kv_post_is_fired(self):

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -952,8 +952,7 @@ class Widget(WidgetBase):
         return m
 
     def _dispatch_on_kv_post_recursively(self):
-        '''(internal)
-        TODO: Want someone who fluent in English to write the doc'''
+        '''(internal)'''
         for widget in self.walk(restrict=True):
             if not widget._on_kv_post_was_fired:
                 widget.dispatch('on_kv_post')

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -333,12 +333,9 @@ class Widget(WidgetBase):
             self._context = get_current_context()
 
         no_builder = '__no_builder' in kwargs
-        is_there_a_rootrule = '__rootrule' in kwargs
         self._disabled_value = False
         if no_builder:
             del kwargs['__no_builder']
-        if is_there_a_rootrule:
-            del kwargs['__rootrule']
         on_args = {k: v for k, v in kwargs.items() if k[:3] == 'on_'}
         for key in on_args:
             del kwargs[key]
@@ -356,8 +353,7 @@ class Widget(WidgetBase):
         # Apply all the styles.
         if not no_builder:
             Builder.apply(self, ignored_consts=self._kwargs_applied_init)
-            if not is_there_a_rootrule:
-                self._dispatch_on_kv_post_recursively()
+            self._dispatch_on_kv_post_recursively()
 
         # Bind all the events.
         if on_args:

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -948,7 +948,14 @@ class Widget(WidgetBase):
         return m
 
     def _dispatch_on_kv_post_recursively(self):
-        '''(internal)'''
+        '''(internal)
+        NOTE: This method might be optimizable because::
+
+            if some_widget._on_post_was_fired:
+                # don't have to 'walk()' some_widget.children
+            else:
+                # have to 'walk()' some_widget.children
+        '''
         for widget in self.walk(restrict=True):
             if not widget._on_kv_post_was_fired:
                 widget.dispatch('on_kv_post')

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -955,9 +955,9 @@ class Widget(WidgetBase):
         '''(internal)
         TODO: Want someone who fluent in English to write the doc'''
         for widget in self.walk(restrict=True):
-            if not widget._on_kv_post_was_done:
+            if not widget._on_kv_post_was_fired:
                 widget.dispatch('on_kv_post')
-                widget._on_kv_post_was_done = True
+                widget._on_kv_post_was_fired = True
 
     x = NumericProperty(0)
     '''X position of the widget.
@@ -1404,8 +1404,8 @@ class Widget(WidgetBase):
         previous state when a parent's disabled state is changed.
     '''
 
-    _on_kv_post_was_done = BooleanProperty(False)
-    '''(internal) Indicates whether 'on_kv_post' was triggered or not
+    _on_kv_post_was_fired = BooleanProperty(False)
+    '''(internal) Indicates whether 'on_kv_post' was fired or not
 
     .. versionadded:: 1.11.0
     '''

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -299,8 +299,10 @@ class Widget(WidgetBase):
             Fired when an existing touch disappears
         `on_kv_pre`:
             Fired before kv rules are applied
+        `on_kv_applied`:
+            Fired after its own kv rules are applied
         `on_kv_post`:
-            Fired after kv rules are applied
+            Fired after all kv rules are applied
 
     .. warning::
         Adding a `__del__` method to a class derived from Widget with Python
@@ -321,7 +323,7 @@ class Widget(WidgetBase):
 
     __metaclass__ = WidgetMetaclass
     __events__ = ('on_touch_down', 'on_touch_move', 'on_touch_up',
-                  'on_kv_pre', 'on_kv_post')
+                  'on_kv_pre', 'on_kv_applied', 'on_kv_post')
     _proxy_ref = None
 
     def __init__(self, **kwargs):
@@ -356,7 +358,7 @@ class Widget(WidgetBase):
             Builder.apply(
                 self, ignored_consts=self._kwargs_applied_init,
                 rule_children=rule_children)
-
+            self.dispatch('on_kv_applied')
             for widget in rule_children:
                 widget.dispatch('on_kv_post', self)
             self.dispatch('on_kv_post', self)
@@ -497,6 +499,9 @@ class Widget(WidgetBase):
                 return True
 
     def on_kv_pre(self):
+        pass
+
+    def on_kv_applied(self):
         pass
 
     def on_kv_post(self, root_widget):


### PR DESCRIPTION
(EDIT)

# Problem

If you want to do some stuff **after** kv rules are applied, you **can't** write like this:

```python3
Builder.load_string('''
<MyWidget>:
    Label:
        id: label
''')

class MyWidget(Widget):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        label = self.ids.label  # A
        # do some stuff for label
```

because kv rules ain't always applied inside `__init__()`.

```python3
# This code causes "KeyError: 'label'" at line A
widget = Builder.load_string('''
Widget:
    MyWidget:
''')
```

# Workaround?

One workaround for the problem might be this:

```python3
class MyWidget(Widget):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        def after_rules_are_applied(__):
            label = self.ids.label
            # do some stuff for label
        Clock.schedule_once(after_rules_are_applied)
```

but in this case, you have another problem. You can't use `MyWidget` right after the instantiation because the instance is not fully initialized until the `Clock` ticks.

```python3
widget = MyWidget()  # the instance is not fully initialized!!
```

# so this PR

This PR gives the user a guaranteed opportunity to initialize widget after applying kv rules by implementing special method `__post_kv__()`.

```python3
class MyWidget(Factory.Widget):
    def __post_kv__(self):
        label = self.ids.label
        # do some stuff for label
```

Do you think this kind of feature is necessary?