### PR TITLE
Fix handling None values in DictProperty and ListProperty

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -794,15 +794,16 @@ cdef class ListProperty(Property):
             [1, 5, {'hi': 'bye'}, 10] [1, 5, {'hi': 'bye'}]
 
     '''
-    def __init__(self, defaultvalue=None, **kw):
-        defaultvalue = defaultvalue or []
+    def __init__(self, defaultvalue=0, **kw):
+        defaultvalue = [] if defaultvalue == 0 else defaultvalue
 
         super(ListProperty, self).__init__(defaultvalue, **kw)
 
     cpdef link(self, EventDispatcher obj, str name):
         Property.link(self, obj, name)
         cdef PropertyStorage ps = obj.__storage[self._name]
-        ps.value = ObservableList(self, obj, ps.value)
+        if ps.value is not None:
+            ps.value = ObservableList(self, obj, ps.value)
 
     cdef check(self, EventDispatcher obj, value):
         if Property.check(self, obj, value):
@@ -813,7 +814,8 @@ cdef class ListProperty(Property):
                 self.name))
 
     cpdef set(self, EventDispatcher obj, value):
-        value = ObservableList(self, obj, value)
+        if value is not None:
+            value = ObservableList(self, obj, value)
         Property.set(self, obj, value)
 
 cdef inline void observable_dict_dispatch(object self):

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -900,8 +900,8 @@ cdef class DictProperty(Property):
         :class:`DictProperty`, the dict stored in the property is a shallow copy of the
         dict and not the original dict. See :class:`ListProperty` for details.
     '''
-    def __init__(self, defaultvalue=None, rebind=False, **kw):
-        defaultvalue = defaultvalue or {}
+    def __init__(self, defaultvalue=0, rebind=False, **kw):
+        defaultvalue = {} if defaultvalue == 0 else defaultvalue
 
         super(DictProperty, self).__init__(defaultvalue, **kw)
         self.rebind = rebind
@@ -909,7 +909,8 @@ cdef class DictProperty(Property):
     cpdef link(self, EventDispatcher obj, str name):
         Property.link(self, obj, name)
         cdef PropertyStorage ps = obj.__storage[self._name]
-        ps.value = ObservableDict(self, obj, ps.value)
+        if ps.value is not None:
+            ps.value = ObservableDict(self, obj, ps.value)
 
     cdef check(self, EventDispatcher obj, value):
         if Property.check(self, obj, value):
@@ -920,7 +921,8 @@ cdef class DictProperty(Property):
                 self.name))
 
     cpdef set(self, EventDispatcher obj, value):
-        value = ObservableDict(self, obj, value)
+        if value is not None:
+            value = ObservableDict(self, obj, value)
         Property.set(self, obj, value)
 
 

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -888,7 +888,7 @@ cdef class DictProperty(Property):
     '''Property that represents a dict.
 
     :Parameters:
-        `defaultvalue`: dict, defaults to None
+        `defaultvalue`: dict, defaults to {}
             Specifies the default value of the property.
         `rebind`: bool, defaults to False
             See :class:`ObjectProperty` for details.

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -766,3 +766,16 @@ class PropertiesTestCase(unittest.TestCase):
         self.assertEqual(wid.getter_called, 2)
         self.assertEqual(wid.setter_called, 2)
         self.assertEqual(wid.callback_called, 2)
+
+
+def test_dictproperty_is_none():
+    from kivy.properties import DictProperty
+
+    d1 = DictProperty(None)
+    d1.link(wid, 'd1')
+    assert d1.get(wid) is None
+
+    d2 = DictProperty({'a': 1, 'b': 2}, allownone=True)
+    d2.link(wid, 'd2')
+    d2.set(wid, None)
+    assert d2.get(wid) is None

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -779,3 +779,16 @@ def test_dictproperty_is_none():
     d2.link(wid, 'd2')
     d2.set(wid, None)
     assert d2.get(wid) is None
+
+
+def test_listproperty_is_none():
+    from kivy.properties import ListProperty
+
+    l1 = ListProperty(None)
+    l1.link(wid, 'l1')
+    assert l1.get(wid) is None
+
+    l2 = ListProperty([1, 2, 3], allownone=True)
+    l2.link(wid, 'l2')
+    l2.set(wid, None)
+    assert l2.get(wid) is None


### PR DESCRIPTION
DictProperty and ListProperty were not correctly processing defaultvalue explicitly set to None during initialization (used {} and [] respectively instead of None). Setting their value to None (with allownone set to True) after the initialization led to crashes. This PR fixes such behaviour.

Fixes #5386