### PR TITLE
Update jsonstore.py

### DIFF
--- a/kivy/storage/jsonstore.py
+++ b/kivy/storage/jsonstore.py
@@ -89,4 +89,4 @@ class JsonStore(AbstractStore):
         return len(self._data)
 
     def store_keys(self):
-        return self._data.keys()
+        return list(self._data.keys())


### PR DESCRIPTION
Same change as was made to DictStore here: https://github.com/kivy/kivy/commit/09ee4b5e6f91d722b535623a05ea2504cc000045#diff-76774a9a72b8018b27fd0d6f93eea2e5

I tried to .clear() my JSON store and got the RTE "dictionary changed size during iteration". Traced it down to this line (dict.keys() does not return a list in python 3, which I use). Seems to fix my problem, just hope I'm not breaking anything else... /noob