### PR TITLE
Respect the alpha value when setting rgb.

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -247,13 +247,14 @@ cdef class Color(ContextInstruction):
                 self.a = args[3]
             elif vec_size == 3:
                 self.hsv = args
+                self.a = 1.
             else:
                 self.set_state('color', [1.0, 1.0, 1.0, 1.0])
         else:
             if vec_size == 4:
                 self.rgba = args
             elif vec_size == 3:
-                self.rgb = args
+                self.rgb = [args[0], args[1], args[2], 1.]
             else:
                 self.set_state('color', [1.0, 1.0, 1.0, 1.0])
 
@@ -281,7 +282,7 @@ cdef class Color(ContextInstruction):
 
     @rgb.setter
     def rgb(self, rgb):
-        self.rgba = (rgb[0], rgb[1], rgb[2], 1.0)
+        self.rgba = (rgb[0], rgb[1], rgb[2], self.a)
 
     @property
     def r(self):

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -243,18 +243,18 @@ cdef class Color(ContextInstruction):
         cdef long vec_size = len(args)
         if kwargs.get('mode', '') == 'hsv':
             if vec_size == 4:
+                self.rgba = [0, 0, 0, 1.]
                 self.hsv = args[:3]
-                self.a = args[3]
             elif vec_size == 3:
+                self.rgba = [0, 0, 0, 1.]
                 self.hsv = args
-                self.a = 1.
             else:
                 self.set_state('color', [1.0, 1.0, 1.0, 1.0])
         else:
             if vec_size == 4:
                 self.rgba = args
             elif vec_size == 3:
-                self.rgb = [args[0], args[1], args[2], 1.]
+                self.rgba = [args[0], args[1], args[2], 1.]
             else:
                 self.set_state('color', [1.0, 1.0, 1.0, 1.0])
 


### PR DESCRIPTION
Currently, the alpha channel gets overwritten by 1. when `rgb` is set. This makes it respect the current alpha value.

I also added the initialization so that `self.a` will not crash if only rgb was ever set.