### PR TITLE
Reverting 38dbbe9 due to performance issues it causes

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -7,7 +7,6 @@ from kivy.config import Config
 from kivy.logger import Logger
 from kivy import platform
 from kivy.graphics.cgl import cgl_get_backend_name
-from kivy.graphics.cgl cimport *
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 
@@ -650,10 +649,7 @@ cdef class _WindowSDL2Storage:
             pass
 
     def flip(self):
-        win = self.win
-        with nogil:
-            SDL_GL_SwapWindow(win)
-            cgl.glFinish()
+        SDL_GL_SwapWindow(self.win)
 
     def save_bytes_in_png(self, filename, data, int width, int height):
         cdef SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -604,7 +604,7 @@ cdef extern from "SDL.h":
     cdef SDL_GLContext SDL_GL_GetCurrentContext()
     cdef int SDL_GL_SetSwapInterval(int interval)
     cdef int SDL_GL_GetSwapInterval()
-    cdef void SDL_GL_SwapWindow(SDL_Window * window) nogil
+    cdef void SDL_GL_SwapWindow(SDL_Window * window)
     cdef void SDL_GL_DeleteContext(SDL_GLContext context)
 
     cdef int SDL_NumJoysticks()


### PR DESCRIPTION
Took me a while to pin point this commit (kept rebuilding my app with different baseline for kivy, profiling specific spot in the app for 15-25 seconds and comparing stats).

All stats built on kivy after 38dbbe9 look as follows:
```
        761037 function calls (678305 primitive calls) in 22.362 seconds

   Ordered by: cumulative time
   List reduced from 777 to 233 due to restriction <0.3>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      403    0.015    0.000   21.471    0.053 window_sdl2.py:458(_mainloop)
      403    0.057    0.000   21.435    0.053 base.py:327(idle)
34039/490    0.112    0.000   16.989    0.035 {method 'dispatch' of 'kivy._event.EventDispatcher' objects}
      191    0.005    0.000    8.622    0.045 __init__.py:1355(on_draw)
      191    8.215    0.043    8.277    0.043 {method 'draw' of 'kivy.graphics.instructions.Canvas' objects}
      191    0.001    0.000    7.006    0.037 __init__.py:1252(on_flip)
      191    0.007    0.000    7.004    0.037 window_sdl2.py:387(flip)
      191    6.997    0.037    6.997    0.037 {method 'flip' of 'kivy.core.window._window_sdl2._WindowSDL2Storage' objects}
      403    0.040    0.000    3.500    0.009 clock.py:545(tick)
      403    0.032    0.000    2.204    0.005 clock.py:521(idle)
      201    0.008    0.000    2.139    0.011 clock.py:716(usleep)
      201    0.010    0.000    2.131    0.011 clock.py:454(_usleep)
      201    2.121    0.011    2.121    0.011 {time.sleep}
      404    0.072    0.000    1.520    0.004 base.py:307(dispatch_input)
      403    0.008    0.000    1.472    0.004 clock.py:585(tick_draw)
      403    0.024    0.000    1.464    0.004 {method '_process_events_before_frame' of 'kivy._clock.CyClockBase' objects}
       25    0.002    0.000    1.362    0.054 base.py:216(post_dispatch_input)
       25    0.000    0.000    1.293    0.052 __init__.py:1359(on_motion)
      403    0.053    0.000    1.249    0.003 {method '_process_events' of 'kivy._clock.CyClockBase' objects}
      338    0.039    0.000    0.882    0.003 label.py:352(texture_update)
       12    0.000    0.000    0.858    0.071 __init__.py:1405(on_touch_up)
       12    0.000    0.000    0.858    0.071 screenmanager.py:1198(on_touch_up)
 20755/12    0.162    0.000    0.857    0.071 widget.py:474(on_touch_up)
  8648/12    0.080    0.000    0.857    0.071 relativelayout.py:300(on_touch_up)
167501/166473    0.179    0.000    0.683    0.000 {setattr}
5397/4369    0.024    0.000    0.680    0.000 builder.py:67(call_fn)
      311    0.120    0.000    0.679    0.002 boxlayout.py:289(do_layout)
      582    0.012    0.000    0.660    0.001 markup.py:138(render)
       11    0.000    0.000    0.568    0.052 threading.py:717(start)
       11    0.000    0.000    0.567    0.052 threading.py:597(wait)
       11    0.000    0.000    0.567    0.052 threading.py:309(wait)
       44    0.567    0.013    0.567    0.013 {method 'acquire' of 'thread.lock' objects}
```

Stats before that commit, or after rolling it back from master:

```
   850610 function calls (759508 primitive calls) in 18.370 seconds

   Ordered by: cumulative time
   List reduced from 1008 to 302 due to restriction <0.3>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      354    0.010    0.000   17.548    0.050 window_sdl2.py:458(_mainloop)
      354    0.029    0.000   17.524    0.050 base.py:327(idle)
37266/671    0.131    0.000   13.894    0.021 {method 'dispatch' of 'kivy._event.EventDispatcher' objects}
      251    0.006    0.000   11.538    0.046 __init__.py:1361(on_draw)
      251   11.025    0.044   11.088    0.044 {method 'draw' of 'kivy.graphics.instructions.Canvas' objects}
      354    0.015    0.000    2.430    0.007 clock.py:545(tick)
      354    0.003    0.000    1.761    0.005 clock.py:585(tick_draw)
      354    0.025    0.000    1.758    0.005 {method '_process_events_before_frame' of 'kivy._clock.CyClockBase' objects}
      355    0.029    0.000    1.599    0.005 base.py:307(dispatch_input)
       29    0.002    0.000    1.521    0.052 base.py:216(post_dispatch_input)
       29    0.001    0.000    1.445    0.050 __init__.py:1365(on_motion)
      354    0.031    0.000    1.222    0.003 {method '_process_events' of 'kivy._clock.CyClockBase' objects}
      354    0.015    0.000    1.188    0.003 clock.py:521(idle)
      102    0.003    0.000    1.160    0.011 clock.py:716(usleep)
      102    0.004    0.000    1.157    0.011 clock.py:454(_usleep)
      102    1.153    0.011    1.153    0.011 {time.sleep}
7227/5685    0.031    0.000    1.005    0.000 builder.py:67(call_fn)
      496    0.052    0.000    1.003    0.002 label.py:352(texture_update)
183469/181927    0.218    0.000    0.989    0.000 {setattr}
       14    0.000    0.000    0.949    0.068 __init__.py:1411(on_touch_up)
 22589/14    0.165    0.000    0.949    0.068 widget.py:474(on_touch_up)
  9400/14    0.091    0.000    0.949    0.068 relativelayout.py:300(on_touch_up)
       13    0.000    0.000    0.946    0.073 screenmanager.py:1198(on_touch_up)
      434    0.147    0.000    0.839    0.002 boxlayout.py:289(do_layout)
      251    0.002    0.000    0.835    0.003 __init__.py:1258(on_flip)
      251    0.010    0.000    0.833    0.003 window_sdl2.py:387(flip)
      251    0.823    0.003    0.823    0.003 {method 'flip' of 'kivy.core.window._window_sdl2._WindowSDL2Storage' objects}
      856    0.015    0.000    0.735    0.001 markup.py:138(render)
      353    0.030    0.000    0.573    0.002 gameworld.pyx:494(update)
        9    0.000    0.000    0.541    0.060 threading.py:717(start)
        9    0.000    0.000    0.540    0.060 threading.py:597(wait)
        9    0.001    0.000    0.540    0.060 threading.py:309(wait)
       42    0.539    0.013    0.539    0.013 {method 'acquire' of 'thread.lock' objects}
     1028    0.276    0.000    0.529    0.001 animations.py:179(update)
```

Note: methods `__init__.py:1258(on_flip)`, `window_sdl2.py:387(flip)` and `{method 'flip' of 'kivy.core.window._window_sdl2._WindowSDL2Storage' objects}` started to take way more processing time. As a result, fps dropped to below 30, down from steady 60.

I have little understanding of what this commit fixed or improved, and rolling it back is just a quick work-around. Feel free to disregard this PR and fix it properly - I am happy to test other solutions to make sure they do not kill performance.