### PR TITLE
Disabled set_volume() in core.video.ffpyplayer play() function. Fix for #6210

### DIFF
--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -346,7 +346,9 @@ class VideoFFPy(VideoBase):
                 self._filename, callback=self._player_callback,
                 thread_lib='SDL',
                 loglevel='info', ff_opts=ff_opts)
-        self._ffplayer.set_volume(self._volume)
+
+        # Disabled as an attempt to fix kivy issue #6210
+        # self._ffplayer.set_volume(self._volume)
 
         self._thread = Thread(target=self._next_frame_run, name='Next frame')
         self._thread.daemon = True

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -341,6 +341,7 @@ class VideoFFPy(VideoBase):
             'paused': True,
             'out_fmt': self._out_fmt,
             'sn': True,
+            'volume': self._volume,
         }
         self._ffplayer = MediaPlayer(
                 self._filename, callback=self._player_callback,


### PR DESCRIPTION
As mentioned in issue #6210 , on Android the video and videoplayer works only once.

Actual implementation on the ffpyplayer provider in core.video.ffpyplayer sets the volume just after the creation of the MediaPlayer.

After some investigation, seems that, the second usage of the Video/VideoPlayer w/ ffpyplayer takes more time to instantiate the AudioTrack that it looks like to be async.

In order to get my app running correctly I've commented out (as proposed in this PR) the set_volume call in the play() function.

I think that is not to be considered as the final fix ( we need to investigate further on the ffpyplayer implementation ), but should be merged ASAP, in order to temporarily solve this issue for all the affected users.