### PR TITLE
Add manylinux2010 support

### DIFF
--- a/.ci/build-wheels-linux.sh
+++ b/.ci/build-wheels-linux.sh
@@ -1,40 +1,40 @@
 #!/bin/bash
 set -e -x
 
-yum -y install  autoconf automake cmake gcc gcc-c++ git make pkgconfig zlib-devel portmidi portmidi-devel Xorg-x11-server-deve mesa-libEGL-devel mtdev-devel mesa-libEGL freetype freetype-devel openjpeg openjpeg-devel libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel dbus-devel dbus ibus-devel ibus libsamplerate-devel libsamplerate libudev-devel libudev libmodplug-devel libmodplug libvorbis-devel libvorbis flac-devel flac libjpeg-turbo-devel libjpeg-turbo;
+yum -y install  autoconf automake cmake gcc gcc-c++ git make pkgconfig zlib-devel portmidi portmidi-devel Xorg-x11-server-deve mesa-libEGL-devel mtdev-devel mesa-libEGL freetype freetype-devel openjpeg openjpeg-devel libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel dbus-devel dbus ibus-devel ibus libsamplerate-devel libsamplerate libudev-devel libudev libmodplug-devel libmodplug libvorbis-devel libvorbis flac-devel flac libjpeg-turbo-devel libjpeg-turbo wget;
 mkdir ~/kivy_sources;
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/kivy_build/lib;
 
 cd ~/kivy_sources;
 git clone --depth 1 https://github.com/spurious/SDL-mirror.git
 cd SDL-mirror;
-./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin"  --enable-alsa-shared=no  --enable-jack-shared=no  --enable-pulseaudio-shared=no  --enable-esd-shared=no  --enable-arts-shared=no  --enable-nas-shared=no  --enable-sndio-shared=no  --enable-fusionsound-shared=no  --enable-libsamplerate-shared=no  --enable-wayland-shared=no  --enable-mir-shared=no  --enable-x11-shared=no --enable-directfb-shared=no --enable-kmsdrm-shared=no;
+./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin"  --enable-alsa-shared=no  --enable-jack-shared=no  --enable-pulseaudio-shared=no  --enable-esd-shared=no  --enable-arts-shared=no  --enable-nas-shared=no  --enable-sndio-shared=no  --enable-fusionsound-shared=no  --enable-libsamplerate-shared=no  --enable-wayland-shared=no --enable-x11-shared=no --enable-directfb-shared=no --enable-kmsdrm-shared=no;
 make;
 make install;
 make distclean;
 
 cd ~/kivy_sources;
-wget http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2.tar.gz;
-tar xzf SDL2_mixer-2.0.2.tar.gz;
-cd SDL2_mixer-2.0.2;
-PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-smpeg-shared=no --enable-music-mp3-mpg123-shared=no;
+wget http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz;
+tar xzf SDL2_mixer-2.0.4.tar.gz;
+cd SDL2_mixer-2.0.4;
+PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-mpg123-shared=no;
 PATH="$HOME/kivy_build/bin:$PATH" make;
 make install;
 make distclean;
 
 cd ~/kivy_sources;
-wget http://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.3.tar.gz;
-tar xzf SDL2_image-2.0.3.tar.gz;
-cd SDL2_image-2.0.3;
+wget http://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.4.tar.gz;
+tar xzf SDL2_image-2.0.4.tar.gz;
+cd SDL2_image-2.0.4;
 PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no;
 PATH="$HOME/kivy_build/bin:$PATH" make;
 make install;
 make distclean;
 
 cd ~/kivy_sources;
-wget http://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14.tar.gz;
-tar xzf SDL2_ttf-2.0.14.tar.gz;
-cd SDL2_ttf-2.0.14;
+wget http://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz;
+tar xzf SDL2_ttf-2.0.15.tar.gz;
+cd SDL2_ttf-2.0.15;
 PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin";
 PATH="$HOME/kivy_build/bin:$PATH" make;
 make install;
@@ -42,9 +42,11 @@ make distclean;
 
 cd /io;
 for PYBIN in /opt/python/*3*/bin; do
-    "${PYBIN}/pip" install --upgrade setuptools pip;
-    "${PYBIN}/pip" install --upgrade cython nose pygments docutils;
-    USE_X11=1 USE_SDL2=1 USE_GSTREAMER=0 PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" "${PYBIN}/pip" wheel --no-deps . -w wheelhouse/;
+    if [[ $PYBIN != *"34"* ]]; then
+        "${PYBIN}/pip" install --upgrade setuptools pip;
+        "${PYBIN}/pip" install --upgrade cython nose pygments docutils;
+        USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" "${PYBIN}/pip" wheel --no-deps . -w wheelhouse/;
+    fi
 done
 
 for name in /io/wheelhouse/*.whl; do

--- a/.ci/build-wheels-linux.sh
+++ b/.ci/build-wheels-linux.sh
@@ -51,5 +51,5 @@ done
 
 for name in /io/wheelhouse/*.whl; do
     echo "Fixing $name";
-    auditwheel repair $name -w /io/wheelhouse/;
+    auditwheel repair --plat manylinux2010_x86_64 $name -w /io/wheelhouse/;
 done

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       dist: bionic
     - language: python
       sudo: required
-      env: RUN=wheels DOCKER_IMAGE=markrwilliams/manylinux2:x86_64 USE_PANGOFT2=0
+      env: RUN=wheels DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
       services:
         - docker
     - language: generic


### PR DESCRIPTION
manylinux2010 using centos6 has finally been merged into pypa (https://github.com/pypa/manylinux/pull/279) so we can finally publish linux wheels on pypi.

I've fixed up our wheel generation scripts to work with the newly published official manylinux docker and it's ready to be merged into master. You can see the wheels already generated here: https://kivy.org/downloads/ci/linux/kivy.

I tested the wheels in ubuntu and it worked. But it needs to be tested in various platforms. To test make sure your `pip` and `setuptools` are updated to the latest version - required to support the manylinux2010 tag.