### PR TITLE
Fix " object has no attribute 'startswith' "

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -764,7 +764,8 @@ class ScrollView(StencilView):
         if touch.grab_current is not self:
             return True
 
-        if not any(key.startswith('sv.') for key in touch.ud):
+        if not any(isinstance(key, str) and key.startswith('sv.')
+                   for key in touch.ud):
             # don't pass on touch to children if outside the sv
             if self.collide_point(*touch.pos):
                 return super(ScrollView, self).on_touch_move(touch)

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -764,7 +764,7 @@ class ScrollView(StencilView):
         if touch.grab_current is not self:
             return True
 
-        if touch.ud.get(self._get_uid()) is None:
+        if not any(key.startswith('sv.') for key in touch.ud):
             # don't pass on touch to children if outside the sv
             if self.collide_point(*touch.pos):
                 return super(ScrollView, self).on_touch_move(touch)


### PR DESCRIPTION
As @matham proposed here: https://github.com/kivy/kivy/pull/6252#issuecomment-483562572 my previous PR added a potentially crash condition.

This PR will fix that problem.