### PR TITLE
Set cookie header workaround

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -460,6 +460,17 @@ class UrlRequest(Thread):
             except IndexError:
                 return
             if resp:
+                # Small workaround in order to prevent the situation mentioned
+                # in the comment below
+                final_cookies = ""
+                parsed_headers = []
+                for key, value in resp.getheaders():
+                    if key == "Set-Cookie":
+                        final_cookies += "{};".format(value)
+                    else:
+                        parsed_headers.append((key, value))
+                parsed_headers.append(("Set-Cookie", final_cookies[:-1]))
+
                 # XXX usage of dict can be dangerous if multiple headers
                 # are set even if it's invalid. But it look like it's ok
                 # ?  http://stackoverflow.com/questions/2454494/..

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -475,7 +475,7 @@ class UrlRequest(Thread):
                 # are set even if it's invalid. But it look like it's ok
                 # ?  http://stackoverflow.com/questions/2454494/..
                 # ..urllib2-multiple-set-cookie-headers-in-response
-                self._resp_headers = dict(resp.getheaders())
+                self._resp_headers = dict(parsed_headers)
                 self._resp_status = resp.status
             if result == 'success':
                 status_class = resp.status // 100


### PR DESCRIPTION
This is a small workaround for the Set-Cookie header issue, should a resource provide multiple headers of Set-Cookie.

It feels a little bit hacky, but I'm not entirely sure what the best way to improve this specific use case would be.

I have done some testing with this particular implementation, and there doesn't appear to be any interference with anything else operating as usual.

The base issue here seems to be that UrlRequest is based on urllib2 - as Requests doesn't seem to have this particular issue (seems to be based on urllib3)