### PR TITLE
Give the user the opportunity to initialize widget before/after applying kv rules

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -467,10 +467,20 @@ class BuilderBase(object):
     def apply(self, widget, ignored_consts=set(), rule_children=None):
         '''Search all the rules that match the widget and apply them.
 
-        `ignored_consts` is a set or list type whose elements are property
-        names for which constant KV rules (i.e. those that don't create
-        bindings) of that widget will not be applied. This allows e.g. skipping
-        constant rules that overwrite a value initialized in python.
+        :Parameters:
+
+            `widget`: :class:`~kivy.uix.widget.Widget`
+                The widget whose class rules should be applied to this widget.
+            `ignored_consts`: set
+                A set or list type whose elements are property names for which
+                constant KV rules (i.e. those that don't create bindings) of
+                that widget will not be applied. This allows e.g. skipping
+                constant rules that overwrite a value initialized in python.
+            `rule_children`: list
+                If not ``None``, it should be a list that will be populated
+                with all the widgets created by the kv rules being applied.
+
+                .. versionchanged:: 1.11.0
         '''
         rules = self.match(widget)
         if __debug__:

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -399,11 +399,11 @@ class BuilderBase(object):
                 widget = Factory.get(parser.root.name)(__no_builder=True)
                 rule_children = []
                 self.apply(widget, rule_children=rule_children)
+                widget.dispatch('on_kv_applied', widget)
                 self._apply_rule(
                     widget, parser.root, parser.root,
                     rule_children=rule_children)
 
-                widget.dispatch('on_kv_applied', widget)
                 for child in rule_children:
                     child.dispatch('on_kv_post', widget)
                 widget.dispatch('on_kv_post', widget)
@@ -596,9 +596,9 @@ class BuilderBase(object):
                 child = cls(__no_builder=True)
                 widget.add_widget(child)
                 self.apply(child, rule_children=rule_children)
+                child.dispatch('on_kv_applied', rctx['ids']['root'])
                 self._apply_rule(
                     child, crule, rootrule, rule_children=rule_children)
-                child.dispatch('on_kv_applied', rctx['ids']['root'])
 
                 if rule_children is not None:
                     rule_children.append(child)

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -402,7 +402,8 @@ class BuilderBase(object):
                 self._apply_rule(
                     widget, parser.root, parser.root,
                     rule_children=rule_children)
-                widget.dispatch('on_kv_applied')
+
+                widget.dispatch('on_kv_applied', widget)
                 for child in rule_children:
                     child.dispatch('on_kv_post', widget)
                 widget.dispatch('on_kv_post', widget)
@@ -595,9 +596,9 @@ class BuilderBase(object):
                 child = cls(__no_builder=True)
                 widget.add_widget(child)
                 self.apply(child, rule_children=rule_children)
-                child.dispatch('on_kv_applied')
                 self._apply_rule(
                     child, crule, rootrule, rule_children=rule_children)
+                child.dispatch('on_kv_applied', rctx['ids']['root'])
 
                 if rule_children is not None:
                     rule_children.append(child)

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -398,8 +398,8 @@ class BuilderBase(object):
             if parser.root:
                 widget = Factory.get(parser.root.name)(__no_builder=True)
                 rule_children = []
-                self.apply(widget, rule_children=rule_children)
-                widget.dispatch('on_kv_applied', widget)
+                widget.apply_class_lang_rules(
+                    root=widget, rule_children=rule_children)
                 self._apply_rule(
                     widget, parser.root, parser.root,
                     rule_children=rule_children)
@@ -595,8 +595,8 @@ class BuilderBase(object):
                 # apply(), and so, we could use "self.parent".
                 child = cls(__no_builder=True)
                 widget.add_widget(child)
-                self.apply(child, rule_children=rule_children)
-                child.dispatch('on_kv_applied', rctx['ids']['root'])
+                child.apply_class_lang_rules(
+                    root=rctx['ids']['root'], rule_children=rule_children)
                 self._apply_rule(
                     child, crule, rootrule, rule_children=rule_children)
 

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -396,8 +396,16 @@ class BuilderBase(object):
                 self.files.append(fn)
 
             if parser.root:
-                widget = Factory.get(parser.root.name)()
-                self._apply_rule(widget, parser.root, parser.root)
+                widget = Factory.get(parser.root.name)(__no_builder=True)
+                rule_children = []
+                self.apply(widget, rule_children=rule_children)
+                self._apply_rule(
+                    widget, parser.root, parser.root,
+                    rule_children=rule_children)
+                widget.dispatch('on_kv_applied')
+                for child in rule_children:
+                    child.dispatch('on_kv_post', widget)
+                widget.dispatch('on_kv_post', widget)
                 return widget
         finally:
             self._current_filename = None
@@ -433,7 +441,8 @@ class BuilderBase(object):
         self._apply_rule(widget, rule, rule, template_ctx=proxy_ctx)
         return widget
 
-    def apply_rules(self, widget, rule_name, ignored_consts=set()):
+    def apply_rules(
+            self, widget, rule_name, ignored_consts=set(), rule_children=None):
         '''Search all the rules that match `rule_name` widget
         and apply them to `widget`.
 
@@ -450,9 +459,11 @@ class BuilderBase(object):
         if not rules:
             return
         for rule in rules:
-            self._apply_rule(widget, rule, rule, ignored_consts=ignored_consts)
+            self._apply_rule(
+                widget, rule, rule, ignored_consts=ignored_consts,
+                rule_children=rule_children)
 
-    def apply(self, widget, ignored_consts=set()):
+    def apply(self, widget, ignored_consts=set(), rule_children=None):
         '''Search all the rules that match the widget and apply them.
 
         `ignored_consts` is a set or list type whose elements are property
@@ -466,14 +477,16 @@ class BuilderBase(object):
         if not rules:
             return
         for rule in rules:
-            self._apply_rule(widget, rule, rule, ignored_consts=ignored_consts)
+            self._apply_rule(
+                widget, rule, rule, ignored_consts=ignored_consts,
+                rule_children=rule_children)
 
     def _clear_matchcache(self):
         BuilderBase._match_cache = {}
         BuilderBase._match_name_cache = {}
 
     def _apply_rule(self, widget, rule, rootrule, template_ctx=None,
-                    ignored_consts=set()):
+                    ignored_consts=set(), rule_children=None):
         # widget: the current instantiated widget
         # rule: the current rule
         # rootrule: the current root rule (for children of a rule)
@@ -581,8 +594,13 @@ class BuilderBase(object):
                 # apply(), and so, we could use "self.parent".
                 child = cls(__no_builder=True)
                 widget.add_widget(child)
-                self.apply(child)
-                self._apply_rule(child, crule, rootrule)
+                self.apply(child, rule_children=rule_children)
+                child.dispatch('on_kv_applied')
+                self._apply_rule(
+                    child, crule, rootrule, rule_children=rule_children)
+
+                if rule_children is not None:
+                    rule_children.append(child)
 
         # append the properties and handlers to our final resolution task
         if rule.properties:

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -29,6 +29,9 @@ class BaseClass(object):
         self.children.append(widget)
         widget.parent = self
 
+    def dispatch(self, event_type, *largs, **kwargs):
+        pass
+
     def create_property(self, name, value=None):
         pass
 

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -42,6 +42,10 @@ class BaseClass(object):
         self.binded_func[name] = partial(func, *largs)
         return True
 
+    def apply_class_lang_rules(
+            self, root=None, ignored_consts=set(), rule_children=None):
+        pass
+
 
 class TLangClass(BaseClass):
     obj = None

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -297,6 +297,9 @@ class TrackCallbacks(object):
         from kivy.uix.widget import Widget
 
         class TestEventsBase(TrackCallbacks, Widget):
+
+            __events__ = ('on_kv_pre', 'on_kv_applied')
+
             instantiated_widgets = []
 
             events_in_pre = [1, ]
@@ -313,6 +316,12 @@ class TrackCallbacks(object):
             def on_kv_post(self, base_widget):
                 self.add(1, 'post')
                 self.actual_base_widget = base_widget
+
+            def apply_class_lang_rules(self, root=None, **kwargs):
+                self.dispatch('on_kv_pre')
+                super(TestEventsBase, self).apply_class_lang_rules(
+                    root=root, **kwargs)
+                self.dispatch('on_kv_applied', root)
 
         return TestEventsBase
 

--- a/kivy/tests/test_lang_pre_process_and_post_process.py
+++ b/kivy/tests/test_lang_pre_process_and_post_process.py
@@ -1,0 +1,202 @@
+import unittest
+import textwrap
+from kivy.lang import Builder
+from kivy.factory import Factory
+from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty
+
+
+class LangTestCase(unittest.TestCase):
+
+    def test_how_many_times_handlers_are_called(self):
+        '''NOTE: Event handlers are supposed to be called in the order below:
+                 'root rule' -> 'class rule' -> 'default handler'
+        '''
+        testcase = self
+        ae = self.assertEqual
+        NP = NumericProperty
+
+        class EventCounter(Factory.Widget):
+            there_is_a_rootrule = BooleanProperty(True)
+            _n_pre_from_d = NP(0)  # 'd' stands for 'default handler'
+            _n_post_from_r = NP(0)  # 'r' stands for 'root rule'
+            _n_post_from_c = NP(0)  # 'c' stands for 'class rule'
+            _n_post_from_d = NP(0)
+
+            def on_kv_pre(self):
+                self._n_pre_from_d += 1
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 0)
+                ae(self._n_post_from_c, 0)
+                ae(self._n_post_from_d, 0)
+
+            def on_kv_pre_from_c(self):
+                testcase.fail('This method is not supposed to be called')
+
+            def on_kv_pre_from_r(self):
+                testcase.fail('This method is not supposed to be called')
+
+            def on_kv_post(self, root_widget):
+                self._n_post_from_d += 1
+                self.assert_all_handlers_were_called_correctly()
+
+            def on_kv_post_from_c(self):
+                self._n_post_from_c += 1
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 1 if self.there_is_a_rootrule else 0)
+                ae(self._n_post_from_c, 1)
+                ae(self._n_post_from_d, 0)
+
+            def on_kv_post_from_r(self):
+                if not self.there_is_a_rootrule:
+                    testcase.fail(
+                        "Strange. The handler was called even though "
+                        "there is no root rule.")
+                self._n_post_from_r += 1
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 1)
+                ae(self._n_post_from_c, 0)
+                ae(self._n_post_from_d, 0)
+
+            def assert_all_handlers_were_called_correctly(self):
+                ae(self._n_pre_from_d, 1)
+                ae(self._n_post_from_r, 1 if self.there_is_a_rootrule else 0)
+                ae(self._n_post_from_c, 1)
+                ae(self._n_post_from_d, 1)
+
+        Builder.load_string(textwrap.dedent('''
+        <EventCounter>:
+            on_kv_pre: self.on_kv_pre_from_c()  # This line won't be excuted
+            on_kv_post: self.on_kv_post_from_c()
+        '''))
+
+        # case #1: Without root rule
+        root = EventCounter(there_is_a_rootrule=False)
+        root.assert_all_handlers_were_called_correctly()
+
+        # case #2: With root rule
+        root = Builder.load_string(textwrap.dedent('''
+        EventCounter:
+            on_kv_pre: self.on_kv_pre_from_r()  # won't be excuted
+            on_kv_post: self.on_kv_post_from_r()
+            EventCounter:
+                id: child
+                on_kv_pre: self.on_kv_pre_from_r()  # won't be excuted
+                on_kv_post: self.on_kv_post_from_r()
+        '''))
+        root.assert_all_handlers_were_called_correctly()
+        root.ids.child.assert_all_handlers_were_called_correctly()
+
+        # case #3: If the user add a widget during 'on_kv_pre()' or
+        #          '__init__()', is 'on_kv_post' still fired exactly
+        #          once on that widget?
+        class TestWidget(Factory.Widget):
+            def __init__(self, **kwargs):
+                super(TestWidget, self).__init__(**kwargs)
+                self._ec1 = EventCounter(there_is_a_rootrule=False)
+                self.add_widget(self._ec1)
+
+            def on_kv_pre(self):
+                self._ec2 = EventCounter(there_is_a_rootrule=False)
+                self.add_widget(self._ec2)
+        root = TestWidget()
+        root._ec1.assert_all_handlers_were_called_correctly()
+        root._ec2.assert_all_handlers_were_called_correctly()
+
+    def test_each_rule_is_applied_at_proper_timing(self):
+        tc = self
+
+        class TestBoxLayout(Factory.BoxLayout):
+            def assert_my_own_rule_is_applied(self):
+                ids = self.ids
+                tc.assertIn('textinput', ids)
+                tc.assertIn('label', ids)
+                tc.assertIn('button', ids)
+
+                # check property binding
+                textinput = ids.textinput
+                label = ids.label
+                label.text = 'A'
+                textinput.text = ''
+                textinput.text = 'B'
+                tc.assertEqual(label.text, 'B')
+
+                # check event handler
+                button = ids.button
+                button.text = ''
+                button.dispatch('on_press')
+                tc.assertEqual(button.text, 'pressed')
+
+            def assert_the_rule_i_participate_in_is_applied(
+                    self, reverse=False):
+                parent = self.parent
+                assertTrue = tc.assertFalse if reverse else tc.assertTrue
+                assertEqual = tc.assertNotEqual if reverse else tc.assertEqual
+
+                # check 'parent' property
+                tc.assertTrue(parent is not None)
+
+                # check property binding
+                parent.x = 0
+                parent.y = 0
+                parent.y = 50
+                assertEqual(parent.x, 150)
+
+                # check event handler
+                parent.x = 0
+                parent.dispatch('on_press')
+                assertEqual(parent.x, 200)
+
+            def assert_the_rule_i_dont_participate_in_is_applied(
+                    self, reverse=False):
+                parent = self.parent
+                assertTrue = tc.assertFalse if reverse else tc.assertTrue
+                assertEqual = tc.assertNotEqual if reverse else tc.assertEqual
+
+                # check 'parent' property
+                tc.assertTrue(parent is not None)
+
+                # check property binding
+                parent.height = 1
+                parent.width = 0
+                parent.width = 50
+                assertEqual(parent.height, 100)
+
+                # check event handler
+                parent.height = 1
+                parent.dispatch('on_press')
+                assertEqual(parent.height, 123)
+
+            def on_kv_applied(self):
+                self._on_kv_applied_was_actually_fired = True
+                self.assert_my_own_rule_is_applied()
+                self.assert_the_rule_i_participate_in_is_applied(reverse=True)
+                self.assert_the_rule_i_dont_participate_in_is_applied(
+                    reverse=True)
+
+            def on_kv_post(self, root_widget):
+                self._on_kv_post_was_actually_fired = True
+                self.assert_my_own_rule_is_applied()
+                self.assert_the_rule_i_participate_in_is_applied()
+                self.assert_the_rule_i_dont_participate_in_is_applied()
+        root = Builder.load_string(textwrap.dedent('''
+        <TestBoxLayout>:
+            Label:
+                id: label
+                text: textinput.text
+            TextInput:
+                id: textinput
+            Button:
+                id: button
+                on_press: self.text = 'pressed'
+        <TestButton@Button>:
+            x: self.y + 100
+            on_press: self.x = 200
+            TestBoxLayout:
+        TestButton:
+            height: self.width * 2
+            on_press: self.height = 123
+        '''))
+        tc.assertTrue(hasattr(root.children[0],
+                              '_on_kv_applied_was_actually_fired'))
+        tc.assertTrue(hasattr(root.children[0],
+                              '_on_kv_post_was_actually_fired'))

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -291,18 +291,25 @@ class Widget(WidgetBase):
     '''Widget class. See module documentation for more information.
 
     :Events:
-        `on_touch_down`:
-            Fired when a new touch event occurs
-        `on_touch_move`:
-            Fired when an existing touch moves
-        `on_touch_up`:
-            Fired when an existing touch disappears
-        `on_kv_pre`:
-            Fired before kv rules are applied
-        `on_kv_applied`:
-            Fired after its own kv rules are applied
-        `on_kv_post`:
-            Fired after all kv rules are applied
+        `on_touch_down`: `(touch, )`
+            Fired when a new touch event occurs. `touch` is the touch object.
+        `on_touch_move`: `(touch, )`
+            Fired when an existing touch moves. `touch` is the touch object.
+        `on_touch_up`: `(touch, )`
+            Fired when an existing touch disappears. `touch` is the touch
+            object.
+        `on_kv_pre`: `()`
+            Fired before kv rules are applied. It doesn't pass any parameters.
+        `on_kv_applied`: `(root_widget, )`
+            Fired after all the kv rules of the widget is applied.
+            `root_widget` is the widget at the root of the kv rule that
+            instantiated this widget, or `None` if it wasn't part of a rule
+            because it is instantiated in python.
+        `on_kv_post`: `(base_widget, )`
+            Fired after all the kv rules associated with the widget
+            and all other widgets that are in any of those rules have had
+            all their kv rules applied. `base_widget` is the base-most widget
+            whose instantiation triggered the kv rules.
 
     .. warning::
         Adding a `__del__` method to a class derived from Widget with Python
@@ -358,7 +365,7 @@ class Widget(WidgetBase):
             Builder.apply(
                 self, ignored_consts=self._kwargs_applied_init,
                 rule_children=rule_children)
-            self.dispatch('on_kv_applied')
+            self.dispatch('on_kv_applied', None)
             for widget in rule_children:
                 widget.dispatch('on_kv_post', self)
             self.dispatch('on_kv_post', self)
@@ -501,10 +508,10 @@ class Widget(WidgetBase):
     def on_kv_pre(self):
         pass
 
-    def on_kv_applied(self):
+    def on_kv_applied(self, root_widget):
         pass
 
-    def on_kv_post(self, root_widget):
+    def on_kv_post(self, base_widget):
         pass
 
     #

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -305,6 +305,8 @@ class Widget(WidgetBase):
             whose instantiation triggered the kv rules (i.e. the widget
             instantiated from Python, e.g. ``MyWidget()``).
 
+            .. versionchanged:: 1.11.0
+
     .. warning::
         Adding a `__del__` method to a class derived from Widget with Python
         prior to 3.4 will disable automatic garbage collection for instances
@@ -396,6 +398,72 @@ class Widget(WidgetBase):
 
     def apply_class_lang_rules(
             self, root=None, ignored_consts=set(), rule_children=None):
+        '''
+        Method that is called by kivy to apply the kv rules of this widget's
+        class.
+
+        :Parameters:
+            `root`: :class:`Widget`
+                The root widget that instantiated this widget in kv, if the
+                widget was instantiated in kv, otherwise ``None``.
+            `ignored_consts`: set
+                (internal) See :meth:`~kivy.lang.builder.BuilderBase.apply`.
+            `rule_children`: list
+                (internal) See :meth:`~kivy.lang.builder.BuilderBase.apply`.
+
+        This is useful to be able to execute code before/after the class kv
+        rules are applied to the widget. E.g. if the kv code requires some
+        properties to be initialized before it is used in a binding rule.
+        If overwriting remember to call ``super``, otherwise the kv rules will
+        not be applied.
+
+        In the following example,
+
+        .. code-block:: python
+
+            class MyWidget(Widget):
+                pass
+
+            class OtherWidget(MyWidget):
+                pass
+
+        .. code-block:: kv
+
+        <MyWidget>:
+            my_prop: some_value
+
+        <OtherWidget>:
+            other_prop: some_value
+
+        When ``OtherWidget`` is instantiated with ``OtherWidget()``, the
+        widget's :meth:`apply_class_lang_rules` is called and it applies the
+        kv rules of this class - ``<MyWidget>`` and ``<OtherWidget>``.
+
+        Similarly, when the widget is instantiated from kv, e.g.
+
+        .. code-block:: kv
+
+            <MyBox@BoxLayout>:
+                height: 55
+                OtherWidget:
+                    width: 124
+
+        ``OtherWidget``'s :meth:`apply_class_lang_rules` is called and it
+        applies the kv rules of this class - ``<MyWidget>`` and
+        ``<OtherWidget>``.
+
+        .. note::
+
+            It applies only the class rules not the instance rules. I.e. in the
+            above kv example in the ``MyBox`` rule when ``OtherWidget`` is
+            instantiated, its :meth:`apply_class_lang_rules` applies the
+            ``<MyWidget>`` and ``<OtherWidget>`` rules to it - it does not
+            apply the ``width: 124`` rule. The ``width: 124`` rule is part of
+            the ``MyBox`` rule and is applied by the ``MyBox``'s instance's
+            :meth:`apply_class_lang_rules`.
+
+        .. versionchanged:: 1.11.0
+        '''
         Builder.apply(
             self, ignored_consts=ignored_consts,
             rule_children=rule_children)


### PR DESCRIPTION
This is  a continuation of #6221.

EDIT by @matham:

Kv initialization events
====================

This PR introduces **three** new events to help users manage the boundary of python and KV code.

This has been something that has come up a lot before. Looking at the survey of how we can improve python, people often asked for ways to be able to interact with kv code from Python.

* Introducing ``ids`` was one such improvement, however,
this led to new issues, [where accessing](https://github.com/kivy/kivy/issues/2479) ``ids`` from Python failed if accessed too soon.
* Another common workaround is the usage of ``on_parent`` as a chance to initialize stuff from kv after most everything else has been initialized. This has issues because ``on_parent`` may be triggered whenever the widget is removed from the parent, and this doesn't help us integrate it with Python.

This PR proposes the following three events to solve this issue permanently. All these events are fired whether there are kv rules to be applied, but if there are kv rules it is fired at a specific time during the kv rule application.

on_kv_pre
-------------

This event is fired for each widget before any kv rules are applied. This event is fired in the instant before any kv rules are potentially applied to the widget during the ``__init__`` of the widget. This event is meant to give the user an opportunity to initialize stuff from Python before anything kv is run for this widget. Typical usage is e.g.::

```python
class MyWidget(Widget):

    def on_kv_pre(self):
        self.variable_used_in_kv = some_value
```

In the following code ``do_something`` is never called because the widget is instantiated before the kv rule could be bound::

```yaml
<SomeWidget>:
    on_kv_pre: do_something
```

I propose that any kv ``on_kv_pre`` rule should raise a error to help users find such silent bugs which are never executed.

on_kv_applied
---------------

This event is fired after the rules of the widget class is applied (excluding any rules associated with its instantiation). The dispatched parameter to the event is the widget in the root rule that instantiated this widget (or ``None``). Specifically, it is fired after the class rules, but before the instance rules in the example below is applied::

```yaml
<SomeWidget>:
    class_rules

<SomeOtherWidget@SomeWidget>:
    more_class_rules

Widget:
    SomeOtherWidget:
        instance_rules
```

The use of this would be to be able to do something within python after the widget rules has been applied such is in this example::

```python
class MyWidget(Widget):

    def on_kv_applied(self, root_widget):
        assert isinstance(root_widget, BoxLayout)

Builder.load_string("""
BoxLayout:
    Widget:
        MyWidget
""")
```

Something to keep in mind, when it's fired ``ids`` would still not be initialized and is also not a good replacement for ``on_parent`` as it happens before kv is fully initialized.

Issues:
********

I forsee some issues with this event though. Because it is triggered before the rules of the instantiated widget is applied I think it'd lead to confusion. Consider the following basic example, similar to above::

```python
class MyWidget(Widget):

    def on_kv_applied(self, root_widget):
        assert self.name == 'Kivy'

Builder.load_string("""
BoxLayout:
    Widget:
        MyWidget:
            name: 'Kivy'
""")
```

The ``assert`` would fail because ``name`` would not have been yet initialized when the event is fired, because it's fired after the class rules, but before instance rules are applied.

An similar example IMO is the following::

```yaml
<MyWidget>:
    on_kv_applied: do_a

<SomWidget>:
    on_kv_applied: do_c
    MyWidget:
        on_kv_applied: do_b
```

In the above example only ``do_b`` is never executed for the reason mentioned above. To me this is a problem because I don't think people will be able to keep track of when it is and isn't legal to use ``on_kv_applied`` from kv and would lead to complaints and silent bugs when the callback is not executed.

I'm not sure of the utility of the event, but @tito was interested in this event so we included it. @tito, can you confirm that you want to keep this event?

A potential fix for the second example that I want to suggest is to either disallow using ``on_kv_applied`` from kv at all, or raise an exception if the event is used in the ``do_b`` case. This however does not solve the issues with the first example. 

on_kv_post
------------

This event is fired after all the kv rules associated with the widget is applied. This is intended to replace initialization from kv in ``on_parent`` and when it's dispatched ``ids`` would be fully initialized. The dispatched parameter in the event is the ``base_widget`` that was instantiated from python and which caused the application of all the rules. 

The use of this would be to do anything post initialization after all te kv rules has been applied. E.g.::

```python
class MyWidget(Widget):

    def on_kv_applied(self, base_widget):
        assert isinstance(base_widget, BoxLayout)

Builder.load_string("""
<SomeWidget@Widget>:
    MyWidget

BoxLayout:
    on_kv_post: assert self.ids.root == self
    SomeWidget
""")
```

The exact parameter it takes is not as important as the time when it is fired. It is fired after **all** the kv rules above has been fully applied.
