### PR TITLE
Fix the ctrl bug in hidinput (Issue #4007)

### DIFF
--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -595,9 +595,9 @@ else:
                             dispatch_queue.append(('key_up', (
                                 keycode, ev_code,
                                 keys_str.get(z, z), Window._modifiers)))
-                            if z == 'shift' or z == 'alt':
+                            if (z == 'shift' or z == 'alt') and z in Window._modifiers:
                                 Window._modifiers.remove(z)
-                            elif z.endswith('ctrl'):
+                            elif z.endswith('ctrl') and 'ctrl' in Window._modifiers:
                                 Window._modifiers.remove('ctrl')
 
 

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -454,6 +454,10 @@ else:
                 elif rotation == 270:
                     point[cy] += -value
 
+                # limit it to the screen area 0-1
+                point['x'] = min(1., max(0., point['x']))
+                point['y'] = min(1., max(0., point['y']))
+
             def process_as_multitouch(tv_sec, tv_usec, ev_type,
                                       ev_code, ev_value):
                 # sync event

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -42,12 +42,12 @@ max_position_y=32768
     `rotation` configuration token added.
 
 '''
-
-__all__ = ('HIDInputMotionEventProvider', 'HIDMotionEvent')
-
 import os
 from kivy.input.motionevent import MotionEvent
 from kivy.input.shape import ShapeRect
+
+__all__ = ('HIDInputMotionEventProvider', 'HIDMotionEvent')
+
 # late imports
 Window = None
 Keyboard = None

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -68,6 +68,10 @@ class HIDMotionEvent(MotionEvent):
         if 'pressure' in args:
             self.pressure = args['pressure']
             self.profile.append('pressure')
+        if 'button' in args:
+            self.button = args['button']
+            self.profile.append('button')
+
         super(HIDMotionEvent, self).depack(args)
 
     def __str__(self):
@@ -200,14 +204,14 @@ else:
         0x35: ('/', '?'),
         0x36: ('shift', ),
         0x56: ('pipe', ),
-        0x1d: ('ctrl', ),
+        0x1d: ('lctrl', ),
         0x7D: ('super', ),
         0x38: ('alt', ),
         0x39: ('spacebar', ),
         0x64: ('alt-gr', ),
         0x7e: ('super', ),
         0x7f: ('compose', ),
-        0x61: ('ctrl', ),
+        0x61: ('rctrl', ),
         0x45: ('numlock', ),
         0x47: ('numpad7', 'home'),
         0x4b: ('numpad4', 'left'),
@@ -498,6 +502,13 @@ else:
                 if ev_type == EV_SYN:
                     if ev_code == SYN_REPORT:
                         process([point])
+                        if 'button' in point and point['button'].startswith('scroll'):
+                            # for scrolls we need to remove it as there is no up key
+                            del point['button']
+                            point['id'] += 1
+                            point['_avoid'] = True
+                            process([point])
+
                 elif ev_type == EV_REL:
                     if ev_code == 0:
                         assign_rel_coord(point,
@@ -507,6 +518,15 @@ else:
                         assign_rel_coord(point,
                             min(1., max(-1., ev_value / 1000.)),
                             invert_y, 'yx')
+                    elif ev_code == 8: # Wheel
+                        # translates the wheel move to a button
+                        b= "scrollup" if ev_value < 0 else "scrolldown"
+                        if 'button' not in point:
+                            point['button'] = b
+                            point['id'] += 1
+                            if '_avoid' in point:
+                                del point['_avoid']
+
                 elif ev_type != EV_KEY:
                     if ev_code == ABS_X:
                         val = normalize(ev_value,
@@ -553,6 +573,9 @@ else:
                                 if 'shift' in Window._modifiers else 0]
                             if z == 'shift' or z == 'alt':
                                 Window._modifiers.append(z)
+                            elif z.endswith('ctrl'):
+                                Window._modifiers.append('ctrl')
+
                             dispatch_queue.append(('key_down', (
                                 Keyboard.keycodes[z.lower()], ev_code,
                                 keys_str.get(z, z), Window._modifiers)))
@@ -562,8 +585,11 @@ else:
                             dispatch_queue.append(('key_up', (
                                 Keyboard.keycodes[z.lower()], ev_code,
                                 keys_str.get(z, z), Window._modifiers)))
-                            if z == 'shift':
-                                Window._modifiers.remove('shift')
+                            if z == 'shift' or z == 'alt':
+                                Window._modifiers.remove(z)
+                            elif z.endswith('ctrl'):
+                                Window._modifiers.remove('ctrl')
+
 
             def process(points):
                 if not is_multitouch:

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -568,22 +568,32 @@ else:
                                 point['id'] += 1
                                 point['_avoid'] = True
                     else:
+                        if ev_value < 0 or ev_value > 1:
+                            return
+
+                        if ev_code not in keyboard_keys:
+                            # we don't want to crash if an unknown key is pressed
+                            return
+
+                        z = keyboard_keys[ev_code][-1 if 'shift' in Window._modifiers else 0]
+                        if z.lower() not in Keyboard.keycodes:
+                            # or if it is not in this LUT
+                            return
+
+                        keycode= Keyboard.keycodes[z.lower()]
+
                         if ev_value == 1:
-                            z = keyboard_keys[ev_code][-1
-                                if 'shift' in Window._modifiers else 0]
                             if z == 'shift' or z == 'alt':
                                 Window._modifiers.append(z)
                             elif z.endswith('ctrl'):
                                 Window._modifiers.append('ctrl')
 
                             dispatch_queue.append(('key_down', (
-                                Keyboard.keycodes[z.lower()], ev_code,
+                                keycode, ev_code,
                                 keys_str.get(z, z), Window._modifiers)))
                         elif ev_value == 0:
-                            z = keyboard_keys[ev_code][-1
-                                if 'shift' in Window._modifiers else 0]
                             dispatch_queue.append(('key_up', (
-                                Keyboard.keycodes[z.lower()], ev_code,
+                                keycode, ev_code,
                                 keys_str.get(z, z), Window._modifiers)))
                             if z == 'shift' or z == 'alt':
                                 Window._modifiers.remove(z)

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -573,11 +573,13 @@ else:
 
                         if ev_code not in keyboard_keys:
                             # we don't want to crash if an unknown key is pressed
+                            Logger.warn('HIDInput: unhandled HID code: {}'.format(ev_code))
                             return
 
                         z = keyboard_keys[ev_code][-1 if 'shift' in Window._modifiers else 0]
                         if z.lower() not in Keyboard.keycodes:
                             # or if it is not in this LUT
+                            Logger.warn('HIDInput: unhandled character: {}'.format(z))
                             return
 
                         keycode= Keyboard.keycodes[z.lower()]

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -572,7 +572,7 @@ else:
                                 point['id'] += 1
                                 point['_avoid'] = True
                     else:
-                        if ev_value < 0 or ev_value > 1:
+                        if not 0 <= ev_value <= 1:
                             return
 
                         if ev_code not in keyboard_keys:

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -506,7 +506,8 @@ else:
                 if ev_type == EV_SYN:
                     if ev_code == SYN_REPORT:
                         process([point])
-                        if 'button' in point and point['button'].startswith('scroll'):
+                        if ('button' in point and
+                                point['button'].startswith('scroll')):
                             # for scrolls we need to remove it as there is
                             # no up key
                             del point['button']
@@ -581,10 +582,12 @@ else:
                                         format(ev_code))
                             return
 
-                        z = keyboard_keys[ev_code][-1 if 'shift' in Window._modifiers else 0]
+                        z = keyboard_keys[ev_code][-1 if 'shift' in
+                                                   Window._modifiers else 0]
                         if z.lower() not in Keyboard.keycodes:
                             # or if it is not in this LUT
-                            Logger.warn('HIDInput: unhandled character: {}'.format(z))
+                            Logger.warn('HIDInput: unhandled character: {}'.
+                                        format(z))
                             return
 
                         keycode = Keyboard.keycodes[z.lower()]
@@ -602,9 +605,11 @@ else:
                             dispatch_queue.append(('key_up', (
                                 keycode, ev_code,
                                 keys_str.get(z, z), Window._modifiers)))
-                            if (z == 'shift' or z == 'alt') and z in Window._modifiers:
+                            if ((z == 'shift' or z == 'alt') and
+                                    (z in Window._modifiers)):
                                 Window._modifiers.remove(z)
-                            elif z.endswith('ctrl') and 'ctrl' in Window._modifiers:
+                            elif (z.endswith('ctrl') and
+                                  'ctrl' in Window._modifiers):
                                 Window._modifiers.remove('ctrl')
 
             def process(points):

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -522,7 +522,7 @@ else:
                         assign_rel_coord(point,
                             min(1., max(-1., ev_value / 1000.)),
                             invert_y, 'yx')
-                    elif ev_code == 8: # Wheel
+                    elif ev_code == 8:  # Wheel
                         # translates the wheel move to a button
                         b = "scrollup" if ev_value < 0 else "scrolldown"
                         if 'button' not in point:
@@ -586,7 +586,7 @@ else:
                             Logger.warn('HIDInput: unhandled character: {}'.format(z))
                             return
 
-                        keycode= Keyboard.keycodes[z.lower()]
+                        keycode = Keyboard.keycodes[z.lower()]
 
                         if ev_value == 1:
                             if z == 'shift' or z == 'alt':
@@ -605,7 +605,6 @@ else:
                                 Window._modifiers.remove(z)
                             elif z.endswith('ctrl') and 'ctrl' in Window._modifiers:
                                 Window._modifiers.remove('ctrl')
-
 
             def process(points):
                 if not is_multitouch:

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -502,12 +502,13 @@ else:
                         point['size_h'] = ev_value
 
             def process_as_mouse_or_keyboard(
-                tv_sec, tv_usec, ev_type, ev_code, ev_value):
+                    tv_sec, tv_usec, ev_type, ev_code, ev_value):
                 if ev_type == EV_SYN:
                     if ev_code == SYN_REPORT:
                         process([point])
                         if 'button' in point and point['button'].startswith('scroll'):
-                            # for scrolls we need to remove it as there is no up key
+                            # for scrolls we need to remove it as there is
+                            # no up key
                             del point['button']
                             point['id'] += 1
                             point['_avoid'] = True
@@ -516,12 +517,12 @@ else:
                 elif ev_type == EV_REL:
                     if ev_code == 0:
                         assign_rel_coord(point,
-                            min(1., max(-1., ev_value / 1000.)),
-                            invert_x, 'xy')
+                                         min(1., max(-1., ev_value / 1000.)),
+                                         invert_x, 'xy')
                     elif ev_code == 1:
                         assign_rel_coord(point,
-                            min(1., max(-1., ev_value / 1000.)),
-                            invert_y, 'yx')
+                                         min(1., max(-1., ev_value / 1000.)),
+                                         invert_y, 'yx')
                     elif ev_code == 8:  # Wheel
                         # translates the wheel move to a button
                         b = "scrollup" if ev_value < 0 else "scrolldown"
@@ -576,8 +577,8 @@ else:
                             return
 
                         if ev_code not in keyboard_keys:
-                            # we don't want to crash if an unknown key is pressed
-                            Logger.warn('HIDInput: unhandled HID code: {}'.format(ev_code))
+                            Logger.warn('HIDInput: unhandled HID code: {}'.
+                                        format(ev_code))
                             return
 
                         z = keyboard_keys[ev_code][-1 if 'shift' in Window._modifiers else 0]

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -524,7 +524,7 @@ else:
                             invert_y, 'yx')
                     elif ev_code == 8: # Wheel
                         # translates the wheel move to a button
-                        b= "scrollup" if ev_value < 0 else "scrolldown"
+                        b = "scrollup" if ev_value < 0 else "scrolldown"
                         if 'button' not in point:
                             point['button'] = b
                             point['id'] += 1


### PR DESCRIPTION
Add mouse button handling to hidinput (was partially implemented before), enabled button profile.
Add scroll wheel events to hidinput, converts to correct button event.
Add ctrl key handling to hidinput, previously ctrl key was not handled at all.
Tighten up protections against crash if unexpected keys are used.
Also fixes Issue #4680 