### PR TITLE
Fix "Object no attribute active" (Bug introduced via PR #4898)

### DIFF
--- a/kivy/uix/behaviors/togglebutton.py
+++ b/kivy/uix/behaviors/togglebutton.py
@@ -104,8 +104,6 @@ class ToggleButtonBehavior(ButtonBehavior):
             groups[group] = []
         r = ref(self, ToggleButtonBehavior._clear_groups)
         groups[group].append(r)
-        if self.active:
-            self._release_group(self)
 
     def _release_group(self, current):
         if self.group is None:

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -33,6 +33,7 @@ __all__ = ('CheckBox', )
 from kivy.uix.widget import Widget
 from kivy.properties import BooleanProperty, StringProperty, ListProperty
 from kivy.uix.behaviors import ToggleButtonBehavior
+from weakref import ref
 
 
 class CheckBox(ToggleButtonBehavior, Widget):
@@ -171,6 +172,22 @@ class CheckBox(ToggleButtonBehavior, Widget):
         self.state = 'down' if value else 'normal'
         if self._check_variable:
             self._check_variable = False
+
+    def on_group(self, *largs):
+        groups = ToggleButtonBehavior._ToggleButtonBehavior__groups
+        if self._previous_group:
+            group = groups[self._previous_group]
+            for item in group[:]:
+                if item() is self:
+                    group.remove(item)
+                    break
+        group = self._previous_group = self.group
+        if group not in groups:
+            groups[group] = []
+        r = ref(self, ToggleButtonBehavior._clear_groups)
+        groups[group].append(r) 
+        if self.active:
+            self._release_group(self)
 
 
 if __name__ == '__main__':

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -174,18 +174,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
             self._check_variable = False
 
     def on_group(self, *largs):
-        groups = ToggleButtonBehavior._ToggleButtonBehavior__groups
-        if self._previous_group:
-            group = groups[self._previous_group]
-            for item in group[:]:
-                if item() is self:
-                    group.remove(item)
-                    break
-        group = self._previous_group = self.group
-        if group not in groups:
-            groups[group] = []
-        r = ref(self, ToggleButtonBehavior._clear_groups)
-        groups[group].append(r) 
+        super().on_group(*largs)
         if self.active:
             self._release_group(self)
 


### PR DESCRIPTION
When using the `ToggleButtonBehavior` in a object without the `.active` variable (ex. tabbedbar) the PR #4898 introduces a "object has no attribute `active`" error.

This fix moves the edited `on_group` function, in the checkbox implementation.

 