### PR TITLE
Add helpful troubleshooting tips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ clean:
 	-rm -f .noseids
 	-rm -rf kivy/tests/build
 	-find kivy -iname '*.so' -exec rm {} \;
+	-find kivy -iname '*.pyd' -exec rm {} \;
 	-find kivy -iname '*.pyc' -exec rm {} \;
 	-find kivy -iname '*.pyo' -exec rm {} \;
 	-find . -iname '*.pyx' -exec sh -c 'echo `dirname {}`/`basename {} .pyx`.c' \; | xargs rm

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -359,8 +359,18 @@ from kivy.config import Config
 from kivy.logger import Logger
 from kivy.compat import clock as _default_time, PY2
 import time
-from kivy._clock import CyClockBase, ClockEvent, FreeClockEvent, \
-    CyClockBaseFree
+try:
+    from kivy._clock import CyClockBase, ClockEvent, FreeClockEvent, \
+        CyClockBaseFree
+except ImportError:
+    Logger.error(
+        'Clock: Unable to import kivy._clock. Have you perhaps forgotten to '
+        'compile kivy? Kivy contains Cython code which needs to be compiled. '
+        'A missing kivy._clock often indicates the Cython code has not been '
+        'compiled. Please follow the installation instructions and make sure '
+        'to compile Kivy')
+    raise
+
 try:
     from multiprocessing import Event as MultiprocessingEvent
 except ImportError:  # https://bugs.python.org/issue3770

--- a/kivy/core/__init__.py
+++ b/kivy/core/__init__.py
@@ -20,10 +20,14 @@ opening a new Bug report instead of relying on your library.
 
 
 import os
+import sysconfig
 import sys
 import traceback
+import tempfile
+import subprocess
 import kivy
 from kivy.logger import Logger
+from kivy.compat import PY2
 
 
 class CoreCriticalException(Exception):
@@ -93,8 +97,10 @@ def core_select_lib(category, llist, create_instance=False,
     err = '\n'.join(['{} - {}: {}\n{}'.format(opt, e.__class__.__name__, e,
                    ''.join(traceback.format_tb(tb))) for opt, e, tb in errs])
     Logger.critical(
-        '{0}: Unable to find any valuable {0} provider.\n{1}'.format(
-            category.capitalize(), err))
+        '{0}: Unable to find any valuable {0} provider. Please enable '
+        'debug logging (e.g. add -d if running from the command line, or '
+        'change the log level in the config) and re-run your app to '
+        'identify potential causes\n{1}'.format(category.capitalize(), err))
 
 
 def core_register_libs(category, libs, base='kivy.core'):
@@ -142,3 +148,98 @@ def core_register_libs(category, libs, base='kivy.core'):
         '({0} ignored)'.format(
             ', '.join(libs_ignored)) if libs_ignored else ''))
     return libs_loaded
+
+
+def handle_win_lib_import_error(category, provider, mod_name):
+    if sys.platform != 'win32':
+        return
+
+    assert mod_name.startswith('kivy.')
+    kivy_root = os.path.dirname(kivy.__file__)
+    dirs = mod_name[5:].split('.')
+    mod_path = os.path.join(kivy_root, *dirs)
+
+    # get the full expected path to the compiled pyd file
+    if PY2:
+        mod_path += '.pyd'
+    else:
+        # filename is <debug>.cp<major><minor>-<platform>.pyd
+        # https://github.com/python/cpython/blob/master/Doc/whatsnew/3.5.rst
+        if hasattr(sys, 'gettotalrefcount'):  # debug
+            mod_path += '._d'
+        mod_path += '.cp{}{}-{}.pyd'.format(
+            sys.version_info.major, sys.version_info.minor,
+            sysconfig.get_platform().replace('-', '_'))
+
+    # does the compiled pyd exist at all?
+    if not os.path.exists(mod_path):
+        Logger.debug(
+            '{}: Failed trying to import "{}" for provider {}. Compiled file '
+            'does not exist. Have you perhaps forgotten to compile Kivy, or '
+            'did not install all required dependencies?'.format(
+                category, provider, mod_path))
+        return
+
+    # tell user to provide dependency walker
+    env_var = 'KIVY_{}_DEPENDENCY_WALKER'.format(provider.upper())
+    if env_var not in os.environ:
+        Logger.debug(
+            '{0}: Failed trying to import the "{1}" provider from "{2}". '
+            'This error is often encountered when a dependency is missing,'
+            ' or if there are multiple copies of the same dependency dll on '
+            'the Windows PATH and they are incompatible with each other. '
+            'This can occur if you are mixing installations (such as different'
+            ' python installations, like anaconda python and a system python) '
+            'or if another unrelated program added its directory to the PATH. '
+            'Please examine your PATH and python installation for potential '
+            'issues. To further troubleshoot a "DLL load failed" error, '
+            'please download '
+            '"Dependency Walker" (64 or 32 bit version - matching your python '
+            'bitness) from dependencywalker.com and set the environment '
+            'variable {3} to the full path of the downloaded depends.exe file '
+            'and rerun your application to generate an error report'.
+            format(category, provider, mod_path, env_var))
+        return
+
+    depends_bin = os.environ[env_var]
+    if not os.path.exists(depends_bin):
+        raise ValueError('"{}" provided in {} does not exist'.format(
+            depends_bin, env_var))
+
+    # make file for the resultant log
+    fd, temp_file = tempfile.mkstemp(
+        suffix='.dwi', prefix='kivy_depends_{}_log_'.format(provider),
+        dir=os.path.expanduser('~/'))
+    os.close(fd)
+
+    Logger.info(
+        '{}: Running dependency walker "{}" on "{}" to generate '
+        'troubleshooting log. Please wait for it to complete'.format(
+            category, depends_bin, mod_path))
+    Logger.debug(
+        '{}: Dependency walker command is "{}"'.format(
+            category,
+            [depends_bin, '/c', '/od:{}'.format(temp_file), mod_path]))
+
+    try:
+        subprocess.check_output([
+            depends_bin, '/c', '/od:{}'.format(temp_file), mod_path])
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode >= 0x00010000:
+            Logger.error(
+                '{}: Dependency walker failed with error code "{}". No '
+                'error report was generated'.
+                format(category, exc.returncode))
+            return
+
+    Logger.info(
+        '{}: dependency walker generated "{}" containing troubleshooting '
+        'information about provider {} and its failing file "{} ({})". You '
+        'can open the file in dependency walker to view any potential issues '
+        'and troubleshoot it yourself. '
+        'To share the file with the Kivy developers and request support, '
+        'please contact us at our support channels '
+        'https://kivy.org/doc/master/contact.html (not on github, unless '
+        'it\'s truly a bug). Make sure to provide the generated file as well '
+        'as the *complete* Kivy log being printed here'.format(
+            category, temp_file, provider, mod_name, mod_path))

--- a/kivy/core/__init__.py
+++ b/kivy/core/__init__.py
@@ -241,5 +241,10 @@ def handle_win_lib_import_error(category, provider, mod_name):
         'please contact us at our support channels '
         'https://kivy.org/doc/master/contact.html (not on github, unless '
         'it\'s truly a bug). Make sure to provide the generated file as well '
-        'as the *complete* Kivy log being printed here'.format(
+        'as the *complete* Kivy log being printed here. Keep in mind the '
+        'generated dependency walker log file contains paths to dlls on your '
+        'system used by kivy or its dependencies to help troubleshoot them, '
+        'and these paths may include your name in them. Please view the '
+        'log file in dependency walker before sharing to ensure you are not '
+        'sharing sensitive paths'.format(
             category, temp_file, provider, mod_name, mod_path))

--- a/kivy/core/clipboard/clipboard_sdl2.py
+++ b/kivy/core/clipboard/clipboard_sdl2.py
@@ -14,7 +14,10 @@ try:
     from kivy.core.clipboard._clipboard_sdl2 import (
         _get_text, _has_text, _set_text)
 except ImportError:
-    raise SystemError('extension not compiled?')
+    from kivy.core import handle_win_lib_import_error
+    handle_win_lib_import_error(
+        'Clipboard', 'sdl2', 'kivy.core.clipboard._clipboard_sdl2')
+    raise
 
 
 class ClipboardSDL2(ClipboardBase):

--- a/kivy/core/image/img_sdl2.py
+++ b/kivy/core/image/img_sdl2.py
@@ -7,7 +7,13 @@ __all__ = ('ImageLoaderSDL2', )
 
 from kivy.logger import Logger
 from kivy.core.image import ImageLoaderBase, ImageData, ImageLoader
-from kivy.core.image import _img_sdl2
+try:
+    from kivy.core.image import _img_sdl2
+except ImportError:
+    from kivy.core import handle_win_lib_import_error
+    handle_win_lib_import_error(
+        'image', 'sdl2', 'kivy.core.image._img_sdl2')
+    raise
 
 
 class ImageLoaderSDL2(ImageLoaderBase):

--- a/kivy/core/text/text_sdl2.py
+++ b/kivy/core/text/text_sdl2.py
@@ -9,8 +9,14 @@ __all__ = ('LabelSDL2', )
 
 from kivy.compat import PY2
 from kivy.core.text import LabelBase
-from kivy.core.text._text_sdl2 import (_SurfaceContainer, _get_extents,
-                                       _get_fontdescent, _get_fontascent)
+try:
+    from kivy.core.text._text_sdl2 import (_SurfaceContainer, _get_extents,
+                                           _get_fontdescent, _get_fontascent)
+except ImportError:
+    from kivy.core import handle_win_lib_import_error
+    handle_win_lib_import_error(
+        'text', 'sdl2', 'kivy.core.text._text_sdl2')
+    raise
 
 
 class LabelSDL2(LabelBase):

--- a/kivy/core/video/video_gstplayer.py
+++ b/kivy/core/video/video_gstplayer.py
@@ -9,7 +9,13 @@ This player is the preferred player, using Gstreamer 1.0, working on both
 Python 2 and 3.
 '''
 
-from kivy.lib.gstplayer import GstPlayer, get_gst_version
+try:
+    from kivy.lib.gstplayer import GstPlayer, get_gst_version
+except ImportError:
+    from kivy.core import handle_win_lib_import_error
+    handle_win_lib_import_error(
+        'VideoGstplayer', 'gst', 'kivy.lib.gstplayer._gstplayer')
+    raise
 from kivy.graphics.texture import Texture
 from kivy.core.video import VideoBase
 from kivy.logger import Logger

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -23,7 +23,13 @@ from kivy.base import EventLoop, ExceptionManager, stopTouchApp
 from kivy.clock import Clock
 from kivy.config import Config
 from kivy.core.window import WindowBase
-from kivy.core.window._window_sdl2 import _WindowSDL2Storage
+try:
+    from kivy.core.window._window_sdl2 import _WindowSDL2Storage
+except ImportError:
+    from kivy.core import handle_win_lib_import_error
+    handle_win_lib_import_error(
+        'window', 'sdl2', 'kivy.core.window._window_sdl2')
+    raise
 from kivy.input.provider import MotionEventProvider
 from kivy.input.motionevent import MotionEvent
 from kivy.resources import resource_find


### PR DESCRIPTION
This adds some clearer error messages and tools to help users struggling with kivy installation issues.

Among the bigger things is it tries to detect is if the user forgot to compile kivy and warns about. It also adds the opportunity to use the dependency walker tool to figure out which of the dependencies is missing in the **Unable to find any valuable Window provider** case. They can then share the generated file, which anyone could open with the dependency walker tool to figure out which dlls are missing etc.

I'm hopeful that this will significantly cut down on the number of users who get stuck on installation issues and open requests on github about it. And in case it does happen, people on discord/mailing list will have the tools to help them using the generated log.