### PR TITLE
SetWindowLongPtrW ctypes prototype bug

### DIFF
--- a/kivy/input/providers/wm_common.py
+++ b/kivy/input/providers/wm_common.py
@@ -62,8 +62,6 @@ if 'KIVY_DOC' not in os.environ:
                         c_int, c_longlong, c_void_p, Structure,
                         sizeof, byref, cast)
 
-    LONG_PTR = c_longlong
-
     class RECT(Structure):
         _fields_ = [
             ('left', LONG),
@@ -127,6 +125,7 @@ if 'KIVY_DOC' not in os.environ:
         return _closure
 
     try:
+        LONG_PTR = c_longlong
         windll.user32.SetWindowLongPtrW.restype = LONG_PTR
         windll.user32.SetWindowLongPtrW.argtypes = [HWND, c_int, LONG_PTR]
         SetWindowLong_WndProc_wrapper = \

--- a/kivy/input/providers/wm_common.py
+++ b/kivy/input/providers/wm_common.py
@@ -57,10 +57,12 @@ QUERYSYSTEMGESTURE_WNDPROC = (
 
 if 'KIVY_DOC' not in os.environ:
     from ctypes.wintypes import (ULONG, HANDLE, DWORD, LONG, UINT,
-                                 WPARAM, LPARAM, BOOL)
+                                 WPARAM, LPARAM, BOOL, HWND)
     from ctypes import (windll, WINFUNCTYPE, POINTER,
-                        c_int, c_long, c_longlong, c_void_p, Structure,
+                        c_int, c_longlong, c_void_p, Structure,
                         sizeof, byref, cast)
+
+    LONG_PTR = c_longlong
 
     class RECT(Structure):
         _fields_ = [
@@ -125,14 +127,14 @@ if 'KIVY_DOC' not in os.environ:
         return _closure
 
     try:
-        windll.user32.SetWindowLongPtrW.restype = c_longlong
-        windll.user32.SetWindowLongPtrW.argtypes = [HANDLE, c_int, c_longlong]
+        windll.user32.SetWindowLongPtrW.restype = LONG_PTR
+        windll.user32.SetWindowLongPtrW.argtypes = [HWND, c_int, LONG_PTR]
         SetWindowLong_WndProc_wrapper = \
             SetWindowLong_WndProc_wrapper_generator(
                 windll.user32.SetWindowLongPtrW)
     except AttributeError:
-        windll.user32.SetWindowLongW.restype = c_long
-        windll.user32.SetWindowLongW.argtypes = [HANDLE, c_int, c_long]
+        windll.user32.SetWindowLongW.restype = LONG
+        windll.user32.SetWindowLongW.argtypes = [HWND, c_int, LONG]
         SetWindowLong_WndProc_wrapper = \
             SetWindowLong_WndProc_wrapper_generator(
                 windll.user32.SetWindowLongW)

--- a/kivy/input/providers/wm_pen.py
+++ b/kivy/input/providers/wm_pen.py
@@ -85,8 +85,8 @@ else:
             # inject our own wndProc to handle messages
             # before window manager does
             self.new_windProc = WNDPROC(self._pen_wndProc)
-            self.old_windProc = SetWindowLong_wrapper(
-                self.hwnd, GWL_WNDPROC, self.new_windProc)
+            self.old_windProc = SetWindowLong_WndProc_wrapper(
+                self.hwnd, self.new_windProc)
 
         def update(self, dispatch_fn):
             while True:
@@ -108,6 +108,6 @@ else:
 
         def stop(self):
             self.pen = None
-            SetWindowLong_wrapper(self.hwnd, GWL_WNDPROC, self.old_windProc)
+            SetWindowLong_WndProc_wrapper(self.hwnd, self.old_windProc)
 
     MotionEventFactory.register('wm_pen', WM_PenProvider)

--- a/kivy/input/providers/wm_touch.py
+++ b/kivy/input/providers/wm_touch.py
@@ -64,8 +64,8 @@ else:
             # inject our own wndProc to handle messages
             # before window manager does
             self.new_windProc = WNDPROC(self._touch_wndProc)
-            self.old_windProc = SetWindowLong_wrapper(
-                self.hwnd, GWL_WNDPROC, self.new_windProc)
+            self.old_windProc = SetWindowLong_WndProc_wrapper(
+                self.hwnd, self.new_windProc)
 
         def update(self, dispatch_fn):
             c_rect = RECT()
@@ -105,8 +105,8 @@ else:
 
         def stop(self):
             windll.user32.UnregisterTouchWindow(self.hwnd)
-            self.new_windProc = SetWindowLong_wrapper(
-                self.hwnd, GWL_WNDPROC, self.old_windProc)
+            self.new_windProc = SetWindowLong_WndProc_wrapper(
+                self.hwnd, self.old_windProc)
 
         # we inject this wndProc into our main window, to process
         # WM_TOUCH and mouse messages before the window manager does


### PR DESCRIPTION
*SetWindowLongPtrW*'s prototype (*ctypes*) is incorrectly defined (type sizes are correct though, and in *C*  it would work with some *cast*s, but in *Python* things are a bit trickier).

Also, when used in conjunction with other modules (e.g. *Pywinauto*) that correctly set the prototype, (there are cases when) program abnormally exits.

Encountered on v*1.10.1*.

Investigation details are on **[[SO]: ctypes.ArgumentError when using kivy with pywinauto (@CristiFati's answer)](https://stackoverflow.com/questions/55928463/ctypes-argumenterror-when-using-kivy-with-pywinauto/55931295#55931295)**.

The proposed fix:
- Corrects the function prototype
- Creates a wrapper function that does all the conversions required to work with current scenario
- Removed *GWL\_WNDPROC* (2<sup>nd</sup> argument) from all client places, and only specified it once
- Since only the *GWL\_WNDPROC* use-case is required, changed wrapper name from *SetWindowLong\_wrapper* to *SetWindowLong\_WndProc\_wrapper*, as it better reflects the behavior

I didn't test it on *32bit* (lol, I didn't test a lot of things, good thing *CI* is in place).
