### PR TITLE
Add caps and numlock to the modifiers

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -37,14 +37,20 @@ from kivy.utils import platform, deprecated
 from kivy.compat import unichr
 from collections import deque
 
-KMOD_LCTRL = 64
-KMOD_RCTRL = 128
-KMOD_RSHIFT = 2
-KMOD_LSHIFT = 1
-KMOD_RALT = 512
-KMOD_LALT = 256
-KMOD_LMETA = 1024
-KMOD_RMETA = 2048
+
+# SDL_keycode.h, https://wiki.libsdl.org/SDL_Keymod
+KMOD_NONE = 0x0000
+KMOD_LSHIFT = 0x0001
+KMOD_RSHIFT = 0x0002
+KMOD_LCTRL = 0x0040
+KMOD_RCTRL = 0x0080
+KMOD_LALT = 0x0100
+KMOD_RALT = 0x0200
+KMOD_LGUI = 0x0400
+KMOD_RGUI = 0x0800
+KMOD_NUM = 0x1000
+KMOD_CAPS = 0x2000
+KMOD_MODE = 0x4000
 
 SDLK_SHIFTL = 1073742049
 SDLK_SHIFTR = 1073742053
@@ -145,9 +151,10 @@ class WindowSDL(WindowBase):
         self._win = _WindowSDL2Storage()
         super(WindowSDL, self).__init__()
         self._mouse_x = self._mouse_y = -1
-        self._meta_keys = (KMOD_LCTRL, KMOD_RCTRL, KMOD_RSHIFT,
-            KMOD_LSHIFT, KMOD_RALT, KMOD_LALT, KMOD_LMETA,
-            KMOD_RMETA)
+        self._meta_keys = (
+            KMOD_LCTRL, KMOD_RCTRL, KMOD_RSHIFT,
+            KMOD_LSHIFT, KMOD_RALT, KMOD_LALT, KMOD_LGUI,
+            KMOD_RGUI, KMOD_NUM, KMOD_CAPS, KMOD_MODE)
         self.command_keys = {
                     27: 'escape',
                     9: 'tab',
@@ -748,14 +755,7 @@ class WindowSDL(WindowBase):
         Logger.info("WindowSDL: exiting mainloop and closing.")
         self.close()
 
-    #
-    # Pygame wrapper
-    #
     def _update_modifiers(self, mods=None, key=None):
-        # Available mod, from dir(pygame)
-        # 'KMOD_ALT', 'KMOD_CAPS', 'KMOD_CTRL', 'KMOD_LALT',
-        # 'KMOD_LCTRL', 'KMOD_LMETA', 'KMOD_LSHIFT', 'KMOD_META',
-        # 'KMOD_MODE', 'KMOD_NONE'
         if mods is None and key is None:
             return
         modifiers = set()
@@ -763,22 +763,30 @@ class WindowSDL(WindowBase):
         if mods is not None:
             if mods & (KMOD_RSHIFT | KMOD_LSHIFT):
                 modifiers.add('shift')
-            if mods & (KMOD_RALT | KMOD_LALT):
+            if mods & (KMOD_RALT | KMOD_LALT | KMOD_MODE):
                 modifiers.add('alt')
             if mods & (KMOD_RCTRL | KMOD_LCTRL):
                 modifiers.add('ctrl')
-            if mods & (KMOD_RMETA | KMOD_LMETA):
+            if mods & (KMOD_RGUI | KMOD_LGUI):
                 modifiers.add('meta')
+            if mods & KMOD_NUM:
+                modifiers.add('numlock')
+            if mods & KMOD_CAPS:
+                modifiers.add('capslock')
 
         if key is not None:
             if key in (KMOD_RSHIFT, KMOD_LSHIFT):
                 modifiers.add('shift')
-            if key in (KMOD_RALT, KMOD_LALT):
+            if key in (KMOD_RALT, KMOD_LALT, KMOD_MODE):
                 modifiers.add('alt')
             if key in (KMOD_RCTRL, KMOD_LCTRL):
                 modifiers.add('ctrl')
-            if key in (KMOD_RMETA, KMOD_LMETA):
+            if key in (KMOD_RGUI, KMOD_LGUI):
                 modifiers.add('meta')
+            if key == KMOD_NUM:
+                modifiers.add('numlock')
+            if key == KMOD_CAPS:
+                modifiers.add('capslock')
 
         self._modifiers = list(modifiers)
         return


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy/issues/6285.

I looked at https://wiki.libsdl.org/SDL_Keymod and SDL_keycode.h and updated the code based on this. 

Specifically,
* I renamed the `KMOD_xMETA` key to `KMOD_xGUI`, because that's what sdl2 calls it (it's the key with the windows icon typically).
* I added `KMOD_MODE`, this is basically the same as the right alt key.
* I added the `KMOD_NUM` and `KMOD_CAPS` keys, which are the numslock and capslock keys.