### PR TITLE
- calculate dpi on window update

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -81,6 +81,7 @@ from functools import partial
 from copy import copy
 from kivy import kivy_data_dir
 from kivy.config import Config
+from kivy.logger import Logger
 from kivy.utils import platform
 from kivy.graphics.texture import Texture
 from kivy.core import core_select_lib

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -404,6 +404,14 @@ class WindowBase(EventDispatcher):
         else:
             return False
 
+    def _recalc_dpi(self):
+        # calculate density
+        w, h = self.system_size
+        sw, sh = self._win._get_gl_size()
+        self._density = density = sw / w
+        if self._is_desktop and self.size[0] != w:
+            self.dpi = density * 96.
+
     minimum_width = NumericProperty(0)
     '''The minimum width to restrict the window to.
 
@@ -1440,6 +1448,9 @@ class WindowBase(EventDispatcher):
         from math import radians
 
         w, h = self.system_size
+
+        self._recalc_dpi()
+
         if self._density != 1:
             w, h = self.size
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -277,15 +277,9 @@ class WindowSDL(WindowBase):
             resizable = Config.getboolean('graphics', 'resizable')
             state = (Config.get('graphics', 'window_state')
                      if self._is_desktop else None)
-            self.system_size = _size = self._win.setup_window(
+            self.system_size = self._win.setup_window(
                 pos[0], pos[1], w, h, self.borderless,
                 self.fullscreen, resizable, state)
-
-            # calculate density
-            sz = self._win._get_gl_size()[0]
-            self._density = density = sz / _size[0]
-            if self._is_desktop and self.size[0] != _size[0]:
-                self.dpi = density * 96.
 
             # never stay with a None pos, application using w.center
             # will be fired.


### PR DESCRIPTION
this is fix of issue #6144.

It's not ideal solution, as fonts are 2x larger after moving window from retina to non-retina, or 2x smaller if moved window from non-retina to retina. 

However, it's way better than it was before, so I think it's worth to apply. 