### PR TITLE
Widget: Fix signature of add/remove/clear_widget  to be consistent with base class

### DIFF
--- a/examples/canvas/fbo_canvas.py
+++ b/examples/canvas/fbo_canvas.py
@@ -43,10 +43,10 @@ class FboFloatLayout(FloatLayout):
 
     def add_widget(self, *args, **kwargs):
         # trick to attach graphics instruction to fbo instead of canvas
-        _canvas = self.canvas
+        canvas = self.canvas
         self.canvas = self.fbo
         ret = super(FboFloatLayout, self).add_widget(*args, **kwargs)
-        self.canvas = _canvas
+        self.canvas = canvas
         return ret
 
     def remove_widget(self, widget):

--- a/examples/canvas/fbo_canvas.py
+++ b/examples/canvas/fbo_canvas.py
@@ -49,10 +49,10 @@ class FboFloatLayout(FloatLayout):
         self.canvas = canvas
         return ret
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         canvas = self.canvas
         self.canvas = self.fbo
-        super(FboFloatLayout, self).remove_widget(widget)
+        super(FboFloatLayout, self).remove_widget(*args, **kwargs)
         self.canvas = canvas
 
     def on_size(self, instance, value):

--- a/examples/canvas/fbo_canvas.py
+++ b/examples/canvas/fbo_canvas.py
@@ -41,11 +41,11 @@ class FboFloatLayout(FloatLayout):
         self.texture = self.fbo.texture
         super(FboFloatLayout, self).__init__(**kwargs)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         # trick to attach graphics instruction to fbo instead of canvas
         _canvas = self.canvas
         self.canvas = self.fbo
-        ret = super(FboFloatLayout, self).add_widget(widget, index, canvas)
+        ret = super(FboFloatLayout, self).add_widget(*args, **kwargs)
         self.canvas = _canvas
         return ret
 

--- a/examples/canvas/fbo_canvas.py
+++ b/examples/canvas/fbo_canvas.py
@@ -49,10 +49,10 @@ class FboFloatLayout(FloatLayout):
         self.canvas = _canvas
         return ret
 
-    def remove_widget(self, *largs):
+    def remove_widget(self, widget):
         canvas = self.canvas
         self.canvas = self.fbo
-        super(FboFloatLayout, self).remove_widget(*largs)
+        super(FboFloatLayout, self).remove_widget(widget)
         self.canvas = canvas
 
     def on_size(self, instance, value):

--- a/examples/canvas/fbo_canvas.py
+++ b/examples/canvas/fbo_canvas.py
@@ -41,12 +41,12 @@ class FboFloatLayout(FloatLayout):
         self.texture = self.fbo.texture
         super(FboFloatLayout, self).__init__(**kwargs)
 
-    def add_widget(self, *largs):
+    def add_widget(self, widget, index=0, canvas=None):
         # trick to attach graphics instruction to fbo instead of canvas
-        canvas = self.canvas
+        _canvas = self.canvas
         self.canvas = self.fbo
-        ret = super(FboFloatLayout, self).add_widget(*largs)
-        self.canvas = canvas
+        ret = super(FboFloatLayout, self).add_widget(widget, index, canvas)
+        self.canvas = _canvas
         return ret
 
     def remove_widget(self, *largs):

--- a/examples/demo/showcase/main.py
+++ b/examples/demo/showcase/main.py
@@ -39,10 +39,10 @@ from kivy.uix.screenmanager import Screen
 class ShowcaseScreen(Screen):
     fullscreen = BooleanProperty(False)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         if 'content' in self.ids:
-            return self.ids.content.add_widget(widget, index, canvas)
-        return super(ShowcaseScreen, self).add_widget(widget, index, canvas)
+            return self.ids.content.add_widget(*args, **kwargs)
+        return super(ShowcaseScreen, self).add_widget(*args, **kwargs)
 
 
 class ShowcaseApp(App):

--- a/examples/demo/showcase/main.py
+++ b/examples/demo/showcase/main.py
@@ -39,10 +39,10 @@ from kivy.uix.screenmanager import Screen
 class ShowcaseScreen(Screen):
     fullscreen = BooleanProperty(False)
 
-    def add_widget(self, *args):
+    def add_widget(self, widget, index=0, canvas=None):
         if 'content' in self.ids:
-            return self.ids.content.add_widget(*args)
-        return super(ShowcaseScreen, self).add_widget(*args)
+            return self.ids.content.add_widget(widget, index, canvas)
+        return super(ShowcaseScreen, self).add_widget(widget, index, canvas)
 
 
 class ShowcaseApp(App):

--- a/examples/shader/shadertree.py
+++ b/examples/shader/shadertree.py
@@ -145,10 +145,10 @@ class ShaderWidget(FloatLayout):
         super(ShaderWidget, self).add_widget(*args, **kwargs)
         self.canvas = c
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         c = self.canvas
         self.canvas = self.fbo
-        super(ShaderWidget, self).remove_widget(widget)
+        super(ShaderWidget, self).remove_widget(*args, **kwargs)
         self.canvas = c
 
     def on_size(self, instance, value):

--- a/examples/shader/shadertree.py
+++ b/examples/shader/shadertree.py
@@ -139,10 +139,10 @@ class ShaderWidget(FloatLayout):
     # add their graphics canvas to our Framebuffer, not the usual canvas.
     #
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         c = self.canvas
         self.canvas = self.fbo
-        super(ShaderWidget, self).add_widget(widget, index, canvas)
+        super(ShaderWidget, self).add_widget(*args, **kwargs)
         self.canvas = c
 
     def remove_widget(self, widget):

--- a/examples/shader/shadertree.py
+++ b/examples/shader/shadertree.py
@@ -139,10 +139,10 @@ class ShaderWidget(FloatLayout):
     # add their graphics canvas to our Framebuffer, not the usual canvas.
     #
 
-    def add_widget(self, widget):
+    def add_widget(self, widget, index=0, canvas=None):
         c = self.canvas
         self.canvas = self.fbo
-        super(ShaderWidget, self).add_widget(widget)
+        super(ShaderWidget, self).add_widget(widget, index, canvas)
         self.canvas = c
 
     def remove_widget(self, widget):

--- a/examples/widgets/fbowidget.py
+++ b/examples/widgets/fbowidget.py
@@ -62,10 +62,10 @@ class FboFloatLayout(FloatLayout):
         self.canvas = canvas
         return ret
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         canvas = self.canvas
         self.canvas = self.fbo
-        super(FboFloatLayout, self).remove_widget(widget)
+        super(FboFloatLayout, self).remove_widget(*args, **kwargs)
         self.canvas = canvas
 
     def on_size(self, instance, value):

--- a/examples/widgets/fbowidget.py
+++ b/examples/widgets/fbowidget.py
@@ -62,10 +62,10 @@ class FboFloatLayout(FloatLayout):
         self.canvas = _canvas
         return ret
 
-    def remove_widget(self, *largs):
+    def remove_widget(self, widget):
         canvas = self.canvas
         self.canvas = self.fbo
-        super(FboFloatLayout, self).remove_widget(*largs)
+        super(FboFloatLayout, self).remove_widget(widget)
         self.canvas = canvas
 
     def on_size(self, instance, value):

--- a/examples/widgets/fbowidget.py
+++ b/examples/widgets/fbowidget.py
@@ -56,10 +56,10 @@ class FboFloatLayout(FloatLayout):
 
     def add_widget(self, *args, **kwargs):
         # trick to attach graphics instruction to fbo instead of canvas
-        _canvas = self.canvas
+        canvas = self.canvas
         self.canvas = self.fbo
         ret = super(FboFloatLayout, self).add_widget(*args, **kwargs)
-        self.canvas = _canvas
+        self.canvas = canvas
         return ret
 
     def remove_widget(self, widget):

--- a/examples/widgets/fbowidget.py
+++ b/examples/widgets/fbowidget.py
@@ -54,11 +54,11 @@ class FboFloatLayout(FloatLayout):
         self.texture = self.fbo.texture
         super(FboFloatLayout, self).__init__(**kwargs)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         # trick to attach graphics instruction to fbo instead of canvas
         _canvas = self.canvas
         self.canvas = self.fbo
-        ret = super(FboFloatLayout, self).add_widget(widget, index, canvas)
+        ret = super(FboFloatLayout, self).add_widget(*args, **kwargs)
         self.canvas = _canvas
         return ret
 

--- a/examples/widgets/fbowidget.py
+++ b/examples/widgets/fbowidget.py
@@ -54,12 +54,12 @@ class FboFloatLayout(FloatLayout):
         self.texture = self.fbo.texture
         super(FboFloatLayout, self).__init__(**kwargs)
 
-    def add_widget(self, *largs):
+    def add_widget(self, widget, index=0, canvas=None):
         # trick to attach graphics instruction to fbo instead of canvas
-        canvas = self.canvas
+        _canvas = self.canvas
         self.canvas = self.fbo
-        ret = super(FboFloatLayout, self).add_widget(*largs)
-        self.canvas = canvas
+        ret = super(FboFloatLayout, self).add_widget(widget, index, canvas)
+        self.canvas = _canvas
         return ret
 
     def remove_widget(self, *largs):

--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -269,10 +269,10 @@ class AccordionItem(FloatLayout):
             return super(AccordionItem, self).add_widget(*args, **kwargs)
         return self.container.add_widget(*args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         if self.container:
-            self.container.remove_widget(widget)
-        super(AccordionItem, self).remove_widget(widget)
+            self.container.remove_widget(*args, **kwargs)
+        super(AccordionItem, self).remove_widget(*args, **kwargs)
 
     def on_collapse(self, instance, value):
         accordion = self.accordion

--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -369,12 +369,11 @@ class Accordion(Widget):
         fbind('pos', update)
         fbind('min_space', update)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         if not isinstance(widget, AccordionItem):
             raise AccordionException('Accordion accept only AccordionItem')
-
         widget.accordion = self
-        ret = super(Accordion, self).add_widget(widget, index, canvas)
+        ret = super(Accordion, self).add_widget(widget, *args, **kwargs)
         return ret
 
     def select(self, instance):

--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -266,12 +266,14 @@ class AccordionItem(FloatLayout):
 
     def add_widget(self, *args, **kwargs):
         if self.container is None:
-            return super(AccordionItem, self).add_widget(*args, **kwargs)
-        return self.container.add_widget(*args, **kwargs)
+            super(AccordionItem, self).add_widget(*args, **kwargs)
+            return
+        self.container.add_widget(*args, **kwargs)
 
     def remove_widget(self, *args, **kwargs):
         if self.container:
             self.container.remove_widget(*args, **kwargs)
+            return
         super(AccordionItem, self).remove_widget(*args, **kwargs)
 
     def on_collapse(self, instance, value):
@@ -373,8 +375,7 @@ class Accordion(Widget):
         if not isinstance(widget, AccordionItem):
             raise AccordionException('Accordion accept only AccordionItem')
         widget.accordion = self
-        ret = super(Accordion, self).add_widget(widget, *args, **kwargs)
-        return ret
+        super(Accordion, self).add_widget(widget, *args, **kwargs)
 
     def select(self, instance):
         if instance not in self.children:

--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -264,10 +264,10 @@ class AccordionItem(FloatLayout):
         fbind('title_args', trigger_title)
         trigger_title()
 
-    def add_widget(self, widget):
+    def add_widget(self, widget, index=0, canvas=None):
         if self.container is None:
             return super(AccordionItem, self).add_widget(widget)
-        return self.container.add_widget(widget)
+        return self.container.add_widget(widget, index, canvas)
 
     def remove_widget(self, widget):
         if self.container:
@@ -369,12 +369,12 @@ class Accordion(Widget):
         fbind('pos', update)
         fbind('min_space', update)
 
-    def add_widget(self, widget, *largs):
+    def add_widget(self, widget, index=0, canvas=None):
         if not isinstance(widget, AccordionItem):
             raise AccordionException('Accordion accept only AccordionItem')
 
         widget.accordion = self
-        ret = super(Accordion, self).add_widget(widget, *largs)
+        ret = super(Accordion, self).add_widget(widget, index, canvas)
         return ret
 
     def select(self, instance):

--- a/kivy/uix/accordion.py
+++ b/kivy/uix/accordion.py
@@ -264,10 +264,10 @@ class AccordionItem(FloatLayout):
         fbind('title_args', trigger_title)
         trigger_title()
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         if self.container is None:
-            return super(AccordionItem, self).add_widget(widget)
-        return self.container.add_widget(widget, index, canvas)
+            return super(AccordionItem, self).add_widget(*args, **kwargs)
+        return self.container.add_widget(*args, **kwargs)
 
     def remove_widget(self, widget):
         if self.container:

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -452,17 +452,17 @@ class ActionGroup(ActionItem, Button):
             # auto_dismiss applies to touching outside of the DropDown
             item.bind(on_release=ddn.dismiss)
 
-    def add_widget(self, item):
+    def add_widget(self, widget, index=0, canvas=None):
         # if adding ActionSeparator ('normal' mode,
         # everything visible), add it to the parent
-        if isinstance(item, ActionSeparator):
-            super(ActionGroup, self).add_widget(item)
+        if isinstance(widget, ActionSeparator):
+            super(ActionGroup, self).add_widget(widget, index, canvas)
             return
 
-        if not isinstance(item, ActionItem):
+        if not isinstance(widget, ActionItem):
             raise ActionBarException('ActionGroup only accepts ActionItem')
 
-        self.list_action_item.append(item)
+        self.list_action_item.append(widget)
 
     def show_group(self):
         # 'normal' mode, items can fit to the view
@@ -489,21 +489,21 @@ class ActionOverflow(ActionGroup):
     and defaults to 'atlas://data/images/defaulttheme/overflow'.
     '''
 
-    def add_widget(self, action_item, index=0):
-        if action_item is None:
+    def add_widget(self, widget, index=0, canvas=None):
+        if widget is None:
             return
 
-        if isinstance(action_item, ActionSeparator):
+        if isinstance(widget, ActionSeparator):
             return
 
-        if not isinstance(action_item, ActionItem):
+        if not isinstance(widget, ActionItem):
             raise ActionBarException('ActionView only accepts ActionItem'
-                                     ' (got {!r}'.format(action_item))
+                                     ' (got {!r}'.format(widget))
 
         else:
             if index == 0:
                 index = len(self._list_overflow_items)
-            self._list_overflow_items.insert(index, action_item)
+            self._list_overflow_items.insert(index, widget)
 
     def show_default_items(self, parent):
         # display overflow and its items if widget's directly added to it
@@ -575,30 +575,30 @@ class ActionView(BoxLayout):
     def on_action_previous(self, instance, value):
         self._list_action_items.insert(0, value)
 
-    def add_widget(self, action_item, index=0):
-        if action_item is None:
+    def add_widget(self, widget, index=0, canvas=None):
+        if widget is None:
             return
 
-        if not isinstance(action_item, ActionItem):
+        if not isinstance(widget, ActionItem):
             raise ActionBarException('ActionView only accepts ActionItem'
-                                     ' (got {!r}'.format(action_item))
+                                     ' (got {!r}'.format(widget))
 
-        elif isinstance(action_item, ActionOverflow):
-            self.overflow_group = action_item
-            action_item.use_separator = self.use_separator
+        elif isinstance(widget, ActionOverflow):
+            self.overflow_group = widget
+            widget.use_separator = self.use_separator
 
-        elif isinstance(action_item, ActionGroup):
-            self._list_action_group.append(action_item)
-            action_item.use_separator = self.use_separator
+        elif isinstance(widget, ActionGroup):
+            self._list_action_group.append(widget)
+            widget.use_separator = self.use_separator
 
-        elif isinstance(action_item, ActionPrevious):
-            self.action_previous = action_item
+        elif isinstance(widget, ActionPrevious):
+            self.action_previous = widget
 
         else:
-            super(ActionView, self).add_widget(action_item, index)
+            super(ActionView, self).add_widget(widget, index, canvas)
             if index == 0:
                 index = len(self._list_action_items)
-            self._list_action_items.insert(index, action_item)
+            self._list_action_items.insert(index, widget)
 
     def on_use_separator(self, instance, value):
         for group in self._list_action_group:
@@ -835,18 +835,18 @@ class ActionBar(BoxLayout):
         self._stack_cont_action_view = []
         self._emit_previous = partial(self.dispatch, 'on_previous')
 
-    def add_widget(self, view):
-        if isinstance(view, ContextualActionView):
-            self._stack_cont_action_view.append(view)
-            if view.action_previous is not None:
-                view.action_previous.unbind(on_release=self._emit_previous)
-                view.action_previous.bind(on_release=self._emit_previous)
+    def add_widget(self, widget, index=0, canvas=None):
+        if isinstance(widget, ContextualActionView):
+            self._stack_cont_action_view.append(widget)
+            if widget.action_previous is not None:
+                widget.action_previous.unbind(on_release=self._emit_previous)
+                widget.action_previous.bind(on_release=self._emit_previous)
             self.clear_widgets()
-            super(ActionBar, self).add_widget(view)
+            super(ActionBar, self).add_widget(widget, index, canvas)
 
-        elif isinstance(view, ActionView):
-            self.action_view = view
-            super(ActionBar, self).add_widget(view)
+        elif isinstance(widget, ActionView):
+            self.action_view = widget
+            super(ActionBar, self).add_widget(widget, index, canvas)
 
         else:
             raise ActionBarException(

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -452,11 +452,15 @@ class ActionGroup(ActionItem, Button):
             # auto_dismiss applies to touching outside of the DropDown
             item.bind(on_release=ddn.dismiss)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
+        '''
+        .. versionchanged:: 2.1.0
+            Renamed argument `item` to `widget`.
+        '''
         # if adding ActionSeparator ('normal' mode,
         # everything visible), add it to the parent
         if isinstance(widget, ActionSeparator):
-            super(ActionGroup, self).add_widget(widget, index, canvas)
+            super(ActionGroup, self).add_widget(widget, *args, **kwargs)
             return
 
         if not isinstance(widget, ActionItem):
@@ -489,7 +493,11 @@ class ActionOverflow(ActionGroup):
     and defaults to 'atlas://data/images/defaulttheme/overflow'.
     '''
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, index=0, *args, **kwargs):
+        '''
+        .. versionchanged:: 2.1.0
+             Renamed argument `action_item` to `widget`.
+        '''
         if widget is None:
             return
 
@@ -575,7 +583,11 @@ class ActionView(BoxLayout):
     def on_action_previous(self, instance, value):
         self._list_action_items.insert(0, value)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, index=0, *args, **kwargs):
+        '''
+        .. versionchanged:: 2.1.0
+            Renamed argument `action_item` to `widget`.
+        '''
         if widget is None:
             return
 
@@ -595,7 +607,7 @@ class ActionView(BoxLayout):
             self.action_previous = widget
 
         else:
-            super(ActionView, self).add_widget(widget, index, canvas)
+            super(ActionView, self).add_widget(widget, index, *args, **kwargs)
             if index == 0:
                 index = len(self._list_action_items)
             self._list_action_items.insert(index, widget)
@@ -835,18 +847,22 @@ class ActionBar(BoxLayout):
         self._stack_cont_action_view = []
         self._emit_previous = partial(self.dispatch, 'on_previous')
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
+        '''
+        .. versionchanged:: 2.1.0
+            Renamed argument `view` to `widget`.
+        '''
         if isinstance(widget, ContextualActionView):
             self._stack_cont_action_view.append(widget)
             if widget.action_previous is not None:
                 widget.action_previous.unbind(on_release=self._emit_previous)
                 widget.action_previous.bind(on_release=self._emit_previous)
             self.clear_widgets()
-            super(ActionBar, self).add_widget(widget, index, canvas)
+            super(ActionBar, self).add_widget(widget, *args, **kwargs)
 
         elif isinstance(widget, ActionView):
             self.action_view = widget
-            super(ActionBar, self).add_widget(widget, index, canvas)
+            super(ActionBar, self).add_widget(widget, *args, **kwargs)
 
         else:
             raise ActionBarException(

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -471,8 +471,8 @@ class ActionGroup(ActionItem, Button):
             item.inside_group = True
             self._dropdown.add_widget(item)
 
-    def clear_widgets(self):
-        self._dropdown.clear_widgets()
+    def clear_widgets(self, children=None):
+        self._dropdown.clear_widgets(children)
 
 
 class ActionOverflow(ActionGroup):

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -618,8 +618,8 @@ class ActionView(BoxLayout):
         if self.overflow_group:
             self.overflow_group.use_separator = value
 
-    def remove_widget(self, widget):
-        super(ActionView, self).remove_widget(widget)
+    def remove_widget(self, widget, *args, **kwargs):
+        super(ActionView, self).remove_widget(widget, *args, **kwargs)
         if isinstance(widget, ActionOverflow):
             for item in widget.list_action_item:
                 if item in self._list_action_items:

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -475,8 +475,8 @@ class ActionGroup(ActionItem, Button):
             item.inside_group = True
             self._dropdown.add_widget(item)
 
-    def clear_widgets(self, children=None):
-        self._dropdown.clear_widgets(children)
+    def clear_widgets(self, *args, **kwargs):
+        self._dropdown.clear_widgets(*args, **kwargs)
 
 
 class ActionOverflow(ActionGroup):

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -72,12 +72,13 @@ to :meth:`select_with_touch` to pass on the touch events::
                 return True
             return False
 
-        def add_widget(self, widget):
+        def add_widget(self, widget, *args, **kwargs):
             """ Override the adding of widgets so we can bind and catch their
             *on_touch_down* events. """
             widget.bind(on_touch_down=self.button_touch_down,
                         on_touch_up=self.button_touch_up)
-            return super(SelectableGrid, self).add_widget(widget)
+            return super(SelectableGrid, self)\
+                .add_widget(widget, *args, **kwargs)
 
         def button_touch_down(self, button, touch):
             """ Use collision detection to select buttons when the touch occurs

--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -322,9 +322,9 @@ class BoxLayout(Layout):
                 else:
                     c.size = (w, h)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         widget.fbind('pos_hint', self._trigger_layout)
-        return super(BoxLayout, self).add_widget(widget, index, canvas)
+        return super(BoxLayout, self).add_widget(widget, *args, **kwargs)
 
     def remove_widget(self, widget):
         widget.funbind('pos_hint', self._trigger_layout)

--- a/kivy/uix/boxlayout.py
+++ b/kivy/uix/boxlayout.py
@@ -326,6 +326,6 @@ class BoxLayout(Layout):
         widget.fbind('pos_hint', self._trigger_layout)
         return super(BoxLayout, self).add_widget(widget, *args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         widget.funbind('pos_hint', self._trigger_layout)
-        return super(BoxLayout, self).remove_widget(widget)
+        return super(BoxLayout, self).remove_widget(widget, *args, **kwargs)

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -220,15 +220,15 @@ class Bubble(GridLayout):
         else:
             content.add_widget(widget, index, canvas)
 
-    def remove_widget(self, *l):
+    def remove_widget(self, widget):
         content = self.content
         if not content:
             return
-        if l[0] == content or l[0] == self._arrow_img\
-                or l[0] == self._arrow_layout:
-            super(Bubble, self).remove_widget(*l)
+        if widget == content or widget == self._arrow_img\
+                or widget == self._arrow_layout:
+            super(Bubble, self).remove_widget(widget)
         else:
-            content.remove_widget(l[0])
+            content.remove_widget(widget)
 
     def clear_widgets(self, **kwargs):
         content = self.content

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -230,9 +230,9 @@ class Bubble(GridLayout):
         else:
             content.remove_widget(widget, *args, **kwargs)
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, *args, **kwargs):
         if self.content:
-            self.content.clear_widgets(children)
+            self.content.clear_widgets(*args, **kwargs)
 
     def on_show_arrow(self, instance, value):
         self._arrow_img.opacity = int(value)

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -210,15 +210,15 @@ class Bubble(GridLayout):
         self.add_widget(content)
         self.on_arrow_pos()
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         content = self.content
         if content is None:
             return
         if widget == content or widget == self._arrow_img\
                 or widget == self._arrow_layout:
-            super(Bubble, self).add_widget(widget, index, canvas)
+            super(Bubble, self).add_widget(widget, *args, **kwargs)
         else:
-            content.add_widget(widget, index, canvas)
+            content.add_widget(widget, *args, **kwargs)
 
     def remove_widget(self, widget):
         content = self.content

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -210,15 +210,15 @@ class Bubble(GridLayout):
         self.add_widget(content)
         self.on_arrow_pos()
 
-    def add_widget(self, *l):
+    def add_widget(self, widget, index=0, canvas=None):
         content = self.content
         if content is None:
             return
-        if l[0] == content or l[0] == self._arrow_img\
-                or l[0] == self._arrow_layout:
-            super(Bubble, self).add_widget(*l)
+        if widget == content or widget == self._arrow_img\
+                or widget == self._arrow_layout:
+            super(Bubble, self).add_widget(widget, index, canvas)
         else:
-            content.add_widget(*l)
+            content.add_widget(widget, index, canvas)
 
     def remove_widget(self, *l):
         content = self.content

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -220,15 +220,15 @@ class Bubble(GridLayout):
         else:
             content.add_widget(widget, *args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         content = self.content
         if not content:
             return
         if widget == content or widget == self._arrow_img\
                 or widget == self._arrow_layout:
-            super(Bubble, self).remove_widget(widget)
+            super(Bubble, self).remove_widget(widget, *args, **kwargs)
         else:
-            content.remove_widget(widget)
+            content.remove_widget(widget, *args, **kwargs)
 
     def clear_widgets(self, children=None):
         if self.content:

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -230,14 +230,12 @@ class Bubble(GridLayout):
         else:
             content.remove_widget(widget)
 
-    def clear_widgets(self, **kwargs):
-        content = self.content
-        if not content:
-            return
-        if kwargs.get('do_super', False):
-            super(Bubble, self).clear_widgets()
-        else:
-            content.clear_widgets()
+    def clear_widgets(self, children=None):
+        if self.content:
+            self.content.clear_widgets(children)
+
+    def _super_clear_widgets(self):
+        super(Bubble, self).clear_widgets()
 
     def on_show_arrow(self, instance, value):
         self._arrow_img.opacity = int(value)
@@ -303,7 +301,7 @@ class Bubble(GridLayout):
         self_arrow_layout.clear_widgets()
         self_arrow_img = self._arrow_img
         self._sctr = self._arrow_img
-        self.clear_widgets(do_super=True)
+        self._super_clear_widgets()
         self_content.parent = None
 
         self_arrow_img.size_hint = (1, None)

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -234,9 +234,6 @@ class Bubble(GridLayout):
         if self.content:
             self.content.clear_widgets(children)
 
-    def _super_clear_widgets(self):
-        super(Bubble, self).clear_widgets()
-
     def on_show_arrow(self, instance, value):
         self._arrow_img.opacity = int(value)
 
@@ -301,7 +298,7 @@ class Bubble(GridLayout):
         self_arrow_layout.clear_widgets()
         self_arrow_img = self._arrow_img
         self._sctr = self._arrow_img
-        self._super_clear_widgets()
+        super(Bubble, self).clear_widgets()
         self_content.parent = None
 
         self_arrow_img.size_hint = (1, None)

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -668,7 +668,7 @@ class Carousel(StencilView):
             return
         super(Carousel, self).remove_widget(widget, *args, **kwargs)
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, children=None, *args, **kwargs):
         # `children` must be a list of slides or None
         if children is None:
             children = self.slides[:]

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -652,7 +652,7 @@ class Carousel(StencilView):
         else:
             self.slides.append(widget)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         # XXX be careful, the widget.parent refer to the RelativeLayout
         # added in add_widget(). But it will break if RelativeLayout
         # implementation change.
@@ -663,9 +663,10 @@ class Carousel(StencilView):
                 self.index = max(0, self.index - 1)
             container = widget.parent
             slides.remove(widget)
-            super(Carousel, self).remove_widget(container)
+            super(Carousel, self).remove_widget(container, *args, **kwargs)
             container.remove_widget(widget)
-        super(Carousel, self).remove_widget(widget)
+            return
+        super(Carousel, self).remove_widget(widget, *args, **kwargs)
 
     def clear_widgets(self, children=None):
         # `children` must be a list of slides or None

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -642,11 +642,11 @@ class Carousel(StencilView):
             super(Carousel, self).on_touch_down(touch)
             return
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, index=0, *args, **kwargs):
         container = RelativeLayout(
             size=self.size, x=self.x - self.width, y=self.y)
         container.add_widget(widget)
-        super(Carousel, self).add_widget(container, index, canvas)
+        super(Carousel, self).add_widget(container, index, *args, **kwargs)
         if index != 0:
             self.slides.insert(index - len(self.slides), widget)
         else:

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -669,11 +669,11 @@ class Carousel(StencilView):
 
     def clear_widgets(self, children=None):
         # `children` must be a list of slides or None
-        if not children:
+        if children is None:
             children = self.slides[:]
         remove_widget = self.remove_widget
-        for slide in children:
-            remove_widget(slide)
+        for widget in children:
+            remove_widget(widget)
         super(Carousel, self).clear_widgets()
 
 

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -664,14 +664,16 @@ class Carousel(StencilView):
             container = widget.parent
             slides.remove(widget)
             super(Carousel, self).remove_widget(container)
-            return container.remove_widget(widget)
-        return super(Carousel, self).remove_widget(widget)
+            container.remove_widget(widget)
+        super(Carousel, self).remove_widget(widget)
 
     def clear_widgets(self, children=None):
+        # `children` must be a list of slides or None
         if not children:
             children = self.slides[:]
+        remove_widget = self.remove_widget
         for slide in children:
-            self.remove_widget(slide)
+            remove_widget(slide)
         super(Carousel, self).clear_widgets()
 
 

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -652,7 +652,7 @@ class Carousel(StencilView):
         else:
             self.slides.append(widget)
 
-    def remove_widget(self, widget, *args, **kwargs):
+    def remove_widget(self, widget):
         # XXX be careful, the widget.parent refer to the RelativeLayout
         # added in add_widget(). But it will break if RelativeLayout
         # implementation change.
@@ -664,11 +664,13 @@ class Carousel(StencilView):
             container = widget.parent
             slides.remove(widget)
             super(Carousel, self).remove_widget(container)
-            return container.remove_widget(widget, *args, **kwargs)
-        return super(Carousel, self).remove_widget(widget, *args, **kwargs)
+            return container.remove_widget(widget)
+        return super(Carousel, self).remove_widget(widget)
 
-    def clear_widgets(self):
-        for slide in self.slides[:]:
+    def clear_widgets(self, children=None):
+        if not children:
+            children = self.slides[:]
+        for slide in children:
             self.remove_widget(slide)
         super(Carousel, self).clear_widgets()
 

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -281,10 +281,10 @@ class DropDown(ScrollView):
     def on_select(self, data):
         pass
 
-    def add_widget(self, *largs):
+    def add_widget(self, widget, index=0, canvas=None):
         if self.container:
-            return self.container.add_widget(*largs)
-        return super(DropDown, self).add_widget(*largs)
+            return self.container.add_widget(widget, index, canvas)
+        return super(DropDown, self).add_widget(widget, index, canvas)
 
     def remove_widget(self, *largs):
         if self.container:

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -286,10 +286,10 @@ class DropDown(ScrollView):
             return self.container.add_widget(widget, index, canvas)
         return super(DropDown, self).add_widget(widget, index, canvas)
 
-    def remove_widget(self, *largs):
+    def remove_widget(self, widget):
         if self.container:
-            return self.container.remove_widget(*largs)
-        return super(DropDown, self).remove_widget(*largs)
+            return self.container.remove_widget(widget)
+        return super(DropDown, self).remove_widget(widget)
 
     def clear_widgets(self):
         if self.container:

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -291,10 +291,10 @@ class DropDown(ScrollView):
             return self.container.remove_widget(widget)
         return super(DropDown, self).remove_widget(widget)
 
-    def clear_widgets(self):
+    def clear_widgets(self, children=None):
         if self.container:
-            return self.container.clear_widgets()
-        return super(DropDown, self).clear_widgets()
+            return self.container.clear_widgets(children)
+        return super(DropDown, self).clear_widgets(children)
 
     def on_touch_down(self, touch):
         self._touch_started_inside = self.collide_point(*touch.pos)

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -286,10 +286,10 @@ class DropDown(ScrollView):
             return self.container.add_widget(*args, **kwargs)
         return super(DropDown, self).add_widget(*args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         if self.container:
-            return self.container.remove_widget(widget)
-        return super(DropDown, self).remove_widget(widget)
+            return self.container.remove_widget(*args, **kwargs)
+        return super(DropDown, self).remove_widget(*args, **kwargs)
 
     def clear_widgets(self, children=None):
         if self.container:

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -291,10 +291,10 @@ class DropDown(ScrollView):
             return self.container.remove_widget(*args, **kwargs)
         return super(DropDown, self).remove_widget(*args, **kwargs)
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, *args, **kwargs):
         if self.container:
-            return self.container.clear_widgets(children)
-        return super(DropDown, self).clear_widgets(children)
+            return self.container.clear_widgets(*args, **kwargs)
+        return super(DropDown, self).clear_widgets(*args, **kwargs)
 
     def on_touch_down(self, touch):
         self._touch_started_inside = self.collide_point(*touch.pos)

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -281,10 +281,10 @@ class DropDown(ScrollView):
     def on_select(self, data):
         pass
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         if self.container:
-            return self.container.add_widget(widget, index, canvas)
-        return super(DropDown, self).add_widget(widget, index, canvas)
+            return self.container.add_widget(*args, **kwargs)
+        return super(DropDown, self).add_widget(*args, **kwargs)
 
     def remove_widget(self, widget):
         if self.container:

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -757,11 +757,11 @@ class EffectWidget(RelativeLayout):
         super(EffectWidget, self).add_widget(*args, **kwargs)
         self.canvas = c
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         # Remove the widget from our Fbo instead of the normal canvas
         c = self.canvas
         self.canvas = self.fbo
-        super(EffectWidget, self).remove_widget(widget)
+        super(EffectWidget, self).remove_widget(*args, **kwargs)
         self.canvas = c
 
     def clear_widgets(self, children=None):

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -764,9 +764,9 @@ class EffectWidget(RelativeLayout):
         super(EffectWidget, self).remove_widget(*args, **kwargs)
         self.canvas = c
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, *args, **kwargs):
         # Clear widgets from our Fbo instead of the normal canvas
         c = self.canvas
         self.canvas = self.fbo
-        super(EffectWidget, self).clear_widgets(children)
+        super(EffectWidget, self).clear_widgets(*args, **kwargs)
         self.canvas = c

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -750,11 +750,11 @@ class EffectWidget(RelativeLayout):
             fbo.draw()
         self.fbo.draw()
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         # Add the widget to our Fbo instead of the normal canvas
         c = self.canvas
         self.canvas = self.fbo
-        super(EffectWidget, self).add_widget(widget, index, canvas)
+        super(EffectWidget, self).add_widget(widget, *args, **kwargs)
         self.canvas = c
 
     def remove_widget(self, widget):

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -750,11 +750,11 @@ class EffectWidget(RelativeLayout):
             fbo.draw()
         self.fbo.draw()
 
-    def add_widget(self, widget, *args, **kwargs):
+    def add_widget(self, *args, **kwargs):
         # Add the widget to our Fbo instead of the normal canvas
         c = self.canvas
         self.canvas = self.fbo
-        super(EffectWidget, self).add_widget(widget, *args, **kwargs)
+        super(EffectWidget, self).add_widget(*args, **kwargs)
         self.canvas = c
 
     def remove_widget(self, widget):

--- a/kivy/uix/effectwidget.py
+++ b/kivy/uix/effectwidget.py
@@ -750,11 +750,11 @@ class EffectWidget(RelativeLayout):
             fbo.draw()
         self.fbo.draw()
 
-    def add_widget(self, widget):
+    def add_widget(self, widget, index=0, canvas=None):
         # Add the widget to our Fbo instead of the normal canvas
         c = self.canvas
         self.canvas = self.fbo
-        super(EffectWidget, self).add_widget(widget)
+        super(EffectWidget, self).add_widget(widget, index, canvas)
         self.canvas = c
 
     def remove_widget(self, widget):

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -1010,9 +1010,9 @@ class FileChooser(FileChooserController):
 
         self.fbind('view_mode', self.trigger_update_view)
 
-    def add_widget(self, widget, **kwargs):
+    def add_widget(self, widget, index=0, canvas=None):
         if widget is self._progress:
-            super(FileChooser, self).add_widget(widget, **kwargs)
+            super(FileChooser, self).add_widget(widget, index, canvas)
         elif hasattr(widget, 'VIEWNAME'):
             name = widget.VIEWNAME + 'view'
             screen = Screen(name=name)

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -1010,9 +1010,9 @@ class FileChooser(FileChooserController):
 
         self.fbind('view_mode', self.trigger_update_view)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         if widget is self._progress:
-            super(FileChooser, self).add_widget(widget, index, canvas)
+            super(FileChooser, self).add_widget(widget, *args, **kwargs)
         elif hasattr(widget, 'VIEWNAME'):
             name = widget.VIEWNAME + 'view'
             screen = Screen(name=name)

--- a/kivy/uix/floatlayout.py
+++ b/kivy/uix/floatlayout.py
@@ -139,10 +139,10 @@ class FloatLayout(Layout):
             pos_hint=self._trigger_layout)
         return super(FloatLayout, self).add_widget(widget, *args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         widget.unbind(
             # size=self._trigger_layout,
             # size_hint=self._trigger_layout,
             pos=self._trigger_layout,
             pos_hint=self._trigger_layout)
-        return super(FloatLayout, self).remove_widget(widget)
+        return super(FloatLayout, self).remove_widget(widget, *args, **kwargs)

--- a/kivy/uix/floatlayout.py
+++ b/kivy/uix/floatlayout.py
@@ -131,13 +131,13 @@ class FloatLayout(Layout):
                 elif key == 'center_y':
                     c.center_y = y + value * h
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         widget.bind(
             # size=self._trigger_layout,
             # size_hint=self._trigger_layout,
             pos=self._trigger_layout,
             pos_hint=self._trigger_layout)
-        return super(FloatLayout, self).add_widget(widget, index, canvas)
+        return super(FloatLayout, self).add_widget(widget, *args, **kwargs)
 
     def remove_widget(self, widget):
         widget.unbind(

--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -88,13 +88,13 @@ class Layout(Widget):
         '''
         raise NotImplementedError('Must be implemented in subclasses.')
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         fbind = widget.fbind
         fbind('size', self._trigger_layout)
         fbind('size_hint', self._trigger_layout)
         fbind('size_hint_max', self._trigger_layout)
         fbind('size_hint_min', self._trigger_layout)
-        return super(Layout, self).add_widget(widget, index, canvas)
+        return super(Layout, self).add_widget(widget, *args, **kwargs)
 
     def remove_widget(self, widget):
         funbind = widget.funbind

--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -94,15 +94,15 @@ class Layout(Widget):
         fbind('size_hint', self._trigger_layout)
         fbind('size_hint_max', self._trigger_layout)
         fbind('size_hint_min', self._trigger_layout)
-        return super(Layout, self).add_widget(widget, *args, **kwargs)
+        super(Layout, self).add_widget(widget, *args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         funbind = widget.funbind
         funbind('size', self._trigger_layout)
         funbind('size_hint', self._trigger_layout)
         funbind('size_hint_max', self._trigger_layout)
         funbind('size_hint_min', self._trigger_layout)
-        return super(Layout, self).remove_widget(widget)
+        super(Layout, self).remove_widget(widget, *args, **kwargs)
 
     def layout_hint_with_bounds(
             self, sh_sum, available_space, min_bounded_size, sh_min_vals,

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -210,14 +210,14 @@ class Popup(ModalView):
 
     _container = ObjectProperty(None)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         if self._container:
             if self.content:
                 raise PopupException(
                     'Popup can have only one widget as content')
             self.content = widget
         else:
-            super(Popup, self).add_widget(widget, index, canvas)
+            super(Popup, self).add_widget(widget, *args, **kwargs)
 
     def on_content(self, instance, value):
         if self._container:

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -210,14 +210,14 @@ class Popup(ModalView):
 
     _container = ObjectProperty(None)
 
-    def add_widget(self, widget):
+    def add_widget(self, widget, index=0, canvas=None):
         if self._container:
             if self.content:
                 raise PopupException(
                     'Popup can have only one widget as content')
             self.content = widget
         else:
-            super(Popup, self).add_widget(widget)
+            super(Popup, self).add_widget(widget, index, canvas)
 
     def on_content(self, instance, value):
         if self._container:

--- a/kivy/uix/recycleview/__init__.py
+++ b/kivy/uix/recycleview/__init__.py
@@ -557,8 +557,8 @@ class RecycleView(RecycleViewBehavior, ScrollView):
     def restore_viewport(self):
         pass
 
-    def add_widget(self, widget, index=0, canvas=None):
-        super(RecycleView, self).add_widget(widget, index, canvas)
+    def add_widget(self, widget, *args, **kwargs):
+        super(RecycleView, self).add_widget(widget, *args, **kwargs)
         if (isinstance(widget, RecycleLayoutManagerBehavior) and
                 not self.layout_manager):
             self.layout_manager = widget

--- a/kivy/uix/recycleview/__init__.py
+++ b/kivy/uix/recycleview/__init__.py
@@ -563,8 +563,8 @@ class RecycleView(RecycleViewBehavior, ScrollView):
                 not self.layout_manager):
             self.layout_manager = widget
 
-    def remove_widget(self, widget):
-        super(RecycleView, self).remove_widget(widget)
+    def remove_widget(self, widget, *args, **kwargs):
+        super(RecycleView, self).remove_widget(widget, *args, **kwargs)
         if self.layout_manager == widget:
             self.layout_manager = None
 

--- a/kivy/uix/recycleview/__init__.py
+++ b/kivy/uix/recycleview/__init__.py
@@ -557,8 +557,8 @@ class RecycleView(RecycleViewBehavior, ScrollView):
     def restore_viewport(self):
         pass
 
-    def add_widget(self, widget, *largs):
-        super(RecycleView, self).add_widget(widget, *largs)
+    def add_widget(self, widget, index=0, canvas=None):
+        super(RecycleView, self).add_widget(widget, index, canvas)
         if (isinstance(widget, RecycleLayoutManagerBehavior) and
                 not self.layout_manager):
             self.layout_manager = widget

--- a/kivy/uix/recycleview/__init__.py
+++ b/kivy/uix/recycleview/__init__.py
@@ -563,8 +563,8 @@ class RecycleView(RecycleViewBehavior, ScrollView):
                 not self.layout_manager):
             self.layout_manager = widget
 
-    def remove_widget(self, widget, *largs):
-        super(RecycleView, self).remove_widget(widget, *largs)
+    def remove_widget(self, widget):
+        super(RecycleView, self).remove_widget(widget)
         if self.layout_manager == widget:
             self.layout_manager = None
 

--- a/kivy/uix/sandbox.py
+++ b/kivy/uix/sandbox.py
@@ -116,8 +116,8 @@ class Sandbox(FloatLayout):
         self._container.add_widget(widget, index, canvas)
 
     @sandbox
-    def remove_widget(self, *args, **kwargs):
-        self._container.remove_widget(*args, **kwargs)
+    def remove_widget(self, widget):
+        self._container.remove_widget(widget)
 
     @sandbox
     def clear_widgets(self, *args, **kwargs):

--- a/kivy/uix/sandbox.py
+++ b/kivy/uix/sandbox.py
@@ -116,8 +116,8 @@ class Sandbox(FloatLayout):
         self._container.add_widget(*args, **kwargs)
 
     @sandbox
-    def remove_widget(self, widget):
-        self._container.remove_widget(widget)
+    def remove_widget(self, *args, **kwargs):
+        self._container.remove_widget(*args, **kwargs)
 
     @sandbox
     def clear_widgets(self, children=None):

--- a/kivy/uix/sandbox.py
+++ b/kivy/uix/sandbox.py
@@ -120,8 +120,8 @@ class Sandbox(FloatLayout):
         self._container.remove_widget(widget)
 
     @sandbox
-    def clear_widgets(self, *args, **kwargs):
-        self._container.clear_widgets()
+    def clear_widgets(self, children=None):
+        self._container.clear_widgets(children)
 
     @sandbox
     def on_size(self, *args):

--- a/kivy/uix/sandbox.py
+++ b/kivy/uix/sandbox.py
@@ -112,8 +112,8 @@ class Sandbox(FloatLayout):
     on_touch_up = sandbox(Widget.on_touch_up)
 
     @sandbox
-    def add_widget(self, *args, **kwargs):
-        self._container.add_widget(*args, **kwargs)
+    def add_widget(self, widget, index=0, canvas=None):
+        self._container.add_widget(widget, index, canvas)
 
     @sandbox
     def remove_widget(self, *args, **kwargs):

--- a/kivy/uix/sandbox.py
+++ b/kivy/uix/sandbox.py
@@ -120,8 +120,8 @@ class Sandbox(FloatLayout):
         self._container.remove_widget(*args, **kwargs)
 
     @sandbox
-    def clear_widgets(self, children=None):
-        self._container.clear_widgets(children)
+    def clear_widgets(self, *args, **kwargs):
+        self._container.clear_widgets(*args, **kwargs)
 
     @sandbox
     def on_size(self, *args):

--- a/kivy/uix/sandbox.py
+++ b/kivy/uix/sandbox.py
@@ -112,8 +112,8 @@ class Sandbox(FloatLayout):
     on_touch_up = sandbox(Widget.on_touch_up)
 
     @sandbox
-    def add_widget(self, widget, index=0, canvas=None):
-        self._container.add_widget(widget, index, canvas)
+    def add_widget(self, *args, **kwargs):
+        self._container.add_widget(*args, **kwargs)
 
     @sandbox
     def remove_widget(self, widget):

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -70,8 +70,8 @@ class ScatterLayout(Scatter):
     def update_size(self, instance, size):
         self.content.size = size
 
-    def add_widget(self, *l):
-        self.content.add_widget(*l)
+    def add_widget(self, widget, index=0, canvas=None):
+        self.content.add_widget(widget, index, canvas)
 
     def remove_widget(self, *l):
         self.content.remove_widget(*l)

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -76,8 +76,8 @@ class ScatterLayout(Scatter):
     def remove_widget(self, widget):
         self.content.remove_widget(widget)
 
-    def clear_widgets(self):
-        self.content.clear_widgets()
+    def clear_widgets(self, children=None):
+        self.content.clear_widgets(children)
 
 
 class ScatterPlaneLayout(ScatterPlane):

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -76,8 +76,8 @@ class ScatterLayout(Scatter):
     def remove_widget(self, *args, **kwargs):
         self.content.remove_widget(*args, **kwargs)
 
-    def clear_widgets(self, children=None):
-        self.content.clear_widgets(children)
+    def clear_widgets(self, *args, **kwargs):
+        self.content.clear_widgets(*args, **kwargs)
 
 
 class ScatterPlaneLayout(ScatterPlane):

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -70,8 +70,8 @@ class ScatterLayout(Scatter):
     def update_size(self, instance, size):
         self.content.size = size
 
-    def add_widget(self, widget, index=0, canvas=None):
-        self.content.add_widget(widget, index, canvas)
+    def add_widget(self, *args, **kwargs):
+        self.content.add_widget(*args, **kwargs)
 
     def remove_widget(self, widget):
         self.content.remove_widget(widget)

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -73,8 +73,8 @@ class ScatterLayout(Scatter):
     def add_widget(self, widget, index=0, canvas=None):
         self.content.add_widget(widget, index, canvas)
 
-    def remove_widget(self, *l):
-        self.content.remove_widget(*l)
+    def remove_widget(self, widget):
+        self.content.remove_widget(widget)
 
     def clear_widgets(self):
         self.content.clear_widgets()

--- a/kivy/uix/scatterlayout.py
+++ b/kivy/uix/scatterlayout.py
@@ -73,8 +73,8 @@ class ScatterLayout(Scatter):
     def add_widget(self, *args, **kwargs):
         self.content.add_widget(*args, **kwargs)
 
-    def remove_widget(self, widget):
-        self.content.remove_widget(widget)
+    def remove_widget(self, *args, **kwargs):
+        self.content.remove_widget(*args, **kwargs)
 
     def clear_widgets(self, children=None):
         self.content.clear_widgets(children)

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1021,13 +1021,17 @@ class ScreenManager(FloatLayout):
         self.screens.remove(widget)
 
     def clear_widgets(self, children=None):
+        '''
+        .. versionchanged:: 2.1.0
+            Renamed argument `screens` to `children`.
+        '''
         if not children:
             # iterate over a copy of screens, as self.remove_widget
             # modifies self.screens in place
             children = self.screens[:]
         remove_widget = self.remove_widget
-        for screen in children:
-            remove_widget(screen)
+        for widget in children:
+            remove_widget(widget)
 
     def real_add_widget(self, screen, *args):
         # ensure screen is removed from its previous parent

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -996,26 +996,25 @@ class ScreenManager(FloatLayout):
         if self.current is None:
             self.current = widget.name
 
-    def remove_widget(self, *l):
-        screen = l[0]
-        if not isinstance(screen, Screen):
+    def remove_widget(self, widget):
+        if not isinstance(widget, Screen):
             raise ScreenManagerException(
                 'ScreenManager uses remove_widget only for removing Screens.')
 
-        if screen not in self.screens:
+        if widget not in self.screens:
             return
 
-        if self.current_screen == screen:
+        if self.current_screen == widget:
             other = next(self)
-            if screen.name == other:
+            if widget.name == other:
                 self.current = None
-                screen.parent.real_remove_widget(screen)
+                widget.parent.real_remove_widget(widget)
             else:
                 self.current = other
 
-        screen.manager = None
-        screen.unbind(name=self._screen_name_changed)
-        self.screens.remove(screen)
+        widget.manager = None
+        widget.unbind(name=self._screen_name_changed)
+        self.screens.remove(widget)
 
     def clear_widgets(self, screens=None):
         if screens is None:

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1016,14 +1016,14 @@ class ScreenManager(FloatLayout):
         widget.unbind(name=self._screen_name_changed)
         self.screens.remove(widget)
 
-    def clear_widgets(self, screens=None):
-        if screens is None:
-            screens = self.screens
-
-        # iterate over a copy of screens, as self.remove_widget
-        # modifies self.screens in place
-        for screen in screens[:]:
-            self.remove_widget(screen)
+    def clear_widgets(self, children=None):
+        if not children:
+            # iterate over a copy of screens, as self.remove_widget
+            # modifies self.screens in place
+            children = self.screens[:]
+        remove_widget = self.remove_widget
+        for screen in children:
+            remove_widget(screen)
 
     def real_add_widget(self, screen, *args):
         # ensure screen is removed from its previous parent

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -978,23 +978,23 @@ class ScreenManager(FloatLayout):
         if screen == self.current_screen:
             self.current = name
 
-    def add_widget(self, screen):
-        if not isinstance(screen, Screen):
+    def add_widget(self, widget, index=0, canvas=None):
+        if not isinstance(widget, Screen):
             raise ScreenManagerException(
                 'ScreenManager accepts only Screen widget.')
-        if screen.manager:
-            if screen.manager is self:
+        if widget.manager:
+            if widget.manager is self:
                 raise ScreenManagerException(
                     'Screen already managed by this ScreenManager (are you '
                     'calling `switch_to` when you should be setting '
                     '`current`?)')
             raise ScreenManagerException(
                 'Screen already managed by another ScreenManager.')
-        screen.manager = self
-        screen.bind(name=self._screen_name_changed)
-        self.screens.append(screen)
+        widget.manager = self
+        widget.bind(name=self._screen_name_changed)
+        self.screens.append(widget)
         if self.current is None:
-            self.current = screen.name
+            self.current = widget.name
 
     def remove_widget(self, *l):
         screen = l[0]

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1020,7 +1020,7 @@ class ScreenManager(FloatLayout):
         widget.unbind(name=self._screen_name_changed)
         self.screens.remove(widget)
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, children=None, *args, **kwargs):
         '''
         .. versionchanged:: 2.1.0
             Renamed argument `screens` to `children`.

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -978,7 +978,11 @@ class ScreenManager(FloatLayout):
         if screen == self.current_screen:
             self.current = name
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
+        '''
+        .. versionchanged:: 2.1.0
+            Renamed argument `screen` to `widget`.
+        '''
         if not isinstance(widget, Screen):
             raise ScreenManagerException(
                 'ScreenManager accepts only Screen widget.')

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1025,7 +1025,7 @@ class ScreenManager(FloatLayout):
         .. versionchanged:: 2.1.0
             Renamed argument `screens` to `children`.
         '''
-        if not children:
+        if children is None:
             # iterate over a copy of screens, as self.remove_widget
             # modifies self.screens in place
             children = self.screens[:]

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1000,7 +1000,7 @@ class ScreenManager(FloatLayout):
         if self.current is None:
             self.current = widget.name
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         if not isinstance(widget, Screen):
             raise ScreenManagerException(
                 'ScreenManager uses remove_widget only for removing Screens.')

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1148,10 +1148,10 @@ class ScrollView(StencilView):
     def add_widget(self, widget, *args, **kwargs):
         if self._viewport:
             raise Exception('ScrollView accept only one widget')
-        _canvas = self.canvas
+        canvas = self.canvas
         self.canvas = self.canvas_viewport
         super(ScrollView, self).add_widget(widget, *args, **kwargs)
-        self.canvas = _canvas
+        self.canvas = canvas
         self._viewport = widget
         widget.bind(size=self._trigger_update_from_scroll,
                     size_hint_min=self._trigger_update_from_scroll)

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1148,13 +1148,13 @@ class ScrollView(StencilView):
     #
     # Private
     #
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         if self._viewport:
             raise Exception('ScrollView accept only one widget')
-        canvas = self.canvas
+        _canvas = self.canvas
         self.canvas = self.canvas_viewport
-        super(ScrollView, self).add_widget(widget, index)
-        self.canvas = canvas
+        super(ScrollView, self).add_widget(widget, index, canvas)
+        self.canvas = _canvas
         self._viewport = widget
         widget.bind(size=self._trigger_update_from_scroll,
                     size_hint_min=self._trigger_update_from_scroll)

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1145,15 +1145,12 @@ class ScrollView(StencilView):
     def _change_bar_color(self, inst, value):
         self._bar_color = value
 
-    #
-    # Private
-    #
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         if self._viewport:
             raise Exception('ScrollView accept only one widget')
         _canvas = self.canvas
         self.canvas = self.canvas_viewport
-        super(ScrollView, self).add_widget(widget, index, canvas)
+        super(ScrollView, self).add_widget(widget, *args, **kwargs)
         self.canvas = _canvas
         self._viewport = widget
         widget.bind(size=self._trigger_update_from_scroll,

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1157,10 +1157,10 @@ class ScrollView(StencilView):
                     size_hint_min=self._trigger_update_from_scroll)
         self._trigger_update_from_scroll()
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         canvas = self.canvas
         self.canvas = self.canvas_viewport
-        super(ScrollView, self).remove_widget(widget)
+        super(ScrollView, self).remove_widget(widget, *args, **kwargs)
         self.canvas = canvas
         if widget is self._viewport:
             self._viewport = None

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -288,10 +288,10 @@ class SettingItem(FloatLayout):
         super(SettingItem, self).__init__(**kwargs)
         self.value = self.panel.get_value(self.section, self.key)
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         if self.content is None:
-            return super(SettingItem, self).add_widget(widget, index, canvas)
-        return self.content.add_widget(widget, index, canvas)
+            return super(SettingItem, self).add_widget(*args, **kwargs)
+        return self.content.add_widget(*args, **kwargs)
 
     def on_touch_down(self, touch):
         if not self.collide_point(*touch.pos):
@@ -868,11 +868,11 @@ class ContentPanel(ScrollView):
             return True
         return False  # New uid doesn't exist
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         if self.container is None:
-            super(ContentPanel, self).add_widget(widget, index, canvas)
+            super(ContentPanel, self).add_widget(*args, **kwargs)
         else:
-            self.container.add_widget(widget, index, canvas)
+            self.container.add_widget(*args, **kwargs)
 
     def remove_widget(self, widget):
         self.container.remove_widget(widget)
@@ -1096,11 +1096,11 @@ class InterfaceWithNoMenu(ContentPanel):
     widget.
 
     '''
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, *args, **kwargs):
         if self.container is not None and len(self.container.children) > 0:
             raise Exception(
                 'ContentNoMenu cannot accept more than one settings panel')
-        super(InterfaceWithNoMenu, self).add_widget(widget, index, canvas)
+        super(InterfaceWithNoMenu, self).add_widget(*args, **kwargs)
 
 
 class InterfaceWithTabbedPanel(FloatLayout):

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -288,10 +288,10 @@ class SettingItem(FloatLayout):
         super(SettingItem, self).__init__(**kwargs)
         self.value = self.panel.get_value(self.section, self.key)
 
-    def add_widget(self, *largs):
+    def add_widget(self, widget, index=0, canvas=None):
         if self.content is None:
-            return super(SettingItem, self).add_widget(*largs)
-        return self.content.add_widget(*largs)
+            return super(SettingItem, self).add_widget(widget, index, canvas)
+        return self.content.add_widget(widget, index, canvas)
 
     def on_touch_down(self, touch):
         if not self.collide_point(*touch.pos):
@@ -868,11 +868,11 @@ class ContentPanel(ScrollView):
             return True
         return False  # New uid doesn't exist
 
-    def add_widget(self, widget):
+    def add_widget(self, widget, index=0, canvas=None):
         if self.container is None:
-            super(ContentPanel, self).add_widget(widget)
+            super(ContentPanel, self).add_widget(widget, index, canvas)
         else:
-            self.container.add_widget(widget)
+            self.container.add_widget(widget, index, canvas)
 
     def remove_widget(self, widget):
         self.container.remove_widget(widget)
@@ -1096,11 +1096,11 @@ class InterfaceWithNoMenu(ContentPanel):
     widget.
 
     '''
-    def add_widget(self, widget):
+    def add_widget(self, widget, index=0, canvas=None):
         if self.container is not None and len(self.container.children) > 0:
             raise Exception(
                 'ContentNoMenu cannot accept more than one settings panel')
-        super(InterfaceWithNoMenu, self).add_widget(widget)
+        super(InterfaceWithNoMenu, self).add_widget(widget, index, canvas)
 
 
 class InterfaceWithTabbedPanel(FloatLayout):

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -874,8 +874,8 @@ class ContentPanel(ScrollView):
         else:
             self.container.add_widget(*args, **kwargs)
 
-    def remove_widget(self, widget):
-        self.container.remove_widget(widget)
+    def remove_widget(self, *args, **kwargs):
+        self.container.remove_widget(*args, **kwargs)
 
 
 class Settings(BoxLayout):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -252,7 +252,7 @@ class Splitter(BoxLayout):
         if widget == self._container:
             self._container = None
 
-    def clear_widgets(self):
+    def clear_widgets(self, children=None):
         self.remove_widget(self._container)
 
     def strip_down(self, instance, touch):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -231,7 +231,7 @@ class Splitter(BoxLayout):
         _strp.disabled = self.disabled
         self.bind(disabled=_strp.setter('disabled'))
 
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         if self._container or not widget:
             return Exception('Splitter accepts only one Child')
         self._container = widget
@@ -244,7 +244,7 @@ class Splitter(BoxLayout):
         index = 0
         if sz_frm in ('r', 'b'):
             index = 1
-        super(Splitter, self).add_widget(widget, index)
+        super(Splitter, self).add_widget(widget, index, canvas)
         self.on_sizable_from(self, self.sizable_from)
 
     def remove_widget(self, widget, *largs):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -252,7 +252,7 @@ class Splitter(BoxLayout):
         if widget == self._container:
             self._container = None
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, *args, **kwargs):
         self.remove_widget(self._container)
 
     def strip_down(self, instance, touch):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -231,7 +231,7 @@ class Splitter(BoxLayout):
         _strp.disabled = self.disabled
         self.bind(disabled=_strp.setter('disabled'))
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, index=0, *args, **kwargs):
         if self._container or not widget:
             return Exception('Splitter accepts only one Child')
         self._container = widget
@@ -244,7 +244,7 @@ class Splitter(BoxLayout):
         index = 0
         if sz_frm in ('r', 'b'):
             index = 1
-        super(Splitter, self).add_widget(widget, index, canvas)
+        super(Splitter, self).add_widget(widget, index, *args, **kwargs)
         self.on_sizable_from(self, self.sizable_from)
 
     def remove_widget(self, widget):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -247,8 +247,8 @@ class Splitter(BoxLayout):
         super(Splitter, self).add_widget(widget, index, *args, **kwargs)
         self.on_sizable_from(self, self.sizable_from)
 
-    def remove_widget(self, widget):
-        super(Splitter, self).remove_widget(widget)
+    def remove_widget(self, widget, *args, **kwargs):
+        super(Splitter, self).remove_widget(widget, *args, **kwargs)
         if widget == self._container:
             self._container = None
 

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -247,7 +247,7 @@ class Splitter(BoxLayout):
         super(Splitter, self).add_widget(widget, index, canvas)
         self.on_sizable_from(self, self.sizable_from)
 
-    def remove_widget(self, widget, *largs):
+    def remove_widget(self, widget):
         super(Splitter, self).remove_widget(widget)
         if widget == self._container:
             self._container = None

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -580,9 +580,6 @@ class TabbedPanel(GridLayout):
         if self.content:
             self.content.clear_widgets(children)
 
-    def _super_clear_widgets(self):
-        super(TabbedPanel, self).clear_widgets()
-
     def on_strip_image(self, instance, value):
         if not self._tab_layout:
             return
@@ -704,7 +701,7 @@ class TabbedPanel(GridLayout):
         tabs.bind(width=self._partial_update_scrollview)
 
         # remove all widgets from the tab_strip
-        self._super_clear_widgets()
+        super(TabbedPanel, self).clear_widgets()
         tab_height = self.tab_height
 
         widget_list = []

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -576,14 +576,12 @@ class TabbedPanel(GridLayout):
             if widget in content.children:
                 content.remove_widget(widget)
 
-    def clear_widgets(self, **kwargs):
-        content = self.content
-        if content is None:
-            return
-        if kwargs.get('do_super', False):
-            super(TabbedPanel, self).clear_widgets()
-        else:
-            content.clear_widgets()
+    def clear_widgets(self, children=None):
+        if self.content:
+            self.content.clear_widgets(children)
+
+    def _super_clear_widgets(self):
+        super(TabbedPanel, self).clear_widgets()
 
     def on_strip_image(self, instance, value):
         if not self._tab_layout:
@@ -706,7 +704,7 @@ class TabbedPanel(GridLayout):
         tabs.bind(width=self._partial_update_scrollview)
 
         # remove all widgets from the tab_strip
-        self.clear_widgets(do_super=True)
+        self._super_clear_widgets()
         tab_height = self.tab_height
 
         widget_list = []

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -201,7 +201,7 @@ class TabbedPanelItem(TabbedPanelHeader):
     .. versionadded:: 1.5.0
     '''
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         self.content = widget
         if not self.parent:
             return
@@ -533,7 +533,7 @@ class TabbedPanel(GridLayout):
             self_tabs.width = self_default_tab.width
         self._reposition_tabs()
 
-    def add_widget(self, widget, index=0, canvas=None):
+    def add_widget(self, widget, *args, **kwargs):
         content = self.content
         if content is None:
             return
@@ -541,17 +541,17 @@ class TabbedPanel(GridLayout):
         if parent:
             parent.remove_widget(widget)
         if widget in (content, self._tab_layout):
-            super(TabbedPanel, self).add_widget(widget, index, canvas)
+            super(TabbedPanel, self).add_widget(widget, *args, **kwargs)
         elif isinstance(widget, TabbedPanelHeader):
             self_tabs = self._tab_strip
-            self_tabs.add_widget(widget, index)
+            self_tabs.add_widget(widget, *args, **kwargs)
             widget.group = '__tab%r__' % self_tabs.uid
             self.on_tab_width()
         else:
             widget.pos_hint = {'x': 0, 'top': 1}
             self._childrens.append(widget)
             content.disabled = self.current_tab.disabled
-            content.add_widget(widget, index, canvas)
+            content.add_widget(widget, *args, **kwargs)
 
     def remove_widget(self, widget):
         content = self.content

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -209,13 +209,13 @@ class TabbedPanelItem(TabbedPanelHeader):
         if panel.current_tab == self:
             panel.switch_to(self)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, *args, **kwargs):
         self.content = None
         if not self.parent:
             return
         panel = self.parent.tabbed_panel
         if panel.current_tab == self:
-            panel.remove_widget(widget)
+            panel.remove_widget(*args, **kwargs)
 
 
 class TabbedPanelStrip(GridLayout):
@@ -553,12 +553,12 @@ class TabbedPanel(GridLayout):
             content.disabled = self.current_tab.disabled
             content.add_widget(widget, *args, **kwargs)
 
-    def remove_widget(self, widget):
+    def remove_widget(self, widget, *args, **kwargs):
         content = self.content
         if content is None:
             return
         if widget in (content, self._tab_layout):
-            super(TabbedPanel, self).remove_widget(widget)
+            super(TabbedPanel, self).remove_widget(widget, *args, **kwargs)
         elif isinstance(widget, TabbedPanelHeader):
             if not (self.do_default_tab and widget is self._default_tab):
                 self_tabs = self._tab_strip
@@ -574,7 +574,7 @@ class TabbedPanel(GridLayout):
             if widget in self._childrens:
                 self._childrens.remove(widget)
             if widget in content.children:
-                content.remove_widget(widget)
+                content.remove_widget(widget, *args, **kwargs)
 
     def clear_widgets(self, children=None):
         if self.content:

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -576,9 +576,9 @@ class TabbedPanel(GridLayout):
             if widget in content.children:
                 content.remove_widget(widget, *args, **kwargs)
 
-    def clear_widgets(self, children=None):
+    def clear_widgets(self, *args, **kwargs):
         if self.content:
-            self.content.clear_widgets(children)
+            self.content.clear_widgets(*args, **kwargs)
 
     def on_strip_image(self, instance, value):
         if not self._tab_layout:

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -201,7 +201,7 @@ class TabbedPanelItem(TabbedPanelHeader):
     .. versionadded:: 1.5.0
     '''
 
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         self.content = widget
         if not self.parent:
             return
@@ -533,7 +533,7 @@ class TabbedPanel(GridLayout):
             self_tabs.width = self_default_tab.width
         self._reposition_tabs()
 
-    def add_widget(self, widget, index=0):
+    def add_widget(self, widget, index=0, canvas=None):
         content = self.content
         if content is None:
             return
@@ -541,7 +541,7 @@ class TabbedPanel(GridLayout):
         if parent:
             parent.remove_widget(widget)
         if widget in (content, self._tab_layout):
-            super(TabbedPanel, self).add_widget(widget, index)
+            super(TabbedPanel, self).add_widget(widget, index, canvas)
         elif isinstance(widget, TabbedPanelHeader):
             self_tabs = self._tab_strip
             self_tabs.add_widget(widget, index)
@@ -551,7 +551,7 @@ class TabbedPanel(GridLayout):
             widget.pos_hint = {'x': 0, 'top': 1}
             self._childrens.append(widget)
             content.disabled = self.current_tab.disabled
-            content.add_widget(widget, index)
+            content.add_widget(widget, index, canvas)
 
     def remove_widget(self, widget):
         content = self.content


### PR DESCRIPTION
Proposed changes are to bring consistency for arguments of methods:
- `add_widget`
- `remove_widget`
- `clear_widgets`

for all subclasses of `Widget` class. Classes affected with this change are:
- AccordionItem
- Accordion
- ActionGroup
- ActionOverflow
- ActionView
- ActionBar
- BoxLayout
- Bubble
- Carousel
- Dropdown
- EffectWidget
- FileChooser
- FloatLayout
- Layout
- Popup
- RecycleView
- ScatterLayout
- ScreenManager
- ScrollView
- ContentPanel
- SettingsItem
- Settings
- Splitter
- TabbedPanelItem
- TabbedPanel
