### PR TITLE
Fix bug in TabbedPanel.remove_widget method

### DIFF
--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -560,7 +560,8 @@ class TabbedPanel(GridLayout):
                 Logger.info('TabbedPanel: default tab! can\'t be removed.\n' +
                             'Change `default_tab` to a different tab.')
         else:
-            self._childrens.pop(widget, None)
+            if widget in self._childrens:
+                self._childrens.remove(widget)
             if widget in content.children:
                 content.remove_widget(widget)
 


### PR DESCRIPTION
Attribute `_childrens` of `TabbedPanel` is a `list` and calling `pop` method with two arguments would raise a `TypeError`. Request fixes this bug by calling `remove` method.