### PR TITLE
From 2.0.15, sdl uses the alpha of color.

### DIFF
--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -58,6 +58,8 @@ cdef class _SurfaceContainer:
         outline_width = container.options['outline_width']
         if font == NULL:
             return
+
+        c.a = oc.a = 255
         c.r = <int>(color[0] * 255)
         c.g = <int>(color[1] * 255)
         c.b = <int>(color[2] * 255)


### PR DESCRIPTION
From https://www.libsdl.org/projects/SDL_ttf/:

```
Changes:

2.0.15:
 * Updated to FreeType version 2.9.1
 * Text rendering functions now use the alpha component of the text colors
 * Added support for characters greater than 0xFFFF (e.g. emoji) in the UTF-8 APIs
```

This led to issues on windows using the newest `kivy.deps.sdl2` where randomly the text was faded. I verified that this fixed the issue.