### PR TITLE
Add deprecation warnings and deprecate pygame

### DIFF
--- a/examples/demo/kivycatalog/kivycatalog.kv
+++ b/examples/demo/kivycatalog/kivycatalog.kv
@@ -1,12 +1,6 @@
 #:kivy 1.4
 #:import KivyLexer kivy.extras.highlight.KivyLexer
 
-[ContainerToggle@ToggleButton]:
-    group: "container_toggle"
-    text: ctx.text
-    on_press: root.parent.parent.parent.show_kv(*args)
-    state: ctx.state if hasattr(ctx, "state") else "normal"
-
 <Container>:
     canvas.before:
         Color:

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -464,3 +464,9 @@ for importer, modname in _packages:
 from kivy.logger import file_log_handler
 if file_log_handler is not None:
     file_log_handler.purge_logs()
+
+
+if PY2:
+    Logger.warning(
+        'Deprecated: Python 2 Kivy support has been deprecated. The '
+        'Kivy release after 1.11.0 will not support Python 2 anymore')

--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -151,7 +151,8 @@ class Sound(EventDispatcher):
     #
     def _get_status(self):
         return self.state
-    status = AliasProperty(_get_status, None, bind=('state', ))
+    status = AliasProperty(
+        _get_status, None, bind=('state', ), deprecated=True)
     '''
     .. deprecated:: 1.3.0
         Use :attr:`state` instead.
@@ -159,7 +160,8 @@ class Sound(EventDispatcher):
 
     def _get_filename(self):
         return self.source
-    filename = AliasProperty(_get_filename, None, bind=('source', ))
+    filename = AliasProperty(
+        _get_filename, None, bind=('source', ), deprecated=True)
     '''
     .. deprecated:: 1.3.0
         Use :attr:`source` instead.

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -1,5 +1,10 @@
 '''
 AudioPygame: implementation of Sound with Pygame
+
+.. warning::
+
+    Pygame has been deprecated and will be removed in the release after Kivy
+    1.11.0.
 '''
 
 __all__ = ('SoundPygame', )
@@ -43,7 +48,8 @@ class SoundPygame(Sound):
             return ('wav', 'ogg', 'mp3', 'm4a')
         return ('wav', 'ogg')
 
-    @deprecated
+    @deprecated(
+        msg='Pygame has been deprecated and will be removed after 1.11.0')
     def __init__(self, **kwargs):
         self._data = None
         self._channel = None

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -5,7 +5,7 @@ AudioPygame: implementation of Sound with Pygame
 __all__ = ('SoundPygame', )
 
 from kivy.clock import Clock
-from kivy.utils import platform
+from kivy.utils import platform, deprecated
 from kivy.core.audio import Sound, SoundLoader
 
 _platform = platform
@@ -43,6 +43,7 @@ class SoundPygame(Sound):
             return ('wav', 'ogg', 'mp3', 'm4a')
         return ('wav', 'ogg')
 
+    @deprecated
     def __init__(self, **kwargs):
         self._data = None
         self._channel = None

--- a/kivy/core/clipboard/clipboard_pygame.py
+++ b/kivy/core/clipboard/clipboard_pygame.py
@@ -1,5 +1,10 @@
 '''
 Clipboard Pygame: an implementation of the Clipboard using pygame.scrap.
+
+.. warning::
+
+    Pygame has been deprecated and will be removed in the release after Kivy
+    1.11.0.
 '''
 
 __all__ = ('ClipboardPygame', )
@@ -27,9 +32,10 @@ class ClipboardPygame(ClipboardBase):
         'text/plain;charset=utf-8': 'UTF8_STRING'
     }
 
-    @deprecated
-    def __init__(self, **kwargs):
-        super(ClipboardPygame, self).__init__(**kwargs)
+    @deprecated(
+        msg='Pygame has been deprecated and will be removed after 1.11.0')
+    def __init__(self, *largs, **kwargs):
+        super(ClipboardPygame, self).__init__(*largs, **kwargs)
 
     def init(self):
         if ClipboardPygame._is_init:

--- a/kivy/core/clipboard/clipboard_pygame.py
+++ b/kivy/core/clipboard/clipboard_pygame.py
@@ -6,6 +6,7 @@ __all__ = ('ClipboardPygame', )
 
 from kivy.utils import platform
 from kivy.core.clipboard import ClipboardBase
+from kivy.utils import deprecated
 
 if platform not in ('win', 'linux', 'macosx'):
     raise SystemError('unsupported platform for pygame clipboard')
@@ -25,6 +26,10 @@ class ClipboardPygame(ClipboardBase):
     _aliases = {
         'text/plain;charset=utf-8': 'UTF8_STRING'
     }
+
+    @deprecated
+    def __init__(self, **kwargs):
+        super(ClipboardPygame, self).__init__(**kwargs)
 
     def init(self):
         if ClipboardPygame._is_init:

--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -7,6 +7,7 @@ __all__ = ('ImageLoaderPygame', )
 from kivy.logger import Logger
 from kivy.core.image import ImageLoaderBase, ImageData, ImageLoader
 from os.path import isfile
+from kivy.utils import deprecated
 
 try:
     import pygame
@@ -16,6 +17,10 @@ except:
 
 class ImageLoaderPygame(ImageLoaderBase):
     '''Image loader based on the PIL library'''
+
+    @deprecated
+    def __init__(self, **kwargs):
+        super(ImageLoaderPygame, self).__init__(**kwargs)
 
     @staticmethod
     def extensions():

--- a/kivy/core/image/img_pygame.py
+++ b/kivy/core/image/img_pygame.py
@@ -1,5 +1,10 @@
 '''
 Pygame: Pygame image loader
+
+.. warning::
+
+    Pygame has been deprecated and will be removed in the release after Kivy
+    1.11.0.
 '''
 
 __all__ = ('ImageLoaderPygame', )
@@ -18,9 +23,10 @@ except:
 class ImageLoaderPygame(ImageLoaderBase):
     '''Image loader based on the PIL library'''
 
-    @deprecated
-    def __init__(self, **kwargs):
-        super(ImageLoaderPygame, self).__init__(**kwargs)
+    @deprecated(
+        msg='Pygame has been deprecated and will be removed after 1.11.0')
+    def __init__(self, *largs, **kwargs):
+        super(ImageLoaderPygame, self).__init__(*largs, **kwargs)
 
     @staticmethod
     def extensions():

--- a/kivy/core/text/text_pygame.py
+++ b/kivy/core/text/text_pygame.py
@@ -7,6 +7,7 @@ __all__ = ('LabelPygame', )
 from kivy.compat import PY2
 from kivy.core.text import LabelBase
 from kivy.core.image import ImageData
+from kivy.utils import deprecated
 
 try:
     import pygame
@@ -25,6 +26,10 @@ except:
 
 
 class LabelPygame(LabelBase):
+
+    @deprecated
+    def __init__(self, **kwargs):
+        super(LabelPygame, self).__init__(**kwargs)
 
     def _get_font_id(self):
         if PY2:

--- a/kivy/core/text/text_pygame.py
+++ b/kivy/core/text/text_pygame.py
@@ -1,5 +1,10 @@
 '''
 Text Pygame: Draw text with pygame
+
+.. warning::
+
+    Pygame has been deprecated and will be removed in the release after Kivy
+    1.11.0.
 '''
 
 __all__ = ('LabelPygame', )
@@ -27,9 +32,10 @@ except:
 
 class LabelPygame(LabelBase):
 
-    @deprecated
-    def __init__(self, **kwargs):
-        super(LabelPygame, self).__init__(**kwargs)
+    @deprecated(
+        msg='Pygame has been deprecated and will be removed after 1.11.0')
+    def __init__(self, *largs, **kwargs):
+        super(LabelPygame, self).__init__(*largs, **kwargs)
 
     def _get_font_id(self):
         if PY2:

--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -1,5 +1,10 @@
 '''
 Window Pygame: windowing provider based on Pygame
+
+.. warning::
+
+    Pygame has been deprecated and will be removed in the release after Kivy
+    1.11.0.
 '''
 
 __all__ = ('WindowPygame', )
@@ -33,9 +38,10 @@ glReadPixels = GL_RGBA = GL_UNSIGNED_BYTE = None
 
 class WindowPygame(WindowBase):
 
-    @deprecated
-    def __init__(self, **kwargs):
-        super(WindowPygame, self).__init__(**kwargs)
+    @deprecated(
+        msg='Pygame has been deprecated and will be removed after 1.11.0')
+    def __init__(self, *largs, **kwargs):
+        super(WindowPygame, self).__init__(*largs, **kwargs)
 
     def create_window(self, *largs):
         # ensure the mouse is still not up after window creation, otherwise, we

--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -33,6 +33,10 @@ glReadPixels = GL_RGBA = GL_UNSIGNED_BYTE = None
 
 class WindowPygame(WindowBase):
 
+    @deprecated
+    def __init__(self, **kwargs):
+        super(WindowPygame, self).__init__(**kwargs)
+
     def create_window(self, *largs):
         # ensure the mouse is still not up after window creation, otherwise, we
         # have some weird bugs

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -741,7 +741,7 @@ class BuilderBase(object):
         '''Return a list of :class:`ParserRule` objects matching the widget.
         '''
         cache = BuilderBase._match_cache
-        k = (widget.__class__, widget.id, tuple(widget.cls))
+        k = (widget.__class__, tuple(widget.cls))
         if k in cache:
             return cache[k]
         rules = []

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -347,6 +347,15 @@ class ParserRule(object):
 
     def _build_template(self):
         name = self.name
+        exception = ParserException(
+            self.ctx, self.line,
+            'Deprecated Kivy lang template syntax used "{}". Templates will '
+            'be removed in a future version'.format(name))
+        if name not in ('[FileListEntry@FloatLayout+TreeViewNode]',
+                        '[FileIconEntry@Widget]',
+                        '[AccordionItemTitle@Label]'):
+            Logger.warning(exception)
+
         if __debug__:
             trace('Builder: build template for %s' % name)
         if name[0] != '[' or name[-1] != ']':

--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -26,6 +26,7 @@ cdef class Property:
     cdef object errorhandler
     cdef int errorvalue_set
     cdef public object defaultvalue
+    cdef int deprecated
     cdef init_storage(self, EventDispatcher obj, PropertyStorage storage)
     cpdef link(self, EventDispatcher obj, str name)
     cpdef link_deps(self, EventDispatcher obj, str name)

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -481,7 +481,8 @@ class FileChooserController(RelativeLayout):
 
     '''
 
-    file_encodings = ListProperty(['utf-8', 'latin1', 'cp1252'])
+    file_encodings = ListProperty(
+        ['utf-8', 'latin1', 'cp1252'], deprecated=True)
     '''Possible encodings for decoding a filename to unicode. In the case that
     the user has a non-ascii filename, undecodable without knowing its
     initial encoding, we have no other choice than to guess it.

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2822,7 +2822,7 @@ class TextInput(FocusBehavior, Widget):
     defaults to 4.
     '''
 
-    padding_x = VariableListProperty([0, 0], length=2)
+    padding_x = VariableListProperty([0, 0], length=2, deprecated=True)
     '''Horizontal padding of the text: [padding_left, padding_right].
 
     padding_x also accepts a one argument form [padding_horizontal].
@@ -2838,7 +2838,7 @@ class TextInput(FocusBehavior, Widget):
         self.padding[0] = value[0]
         self.padding[2] = value[1]
 
-    padding_y = VariableListProperty([0, 0], length=2)
+    padding_y = VariableListProperty([0, 0], length=2, deprecated=True)
     '''Vertical padding of the text: [padding_top, padding_bottom].
 
     padding_y also accepts a one argument form [padding_vertical].

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -53,7 +53,7 @@ class Video(Image):
     to 'stop'.
     '''
 
-    play = BooleanProperty(False)
+    play = BooleanProperty(False, deprecated=True)
     '''
     .. deprecated:: 1.4.0
         Use :attr:`state` instead.

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -344,7 +344,7 @@ class VideoPlayer(GridLayout):
     to 'stop'.
     '''
 
-    play = BooleanProperty(False)
+    play = BooleanProperty(False, deprecated=True)
     '''
     .. deprecated:: 1.4.0
         Use :attr:`state` instead.

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -1146,7 +1146,7 @@ class Widget(WidgetBase):
     '''Class of the widget, used for styling.
     '''
 
-    id = StringProperty(None, allownone=True)
+    id = StringProperty(None, allownone=True, deprecated=True)
     '''Identifier of the widget in the tree.
 
     :attr:`id` is a :class:`~kivy.properties.StringProperty` and defaults to

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -315,13 +315,16 @@ colormap = {k: get_color_from_hex(v) for k, v in hex_colormap.items()}
 DEPRECATED_CALLERS = []
 
 
-def deprecated(func):
+def deprecated(func=None, msg=''):
     '''This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted the first time
     the function is used.'''
 
     import inspect
     import functools
+
+    if func is None:
+        return functools.partial(deprecated, msg=msg)
 
     @functools.wraps(func)
     def new_func(*args, **kwargs):
@@ -338,6 +341,11 @@ def deprecated(func):
                     func.__code__.co_filename,
                     func.__code__.co_firstlineno + 1,
                     file, line, caller))
+
+            if msg:
+                warning = '{}: {}'.format(msg, warning)
+            warning = 'Deprecated: ' + warning
+
             from kivy.logger import Logger
             Logger.warning(warning)
             if func.__doc__:


### PR DESCRIPTION
This adds deprecation warnings. In particular, 
* it warns if a kv template is defined (except for those in style.kv...). Can be tested with
  ```
  from kivy.lang import Builder
  Builder.load_string("""
  [Something@FloatLayout]:
      locked: False
  """)
  ```
* Adds a deprecated parameter to kivy properties, which warn on the first time it is set or accessed that it is deprecated. Can be tested by just adding it to a prop and reading or setting it.
* Adds the deprecation warnings to the properties that have been deprecated in their docs.

It also deprecates **pygame**.