### PR TITLE
ctypes adaptations in order to work with other packages

### DIFF
--- a/kivy/input/providers/wm_common.py
+++ b/kivy/input/providers/wm_common.py
@@ -74,7 +74,7 @@ if 'KIVY_DOC' not in os.environ:
         raise Exception('Unsupported Window version')
 
     LRESULT = LPARAM
-    WNDPROC = WINFUNCTYPE(LRESULT, HANDLE, UINT, WPARAM, LPARAM)
+    WNDPROC = WINFUNCTYPE(LRESULT, HWND, UINT, WPARAM, LPARAM)
 
     class TOUCHINPUT(Structure):
         _fields_ = [
@@ -135,14 +135,14 @@ if 'KIVY_DOC' not in os.environ:
     windll.user32.GetWindowRect.restype = BOOL
     windll.user32.GetWindowRect.argtypes = [HANDLE, POINTER(RECT_BASE)]
     windll.user32.CallWindowProcW.restype = LRESULT
-    windll.user32.CallWindowProcW.argtypes = [WNDPROC, HANDLE, UINT, WPARAM,
+    windll.user32.CallWindowProcW.argtypes = [WNDPROC, HWND, UINT, WPARAM,
                                               LPARAM]
-    windll.user32.GetActiveWindow.restype = HANDLE
+    windll.user32.GetActiveWindow.restype = HWND
     windll.user32.GetActiveWindow.argtypes = []
     windll.user32.RegisterTouchWindow.restype = BOOL
-    windll.user32.RegisterTouchWindow.argtypes = [HANDLE, ULONG]
+    windll.user32.RegisterTouchWindow.argtypes = [HWND, ULONG]
     windll.user32.UnregisterTouchWindow.restype = BOOL
-    windll.user32.UnregisterTouchWindow.argtypes = [HANDLE]
+    windll.user32.UnregisterTouchWindow.argtypes = [HWND]
     windll.user32.GetTouchInputInfo.restype = BOOL
     windll.user32.GetTouchInputInfo.argtypes = [HANDLE, UINT,
                                                 POINTER(TOUCHINPUT), c_int]
@@ -150,4 +150,4 @@ if 'KIVY_DOC' not in os.environ:
     windll.user32.GetSystemMetrics.argtypes = [c_int]
 
     windll.user32.ClientToScreen.restype = BOOL
-    windll.user32.ClientToScreen.argtypes = [HANDLE, POINTER(POINT)]
+    windll.user32.ClientToScreen.argtypes = [HWND, POINTER(POINT)]

--- a/kivy/input/providers/wm_common.py
+++ b/kivy/input/providers/wm_common.py
@@ -57,7 +57,8 @@ QUERYSYSTEMGESTURE_WNDPROC = (
 
 if 'KIVY_DOC' not in os.environ:
     from ctypes.wintypes import (ULONG, HANDLE, DWORD, LONG, UINT,
-                                 WPARAM, LPARAM, BOOL, HWND, RECT as RECT_BASE)
+                                 WPARAM, LPARAM, BOOL, HWND, POINT,
+                                 RECT as RECT_BASE)
     from ctypes import (windll, WINFUNCTYPE, POINTER,
                         c_int, c_longlong, c_void_p, Structure,
                         sizeof, byref, cast)
@@ -67,11 +68,6 @@ if 'KIVY_DOC' not in os.environ:
         y = property(lambda self: self.top)
         w = property(lambda self: self.right - self.left)
         h = property(lambda self: self.bottom - self.top)
-
-    class POINT(Structure):
-        _fields_ = [
-            ('x', LONG),
-            ('y', LONG)]
 
     # check availability of RegisterTouchWindow
     if not hasattr(windll.user32, 'RegisterTouchWindow'):

--- a/kivy/input/providers/wm_common.py
+++ b/kivy/input/providers/wm_common.py
@@ -57,18 +57,12 @@ QUERYSYSTEMGESTURE_WNDPROC = (
 
 if 'KIVY_DOC' not in os.environ:
     from ctypes.wintypes import (ULONG, HANDLE, DWORD, LONG, UINT,
-                                 WPARAM, LPARAM, BOOL, HWND)
+                                 WPARAM, LPARAM, BOOL, HWND, RECT as RECT_BASE)
     from ctypes import (windll, WINFUNCTYPE, POINTER,
                         c_int, c_longlong, c_void_p, Structure,
                         sizeof, byref, cast)
 
-    class RECT(Structure):
-        _fields_ = [
-            ('left', LONG),
-            ('top', LONG),
-            ('right', LONG),
-            ('bottom', LONG)]
-
+    class RECT(RECT_BASE):
         x = property(lambda self: self.left)
         y = property(lambda self: self.top)
         w = property(lambda self: self.right - self.left)
@@ -141,9 +135,9 @@ if 'KIVY_DOC' not in os.environ:
     windll.user32.GetMessageExtraInfo.restype = LPARAM
     windll.user32.GetMessageExtraInfo.argtypes = []
     windll.user32.GetClientRect.restype = BOOL
-    windll.user32.GetClientRect.argtypes = [HANDLE, POINTER(RECT)]
+    windll.user32.GetClientRect.argtypes = [HANDLE, POINTER(RECT_BASE)]
     windll.user32.GetWindowRect.restype = BOOL
-    windll.user32.GetWindowRect.argtypes = [HANDLE, POINTER(RECT)]
+    windll.user32.GetWindowRect.argtypes = [HANDLE, POINTER(RECT_BASE)]
     windll.user32.CallWindowProcW.restype = LRESULT
     windll.user32.CallWindowProcW.argtypes = [WNDPROC, HANDLE, UINT, WPARAM,
                                               LPARAM]


### PR DESCRIPTION
Same thing as [\[GitHub\]: kivy/kivy - SetWindowLongPtrW ctypes prototype bug](https://github.com/kivy/kivy/pull/6281).

Stacktrace (partial):

```python
...
   File "e:\Work\Dev\VEnvs\py_064_03.07.03_test0\lib\site-packages\kivy\input\providers\wm_touch.py", line 72, in update
     windll.user32.GetClientRect(self.hwnd, byref(c_rect))
 ctypes.ArgumentError: argument 2: <class 'TypeError'>: expected LP_RECT instance instead of pointer to RECT
```

A complete history can be found at [\[GitHub\]:  pywinauto/pywinauto - ctypes.ArgumentError @ click_input](https://github.com/pywinauto/pywinauto/issues/419):
- This error was encountered in the past, and was fixed (on the other side) by switching to *PyWin32*
- Then it was switched back, and the error reappears

The investigation and example can be found at [\[SO\]: ctypes.ArgumentError when using kivy with pywinauto (@CristiFati's answer)](https://stackoverflow.com/questions/55928463/ctypes-argumenterror-when-using-kivy-with-pywinauto/55931295#55931295).

This *PR* works in conjunction with [\[GitHub\]: pywinauto/pywinauto - ctypes adaptations in order to work with other packages](https://github.com/pywinauto/pywinauto/pull/732) (changes from both *PR*s are required for the error to be fixed - stating the obvious: they won't make any difference if yet another module is in the same situation).