### PR TITLE
User agent was not correctly resolved.

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -331,10 +331,7 @@ class LoaderBase(object):
             else:
                 # read from internet
                 request = urllib_request.Request(filename)
-                if (
-                    Config.has_section('network')
-                    and 'useragent' in Config.items('network')
-                ):
+                if Config.has_option('network', 'useragent'):
                     useragent = Config.get('network', 'useragent')
                     if useragent:
                         request.add_header('User-Agent', useragent)


### PR DESCRIPTION
Problem was found when tried to use `AsyncImage` and ran into 403 forbidden urllib errors. Upon found out that there was a PR that adresses this issue with adding `network.useragent`attribte to Config that would make urllib request append User-Agent in the request headers.
But user agent is never resolved correctly when added to Config's 'network' under the given 'useragent' key. 
This is because of the `'useragent' in Config.items('network')` check.
`Config.items('network')` returns list of tuples so `useragent` is never in the list and so useragent was never really resolved
Corrected by using `.has_option` method