### PR TITLE
[packaging][highlight]Add support for kivy_deps namespace for kivy's dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
   KIVY_SPLIT_EXAMPLES: 1
   MSYSTEM: MINGW64
   CHERE_INVOKING: 1
+  GST_REGISTRY: ~/registry.bin
   matrix:
   - PYVER: 27
     BITTNESS: 86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -154,9 +154,9 @@ build_script:
       Check-Error
     }
 
-    pip install mock cython pygments docutils pytest kivy.deps.glew_dev kivy.deps.glew kivy.deps.gstreamer_dev kivy.deps.sdl2_dev kivy.deps.sdl2
+    pip install mock cython pygments docutils pytest kivy_deps.glew_dev kivy_deps.glew kivy_deps.gstreamer_dev kivy_deps.sdl2_dev kivy_deps.sdl2
 
-    pip --no-cache-dir install kivy.deps.gstreamer
+    pip --no-cache-dir install kivy_deps.gstreamer
 
     Check-Error
 
@@ -168,7 +168,7 @@ build_script:
     }
 
     if ($env:COMPILER -eq "msvc") {
-      pip install kivy.deps.angle
+      pip install kivy_deps.angle
     }
 
     Copy-Item "$PYTHON_ROOT\Lib\site-packages\kivy\deps\*" -destination "$env:APPVEYOR_BUILD_FOLDER\kivy\deps" -recurse

--- a/doc/sources/faq.rst
+++ b/doc/sources/faq.rst
@@ -24,12 +24,12 @@ this. The underlaying issue depends on many things:
 - Don't mix the architecture of the dependencies (e.g. Python 64-bit and 32-bit extensions/SDL2)
 - Don't mix python installation: e.g. if you have Python and Anaconda installed, the Python actually run may be different than you think. Similarly, if you have multiple Python versions available on the ``PATH``, they may clash.
 - Check your PATH to ensure that other programs in it don't provide the same dlls as Kivy/Python, or bad stuff can happen.
-  
+
   - This commonly happens if some other program that uses similar dependecies as Kivy adds itself to the ``PATH`` so that Kivy's dependecies clash with theirs.
   - Please read `this <https://superuser.com/questions/284342/what-are-path-and-other-environment-variables-and-how-can-i-set-or-use-them>`_ and `this <https://www.digitalcitizen.life/simple-questions-what-are-environment-variables>`_ for more details on ``PATH``.
-  - The best tool to troubleshoot this is with `Dependency Walker <http://www.dependencywalker.com/>`_ explained `here <https://www.thewindowsclub.com/dependency-walker-download>`_ and `here <https://kb.froglogic.com/display/KB/Analyzing+dependencies+with+Dependency+Walker>`_. 
+  - The best tool to troubleshoot this is with `Dependency Walker <http://www.dependencywalker.com/>`_ explained `here <https://www.thewindowsclub.com/dependency-walker-download>`_ and `here <https://kb.froglogic.com/display/KB/Analyzing+dependencies+with+Dependency+Walker>`_.
   - But ensure that you're launching it from the identical environment that you start Python.
-- Ensure you have all dependencies installed (like ``kivy.deps.sdl2``).
+- Ensure you have all dependencies installed (like ``kivy_deps.sdl2``).
 - Maybe your drivers have some missing OpenGL symbols? Try to switch to another graphics backend with ``KIVY_GL_BACKEND``.
 - Maybe your `Pycharm configuration is incorrect <https://stackoverflow.com/questions/49466785/kivy-error-python-2-7-sdl2-import-error>`_.
 

--- a/doc/sources/guide/packaging-windows.rst
+++ b/doc/sources/guide/packaging-windows.rst
@@ -64,7 +64,7 @@ to the examples as ``examples-path``. The touchtracer example is in
    the exe. Open the spec file with your favorite editor and add these lines
    at the beginning of the spec (assuming sdl2 is used, the default now)::
 
-    from kivy.deps import sdl2, glew
+    from kivy_deps import sdl2, glew
 
    Then, find ``COLLECT()`` and add the data for touchtracer
    (`touchtracer.kv`, `particle.png`, ...): Change the line to add a ``Tree()``
@@ -106,7 +106,7 @@ folder and do::
 to create the ``gstvideo.spec`` file. Edit as above and this time include the
 gstreamer dependency as well::
 
-    from kivy.deps import sdl2, glew, gstreamer
+    from kivy_deps import sdl2, glew, gstreamer
 
 and add the ``Tree()`` to include the video files, e.g.
 ``Tree('examples-path\\widgets')`` as well as the gstreamer dependencies so it
@@ -225,6 +225,6 @@ The previous examples used e.g.
 ``*[Tree(p) for p in (sdl2.dep_bins + glew.dep_bins + gstreamer.dep_bins)],``
 to make PyInstaller add all the dlls used by these dependencies. If kivy
 was not installed using the wheels method these commands will not work and e.g.
-``kivy.deps.sdl2`` will fail to import. Instead, one must find the location
+``kivy_deps.sdl2`` will fail to import. Instead, one must find the location
 of these dlls and manually pass them to the ``Tree`` class in a similar fashion
 as the example.

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -47,8 +47,8 @@ install.
 #. Install the dependencies (skip gstreamer (~120MB) if not needed, see
    :ref:`kivy-dependencies`)::
 
-     python -m pip install docutils pygments pypiwin32 kivy.deps.sdl2 kivy.deps.glew
-     python -m pip install kivy.deps.gstreamer
+     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2 kivy_deps.glew
+     python -m pip install kivy_deps.gstreamer
 
    .. note::
 
@@ -58,7 +58,7 @@ install.
    For Python 3.5+, you can also use the angle backend instead of glew. This
    can be installed with::
 
-     python -m pip install kivy.deps.angle
+     python -m pip install kivy_deps.angle
 
 #. Install kivy::
 
@@ -161,7 +161,7 @@ Kivy's dependencies
 
 We offer wheels for Kivy and its dependencies separately so only desired
 dependencies need be installed. The dependencies are offered as
-optional sub-packages of kivy.deps, e.g. ``kivy.deps.sdl2``.
+optional sub-packages of kivy_deps, e.g. ``kivy_deps.sdl2``.
 
 Currently on Windows, we provide the following dependency wheels:
 
@@ -265,9 +265,9 @@ kivy with git rather than a wheel there are some additional steps:
 
    .. parsed-literal::
 
-     python -m pip install |cython_install| docutils pygments pypiwin32 kivy.deps.sdl2 \
-     kivy.deps.glew kivy.deps.gstreamer kivy.deps.glew_dev kivy.deps.sdl2_dev \
-     kivy.deps.gstreamer_dev
+     python -m pip install |cython_install| docutils pygments pypiwin32 kivy_deps.sdl2 \
+     kivy_deps.glew kivy_deps.gstreamer kivy_deps.glew_dev kivy_deps.sdl2_dev \
+     kivy_deps.gstreamer_dev
 
 #. If you downloaded or cloned kivy to an alternate location and don't want to
    install it to site-packages read the next section.
@@ -297,39 +297,14 @@ Installing Kivy to an alternate location
 In development Kivy is often installed to an alternate location and then
 installed with::
 
-    python -m pip install -e location
-
-That allows Kivy to remain in its original location while being available
-to python, which is useful for tracking changes you make in Kivy for example
-directly with Git.
-
-To achieve using Kivy in an alternate location extra tweaking is required.
-Due to this `issue <https://github.com/pypa/pip/issues/2677>`_ ``wheel`` and
-``pip`` install the dependency wheels to ``python\Lib\site-packages\kivy``. So
-they need to be moved to your actual kivy installation from site-packages.
-
-After installing the kivy dependencies and downloading or cloning kivy to your
-favorite location, do the following:
-
-#. Move the contents of ``python\Lib\site-packages\kivy\deps`` to
-   ``your-path\kivy\deps`` where ``your-path`` is the path where your kivy is
-   located. That means if you cloned from GitHub, the ``deps`` have to end up
-   in the **inner** ``kivy`` folder.
-#. Remove the ``python\Lib\site-packages\kivy`` directory altogether.
-#. From ``python\Lib\site-packages`` move **all** ``kivy.deps.*.dist-info``
-   directories to ``your-path`` right next to ``kivy``.
+    python -m pip install -e kivy_path
 
 Now you can safely compile kivy in its current location with one of these
 commands::
 
 > make
-> mingw32-make
 > python -m pip install -e .
 > python setup.py build_ext --inplace
-
-**If kivy fails to be imported,** you probably didn't delete all the
-``*.dist-info`` folders and and the kivy or ``kivy.deps*`` folders from
-site-packages.
 
 Making Python available anywhere
 --------------------------------
@@ -377,5 +352,5 @@ Uninstalling Kivy
 
 To uninstall Kivy, remove the installed packages with pip. E.g. if you isnatlled kivy following the instructions above, do::
 
-     python -m pip uninstall kivy.deps.sdl2 kivy.deps.glew kivy.deps.gstreamer
+     python -m pip uninstall kivy_deps.sdl2 kivy_deps.glew kivy_deps.gstreamer
      python -m pip uninstall kivy

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -33,12 +33,12 @@ location** and not to site-packages, please see :ref:`alternate-win`.
 
 .. _install-win-dist:
 
-Installation
-------------
+Installing the kivy stable release
+-----------------------------------
 
 Now that python is installed, open the :ref:`windows-run-app` and make sure
 python is available by typing ``python --version``. Then, do the following to
-install.
+install the most recent stable kivy release (`1.11.0`) and its dependencies.
 
 #. Ensure you have the latest pip and wheel::
 
@@ -47,8 +47,8 @@ install.
 #. Install the dependencies (skip gstreamer (~120MB) if not needed, see
    :ref:`kivy-dependencies`)::
 
-     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2 kivy_deps.glew
-     python -m pip install kivy_deps.gstreamer
+     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2==0.1.21 kivy_deps.glew==0.1.11
+     python -m pip install kivy_deps.gstreamer==0.1.16
 
    .. note::
 
@@ -58,15 +58,15 @@ install.
    For Python 3.5+, you can also use the angle backend instead of glew. This
    can be installed with::
 
-     python -m pip install kivy_deps.angle
+     python -m pip install kivy_deps.angle==0.1.8
 
 #. Install kivy::
 
-     python -m pip install kivy
+     python -m pip install kivy==1.11.0
 
 #. (Optionally) Install the kivy examples::
 
-     python -m pip install kivy_examples
+     python -m pip install kivy_examples==1.11.0
 
    The examples are installed in the share directory under the root directory where python is installed.
 
@@ -170,11 +170,11 @@ Currently on Windows, we provide the following dependency wheels:
   `angle (3.5 only) <https://github.com/Microsoft/angle>`_ for OpenGL
 * `sdl2 <https://libsdl.org>`_ for control and/or OpenGL.
 
-One can select which of these to use for OpenGL use using the
+One can select which of these to use for OpenGL using the
 `KIVY_GL_BACKEND` envrionment variable by setting it to `glew`
 (the default), `angle`, or `sdl2`. `angle` is currently
 in an experimental phase as a substitute for `glew` on Python
-3.5 only.
+3.5+ only.
 
 `gstreamer` is an optional dependency which only needs to be
 installed if video display or audio is desired. `ffpyplayer`
@@ -261,7 +261,9 @@ kivy with git rather than a wheel there are some additional steps:
    These variables must be set everytime you recompile kivy.
 
 #. Install the other dependencies as well as their dev versions (you can skip
-   gstreamer and gstreamer_dev if you aren't going to use video/audio):
+   gstreamer and gstreamer_dev if you aren't going to use video/audio). we don't pin
+   the versions of the dependencies like for the stable kivy because we want the
+   latest:
 
    .. parsed-literal::
 

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -47,18 +47,24 @@ install the most recent stable kivy release (`1.11.0`) and its dependencies.
 #. Install the dependencies (skip gstreamer (~120MB) if not needed, see
    :ref:`kivy-dependencies`)::
 
-     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2==0.1.21 kivy_deps.glew==0.1.11
-     python -m pip install kivy_deps.gstreamer==0.1.16
+     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2==0.1.22 kivy_deps.glew==0.1.12
+     python -m pip install kivy_deps.gstreamer==0.1.17
 
    .. note::
 
        If you encounter a `MemoryError` while installing, add after
-       `pip install` an option `--no-cache-dir`.
+       `pip install` the `--no-cache-dir` option.
 
    For Python 3.5+, you can also use the angle backend instead of glew. This
    can be installed with::
 
-     python -m pip install kivy_deps.angle==0.1.8
+     python -m pip install kivy_deps.angle==0.1.9
+
+   .. warning::
+
+       When installing, pin kivy's dependencies to the specific version that was released on pypi
+       when your kivy version was released, like above. Otherwise you may get an incompatible dependency
+       when it is updated in the future.
 
 #. Install kivy::
 

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -104,24 +104,20 @@ such as::
 Nightly wheel installation
 --------------------------
 
-.. |cp27_win32| replace:: Python 2.7, 32bit
-.. _cp27_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp27-cp27m-win32.whl
-.. |cp27_amd64| replace:: Python 2.7, 64bit
-.. _cp27_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp27-cp27m-win_amd64.whl
 .. |cp35_win32| replace:: Python 3.5, 32bit
-.. _cp35_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp35-cp35m-win32.whl
+.. _cp35_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-2.0.0.dev0-cp35-cp35m-win32.whl
 .. |cp35_amd64| replace:: Python 3.5, 64bit
-.. _cp35_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp35-cp35m-win_amd64.whl
+.. _cp35_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-2.0.0.dev0-cp35-cp35m-win_amd64.whl
 .. |cp36_win32| replace:: Python 3.6, 32bit
-.. _cp36_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp36-cp36m-win32.whl
+.. _cp36_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-2.0.0.dev0-cp36-cp36m-win32.whl
 .. |cp36_amd64| replace:: Python 3.6, 64bit
-.. _cp36_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp36-cp36m-win_amd64.whl
+.. _cp36_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-2.0.0.dev0-cp36-cp36m-win_amd64.whl
 .. |cp37_win32| replace:: Python 3.7, 32bit
-.. _cp37_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp37-cp37m-win32.whl
+.. _cp37_win32: https://kivy.org/downloads/appveyor/kivy/Kivy-2.0.0.dev0-cp37-cp37m-win32.whl
 .. |cp37_amd64| replace:: Python 3.7, 64bit
-.. _cp37_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-1.11.0.dev0-cp37-cp37m-win_amd64.whl
+.. _cp37_amd64: https://kivy.org/downloads/appveyor/kivy/Kivy-2.0.0.dev0-cp37-cp37m-win_amd64.whl
 .. |examples_whl| replace:: Kivy examples
-.. _examples_whl: https://kivy.org/downloads/appveyor/kivy/Kivy_examples-1.11.0.dev0-py2.py3-none-any.whl
+.. _examples_whl: https://kivy.org/downloads/appveyor/kivy/Kivy_examples-2.0.0.dev0-py2.py3-none-any.whl
 
 .. warning::
 

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -442,11 +442,23 @@ for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
     if not ispkg:
         continue
     if modname.startswith('gst'):
-        _packages.insert(0, (importer, modname))
+        _packages.insert(0, (importer, modname, 'kivy.deps'))
     else:
-        _packages.append((importer, modname))
+        _packages.append((importer, modname, 'kivy.deps'))
 
-for importer, modname in _packages:
+try:
+    import kivy_deps
+    for importer, modname, ispkg in pkgutil.iter_modules(kivy_deps.__path__):
+        if not ispkg:
+            continue
+        if modname.startswith('gst'):
+            _packages.insert(0, (importer, modname, 'kivy_deps'))
+        else:
+            _packages.append((importer, modname, 'kivy_deps'))
+except ImportError:
+    pass
+
+for importer, modname, package in _packages:
     try:
         mod = importer.find_module(modname).load_module(modname)
 
@@ -454,12 +466,12 @@ for importer, modname in _packages:
         if hasattr(mod, '__version__'):
             version = ' {}'.format(mod.__version__)
         Logger.info(
-            'deps: Successfully imported "kivy.deps.{}"{}'.
-            format(modname, version))
+            'deps: Successfully imported "{}.{}"{}'.
+            format(package, modname, version))
     except ImportError as e:
         Logger.warning(
-            'deps: Error importing dependency "kivy.deps.{}": {}'.
-            format(modname, str(e)))
+            'deps: Error importing dependency "{}.{}": {}'.
+            format(package, modname, str(e)))
 
 from kivy.logger import file_log_handler
 if file_log_handler is not None:

--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -20,10 +20,10 @@ At runtime the following backends are available and can be set using
 * ``glew`` -- Available on Windows (the default backend). Unavailable when
   ``USE_OPENGL_MOCK=0``. Requires glew be installed.
 * ``sdl2`` -- Available on Windows/unix (the default when gl/glew is disabled).
-  Unavailable when ``USE_SDL2=0``. Requires ``kivy.deps.sdl2`` be installed.
+  Unavailable when ``USE_SDL2=0``. Requires ``kivy_deps.sdl2`` be installed.
 * ``angle_sdl2`` -- Available on Windows with Python 3.5+.
-  Unavailable when ``USE_SDL2=0``. Requires ``kivy.deps.sdl2`` and
-  ``kivy.deps.angle`` be installed.
+  Unavailable when ``USE_SDL2=0``. Requires ``kivy_deps.sdl2`` and
+  ``kivy_deps.angle`` be installed.
 * ``mock`` -- Always available. Doesn't actually do anything.
 
 


### PR DESCRIPTION
See https://github.com/kivy/kivy/wiki/Moving-kivy.garden.xxx-to-kivy_garden.xxx-and-kivy.deps.xxx-to-kivy_deps.xxx for the full proposal and details.