### PR TITLE
Revert "[widgets/screen]Fix #3143"

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -497,7 +497,6 @@ class ShaderTransition(TransitionBase):
     def add_screen(self, screen):
         self.screen_in.pos = self.screen_out.pos
         self.screen_in.size = self.screen_out.size
-        self.manager.remove_widget(self.screen_out)
         self.manager.real_remove_widget(self.screen_out)
         self.manager.canvas.add(self.screen_out.canvas)
 


### PR DESCRIPTION
Reverts kivy/kivy#6279. See https://github.com/kivy/kivy/issues/6338.

It doesn't make sense to fully remove the widget from the list of screens when a new screen is added.

The original problem with the showcase is that it used `switch_to` to add an already previously added screen to the screen manager. The doc clearly says `"Add a new screen to the ScreenManager and switch to it."`. Hence the problem. The fix is to not call `switch_to` if the screen already is added. Or make `switch_to` accept existing screen.