### PR TITLE
force to use sphinx 1.7.9 to restore search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ install:
         pip install --upgrade cython pillow pytest coveralls docutils PyInstaller;
       fi;
       if [ "${RUN}" == "docs" ]; then
-        pip install --upgrade sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag;
+        pip install --upgrade sphinx==1.7.9 sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag;
       fi;
     fi;
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,5 +1,6 @@
 Cython>=0.24
 # Frozen Sphinx requirements for easier pip installation
+sphinx==1.7.9
 sphinxcontrib-actdiag
 sphinxcontrib-blockdiag
 sphinxcontrib-nwdiag


### PR DESCRIPTION
maybe there is a better fix, but seems our search has been broken by updates to sphinx, tried 2.1, 2.0 then 1.8.5 localy, none of them worked, falling back to 1.7.9 did, so falling back to that for now.