### PR TITLE
Move cython version info to setup.cfg.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,9 @@ install:
         sudo apt-get -y install python3 python3-dev libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff4-dev libX11-dev libmtdev-dev;
         sudo apt-get -y install python3-setuptools build-essential libgl1-mesa-dev libgles2-mesa-dev;
         sudo apt-get -y install xvfb pulseaudio xsel;
-        pip install --upgrade cython pillow pytest coveralls docutils PyInstaller;
+        export CYTHON_INSTALL=$(KIVY_NO_CONSOLELOG=1 python3 -c "from kivy.tools.packaging.cython_cfg import get_cython_versions; print(get_cython_versions()[0])"  --config "kivy:log_level:error");
+        python3 -m pip install -I "$CYTHON_INSTALL";
+        python3 -m pip install --upgrade pillow pytest coveralls docutils PyInstaller;
       fi;
       if [ "${RUN}" == "docs" ]; then
         python3 -m pip install --upgrade sphinx==1.7.9 sphinxcontrib-blockdiag sphinxcontrib-seqdiag sphinxcontrib-actdiag sphinxcontrib-nwdiag;
@@ -98,6 +100,7 @@ install:
       sudo installer -package gstreamer-1.0-1.10.2-x86_64.pkg -target /;
       sudo installer -package gstreamer-1.0-devel-1.10.2-x86_64.pkg -target /;
       curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py;
+
       if [ "${RUN}" == "app" ]  && ([ "${TRAVIS_EVENT_TYPE}" == "cron" ] || [ "${TRAVIS_TAG}" != "" ]  || [[ "$TRAVIS_COMMIT_MESSAGE" =~ "[build app osx]" ]]); then
           curl -O -L http://www.sveinbjorn.org/files/software/platypus/platypus4.8.zip;
           unzip platypus4.8.zip;
@@ -108,13 +111,14 @@ install:
           cp -a Platypus-4.8/Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib;
           chmod -R 755 /usr/local/share/platypus;
       fi;
-      if [ "${RUN}" == "unit" ]; then
-         export PATH=$PATH:$HOME/Library/Python/3.5/bin;
-         curl -O -L https://www.python.org/ftp/python/3.5.2/python-3.5.2-macosx10.6.pkg;
-         sudo installer -package python-3.5.2-macosx10.6.pkg -target /;
-         python3 get-pip.py --user;
-         python3 -m pip install --upgrade --user cython pillow pytest mock docutils PyInstaller;
-      fi;
+
+      export PATH=$PATH:$HOME/Library/Python/3.5/bin;
+      curl -O -L https://www.python.org/ftp/python/3.5.2/python-3.5.2-macosx10.6.pkg;
+      sudo installer -package python-3.5.2-macosx10.6.pkg -target /;
+      python3 get-pip.py --user;
+      export CYTHON_INSTALL=$(KIVY_NO_CONSOLELOG=1 python3 -c "from kivy.tools.packaging.cython_cfg import get_cython_versions; print(get_cython_versions()[0])"  --config "kivy:log_level:error");
+      python3 -m pip install -I --user "$CYTHON_INSTALL";
+      python3 -m pip install --upgrade --user pillow pytest mock docutils PyInstaller;
     fi;
 
 before_script:
@@ -148,9 +152,9 @@ script:
       fi;
       if [ "${RUN}" == "wheels" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]  && ([ "${TRAVIS_EVENT_TYPE}" == "cron" ] || [ "${TRAVIS_TAG}" != "" ] || [[ "$TRAVIS_COMMIT_MESSAGE" =~ "[build wheel]" ]] || [[ "$TRAVIS_COMMIT_MESSAGE" =~ "[build wheel linux]" ]]); then
         mkdir wheelhouse;
-        wheel_date=$(python -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
+        wheel_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
         git_tag=$(git rev-parse --short HEAD);
-        tag_name=$(python -c "from __future__ import print_function; import kivy; _, tag, n = kivy.parse_kivy_version(kivy.__version__); print(tag + n) if n is not None else print(tag or 'something')"  --config "kivy:log_level:error");
+        tag_name=$(KIVY_NO_CONSOLELOG=1 python3 -c "import kivy; _, tag, n = kivy.parse_kivy_version(kivy.__version__); print(tag + n) if n is not None else print(tag or 'something')"  --config "kivy:log_level:error");
         wheel_name="$tag_name.$wheel_date.$git_tag-";
 
         chmod +x .ci/build-wheels-linux.sh;
@@ -182,7 +186,7 @@ script:
 
           git clone https://github.com/kivy/kivy-sdk-packager;
           pushd kivy-sdk-packager/osx;
-          app_date=$(python -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
+          app_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
           git_tag=$(git rev-parse --short HEAD);
 
           yes | ./create-osx-bundle.sh python3 master > output.txt;
@@ -209,7 +213,8 @@ script:
           python$pyver_short -m pip install git+http://github.com/tito/osxrelocator --user;
 
           python$pyver_short -m pip install --upgrade --user pip setuptools wheel;
-          python$pyver_short -m pip install --upgrade --user cython pytest wheel pillow mock docutils;
+          python$pyver_short -m pip install -I --user "$CYTHON_INSTALL";
+          python$pyver_short -m pip install --upgrade --user pytest wheel pillow mock docutils;
           python$pyver_short -m pip install --upgrade delocate;
 
           USE_SDL2=1 USE_GSTREAMER=1 python$pyver_short setup.py build_ext --inplace>output.txt;
@@ -246,9 +251,9 @@ script:
           cp dist/*.whl ../wheelhouse/;
         done;
 
-        wheel_date=$(python -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
+        wheel_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
         git_tag=$(git rev-parse --short HEAD);
-        tag_name=$(python -c "from __future__ import print_function; import kivy; _, tag, n = kivy.parse_kivy_version(kivy.__version__); print(tag + n) if n is not None else print(tag or 'something')"  --config "kivy:log_level:error");
+        tag_name=$(KIVY_NO_CONSOLELOG=1 python3 -c "import kivy; _, tag, n = kivy.parse_kivy_version(kivy.__version__); print(tag + n) if n is not None else print(tag or 'something')"  --config "kivy:log_level:error");
         wheel_name="$tag_name.$wheel_date.$git_tag-";
         ls ../wheelhouse/;
 

--- a/kivy/tools/packaging/cython_cfg.py
+++ b/kivy/tools/packaging/cython_cfg.py
@@ -1,0 +1,82 @@
+import configparser
+from os.path import join, dirname
+import textwrap
+
+__all__ = ('get_cython_versions', 'get_cython_msg')
+
+
+def get_cython_versions(setup_cfg=''):
+    _cython_config = configparser.ConfigParser()
+    if setup_cfg:
+        _cython_config.read(setup_cfg)
+    else:
+        _cython_config.read(
+            join(dirname(__file__), '..', '..', '..', 'setup.cfg'))
+
+    cython_min = _cython_config['kivy']['cython_min']
+    cython_max = _cython_config['kivy']['cython_max']
+    cython_unsupported = _cython_config['kivy']['cython_exclude'].split(',')
+    # ref https://github.com/cython/cython/issues/1968
+
+    cython_requires = (
+        'cython>={min_version},<={max_version},{exclusion}'.format(
+            min_version=cython_min,
+            max_version=cython_max,
+            exclusion=','.join('!=%s' % excl for excl in cython_unsupported),
+        )
+    )
+
+    return cython_requires, cython_min, cython_max, cython_unsupported
+
+
+def get_cython_msg():
+    cython_requires, cython_min, cython_max, cython_unsupported = \
+        get_cython_versions()
+    cython_unsupported_append = '''
+
+    Please note that the following versions of Cython are not supported
+    at all: {}'''.format(', '.join(map(str, cython_unsupported)))
+
+    cython_min_msg = textwrap.dedent('''
+    This version of Cython is not compatible with Kivy. Please upgrade to
+    at least version {0}, preferably the newest supported version {1}.
+
+    If your platform provides a Cython package, make sure you have upgraded
+    to the newest version. If the newest version available is still too low,
+    please remove it and install the newest supported Cython via pip:
+
+        pip install -I "{3}"{2}
+    '''.format(cython_min, cython_max,
+               cython_unsupported_append if cython_unsupported else '',
+               cython_requires))
+
+    cython_max_msg = textwrap.dedent('''
+    This version of Cython is untested with Kivy. While this version may
+    work perfectly fine, it is possible that you may experience issues.
+    Please downgrade to a supported version, or update cython_max in
+    setup.cfg to your version of Cython. It is best to use the newest
+    supported version, {1}, but the minimum supported version is {0}.
+
+    If your platform provides a Cython package, check if you can downgrade
+    to a supported version. Otherwise, uninstall the platform package and
+    install Cython via pip:
+
+        pip install -I "{3}"{2}
+    '''.format(cython_min, cython_max,
+               cython_unsupported_append if cython_unsupported else '',
+               cython_requires))
+
+    cython_unsupported_msg = textwrap.dedent('''
+    This version of Cython suffers from known bugs and is unsupported.
+    Please install the newest supported version, {1}, if possible, but
+    the minimum supported version is {0}.
+
+    If your platform provides a Cython package, check if you can install
+    a supported version. Otherwise, uninstall the platform package and
+    install Cython via pip:
+
+        pip install -I "{3}"{2}
+    '''.format(cython_min, cython_max, cython_unsupported_append,
+               cython_requires))
+
+    return cython_min_msg, cython_max_msg, cython_unsupported_msg

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ cover-package=kivy
 with-id=1
 verbosity=2
 logging-level=DEBUG
+[kivy]
+cython_min=0.24
+cython_max=0.29.10
+cython_exclude=0.27,0.27.2


### PR DESCRIPTION
This does multiple things:

*   It moves the cython min/max/unsupported info to `setup.cfg` so that there's a single point of updated and users can set the config if needed.
*   Add a new module under `kivy/tools/packaging/cython_cfg.py` that returns the info and warning messages about the cython versions. This is used from `setup.py` and reads `setup.cfg` and returns the supported cython versions etc.
*   It also adds back the old cython message that is printed when compiling kivy indicating the version of cython present and whether we support it. The reason is that since the last change all we get is the following error message when cython is too new:
    ```shell
    Download error on https://pypi.python.org/simple/cython/: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:645) -- Some packages may not be found!
    Download error on https://pypi.python.org/simple/: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:645) -- Some packages may not be found!
    No local packages or download links found for cython!=0.27,!=0.27.2,<=0.29.9,>=0.24
    Traceback (most recent call last):
    File "setup.py", line 1203, in <module>
     'tuio': ['oscpy']
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/distutils/core.py", line 108, in setup
     _setup_distribution = dist = klass(attrs)
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/setuptools/dist.py", line 269, in __init__
     self.fetch_build_eggs(attrs['setup_requires'])
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/setuptools/dist.py", line 313, in fetch_build_eggs
     replace_conflicting=True,
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 826, in resolve
     dist = best[req.key] = env.best_match(req, ws, installer)
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1092, in best_match
     return self.obtain(req, installer)
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1104, in obtain
     return installer(requirement)
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/setuptools/dist.py", line 380, in fetch_build_egg
     return cmd.easy_install(req)
    File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 634, in easy_install
     raise DistutilsError(msg)
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('cython!=0.27,!=0.27.2,<=0.29.9,>=0.24')
    ```
    But when getting this message it's not at all clear what the problem is. Here, the problem is that cython released a new version, 0.29.10, which is above the max version. This happened on the PPA and on the macOS travis image whenever cython released a new version.

    With the change it'll now print before the error:

    ```shell
    Found Cython at E:\Python\Python35-x64\lib\site-packages\Cython\__init__.py
    Detected supported Cython version 0.29.10

    This version of Cython is untested with Kivy. While this version may
    work perfectly fine, it is possible that you may experience issues.
    Please downgrade to a supported version, or update cython_max in
    setup.cfg to your version of Cython. It is best to use the newest
    supported version, 0.29.9, but the minimum supported version is 0.24.

    If your platform provides a Cython package, check if you can downgrade
    to a supported version. Otherwise, uninstall the platform package and
    install Cython via pip:

        pip install -I "cython>=0.24,<=0.29.9,!=0.27,!=0.27.2"

    Please note that the following versions of Cython are not supported
    at all: 0.27, 0.27.2
    ```