### PR TITLE
Fix #6358 by setting to bytes

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -339,7 +339,7 @@ def _find_gst_plugin_path():
         return []
     (stdoutdata, stderrdata) = p.communicate()
 
-    match = re.search(r'\s+(\S+libgstcoreelements\.\S+)', stdoutdata)
+    match = re.search(rb'\s+(\S+libgstcoreelements\.\S+)', stdoutdata)
 
     if not match:
         return []

--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -334,12 +334,12 @@ def _find_gst_plugin_path():
     try:
         p = subprocess.Popen(
             ['gst-inspect-1.0', 'coreelements'],
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE, universal_newlines=True)
     except:
         return []
     (stdoutdata, stderrdata) = p.communicate()
 
-    match = re.search(rb'\s+(\S+libgstcoreelements\.\S+)', stdoutdata)
+    match = re.search(r'\s+(\S+libgstcoreelements\.\S+)', stdoutdata)
 
     if not match:
         return []

--- a/kivy/tools/packaging/pyinstaller_hooks/pyi_rth_kivy.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/pyi_rth_kivy.py
@@ -5,7 +5,8 @@ root = os.path.join(sys._MEIPASS, 'kivy_install')
 
 os.environ['KIVY_DATA_DIR'] = os.path.join(root, 'data')
 os.environ['KIVY_MODULES_DIR'] = os.path.join(root, 'modules')
-os.environ['GST_PLUGIN_PATH'] = os.path.join(sys._MEIPASS, 'gst-plugins')
+os.environ['GST_PLUGIN_PATH'] = '{}{}{}'.format(
+    sys._MEIPASS, os.pathsep, os.path.join(sys._MEIPASS, 'gst-plugins'))
 os.environ['GST_REGISTRY'] = os.path.join(sys._MEIPASS, 'registry.bin')
 
 sys.path += [os.path.join(root, '_libs')]


### PR DESCRIPTION
On py3 stdout is bytes so patterns must be one too. Also revert partially #6165.

On windows the root is where all the plugins are saved so it must be on the path.

Fixes #6358