### PR TITLE
Set cython language_level to py3.

### DIFF
--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -171,8 +171,8 @@ class SoundSDL2(Sound):
             return 0
         if not Mix_QuerySpec(&freq, &fmt, &channels):
             return 0
-        points = cc.chunk.alen / ((fmt & 0xFF) / 8)
-        frames = points / channels
+        points = <unsigned int>int(cc.chunk.alen / ((fmt & 0xFF) / 8))
+        frames = <unsigned int>int(points / channels)
         return <double>frames / <double>freq
 
     def on_pitch(self, instance, value):

--- a/kivy/core/image/_img_sdl2.pyx
+++ b/kivy/core/image/_img_sdl2.pyx
@@ -73,7 +73,7 @@ def save(filename, w, h, pixelfmt, pixels, flipped, imagefmt, quality=90):
         # if flipped upside down
         # switch bytes(array) to list
         pixels = list(pixels)
-        lng = len(pixels)
+        lng = <int>len(pixels)
         rng = list(range(0, lng, pitch))
 
         while len(rng):
@@ -217,7 +217,7 @@ def load_from_memory(bytes data):
     cdef SDL_Surface *image = NULL
     cdef char *c_data = data
 
-    rw = SDL_RWFromMem(c_data, len(data))
+    rw = SDL_RWFromMem(c_data, <int>len(data))
     if rw == NULL:
         return
 

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -106,7 +106,7 @@ cdef inline LayoutLine add_line(object text, int lw, int lh, LayoutLine line,
         This assumes that global h is accurate and includes the text previously
         added to the line.
         '''
-        cdef int old_lh = line.h, count = len(lines), add_h
+        cdef int old_lh = line.h, count = <int>len(lines), add_h
         if lw:
             line.words.append(LayoutWord(options, lw, lh, text))
             line.w += lw
@@ -154,7 +154,7 @@ cdef inline void final_strip(LayoutLine line):
 
         stripped = last_word.text.rstrip()  # ends with space
         # subtract ending space length
-        diff = ((len(last_word.text) - len(stripped)) *
+        diff = ((<int>len(last_word.text) - <int>len(stripped)) *
                 last_word.options['space_width'])
         line.w = max(0, line.w - diff)  # line w
         line.words.append(LayoutWord(   # re-add last word
@@ -176,10 +176,10 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
     cdef LayoutLine _line
 
     new_lines = text.split('\n')
-    n = len(new_lines)
+    n = <int>len(new_lines)
     s = 0
     k = n
-    pos = len(lines)  # always include first line, start w/ no lines added
+    pos = <int>len(lines)  # always include first line, start w/ no lines added
     # there's a last line to which first (last) new line must be appended
     if pos:
         if dwn:  # append to last line
@@ -410,7 +410,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
 
 
     new_lines = text.split('\n')
-    n = len(new_lines)
+    n = <int>len(new_lines)
     uw = max(0, uw - xpad * 2)  # actual w, h allowed for rendering
     _, bare_h = get_extents('')
     if dwn:
@@ -419,7 +419,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     # split into lines and find how many line wraps each line requires
     indices = range(n) if dwn else reversed(range(n))
     for i in indices:
-        k = len(lines)
+        k = <int>len(lines)
         if (max_lines > 0 and k > max_lines or uh != -1 and
             h > uh and k > 1):
             break
@@ -447,7 +447,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
         if strip and ends_line:
             line = line.rstrip()
 
-        k = len(line)
+        k = <int>len(line)
         if not k:  # just add empty line if empty
             _line.is_last_line = ends_line  # nothing will be appended
             # ensure we don't leave trailing from before
@@ -514,7 +514,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
                 # try to fit word on new line, if it doesn't fit we'll
                 # have to break the word into as many lines needed
                 if strip or ref_strip and _line.line_wrap:
-                    s = e - len(line[s:e].lstrip())
+                    s = e - <int>len(line[s:e].lstrip())
                 if s == e:  # if it was only a stripped space, move on
                     m = s
                     continue
@@ -568,10 +568,10 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
         if dwn:
             del lines[max_lines:]
         else:
-            del lines[:max(0, len(lines) - max_lines)]
+            del lines[:max(0, <int>len(lines) - max_lines)]
 
     # now make sure we don't have lines outside specified height
-    k = len(lines)
+    k = <int>len(lines)
     if k > 1 and uh != -1 and h > uh:
         val = True
         if dwn:  # remove from last line going up

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -15,13 +15,13 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     is_desktop = Config.get('kivy', 'desktop') == '1'
 
 IF USE_WAYLAND:
-    from window_info cimport WindowInfoWayland
+    from .window_info cimport WindowInfoWayland
 
 IF USE_X11:
-    from window_info cimport WindowInfoX11
+    from .window_info cimport WindowInfoX11
 
 IF UNAME_SYSNAME == 'Windows':
-    from window_info cimport WindowInfoWindows
+    from .window_info cimport WindowInfoWindows
 
 cdef int _event_filter(void *userdata, SDL_Event *event) with gil:
     return (<_WindowSDL2Storage>userdata).cb_event_filter(event)

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -15,7 +15,7 @@ from kivy.base import stopTouchApp, EventLoop, ExceptionManager
 from kivy.utils import platform
 from os import environ
 
-from window_info cimport WindowInfoX11
+from .window_info cimport WindowInfoX11
 
 include "window_attrs.pxi"
 
@@ -48,7 +48,7 @@ cdef extern from "X11/Xutil.h":
         int x, y
         unsigned int state
         unsigned int button
-        
+
     ctypedef struct XConfigureEvent:
         int type
         int x, y
@@ -111,7 +111,7 @@ cdef int event_callback(XEvent *event):
         modifiers = get_modifiers_from_state(event.xmotion.state)
         _window_object.dispatch('on_mouse_move',
                 event.xmotion.x, event.xmotion.y, modifiers)
-                
+
     elif event.type == ConfigureNotify:
         if (event.xconfigure.width != _window_object.system_size[0]) or (event.xconfigure.height != _window_object.system_size[1]):
             _window_object._size = event.xconfigure.width, event.xconfigure.height

--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -39,7 +39,7 @@ include "../include/config.pxi"
 
 from sys import platform
 from os import environ
-from cgl cimport GLES2_Context
+from .cgl cimport GLES2_Context
 import importlib
 from kivy.logger import Logger
 

--- a/kivy/graphics/cgl_backend/cgl_debug.pyx
+++ b/kivy/graphics/cgl_backend/cgl_debug.pyx
@@ -132,7 +132,7 @@ cdef void __stdcall dbgBufferData (GLenum target, GLsizeiptr size, const GLvoid*
         gil_dbgBufferData(target, size, data, usage)
 
 cdef void __stdcall gil_dbgBufferData (GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage) with gil:
-    gl_debug_print("GL glBufferData( target = ", target, ", size = ", size, ", data*=", repr(hex(<long> data)), ", usage = ", usage, ", )")
+    gl_debug_print("GL glBufferData( target = ", target, ", size = ", size, ", data*=", repr(hex(<long long> data)), ", usage = ", usage, ", )")
     cgl_native.glBufferData ( target, size, data, usage)
     gl_check_error()
 
@@ -141,7 +141,7 @@ cdef void __stdcall dbgBufferSubData (GLenum target, GLintptr offset, GLsizeiptr
         gil_dbgBufferSubData(target, offset, size, <GLvoid *>data)
 
 cdef void __stdcall gil_dbgBufferSubData (GLenum target, GLintptr offset, GLsizeiptr size,  GLvoid* data) with gil:
-    gl_debug_print("GL glBufferSubData( target = ", target, ", offset = ", offset, ", size = ", size, ", data*=", repr(hex(<long> data)), ", )")
+    gl_debug_print("GL glBufferSubData( target = ", target, ", offset = ", offset, ", size = ", size, ", data*=", repr(hex(<long long> data)), ", )")
     cgl_native.glBufferSubData ( target, offset, size, data)
     gl_check_error()
 
@@ -216,7 +216,7 @@ cdef void __stdcall dbgCompressedTexImage2D (GLenum target, GLint level, GLenum 
         gil_dbgCompressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data)
 
 cdef void __stdcall gil_dbgCompressedTexImage2D (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const GLvoid* data) with gil:
-    gl_debug_print("GL glCompressedTexImage2D( target = ", target, ", level = ", level, ", internalformat = ", internalformat, ", width = ", width, ", height = ", height, ", border = ", border, ", imageSize = ", imageSize, ", data*=", repr(hex(<long> data)), ", )")
+    gl_debug_print("GL glCompressedTexImage2D( target = ", target, ", level = ", level, ", internalformat = ", internalformat, ", width = ", width, ", height = ", height, ", border = ", border, ", imageSize = ", imageSize, ", data*=", repr(hex(<long long> data)), ", )")
     cgl_native.glCompressedTexImage2D ( target, level, internalformat, width, height, border, imageSize, data)
     gl_check_error()
 
@@ -225,7 +225,7 @@ cdef void __stdcall dbgCompressedTexSubImage2D (GLenum target, GLint level, GLin
         gil_dbgCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, <GLvoid*>data)
 
 cdef void __stdcall gil_dbgCompressedTexSubImage2D (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize,  GLvoid* data) with gil:
-    gl_debug_print("GL glCompressedTexSubImage2D( target = ", target, ", level = ", level, ", xoffset = ", xoffset, ", yoffset = ", yoffset, ", width = ", width, ", height = ", height, ", format = ", format, ", imageSize = ", imageSize, ", data*=", repr(hex(<long> data)), ", )")
+    gl_debug_print("GL glCompressedTexSubImage2D( target = ", target, ", level = ", level, ", xoffset = ", xoffset, ", yoffset = ", yoffset, ", width = ", width, ", height = ", height, ", format = ", format, ", imageSize = ", imageSize, ", data*=", repr(hex(<long long> data)), ", )")
     cgl_native.glCompressedTexSubImage2D ( target, level, xoffset, yoffset, width, height, format, imageSize, data)
     gl_check_error()
 
@@ -281,7 +281,7 @@ cdef void __stdcall dbgDeleteBuffers (GLsizei n, const GLuint* buffers) nogil:
         gil_dbgDeleteBuffers(n, buffers)
 
 cdef void __stdcall gil_dbgDeleteBuffers (GLsizei n, const GLuint* buffers) with gil:
-    gl_debug_print("GL glDeleteBuffers( n = ", n, ", buffers*=", repr(hex(<long> buffers)), ", )")
+    gl_debug_print("GL glDeleteBuffers( n = ", n, ", buffers*=", repr(hex(<long long> buffers)), ", )")
     cgl_native.glDeleteBuffers ( n, buffers)
     gl_check_error()
 
@@ -290,7 +290,7 @@ cdef void __stdcall dbgDeleteFramebuffers (GLsizei n, const GLuint* framebuffers
         gil_dbgDeleteFramebuffers(n, framebuffers)
 
 cdef void __stdcall gil_dbgDeleteFramebuffers (GLsizei n, const GLuint* framebuffers) with gil:
-    gl_debug_print("GL glDeleteFramebuffers( n = ", n, ", framebuffers*=", repr(hex(<long> framebuffers)), ", )")
+    gl_debug_print("GL glDeleteFramebuffers( n = ", n, ", framebuffers*=", repr(hex(<long long> framebuffers)), ", )")
     cgl_native.glDeleteFramebuffers ( n, framebuffers)
     gl_check_error()
 
@@ -308,7 +308,7 @@ cdef void __stdcall dbgDeleteRenderbuffers (GLsizei n, const GLuint* renderbuffe
         gil_dbgDeleteRenderbuffers(n, renderbuffers)
 
 cdef void __stdcall gil_dbgDeleteRenderbuffers (GLsizei n, const GLuint* renderbuffers) with gil:
-    gl_debug_print("GL glDeleteRenderbuffers( n = ", n, ", renderbuffers*=", repr(hex(<long> renderbuffers)), ", )")
+    gl_debug_print("GL glDeleteRenderbuffers( n = ", n, ", renderbuffers*=", repr(hex(<long long> renderbuffers)), ", )")
     cgl_native.glDeleteRenderbuffers ( n, renderbuffers)
     gl_check_error()
 
@@ -326,7 +326,7 @@ cdef void __stdcall dbgDeleteTextures (GLsizei n, const GLuint* textures) nogil:
         gil_dbgDeleteTextures(n, textures)
 
 cdef void __stdcall gil_dbgDeleteTextures (GLsizei n, const GLuint* textures) with gil:
-    gl_debug_print("GL glDeleteTextures( n = ", n, ", textures*=", repr(hex(<long> textures)), ", )")
+    gl_debug_print("GL glDeleteTextures( n = ", n, ", textures*=", repr(hex(<long long> textures)), ", )")
     cgl_native.glDeleteTextures ( n, textures)
     gl_check_error()
 
@@ -399,7 +399,7 @@ cdef void __stdcall dbgDrawElements (GLenum mode, GLsizei count, GLenum type, co
         gil_dbgDrawElements(mode, count, type, <GLvoid*>indices)
 
 cdef void __stdcall gil_dbgDrawElements (GLenum mode, GLsizei count, GLenum type,  GLvoid* indices) with gil:
-    gl_debug_print("GL glDrawElements( mode = ", mode, ", count = ", count, ", type = ", type, ", indices*=", repr(hex(<long> indices)), ", )")
+    gl_debug_print("GL glDrawElements( mode = ", mode, ", count = ", count, ", type = ", type, ", indices*=", repr(hex(<long long> indices)), ", )")
     cgl_native.glDrawElements ( mode, count, type, indices)
     gl_check_error()
 
@@ -471,7 +471,7 @@ cdef void __stdcall dbgGenBuffers (GLsizei n, GLuint* buffers) nogil:
         gil_dbgGenBuffers(n, buffers)
 
 cdef void __stdcall gil_dbgGenBuffers (GLsizei n, GLuint* buffers) with gil:
-    gl_debug_print("GL glGenBuffers( n = ", n, ", buffers*=", repr(hex(<long> buffers)), ", )")
+    gl_debug_print("GL glGenBuffers( n = ", n, ", buffers*=", repr(hex(<long long> buffers)), ", )")
     cgl_native.glGenBuffers ( n, buffers)
     gl_check_error()
 
@@ -489,7 +489,7 @@ cdef void __stdcall dbgGenFramebuffers (GLsizei n, GLuint* framebuffers) nogil:
         gil_dbgGenFramebuffers(n,  framebuffers)
 
 cdef void __stdcall gil_dbgGenFramebuffers (GLsizei n, GLuint* framebuffers) with gil:
-    gl_debug_print("GL glGenFramebuffers( n = ", n, ", framebuffers*=", repr(hex(<long> framebuffers)), ", )")
+    gl_debug_print("GL glGenFramebuffers( n = ", n, ", framebuffers*=", repr(hex(<long long> framebuffers)), ", )")
     cgl_native.glGenFramebuffers ( n, framebuffers)
     gl_check_error()
 
@@ -498,7 +498,7 @@ cdef void __stdcall dbgGenRenderbuffers (GLsizei n, GLuint* renderbuffers) nogil
         gil_dbgGenRenderbuffers(n, renderbuffers)
 
 cdef void __stdcall gil_dbgGenRenderbuffers (GLsizei n, GLuint* renderbuffers) with gil:
-    gl_debug_print("GL glGenRenderbuffers( n = ", n, ", renderbuffers*=", repr(hex(<long> renderbuffers)), ", )")
+    gl_debug_print("GL glGenRenderbuffers( n = ", n, ", renderbuffers*=", repr(hex(<long long> renderbuffers)), ", )")
     cgl_native.glGenRenderbuffers ( n, renderbuffers)
     gl_check_error()
 
@@ -507,7 +507,7 @@ cdef void __stdcall dbgGenTextures (GLsizei n, GLuint* textures) nogil:
         gil_dbgGenTextures(n, textures)
 
 cdef void __stdcall gil_dbgGenTextures (GLsizei n, GLuint* textures) with gil:
-    gl_debug_print("GL glGenTextures( n = ", n, ", textures*=", repr(hex(<long> textures)), ", )")
+    gl_debug_print("GL glGenTextures( n = ", n, ", textures*=", repr(hex(<long long> textures)), ", )")
     cgl_native.glGenTextures ( n, textures)
     gl_check_error()
 
@@ -516,7 +516,7 @@ cdef void __stdcall dbgGetActiveAttrib (GLuint program, GLuint index, GLsizei bu
         gil_dbgGetActiveAttrib(program, index, bufsize,  length,  size,  type,  name)
 
 cdef void __stdcall gil_dbgGetActiveAttrib (GLuint program, GLuint index, GLsizei bufsize, GLsizei* length, GLint* size, GLenum* type, GLchar* name) with gil:
-    gl_debug_print("GL glGetActiveAttrib( program = ", program, ", index = ", index, ", bufsize = ", bufsize, ", length*=", repr(hex(<long> length)), ", size*=", repr(hex(<long> size)), ", type*=", repr(hex(<long> type)), ", name*=", repr(hex(<long> name)), ", )")
+    gl_debug_print("GL glGetActiveAttrib( program = ", program, ", index = ", index, ", bufsize = ", bufsize, ", length*=", repr(hex(<long long> length)), ", size*=", repr(hex(<long long> size)), ", type*=", repr(hex(<long long> type)), ", name*=", repr(hex(<long long> name)), ", )")
     cgl_native.glGetActiveAttrib ( program, index, bufsize, length, size, type, name)
     gl_check_error()
 
@@ -525,7 +525,7 @@ cdef void __stdcall dbgGetActiveUniform (GLuint program, GLuint index, GLsizei b
         gil_dbgGetActiveUniform(program, index, bufsize,  length,  size,  type,  name)
 
 cdef void __stdcall gil_dbgGetActiveUniform (GLuint program, GLuint index, GLsizei bufsize, GLsizei* length, GLint* size, GLenum* type, GLchar* name) with gil:
-    gl_debug_print("GL glGetActiveUniform( program = ", program, ", index = ", index, ", bufsize = ", bufsize, ", length*=", repr(hex(<long> length)), ", size*=", repr(hex(<long> size)), ", type*=", repr(hex(<long> type)), ", name*=", repr(hex(<long> name)), ", )")
+    gl_debug_print("GL glGetActiveUniform( program = ", program, ", index = ", index, ", bufsize = ", bufsize, ", length*=", repr(hex(<long long> length)), ", size*=", repr(hex(<long long> size)), ", type*=", repr(hex(<long long> type)), ", name*=", repr(hex(<long long> name)), ", )")
     cgl_native.glGetActiveUniform ( program, index, bufsize, length, size, type, name)
     gl_check_error()
 
@@ -534,7 +534,7 @@ cdef void __stdcall dbgGetAttachedShaders (GLuint program, GLsizei maxcount, GLs
         gil_dbgGetAttachedShaders(program, maxcount,  count,  shaders)
 
 cdef void __stdcall gil_dbgGetAttachedShaders (GLuint program, GLsizei maxcount, GLsizei* count, GLuint* shaders) with gil:
-    gl_debug_print("GL glGetAttachedShaders( program = ", program, ", maxcount = ", maxcount, ", count*=", repr(hex(<long> count)), ", shaders*=", repr(hex(<long> shaders)), ", )")
+    gl_debug_print("GL glGetAttachedShaders( program = ", program, ", maxcount = ", maxcount, ", count*=", repr(hex(<long long> count)), ", shaders*=", repr(hex(<long long> shaders)), ", )")
     cgl_native.glGetAttachedShaders ( program, maxcount, count, shaders)
     gl_check_error()
 
@@ -543,7 +543,7 @@ cdef int  __stdcall dbgGetAttribLocation (GLuint program, const GLchar* name) no
         return gil_dbgGetAttribLocation(program,  <GLchar*>name)
 
 cdef int  __stdcall gil_dbgGetAttribLocation (GLuint program,  GLchar* name) with gil:
-    gl_debug_print("GL glGetAttribLocation( program = ", program, ", name*=", repr(hex(<long> name)), ", )")
+    gl_debug_print("GL glGetAttribLocation( program = ", program, ", name*=", repr(hex(<long long> name)), ", )")
     ret = cgl_native.glGetAttribLocation ( program, name)
     gl_check_error()
     return ret
@@ -553,7 +553,7 @@ cdef void __stdcall dbgGetBooleanv (GLenum pname, GLboolean* params) nogil:
         gil_dbgGetBooleanv(pname,  params)
 
 cdef void __stdcall gil_dbgGetBooleanv (GLenum pname, GLboolean* params) with gil:
-    gl_debug_print("GL glGetBooleanv( pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetBooleanv( pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetBooleanv ( pname, params)
     gl_check_error()
 
@@ -562,7 +562,7 @@ cdef void __stdcall dbgGetBufferParameteriv (GLenum target, GLenum pname, GLint*
         gil_dbgGetBufferParameteriv(target, pname,  params)
 
 cdef void __stdcall gil_dbgGetBufferParameteriv (GLenum target, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetBufferParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetBufferParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetBufferParameteriv ( target, pname, params)
     gl_check_error()
 
@@ -579,7 +579,7 @@ cdef void __stdcall dbgGetFloatv (GLenum pname, GLfloat* params) nogil:
         gil_dbgGetFloatv(pname,  params)
 
 cdef void __stdcall gil_dbgGetFloatv (GLenum pname, GLfloat* params) with gil:
-    gl_debug_print("GL glGetFloatv( pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetFloatv( pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetFloatv ( pname, params)
     gl_check_error()
 
@@ -588,7 +588,7 @@ cdef void __stdcall dbgGetFramebufferAttachmentParameteriv (GLenum target, GLenu
         gil_dbgGetFramebufferAttachmentParameteriv(target, attachment, pname,  params)
 
 cdef void __stdcall gil_dbgGetFramebufferAttachmentParameteriv (GLenum target, GLenum attachment, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetFramebufferAttachmentParameteriv( target = ", target, ", attachment = ", attachment, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetFramebufferAttachmentParameteriv( target = ", target, ", attachment = ", attachment, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetFramebufferAttachmentParameteriv ( target, attachment, pname, params)
     gl_check_error()
 
@@ -597,7 +597,7 @@ cdef void __stdcall dbgGetIntegerv (GLenum pname, GLint* params) nogil:
         gil_dbgGetIntegerv(pname,  params)
 
 cdef void __stdcall gil_dbgGetIntegerv (GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetIntegerv( pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetIntegerv( pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetIntegerv ( pname, params)
     gl_check_error()
 
@@ -606,7 +606,7 @@ cdef void __stdcall dbgGetProgramiv (GLuint program, GLenum pname, GLint* params
         gil_dbgGetProgramiv(program, pname,  params)
 
 cdef void __stdcall gil_dbgGetProgramiv (GLuint program, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetProgramiv( program = ", program, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetProgramiv( program = ", program, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetProgramiv ( program, pname, params)
     gl_check_error()
 
@@ -615,7 +615,7 @@ cdef void __stdcall dbgGetProgramInfoLog (GLuint program, GLsizei bufsize, GLsiz
         gil_dbgGetProgramInfoLog(program, bufsize,  length,  infolog)
 
 cdef void __stdcall gil_dbgGetProgramInfoLog (GLuint program, GLsizei bufsize, GLsizei* length, GLchar* infolog) with gil:
-    gl_debug_print("GL glGetProgramInfoLog( program = ", program, ", bufsize = ", bufsize, ", length*=", repr(hex(<long> length)), ", infolog*=", repr(hex(<long> infolog)), ", )")
+    gl_debug_print("GL glGetProgramInfoLog( program = ", program, ", bufsize = ", bufsize, ", length*=", repr(hex(<long long> length)), ", infolog*=", repr(hex(<long long> infolog)), ", )")
     cgl_native.glGetProgramInfoLog ( program, bufsize, length, infolog)
     gl_check_error()
 
@@ -624,7 +624,7 @@ cdef void __stdcall dbgGetRenderbufferParameteriv (GLenum target, GLenum pname, 
         gil_dbgGetRenderbufferParameteriv(target, pname,  params)
 
 cdef void __stdcall gil_dbgGetRenderbufferParameteriv (GLenum target, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetRenderbufferParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetRenderbufferParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetRenderbufferParameteriv ( target, pname, params)
     gl_check_error()
 
@@ -633,7 +633,7 @@ cdef void __stdcall dbgGetShaderiv (GLuint shader, GLenum pname, GLint* params) 
         gil_dbgGetShaderiv(shader, pname,  params)
 
 cdef void __stdcall gil_dbgGetShaderiv (GLuint shader, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetShaderiv( shader = ", shader, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetShaderiv( shader = ", shader, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetShaderiv ( shader, pname, params)
     gl_check_error()
 
@@ -642,7 +642,7 @@ cdef void __stdcall dbgGetShaderInfoLog (GLuint shader, GLsizei bufsize, GLsizei
         gil_dbgGetShaderInfoLog(shader, bufsize,  length,  infolog)
 
 cdef void __stdcall gil_dbgGetShaderInfoLog (GLuint shader, GLsizei bufsize, GLsizei* length, GLchar* infolog) with gil:
-    gl_debug_print("GL glGetShaderInfoLog( shader = ", shader, ", bufsize = ", bufsize, ", length*=", repr(hex(<long> length)), ", infolog*=", repr(hex(<long> infolog)), ", )")
+    gl_debug_print("GL glGetShaderInfoLog( shader = ", shader, ", bufsize = ", bufsize, ", length*=", repr(hex(<long long> length)), ", infolog*=", repr(hex(<long long> infolog)), ", )")
     cgl_native.glGetShaderInfoLog ( shader, bufsize, length, infolog)
     gl_check_error()
 # Skipping generation of: "#cdef void __stdcall dbgGetShaderPrecisionFormat (cgl_native.GLenum shadertype, cgl_native.GLenum precisiontype, cgl_native.GLint* range, cgl_native.GLint* precision)"
@@ -652,7 +652,7 @@ cdef void __stdcall dbgGetShaderSource (GLuint shader, GLsizei bufsize, GLsizei*
         gil_dbgGetShaderSource(shader, bufsize,  length,  source)
 
 cdef void __stdcall gil_dbgGetShaderSource (GLuint shader, GLsizei bufsize, GLsizei* length, GLchar* source) with gil:
-    gl_debug_print("GL glGetShaderSource( shader = ", shader, ", bufsize = ", bufsize, ", length*=", repr(hex(<long> length)), ", source*=", repr(hex(<long> source)), ", )")
+    gl_debug_print("GL glGetShaderSource( shader = ", shader, ", bufsize = ", bufsize, ", length*=", repr(hex(<long long> length)), ", source*=", repr(hex(<long long> source)), ", )")
     cgl_native.glGetShaderSource ( shader, bufsize, length, source)
     gl_check_error()
 
@@ -669,7 +669,7 @@ cdef void __stdcall dbgGetTexParameterfv (GLenum target, GLenum pname, GLfloat* 
         gil_dbgGetTexParameterfv(target, pname,  params)
 
 cdef void __stdcall gil_dbgGetTexParameterfv (GLenum target, GLenum pname, GLfloat* params) with gil:
-    gl_debug_print("GL glGetTexParameterfv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetTexParameterfv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetTexParameterfv ( target, pname, params)
     gl_check_error()
 
@@ -678,7 +678,7 @@ cdef void __stdcall dbgGetTexParameteriv (GLenum target, GLenum pname, GLint* pa
         gil_dbgGetTexParameteriv(target, pname,  params)
 
 cdef void __stdcall gil_dbgGetTexParameteriv (GLenum target, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetTexParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetTexParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetTexParameteriv ( target, pname, params)
     gl_check_error()
 
@@ -687,7 +687,7 @@ cdef void __stdcall dbgGetUniformfv (GLuint program, GLint location, GLfloat* pa
         gil_dbgGetUniformfv(program, location,  params)
 
 cdef void __stdcall gil_dbgGetUniformfv (GLuint program, GLint location, GLfloat* params) with gil:
-    gl_debug_print("GL glGetUniformfv( program = ", program, ", location = ", location, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetUniformfv( program = ", program, ", location = ", location, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetUniformfv ( program, location, params)
     gl_check_error()
 
@@ -696,7 +696,7 @@ cdef void __stdcall dbgGetUniformiv (GLuint program, GLint location, GLint* para
         gil_dbgGetUniformiv(program, location,  params)
 
 cdef void __stdcall gil_dbgGetUniformiv (GLuint program, GLint location, GLint* params) with gil:
-    gl_debug_print("GL glGetUniformiv( program = ", program, ", location = ", location, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetUniformiv( program = ", program, ", location = ", location, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetUniformiv ( program, location, params)
     gl_check_error()
 
@@ -714,7 +714,7 @@ cdef void __stdcall dbgGetVertexAttribfv (GLuint index, GLenum pname, GLfloat* p
         gil_dbgGetVertexAttribfv(index, pname, params)
 
 cdef void __stdcall gil_dbgGetVertexAttribfv (GLuint index, GLenum pname, GLfloat* params) with gil:
-    gl_debug_print("GL glGetVertexAttribfv( index = ", index, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetVertexAttribfv( index = ", index, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetVertexAttribfv ( index, pname, params)
     gl_check_error()
 
@@ -723,7 +723,7 @@ cdef void __stdcall dbgGetVertexAttribiv (GLuint index, GLenum pname, GLint* par
         gil_dbgGetVertexAttribiv(index, pname,  params)
 
 cdef void __stdcall gil_dbgGetVertexAttribiv (GLuint index, GLenum pname, GLint* params) with gil:
-    gl_debug_print("GL glGetVertexAttribiv( index = ", index, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+    gl_debug_print("GL glGetVertexAttribiv( index = ", index, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
     cgl_native.glGetVertexAttribiv ( index, pname, params)
     gl_check_error()
 
@@ -732,7 +732,7 @@ cdef void __stdcall gil_dbgGetVertexAttribiv (GLuint index, GLenum pname, GLint*
 #         gil_dbgGetVertexAttribPointerv(index, pname, pointer)
 #
 # cdef void __stdcall gil_dbgGetVertexAttribPointerv (GLuint index, GLenum pname, GLvoid** pointer) with gil:
-#     gl_debug_print("GL glGetVertexAttribPointerv( index = ", index, ", pname = ", pname, ", pointer**=", repr(hex(<long> pointer)), ", )")
+#     gl_debug_print("GL glGetVertexAttribPointerv( index = ", index, ", pname = ", pname, ", pointer**=", repr(hex(<long long> pointer)), ", )")
 #     cgl_native.glGetVertexAttribPointerv ( index, pname, pointer)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -850,7 +850,7 @@ cdef void __stdcall dbgReadPixels (GLint x, GLint y, GLsizei width, GLsizei heig
         gil_dbgReadPixels(x, y, width, height, format, type,  pixels)
 
 cdef void __stdcall gil_dbgReadPixels (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels) with gil:
-    gl_debug_print("GL glReadPixels( x = ", x, ", y = ", y, ", width = ", width, ", height = ", height, ", format = ", format, ", type = ", type, ", pixels*=", repr(hex(<long> pixels)), ", )")
+    gl_debug_print("GL glReadPixels( x = ", x, ", y = ", y, ", width = ", width, ", height = ", height, ", format = ", format, ", type = ", type, ", pixels*=", repr(hex(<long long> pixels)), ", )")
     cgl_native.glReadPixels ( x, y, width, height, format, type, pixels)
     gl_check_error()
 # Skipping generation of: "#cdef void __stdcall dbgReleaseShaderCompiler ()"
@@ -888,7 +888,7 @@ cdef void __stdcall dbgShaderSource (GLuint shader, GLsizei count, const GLchar*
         gil_dbgShaderSource(shader, count, string, length)
 
 cdef void __stdcall gil_dbgShaderSource (GLuint shader, GLsizei count,  const GLchar* const* string, const GLint* length) with gil:
-    gl_debug_print("GL glShaderSource( shader = ", shader, ", count = ", count, ", string**=", repr(hex(<long> string)), ", length*=", repr(hex(<long> length)), ", )")
+    gl_debug_print("GL glShaderSource( shader = ", shader, ", count = ", count, ", string**=", repr(hex(<long long> string)), ", length*=", repr(hex(<long long> length)), ", )")
     cgl_native.glShaderSource ( shader, count, <const_char_ptr*>string, length)
     gl_check_error()
 
@@ -951,7 +951,7 @@ cdef void __stdcall dbgTexImage2D (GLenum target, GLint level, GLint internalfor
         gil_dbgTexImage2D(target, level, internalformat, width, height, border, format, type,   pixels)
 
 cdef void __stdcall gil_dbgTexImage2D (GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid* pixels) with gil:
-    gl_debug_print("GL glTexImage2D( target = ", target, ", level = ", level, ", internalformat = ", internalformat, ", width = ", width, ", height = ", height, ", border = ", border, ", format = ", format, ", type = ", type, ", pixels*=", repr(hex(<long> pixels)), ", )")
+    gl_debug_print("GL glTexImage2D( target = ", target, ", level = ", level, ", internalformat = ", internalformat, ", width = ", width, ", height = ", height, ", border = ", border, ", format = ", format, ", type = ", type, ", pixels*=", repr(hex(<long long> pixels)), ", )")
     cgl_native.glTexImage2D ( target, level, internalformat, width, height, border, format, type, pixels)
     gl_check_error()
 
@@ -969,7 +969,7 @@ cdef void __stdcall gil_dbgTexParameterf (GLenum target, GLenum pname, GLfloat p
 #         gil_dbgTexParameterfv(target, pname,   params)
 #
 # cdef void __stdcall gil_dbgTexParameterfv (GLenum target, GLenum pname,  GLfloat* params) with gil:
-#     gl_debug_print("GL glTexParameterfv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+#     gl_debug_print("GL glTexParameterfv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
 #     cgl_native.glTexParameterfv ( target, pname, params)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -988,7 +988,7 @@ cdef void __stdcall gil_dbgTexParameteri (GLenum target, GLenum pname, GLint par
 #         gil_dbgTexParameteriv(target, pname,   params)
 #
 # cdef void __stdcall gil_dbgTexParameteriv (GLenum target, GLenum pname,  GLint* params) with gil:
-#     gl_debug_print("GL glTexParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long> params)), ", )")
+#     gl_debug_print("GL glTexParameteriv( target = ", target, ", pname = ", pname, ", params*=", repr(hex(<long long> params)), ", )")
 #     cgl_native.glTexParameteriv ( target, pname, params)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -998,7 +998,7 @@ cdef void __stdcall dbgTexSubImage2D (GLenum target, GLint level, GLint xoffset,
         gil_dbgTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type,   pixels)
 
 cdef void __stdcall gil_dbgTexSubImage2D (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* pixels) with gil:
-    gl_debug_print("GL glTexSubImage2D( target = ", target, ", level = ", level, ", xoffset = ", xoffset, ", yoffset = ", yoffset, ", width = ", width, ", height = ", height, ", format = ", format, ", type = ", type, ", pixels*=", repr(hex(<long> pixels)), ", )")
+    gl_debug_print("GL glTexSubImage2D( target = ", target, ", level = ", level, ", xoffset = ", xoffset, ", yoffset = ", yoffset, ", width = ", width, ", height = ", height, ", format = ", format, ", type = ", type, ", pixels*=", repr(hex(<long long> pixels)), ", )")
     cgl_native.glTexSubImage2D ( target, level, xoffset, yoffset, width, height, format, type, pixels)
     gl_check_error()
 
@@ -1016,7 +1016,7 @@ cdef void __stdcall dbgUniform1fv (GLint location, GLsizei count, const GLfloat*
         gil_dbgUniform1fv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform1fv (GLint location, GLsizei count, const GLfloat* v) with gil:
-    gl_debug_print("GL glUniform1fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform1fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform1fv ( location, count, v)
     gl_check_error()
 
@@ -1034,7 +1034,7 @@ cdef void __stdcall dbgUniform1iv (GLint location, GLsizei count, const GLint* v
         gil_dbgUniform1iv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform1iv (GLint location, GLsizei count, const GLint* v) with gil:
-    gl_debug_print("GL glUniform1iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform1iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform1iv ( location, count, v)
     gl_check_error()
 
@@ -1052,7 +1052,7 @@ cdef void __stdcall dbgUniform2fv (GLint location, GLsizei count, const GLfloat*
         gil_dbgUniform2fv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform2fv (GLint location, GLsizei count, const GLfloat* v) with gil:
-    gl_debug_print("GL glUniform2fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform2fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform2fv ( location, count, v)
     gl_check_error()
 
@@ -1070,7 +1070,7 @@ cdef void __stdcall dbgUniform2iv (GLint location, GLsizei count, const GLint* v
         gil_dbgUniform2iv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform2iv (GLint location, GLsizei count, const GLint* v) with gil:
-    gl_debug_print("GL glUniform2iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform2iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform2iv ( location, count, v)
     gl_check_error()
 
@@ -1088,7 +1088,7 @@ cdef void __stdcall dbgUniform3fv (GLint location, GLsizei count, const GLfloat*
         gil_dbgUniform3fv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform3fv (GLint location, GLsizei count, const GLfloat* v) with gil:
-    gl_debug_print("GL glUniform3fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform3fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform3fv ( location, count, v)
     gl_check_error()
 
@@ -1106,7 +1106,7 @@ cdef void __stdcall dbgUniform3iv (GLint location, GLsizei count, const GLint* v
         gil_dbgUniform3iv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform3iv (GLint location, GLsizei count, const GLint* v) with gil:
-    gl_debug_print("GL glUniform3iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform3iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform3iv ( location, count, v)
     gl_check_error()
 
@@ -1124,7 +1124,7 @@ cdef void __stdcall dbgUniform4fv (GLint location, GLsizei count, const GLfloat*
         gil_dbgUniform4fv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform4fv (GLint location, GLsizei count, const GLfloat* v) with gil:
-    gl_debug_print("GL glUniform4fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform4fv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform4fv ( location, count, v)
     gl_check_error()
 
@@ -1142,7 +1142,7 @@ cdef void __stdcall dbgUniform4iv (GLint location, GLsizei count, const GLint* v
         gil_dbgUniform4iv(location, count,   v)
 
 cdef void __stdcall gil_dbgUniform4iv (GLint location, GLsizei count, const GLint* v) with gil:
-    gl_debug_print("GL glUniform4iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long> v)), ", )")
+    gl_debug_print("GL glUniform4iv( location = ", location, ", count = ", count, ", v*=", repr(hex(<long long> v)), ", )")
     cgl_native.glUniform4iv ( location, count, v)
     gl_check_error()
 
@@ -1151,7 +1151,7 @@ cdef void __stdcall gil_dbgUniform4iv (GLint location, GLsizei count, const GLin
 #         gil_dbgUniformMatrix2fv(location, count, transpose,   value)
 #
 # cdef void __stdcall gil_dbgUniformMatrix2fv (GLint location, GLsizei count, GLboolean transpose,  GLfloat* value) with gil:
-#     gl_debug_print("GL glUniformMatrix2fv( location = ", location, ", count = ", count, ", transpose = ", transpose, ", value*=", repr(hex(<long> value)), ", )")
+#     gl_debug_print("GL glUniformMatrix2fv( location = ", location, ", count = ", count, ", transpose = ", transpose, ", value*=", repr(hex(<long long> value)), ", )")
 #     cgl_native.glUniformMatrix2fv ( location, count, transpose, value)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -1161,7 +1161,7 @@ cdef void __stdcall gil_dbgUniform4iv (GLint location, GLsizei count, const GLin
 #         gil_dbgUniformMatrix3fv(location, count, transpose,   value)
 #
 # cdef void __stdcall gil_dbgUniformMatrix3fv (GLint location, GLsizei count, GLboolean transpose,  GLfloat* value) with gil:
-#     gl_debug_print("GL glUniformMatrix3fv( location = ", location, ", count = ", count, ", transpose = ", transpose, ", value*=", repr(hex(<long> value)), ", )")
+#     gl_debug_print("GL glUniformMatrix3fv( location = ", location, ", count = ", count, ", transpose = ", transpose, ", value*=", repr(hex(<long long> value)), ", )")
 #     cgl_native.glUniformMatrix3fv ( location, count, transpose, value)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -1171,7 +1171,7 @@ cdef void __stdcall dbgUniformMatrix4fv (GLint location, GLsizei count, GLboolea
         gil_dbgUniformMatrix4fv(location, count, transpose,   value)
 
 cdef void __stdcall gil_dbgUniformMatrix4fv (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value) with gil:
-    gl_debug_print("GL glUniformMatrix4fv( location = ", location, ", count = ", count, ", transpose = ", transpose, ", value*=", repr(hex(<long> value)), ", )")
+    gl_debug_print("GL glUniformMatrix4fv( location = ", location, ", count = ", count, ", transpose = ", transpose, ", value*=", repr(hex(<long long> value)), ", )")
     cgl_native.glUniformMatrix4fv ( location, count, transpose, value)
     gl_check_error()
 
@@ -1207,7 +1207,7 @@ cdef void __stdcall gil_dbgVertexAttrib1f (GLuint indx, GLfloat x) with gil:
 #         gil_dbgVertexAttrib1fv(indx,   values)
 #
 # cdef void __stdcall gil_dbgVertexAttrib1fv (GLuint indx,  GLfloat* values) with gil:
-#     gl_debug_print("GL glVertexAttrib1fv( indx = ", indx, ", values*=", repr(hex(<long> values)), ", )")
+#     gl_debug_print("GL glVertexAttrib1fv( indx = ", indx, ", values*=", repr(hex(<long long> values)), ", )")
 #     cgl_native.glVertexAttrib1fv ( indx, values)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -1226,7 +1226,7 @@ cdef void __stdcall gil_dbgVertexAttrib2f (GLuint indx, GLfloat x, GLfloat y) wi
 #         gil_dbgVertexAttrib2fv(indx,   values)
 #
 # cdef void __stdcall gil_dbgVertexAttrib2fv (GLuint indx,  GLfloat* values) with gil:
-#     gl_debug_print("GL glVertexAttrib2fv( indx = ", indx, ", values*=", repr(hex(<long> values)), ", )")
+#     gl_debug_print("GL glVertexAttrib2fv( indx = ", indx, ", values*=", repr(hex(<long long> values)), ", )")
 #     cgl_native.glVertexAttrib2fv ( indx, values)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -1245,7 +1245,7 @@ cdef void __stdcall gil_dbgVertexAttrib3f (GLuint indx, GLfloat x, GLfloat y, GL
 #         gil_dbgVertexAttrib3fv(indx,   values)
 #
 # cdef void __stdcall gil_dbgVertexAttrib3fv (GLuint indx,  GLfloat* values) with gil:
-#     gl_debug_print("GL glVertexAttrib3fv( indx = ", indx, ", values*=", repr(hex(<long> values)), ", )")
+#     gl_debug_print("GL glVertexAttrib3fv( indx = ", indx, ", values*=", repr(hex(<long long> values)), ", )")
 #     cgl_native.glVertexAttrib3fv ( indx, values)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -1264,7 +1264,7 @@ cdef void __stdcall gil_dbgVertexAttrib4f (GLuint indx, GLfloat x, GLfloat y, GL
 #         gil_dbgVertexAttrib4fv(indx,   values)
 #
 # cdef void __stdcall gil_dbgVertexAttrib4fv (GLuint indx,  GLfloat* values) with gil:
-#     gl_debug_print("GL glVertexAttrib4fv( indx = ", indx, ", values*=", repr(hex(<long> values)), ", )")
+#     gl_debug_print("GL glVertexAttrib4fv( indx = ", indx, ", values*=", repr(hex(<long long> values)), ", )")
 #     cgl_native.glVertexAttrib4fv ( indx, values)
 #     ret = cgl_native.glGetError()
 #     if ret: print("OpenGL Error %d / %x" % (ret, ret))
@@ -1274,7 +1274,7 @@ cdef void __stdcall dbgVertexAttribPointer (GLuint indx, GLint size, GLenum type
         gil_dbgVertexAttribPointer(indx, size, type, normalized, stride, <GLvoid*>ptr)
 
 cdef void __stdcall gil_dbgVertexAttribPointer (GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride,  GLvoid* ptr) with gil:
-    gl_debug_print("GL glVertexAttribPointer( indx = ", indx, ", size = ", size, ", type = ", type, ", normalized = ", normalized, ", stride = ", stride, ", ptr*=", repr(hex(<long> ptr)), ", )")
+    gl_debug_print("GL glVertexAttribPointer( indx = ", indx, ", size = ", size, ", type = ", type, ", normalized = ", normalized, ", stride = ", stride, ", ptr*=", repr(hex(<long long> ptr)), ", )")
     cgl_native.glVertexAttribPointer ( indx, size, type, normalized, stride, ptr)
     gl_check_error()
 

--- a/kivy/graphics/compiler.pxd
+++ b/kivy/graphics/compiler.pxd
@@ -1,6 +1,6 @@
 cdef class GraphicsCompiler
 
-from instructions cimport InstructionGroup
+from .instructions cimport InstructionGroup
 
 cdef class GraphicsCompiler:
     cdef InstructionGroup compile(self, InstructionGroup group)

--- a/kivy/graphics/context_instructions.pxd
+++ b/kivy/graphics/context_instructions.pxd
@@ -2,9 +2,9 @@ cdef class LineWidth
 cdef class Color
 cdef class BindTexture
 
-from transformation cimport Matrix
-from instructions cimport ContextInstruction
-from texture cimport Texture
+from .transformation cimport Matrix
+from .instructions cimport ContextInstruction
+from .texture cimport Texture
 
 cdef class PushState(ContextInstruction):
     pass
@@ -66,7 +66,7 @@ cdef class Rotate(Transform):
 
 cdef class Scale(Transform):
     cdef tuple _origin
-    cdef float _x, _y, _z
+    cdef double _x, _y, _z
     cdef int apply(self) except -1
     cdef set_scale(self, double x, double y, double z)
 

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -78,19 +78,19 @@ cdef tuple rgb_to_hsv(float r, float g, float b):
     cdef float rc = (maxc-r) / (maxc-minc)
     cdef float gc = (maxc-g) / (maxc-minc)
     cdef float bc = (maxc-b) / (maxc-minc)
-    if r == maxc: h = bc-gc
-    elif g == maxc: h = 2.0+rc-bc
-    else: h = 4.0+gc-rc
-    h = (h/6.0) % 1.0
+    if r == maxc: h = bc - gc
+    elif g == maxc: h = <float>2.0 + rc - bc
+    else: h = <float>4.0 + gc - rc
+    h = (h / <float>6.0) % <float>1.0
     return h, s, v
 
 cdef tuple hsv_to_rgb(float h, float s, float v):
     if s == 0.0: return v, v, v
     cdef long i = long(h * 6.0)
-    cdef float f = (h * 6.0) - i
-    cdef float p = v * (1.0 - s)
-    cdef float q = v * (1.0 - s * f)
-    cdef float t = v * (1.0 - s * (1.0 - f))
+    cdef float f = (h * <float>6.0) - i
+    cdef float p = v * (<float>1.0 - s)
+    cdef float q = v * (<float>1.0 - s * f)
+    cdef float t = v * (<float>1.0 - s * (<float>1.0 - f))
     i = i % 6
     if i == 0: return v, t, p
     if i == 1: return q, v, p
@@ -240,7 +240,7 @@ cdef class Color(ContextInstruction):
     '''
     def __init__(self, *args, **kwargs):
         ContextInstruction.__init__(self, **kwargs)
-        cdef long vec_size = len(args)
+        cdef long vec_size = <long>len(args)
         if kwargs.get('mode', '') == 'hsv':
             if vec_size == 4:
                 self.rgba = [0, 0, 0, 1.]
@@ -788,7 +788,7 @@ cdef class Scale(Transform):
             self.set_scale(1.0, 1.0, 1.0)
 
     cdef set_scale(self, double x, double y, double z):
-        cdef float ox, oy, oz
+        cdef double ox, oy, oz
         self._x = x
         self._y = y
         self._z = z

--- a/kivy/graphics/img_tools.pxi
+++ b/kivy/graphics/img_tools.pxi
@@ -36,7 +36,7 @@ cdef inline convert_to_gl_format(data, fmt, width, height):
 
     # do appropriate conversion, since we accepted it
     if isinstance(data, bytes):
-        datasize = len(data)
+        datasize = <int>len(data)
         ret_array = clone(array('b'), datasize, False)
         src_buffer = <char *>data
     else:

--- a/kivy/graphics/instructions.pxd
+++ b/kivy/graphics/instructions.pxd
@@ -8,10 +8,10 @@ cdef class CanvasBase
 cdef class Canvas
 cdef class RenderContext
 
-from vbo cimport *
-from compiler cimport *
-from shader cimport *
-from texture cimport Texture
+from .vbo cimport *
+from .compiler cimport *
+from .shader cimport *
+from .texture cimport Texture
 from kivy._event cimport ObjectWithUid
 
 cdef void reset_gl_context()
@@ -63,7 +63,7 @@ cdef class ContextInstruction(Instruction):
     cdef int pop_state(self, str name) except -1
 
 
-from context_instructions cimport BindTexture
+from .context_instructions cimport BindTexture
 
 cdef class VertexInstruction(Instruction):
     cdef BindTexture texture_binding

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -747,8 +747,8 @@ cdef popActiveCanvas():
 #TODO: same as canvas, move back to context.pyx..fix circular import
 #on actual import from python problem
 include "common.pxi"
-from vertex cimport *
-#from texture cimport *
+from .vertex cimport *
+#from .texture cimport *
 
 from os.path import join
 from kivy import kivy_shader_dir

--- a/kivy/graphics/opengl.pyx
+++ b/kivy/graphics/opengl.pyx
@@ -690,7 +690,7 @@ def glDrawElements(GLenum mode, GLsizei count, GLenum type, indices):
     if isinstance(indices, bytes):
         ptr = <void *>(<char *>(<bytes>indices))
     elif isinstance(indices, (long, int)):
-        ptr = <void *>(<long>indices)
+        ptr = <void *>(<unsigned int>indices)
     else:
         raise TypeError("Argument 'indices' has incorrect type (expected bytes or int).")
     cgl.glDrawElements(mode, count, type, ptr)
@@ -1540,7 +1540,7 @@ def glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean norma
     if isinstance(data, bytes):
         ptr = <void *>(<char *>(<bytes>data))
     elif isinstance(data, (long, int)):
-        ptr = <void *>(<long>data)
+        ptr = <void *>(<unsigned int>data)
     else:
         raise TypeError("Argument 'data' has incorrect type (expected bytes or int).")
     cgl.glVertexAttribPointer(index, size, type, normalized, stride, ptr)

--- a/kivy/graphics/shader.pyx
+++ b/kivy/graphics/shader.pyx
@@ -150,7 +150,7 @@ cdef class ShaderSource:
         msg = <char *>malloc(info_length * sizeof(char))
         if msg == NULL:
             return ""
-        msg[0] = "\0"
+        msg[0] = b"\0"
         cgl.glGetShaderInfoLog(shader, info_length, NULL, msg)
         py_msg = msg
         free(msg)
@@ -282,7 +282,7 @@ cdef class Shader:
         elif val_type is list:
             list_value = value
             val_type = type(list_value[0])
-            vec_size = len(list_value)
+            vec_size = <long>len(list_value)
             if val_type is float:
                 if vec_size == 2:
                     f1, f2 = list_value
@@ -337,7 +337,7 @@ cdef class Shader:
                     free(int_list)
             elif val_type is list:
                 list_size = <int>len(value)
-                vec_size = len(value[0])
+                vec_size = <long>len(value[0])
                 val_type = type(value[0][0])
                 if val_type is float:
                     float_list = <GLfloat *>malloc(
@@ -392,7 +392,7 @@ cdef class Shader:
         elif val_type is tuple:
             tuple_value = value
             val_type = type(tuple_value[0])
-            vec_size = len(tuple_value)
+            vec_size = <long>len(tuple_value)
             if val_type is float:
                 if vec_size == 2:
                     f1, f2 = tuple_value
@@ -427,7 +427,7 @@ cdef class Shader:
                         ' {name}'.format(name=name))
             elif val_type is list:
                 list_size = <int>len(value)
-                vec_size = len(value[0])
+                vec_size = <long>len(value[0])
                 val_type = type(value[0][0])
                 if val_type is float:
                     float_list = <GLfloat *>malloc(
@@ -499,7 +499,7 @@ cdef class Shader:
         return loc
 
     cdef void bind_vertex_format(self, VertexFormat vertex_format):
-        cdef unsigned int i
+        cdef int i
         cdef vertex_attr_t *attr
         cdef bytes name
 
@@ -513,7 +513,7 @@ cdef class Shader:
 
         # unbind the previous vertex format
         if self._current_vertex_format:
-            for i in xrange(self._current_vertex_format.vattr_count):
+            for i in range(self._current_vertex_format.vattr_count):
                 attr = &self._current_vertex_format.vattr[i]
                 if attr.per_vertex == 0:
                     continue
@@ -525,7 +525,7 @@ cdef class Shader:
         # bind the new vertex format
         if vertex_format:
             vertex_format.last_shader = self
-            for i in xrange(vertex_format.vattr_count):
+            for i in range(vertex_format.vattr_count):
                 attr = &vertex_format.vattr[i]
                 if attr.per_vertex == 0:
                     continue
@@ -621,7 +621,7 @@ cdef class Shader:
         '''Return the program log.'''
         cdef char msg[2048]
         cdef GLsizei length
-        msg[0] = '\0'
+        msg[0] = b'\0'
         cgl.glGetProgramInfoLog(shader, 2048, &length, msg)
         # XXX don't use the msg[:length] as a string directly, or the unicode
         # will fail on shitty driver. Ie, some Intel drivers return a static

--- a/kivy/graphics/svg.pxd
+++ b/kivy/graphics/svg.pxd
@@ -66,9 +66,9 @@ cdef class Svg(RenderContext):
     cdef parse_path(self, pathdef)
     cdef void new_path(self)
     cdef void close_path(self)
-    cdef void set_position(self, float x, float y, int absolute=*)
-    cdef arc_to(self, float rx, float ry, float phi, float large_arc,
-            float sweep, float x, float y)
+    cdef void set_position(self, double x, double y, int absolute=*)
+    cdef arc_to(self, double rx, double ry, double phi, double large_arc,
+            double sweep, double x, double y)
     cdef void quadratic_bezier_curve_to(self, float cx, float cy, float x, float y)
     cdef void curve_to(self, float x1, float y1, float x2, float y2,
             float x, float y)

--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -107,19 +107,19 @@ def _tokenize_path(pathdef):
         for token in RE_FLOAT.findall(x):
             yield token
 
-cdef inline float angle(float ux, float uy, float vx, float vy):
+cdef inline double angle(double ux, double uy, double vx, double vy):
     a = acos((ux * vx + uy * vy) / sqrt((ux ** 2 + uy ** 2) * (vx ** 2 + vy ** 2)))
     sgn = 1 if ux * vy > uy * vx else -1
     return sgn * a
 
 cdef float parse_width(txt, float vbox_width):
     if txt.endswith('%'):
-        return vbox_width * float(txt[:-1]) / 100.
+        return <float>(vbox_width * txt[:-1] / 100.)
     return parse_float(txt)
 
 cdef float parse_height(txt, float vbox_height):
     if txt.endswith('%'):
-        return vbox_height * float(txt[:-1]) / 100.
+        return <float>(vbox_height * txt[:-1] / 100.)
     return parse_float(txt)
 
 cdef float parse_float(txt):
@@ -127,7 +127,7 @@ cdef float parse_float(txt):
         return 0.
     if txt[-2:] in NUMERIC_FORMATS:
         return dpi2px(txt[:-2], txt[-2:])
-    return float(txt)
+    return <float>float(txt)
 
 cdef list parse_list(string):
     return re.findall(RE_LIST, string)
@@ -213,12 +213,12 @@ cdef class Matrix(object):
             if string.startswith('matrix('):
                 i = 0
                 for sf in parse_list(string[7:-1]):
-                    self.mat[i] = float(sf)
+                    self.mat[i] = <float>float(sf)
                     i += 1
             elif string.startswith('translate('):
                 a, b = parse_list(string[10:-1])
-                self.mat[4] = float(a)
-                self.mat[5] = float(b)
+                self.mat[4] = <float>float(a)
+                self.mat[5] = <float>float(b)
             elif string.startswith('scale('):
                 value = parse_list(string[6:-1])
                 if len(value) == 1:
@@ -227,8 +227,8 @@ cdef class Matrix(object):
                     a, b = value
                 else:
                     print("SVG: unknown how to parse: {!r}".format(value))
-                self.mat[0] = float(a)
-                self.mat[3] = float(b)
+                self.mat[0] = <float>float(a)
+                self.mat[3] = <float>float(b)
         elif string is not None:
             i = 0
             for f in string:
@@ -236,13 +236,13 @@ cdef class Matrix(object):
                 i += 1
 
     cdef void transform(self, float ox, float oy, float *x, float *y):
-        cdef float rx = self.mat[0] * ox + self.mat[2] * oy + self.mat[4]
-        cdef float ry = self.mat[1] * ox + self.mat[3] * oy + self.mat[5]
-        x[0] = rx
-        y[0] = ry
+        cdef double rx = self.mat[0] * ox + self.mat[2] * oy + self.mat[4]
+        cdef double ry = self.mat[1] * ox + self.mat[3] * oy + self.mat[5]
+        x[0] = <float>rx
+        y[0] = <float>ry
 
     cpdef Matrix inverse(self):
-        cdef float d = self.mat[0] * self.mat[3] - self.mat[1]*self.mat[2]
+        cdef double d = self.mat[0] * self.mat[3] - self.mat[1]*self.mat[2]
         return Matrix([self.mat[3] / d, -self.mat[1] / d, -self.mat[2] / d, self.mat[0] / d,
                        (self.mat[2] * self.mat[5] - self.mat[3] * self.mat[4]) / d,
                        (self.mat[1] * self.mat[4] - self.mat[0] * self.mat[5]) / d])
@@ -340,7 +340,7 @@ class Gradient(object):
                 v = getattr(parent, param, None)
             my_v = self.element.get(param)
             if my_v:
-                v = float(my_v)
+                v = <float>float(my_v)
             if v:
                 setattr(self, param, v)
 
@@ -553,11 +553,11 @@ cdef class Svg(RenderContext):
         self.fill = parse_color(e.get('fill', 'black'), self.current_color)
         self.stroke = parse_color(e.get('stroke'), self.current_color)
         oldopacity = self.opacity
-        self.opacity *= float(e.get('opacity', 1))
-        fill_opacity = float(e.get('fill-opacity', 1))
-        stroke_opacity = float(e.get('stroke-opacity', 1))
+        self.opacity *= <float>float(e.get('opacity', 1))
+        fill_opacity = <float>float(e.get('fill-opacity', 1))
+        stroke_opacity = <float>float(e.get('stroke-opacity', 1))
         old_line_width = self.line_width
-        self.line_width = float(e.get('stroke-width', self.line_width))
+        self.line_width = <float>float(e.get('stroke-width', self.line_width))
 
         oldtransform = self.transform
         for t in self.parse_transform(e.get('transform')):
@@ -569,11 +569,11 @@ cdef class Svg(RenderContext):
             if 'fill' in sdict:
                 self.fill = parse_color(sdict['fill'], self.current_color)
             if 'fill-opacity' in sdict:
-                fill_opacity *= float(sdict['fill-opacity'])
+                fill_opacity *= <float>float(sdict['fill-opacity'])
             if 'stroke' in sdict:
                 self.stroke = parse_color(sdict['stroke'], self.current_color)
             if 'stroke-opacity' in sdict:
-                stroke_opacity *= float(sdict['stroke-opacity'])
+                stroke_opacity *= <float>float(sdict['stroke-opacity'])
             if 'stroke-width' in sdict:
                 self.line_width = parse_float(sdict['stroke-width'])
 
@@ -816,11 +816,11 @@ cdef class Svg(RenderContext):
                 last_command = 'S'
 
             elif command == 'A':
-                rx = float(elements.pop())
-                ry = float(elements.pop())
-                rotation = float(elements.pop())
-                arc = float(elements.pop())
-                sweep = float(elements.pop())
+                rx = <float>float(elements.pop())
+                ry = <float>float(elements.pop())
+                rotation = <float>float(elements.pop())
+                arc = <float>float(elements.pop())
+                sweep = <float>float(elements.pop())
                 x = parse_width(elements.pop(), self.vbox_width)
                 y = parse_height(elements.pop(), self.vbox_height)
 
@@ -887,22 +887,22 @@ cdef class Svg(RenderContext):
             self.loop.append(self.loop[0])
             self.loop.append(self.loop[1])
 
-    cdef void set_position(self, float x, float y, int absolute=1):
+    cdef void set_position(self, double x, double y, int absolute=1):
         if absolute:
-            self.x = x
-            self.y = y
+            self.x = <float>x
+            self.y = <float>y
         else:
-            self.x += x
-            self.y += y
+            self.x += <float>x
+            self.y += <float>y
         self.loop.append(self.x)
         self.loop.append(self.y)
 
-    cdef arc_to(self, float rx, float ry, float phi, float large_arc,
-            float sweep, float x, float y):
+    cdef arc_to(self, double rx, double ry, double phi, double large_arc,
+            double sweep, double x, double y):
         # This function is made out of magical fairy dust
         # http://www.w3.org/TR/2003/REC-SVG11-20030114/implnote.html#ArcImplementationNotes
-        cdef float x1, y1, x2, y2, cp, sp, dx, dy, x_, y_, r2, cx_, cy_, cx, cy
-        cdef float psi, delta, ct, st, theta
+        cdef double x1, y1, x2, y2, cp, sp, dx, dy, x_, y_, r2, cx_, cy_, cx, cy
+        cdef double psi, delta, ct, st, theta
         cdef int n_points, i
         x1 = self.x
         y1 = self.y
@@ -934,7 +934,7 @@ cdef class Svg(RenderContext):
         if n_points < 1:
             n_points = 1
 
-        for i in xrange(n_points + 1):
+        for i in range(n_points + 1):
             theta = psi + i * delta / n_points
             ct = cos(theta)
             st = sin(theta)
@@ -959,10 +959,10 @@ cdef class Svg(RenderContext):
                     format="f")
             f_bc = self.bezier_coefficients
             for i in range(bp_count):
-                t = float(i) / self.bezier_points
-                t0 = (1 - t) ** 2
-                t1 = 2 * t * (1 - t)
-                t2 = t ** 2
+                t = <float>(i / self.bezier_points)
+                t0 = <float>pow(1 - t, 2)
+                t1 = <float>(2 * t * (1 - t))
+                t2 = <float>pow(t, 2)
                 f_bc[i * 3] = t0
                 f_bc[i * 3 + 1] = t1
                 f_bc[i * 3 + 2] = t2
@@ -972,7 +972,7 @@ cdef class Svg(RenderContext):
         self.last_cx = cx
         self.last_cy = cy
         count = bp_count * 2
-        ilast = len(self.loop)
+        ilast = <int>len(self.loop)
         array.resize(self.loop, ilast + count)
         f_loop = self.loop.data.as_floats
         for i in range(bp_count):
@@ -1002,11 +1002,11 @@ cdef class Svg(RenderContext):
                     format="f")
             f_bc = self.bezier_coefficients
             for i in range(bp_count):
-                t = float(i) / self.bezier_points
-                t0 = (1 - t) ** 3
-                t1 = 3 * t * (1 - t) ** 2
-                t2 = 3 * t ** 2 * (1 - t)
-                t3 = t ** 3
+                t = <float>float(i) / self.bezier_points
+                t0 = <float>pow(1 - t, 3)
+                t1 = <float>(3 * t * pow(1 - t, 2))
+                t2 = <float>(3 * pow(t, 2) * (1 - t))
+                t3 = <float>pow(t, 3)
                 f_bc[i * 4] = t0
                 f_bc[i * 4 + 1] = t1
                 f_bc[i * 4 + 2] = t2
@@ -1017,7 +1017,7 @@ cdef class Svg(RenderContext):
         self.last_cx = x2
         self.last_cy = y2
         count = bp_count * 2
-        ilast = len(self.loop)
+        ilast = <int>len(self.loop)
         array.resize(self.loop, ilast + count)
         f_loop = self.loop.data.as_floats
         for i in range(bp_count):
@@ -1039,7 +1039,7 @@ cdef class Svg(RenderContext):
         if self.fill:
             tess = Tesselator()
             for loop in self.path:
-                tess.add_contour_data(loop.data.as_voidptr, len(loop) / 2)
+                tess.add_contour_data(loop.data.as_voidptr, <int>int(len(loop) / 2.))
             tess.tesselate()
             tris = tess.vertices
 
@@ -1073,7 +1073,7 @@ cdef class Svg(RenderContext):
         cdef float x, y, r, g, b, a
         cdef Mesh mesh
 
-        cdef int count = len(path) / 2
+        cdef int count = <int>int(len(path) / 2.)
         vertices = <float *>malloc(sizeof(float) * count * 8)
         if vertices == NULL:
             return
@@ -1127,7 +1127,7 @@ cdef class Svg(RenderContext):
         # Caps and joint are missing
         cdef int index, vindex = 0, odd = 0, i
         cdef float ax, ay, bx, _by, r = 0, g = 0, b = 0, a = 0
-        cdef int count = len(path) / 2
+        cdef int count = <int>int(len(path) / 2.)
         cdef float *vertices = NULL
         vindex = 0
 
@@ -1188,14 +1188,14 @@ cdef class Svg(RenderContext):
             vertices[vindex + 7] = vertices[vindex + 15] = \
                 vertices[vindex + 23] = vertices[vindex + 31] = a
 
-            vertices[vindex + 0] = x1
-            vertices[vindex + 1] = y1
-            vertices[vindex + 8] = x4
-            vertices[vindex + 9] = y4
-            vertices[vindex + 16] = x2
-            vertices[vindex + 17] = y2
-            vertices[vindex + 24] = x3
-            vertices[vindex + 25] = y3
+            vertices[vindex + 0] = <float>x1
+            vertices[vindex + 1] = <float>y1
+            vertices[vindex + 8] = <float>x4
+            vertices[vindex + 9] = <float>y4
+            vertices[vindex + 16] = <float>x2
+            vertices[vindex + 17] = <float>y2
+            vertices[vindex + 24] = <float>x3
+            vertices[vindex + 25] = <float>y3
             vindex += 32
 
         # if self.closed:
@@ -1228,7 +1228,7 @@ cdef class Svg(RenderContext):
         #     tindices[17] = i7
         #     tindices = tindices + 18
 
-        self.push_strip_mesh(vertices, vindex, (vindex / 32) * 4, 1)
+        self.push_strip_mesh(vertices, vindex, <int>int((vindex / 32.)) * 4, 1)
         free(vertices)
 
     cdef void render(self):

--- a/kivy/graphics/tesselator.pyx
+++ b/kivy/graphics/tesselator.pyx
@@ -149,7 +149,7 @@ cdef class Tesselator:
 
         cdata = <char *>&float_view[0]
         datasize = float_view.nbytes
-        self.add_contour_data(cdata, len(points) / 2)
+        self.add_contour_data(cdata, int(len(points) / 2.))
 
     cpdef int tesselate(
             self, int winding_rule=WINDING_ODD,

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -922,7 +922,7 @@ cdef class Texture:
 
         # need conversion, do check here because it seems to be faster ?
         if not gl_has_texture_native_format(colorfmt):
-            pbuffer, colorfmt = convert_to_gl_format(pbuffer, colorfmt, 
+            pbuffer, colorfmt = convert_to_gl_format(pbuffer, colorfmt,
                                                      size[0], size[1])
         cdef char [:] char_view
         cdef short [:] short_view
@@ -934,7 +934,7 @@ cdef class Texture:
         cdef long datasize = 0
         if isinstance(pbuffer, bytes):  # if it's bytes, just use memory
             cdata = <bytes>pbuffer  # explicit bytes
-            datasize = len(pbuffer)
+            datasize = <long>len(pbuffer)
         else:   # if it's a memoryview or buffer type, use start of memory
             if glbufferfmt == GL_UNSIGNED_BYTE or glbufferfmt == GL_BYTE:
                 char_view = pbuffer

--- a/kivy/graphics/vbo.pyx
+++ b/kivy/graphics/vbo.pyx
@@ -106,7 +106,7 @@ cdef class VBO:
                 continue
             if attr.index != <unsigned int>-1:
                 cgl.glVertexAttribPointer(attr.index, attr.size, attr.type,
-                        GL_FALSE, <GLsizei>self.format_size, <GLvoid*><long>offset)
+                        GL_FALSE, <GLsizei>self.format_size, <GLvoid*><unsigned int>offset)
                 log_gl_error('VBO.bind-glVertexAttribPointer')
             offset += attr.bytesize
 

--- a/kivy/graphics/vertex.pyx
+++ b/kivy/graphics/vertex.pyx
@@ -36,7 +36,7 @@ cdef class VertexFormat:
             raise VertexFormatException('No format specified')
 
         self.last_shader = None
-        self.vattr_count = len(fmt)
+        self.vattr_count = <long>len(fmt)
         self.vattr = <vertex_attr_t *>malloc(sizeof(vertex_attr_t) * self.vattr_count)
 
         if self.vattr == NULL:

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -162,25 +162,25 @@ cdef class Bezier(VertexInstruction):
             raise MemoryError('indices')
 
         tex_x = x = 0
-        for x in xrange(self._segments):
-            l = x / (1.0 * self._segments)
+        for x in range(self._segments):
+            l = <float>(x / (1.0 * self._segments))
             # http://en.wikipedia.org/wiki/De_Casteljau%27s_algorithm
             # as the list is in the form of (x1, y1, x2, y2...) iteration is
             # done on each item and the current item (xn or yn) in the list is
             # replaced with a calculation of "xn + x(n+1) - xn" x(n+1) is
             # placed at n+2. each iteration makes the list one item shorter
             for i in range(1, len(T)):
-                for j in xrange(len(T) - 2*i):
+                for j in range(len(T) - 2*i):
                     T[j] = T[j] + (T[j+2] - T[j]) * l
 
             # we got the coordinates of the point in T[0] and T[1]
             vertices[x].x = T[0]
             vertices[x].y = T[1]
             if self._dash_offset != 0 and x > 0:
-                tex_x += sqrt(
+                tex_x += <float>(sqrt(
                         pow(vertices[x].x - vertices[x-1].x, 2) +
                         pow(vertices[x].y - vertices[x-1].y, 2)) / (
-                                self._dash_length + self._dash_offset)
+                                self._dash_length + self._dash_offset))
 
                 vertices[x].s0 = tex_x
                 vertices[x].t0 = 0
@@ -191,10 +191,10 @@ cdef class Bezier(VertexInstruction):
         vertices[x+1].x = T[-2]
         vertices[x+1].y = T[-1]
 
-        tex_x += sqrt(
+        tex_x += <float>(sqrt(
                 (vertices[x+1].x - vertices[x].x) ** 2 +
                 (vertices[x+1].y - vertices[x].y) ** 2) / (
-                        self._dash_length + self._dash_offset)
+                        self._dash_length + self._dash_offset))
 
         vertices[x+1].s0 = tex_x
         vertices[x+1].t0 = 0
@@ -310,11 +310,11 @@ cdef class StripMesh(VertexInstruction):
             indices[1] = li
         if mode == 0:
             # polygon
-            for i in range(icount / 2):
+            for i in range(<int>int(icount / 2.)):
                 indices[i * 2 + istart] = li + i
                 indices[i * 2 + istart + 1] = li + (icount - i - 1)
             if icount % 2 == 1:
-                indices[icount + istart - 1] = li + icount / 2
+                indices[icount + istart - 1] = li + <unsigned short>int(icount / 2.)
         elif mode == 1:
             # line
             for i in range(icount):
@@ -443,7 +443,7 @@ cdef class Mesh(VertexInstruction):
         if len(self._vertices) != self.vcount:
             self._vertices, self._fvertices = _ensure_float_view(self._vertices,
                 &self._pvertices)
-            self.vcount = len(self._vertices)
+            self.vcount = <long>len(self._vertices)
 
         if len(self._indices) != self.icount:
             if len(self._indices) > 65535:
@@ -451,7 +451,7 @@ cdef class Mesh(VertexInstruction):
                                        '(OpenGL ES 2 limitation)')
             self._indices, self._lindices = _ensure_ushort_view(self._indices,
                 &self._pindices)
-            self.icount = len(self._indices)
+            self.icount = <long>len(self._indices)
 
         if self.vcount == 0 or self.icount == 0:
             self.batch.clear_data()
@@ -472,7 +472,7 @@ cdef class Mesh(VertexInstruction):
     def vertices(self, value):
         self._vertices, self._fvertices = _ensure_float_view(value,
             &self._pvertices)
-        self.vcount = len(self._vertices)
+        self.vcount = <long>len(self._vertices)
         self.flag_update()
 
     @property
@@ -490,7 +490,7 @@ cdef class Mesh(VertexInstruction):
                 ' limitation - consider setting KIVY_GLES_LIMITS)')
         self._indices, self._lindices = _ensure_ushort_view(value,
             &self._pindices)
-        self.icount = len(self._indices)
+        self.icount = <long>len(self._indices)
         self.flag_update()
 
     @property
@@ -880,10 +880,10 @@ cdef class BorderImage(Rectangle):
         `auto_scale`: string
             .. versionadded:: 1.9.1
 
-            .. versionchanged:: 1.9.2 
+            .. versionchanged:: 1.9.2
 
                 This used to be a bool and has been changed to be a string
-                state. 
+                state.
 
             Can be one of 'off', 'both', 'x_only', 'y_only', 'y_full_x_lower',
             'x_full_y_lower', 'both_lower'.
@@ -903,12 +903,12 @@ cdef class BorderImage(Rectangle):
 
             'both': Scales both x and y dimension borders according to the size
             of the BorderImage, this disables the BorderImage making it render
-            the same as a regular Image. 
+            the same as a regular Image.
 
             'x_only': The Y dimension functions as the default, and the X
             scales to the size of the BorderImage's width.
 
-            'y_only': The X dimension functions as the default, and the Y 
+            'y_only': The X dimension functions as the default, and the Y
             scales to the size of the BorderImage's height.
 
             'y_full_x_lower': Y scales as in 'y_only', Y scales if the
@@ -1143,9 +1143,9 @@ cdef class Ellipse(Rectangle):
     cdef void build(self):
         cdef float *tc = self._tex_coords
         cdef int i, angle_dir
-        cdef float angle_start, angle_end, angle_range
-        cdef float x, y, angle, rx, ry, ttx, tty, tx, ty, tw, th
-        cdef float cx, cy, tangential_factor, radial_factor, fx, fy
+        cdef double angle_start, angle_end, angle_range
+        cdef double x, y, angle, rx, ry, ttx, tty, tx, ty, tw, th
+        cdef double cx, cy, tangential_factor, radial_factor, fx, fy
         cdef vertex_t *vertices = NULL
         cdef unsigned short *indices = NULL
         cdef int count = self._segments
@@ -1186,10 +1186,10 @@ cdef class Ellipse(Rectangle):
         y = self.y + ry
         ttx = ((x - self.x) / self.w) * tw + tx
         tty = ((y - self.y) / self.h) * th + ty
-        vertices[0].x = self.x + rx
-        vertices[0].y = self.y + ry
-        vertices[0].s0 = ttx
-        vertices[0].t0 = tty
+        vertices[0].x = <float>(self.x + rx)
+        vertices[0].y = <float>(self.y + ry)
+        vertices[0].s0 = <float>ttx
+        vertices[0].t0 = <float>tty
         indices[0] = 0
 
         # super fast ellipse drawing
@@ -1205,15 +1205,15 @@ cdef class Ellipse(Rectangle):
         x = r * sin(angle_start)
         y = r * cos(angle_start)
 
-        for i in xrange(1, count + 2):
+        for i in range(1, count + 2):
             ttx = (cx + x) * tw + tx
             tty = (cy + y) * th + ty
             real_x = self.x + (cx + x) * self.w
             real_y = self.y + (cy + y) * self.h
-            vertices[i].x = real_x
-            vertices[i].y = real_y
-            vertices[i].s0 = ttx
-            vertices[i].t0 = tty
+            vertices[i].x = <float>real_x
+            vertices[i].y = <float>real_y
+            vertices[i].s0 = <float>ttx
+            vertices[i].t0 = <float>tty
             indices[i] = i
 
             fx = -y
@@ -1365,8 +1365,8 @@ cdef class RoundedRectangle(Rectangle):
 
             int count, corner, segments, dw, dh, index
             list xradius, yradius
-            float rx, ry, half_w, half_h, angle
-            float tx, ty, tw, th, px, py, x, y
+            double rx, ry, half_w, half_h, angle
+            double tx, ty, tw, th, px, py, x, y
 
         # zero size of the figure
         if self.w == 0 or self.h == 0:
@@ -1404,14 +1404,14 @@ cdef class RoundedRectangle(Rectangle):
         th = tc[5] - ty
 
         # add start vertex in the middle of the figure
-        vertices[0].x = self.x + half_w
-        vertices[0].y = self.y + half_h
-        vertices[0].s0 = tx + tw / 2
-        vertices[0].t0 = ty + th / 2
+        vertices[0].x = <float>(self.x + half_w)
+        vertices[0].y = <float>(self.y + half_h)
+        vertices[0].s0 = <float>(tx + tw / 2)
+        vertices[0].t0 = <float>(ty + th / 2)
         indices[0] = 0
 
         index = 1  # vertex index from 1 to count
-        for corner in xrange(4):
+        for corner in range(4):
             # start angle for the corner. end is 90 degrees lesser (clockwise)
             angle = 180 - 90 * corner
 
@@ -1448,27 +1448,27 @@ cdef class RoundedRectangle(Rectangle):
                 # sharp corner
                 vertices[index].x = self.x + self.w * dw
                 vertices[index].y = self.y + self.h * dh
-                vertices[index].s0 = tx + tw * dw
-                vertices[index].t0 = ty + th * dh
+                vertices[index].s0 = <float>(tx + tw * dw)
+                vertices[index].t0 = <float>(ty + th * dh)
             else:
                 # round corner
                 points = self.draw_arc(px, py, rx, ry, angle, angle - 90, segments)
                 for i, point in enumerate(points, index):
                     x, y = point
-                    vertices[i].x = x
-                    vertices[i].y = y
-                    vertices[i].s0 = (x - self.x) / self.w
-                    vertices[i].t0 = 1 - (y - self.y) / self.h  # flip vertically
+                    vertices[i].x = <float>x
+                    vertices[i].y = <float>y
+                    vertices[i].s0 = <float>((x - self.x) / self.w)
+                    vertices[i].t0 = <float>(1 - (y - self.y) / self.h)  # flip vertically
                     indices[i] = i
                 index += segments
 
                 # Add final vertex that closes the arc, explained below
                 x = px * (dw != dh) + self.x * (dw == dh) + self.w * (dw * dh)
                 y = py * (dw == dh) + self.y * (dw != dh) + self.h * (dh > dw)
-                vertices[index].x = x
-                vertices[index].y = y
-                vertices[index].s0 = (x - self.x) / self.w
-                vertices[index].t0 = 1 - (y - self.y) / self.h  # flip vertically
+                vertices[index].x = <float>x
+                vertices[index].y = <float>y
+                vertices[index].s0 = <float>((x - self.x) / self.w)
+                vertices[index].t0 = <float>(1 - (y - self.y) / self.h)  # flip vertically
 
                 '''
                 We have defined these coefficients for arcs:
@@ -1515,11 +1515,11 @@ cdef class RoundedRectangle(Rectangle):
         free(vertices)
         free(indices)
 
-    cdef object draw_arc(self, float cx, float cy, float rx, float ry,
-                         float angle_start, float angle_end, int segments):
+    cdef object draw_arc(self, double cx, double cy, double rx, double ry,
+                         double angle_start, double angle_end, int segments):
         cdef:
-            float fx, fy, x, y
-            float tangential_factor, radial_factor, theta
+            double fx, fy, x, y
+            double tangential_factor, radial_factor, theta
             list points
 
         # convert to radians
@@ -1538,7 +1538,7 @@ cdef class RoundedRectangle(Rectangle):
         # array of length `segments`
         points = []
 
-        for i in xrange(segments):
+        for i in range(segments):
             real_x = cx + x * rx
             real_y = cy + y * ry
             points.append((real_x, real_y))

--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -17,7 +17,7 @@ DEF LINE_MODE_BEZIER = 5
 from kivy.graphics.stencil_instructions cimport StencilUse, StencilUnUse, StencilPush, StencilPop
 import itertools
 
-cdef float PI = 3.1415926535
+cdef float PI = <float>3.1415926535
 
 cdef inline int line_intersection(double x1, double y1, double x2, double y2,
         double x3, double y3, double x4, double y4, double *px, double *py):
@@ -212,7 +212,7 @@ cdef class Line(VertexInstruction):
 
     cdef void build_legacy(self):
         cdef int i
-        cdef long count = len(self.points) / 2
+        cdef long count = <int>int(len(self.points) / 2.)
         cdef list p = self.points
         cdef vertex_t *vertices = NULL
         cdef unsigned short *indices = NULL
@@ -290,9 +290,9 @@ cdef class Line(VertexInstruction):
         tex_x = 0
         for i in range(count):
             if (self._dash_offset != 0 or self._dash_list) and i > 0:
-                tex_x += sqrt(
+                tex_x += <float>(sqrt(
                         pow(p[i * 2]     - p[(i - 1) * 2], 2)  +
-                        pow(p[i * 2 + 1] - p[(i - 1) * 2 + 1], 2)) / length
+                        pow(p[i * 2 + 1] - p[(i - 1) * 2 + 1], 2)) / length)
 
                 vertices[i].s0 = tex_x
                 vertices[i].t0 = 0
@@ -308,7 +308,7 @@ cdef class Line(VertexInstruction):
 
     cdef void build_extended(self):
         cdef int i, j
-        cdef long count = len(self.points) / 2
+        cdef long count = <int>int(len(self.points) / 2.)
         cdef list p = self.points
         cdef vertex_t *vertices = NULL
         cdef unsigned short *indices = NULL
@@ -366,7 +366,7 @@ cdef class Line(VertexInstruction):
         cdef double ax, ay, bx, _by, cx, cy, angle, a1, a2
         cdef double x1, y1, x2, y2, x3, y3, x4, y4
         cdef double sx1, sy1, sx4, sy4, sangle
-        cdef double pcx, pcy, px1, py1, px2, py2, px3, py3, px4, py4, pangle, pangle2
+        cdef double pcx, pcy, px1, py1, px2, py2, px3, py3, px4, py4, pangle = 0, pangle2
         cdef double w = self._width
         cdef double ix, iy
         cdef unsigned int piv, pii2, piv2, skip = 0
@@ -440,23 +440,23 @@ cdef class Line(VertexInstruction):
             indices[ii + 5] = iv + 3
             ii += 6
 
-            vertices[iv].x = x1
-            vertices[iv].y = y1
+            vertices[iv].x = <float>x1
+            vertices[iv].y = <float>y1
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
             iv += 1
-            vertices[iv].x = x2
-            vertices[iv].y = y2
+            vertices[iv].x = <float>x2
+            vertices[iv].y = <float>y2
             vertices[iv].s0 = 1
             vertices[iv].t0 = 0
             iv += 1
-            vertices[iv].x = x3
-            vertices[iv].y = y3
+            vertices[iv].x = <float>x3
+            vertices[iv].y = <float>y3
             vertices[iv].s0 = 1
             vertices[iv].t0 = 1
             iv += 1
-            vertices[iv].x = x4
-            vertices[iv].y = y4
+            vertices[iv].x = <float>x4
+            vertices[iv].y = <float>y4
             vertices[iv].s0 = 0
             vertices[iv].t0 = 1
             iv += 1
@@ -484,8 +484,8 @@ cdef class Line(VertexInstruction):
                 continue
 
             if self._joint == LINE_JOINT_BEVEL:
-                vertices[iv].x = ax
-                vertices[iv].y = ay
+                vertices[iv].x = <float>ax
+                vertices[iv].y = <float>ay
                 vertices[iv].s0 = 0
                 vertices[iv].t0 = 0
                 if jangle < 0:
@@ -500,8 +500,8 @@ cdef class Line(VertexInstruction):
                 iv += 1
 
             elif self._joint == LINE_JOINT_MITER:
-                vertices[iv].x = ax
-                vertices[iv].y = ay
+                vertices[iv].x = <float>ax
+                vertices[iv].y = <float>ay
                 vertices[iv].s0 = 0
                 vertices[iv].t0 = 0
                 if jangle < 0:
@@ -509,8 +509,8 @@ cdef class Line(VertexInstruction):
                         vertices_count -= 2
                         indices_count -= 6
                         continue
-                    vertices[iv + 1].x = ix
-                    vertices[iv + 1].y = iy
+                    vertices[iv + 1].x = <float>ix
+                    vertices[iv + 1].y = <float>iy
                     vertices[iv + 1].s0 = 0
                     vertices[iv + 1].t0 = 0
                     indices[ii] = iv
@@ -526,8 +526,8 @@ cdef class Line(VertexInstruction):
                         vertices_count -= 2
                         indices_count -= 6
                         continue
-                    vertices[iv + 1].x = ix
-                    vertices[iv + 1].y = iy
+                    vertices[iv + 1].x = <float>ix
+                    vertices[iv + 1].y = <float>iy
                     vertices[iv + 1].s0 = 0
                     vertices[iv + 1].t0 = 0
                     indices[ii] = iv
@@ -557,19 +557,19 @@ cdef class Line(VertexInstruction):
                     pivstart = piv
                     pivend = piv2 + 2
                 siv = iv
-                vertices[iv].x = ax
-                vertices[iv].y = ay
+                vertices[iv].x = <float>ax
+                vertices[iv].y = <float>ay
                 vertices[iv].s0 = 0
                 vertices[iv].t0 = 0
                 iv += 1
                 for j in xrange(0, self._joint_precision - 1):
-                    vertices[iv].x = ax - cos(a0 - step * j) * w
-                    vertices[iv].y = ay - sin(a0 - step * j) * w
+                    vertices[iv].x = <float>(ax - cos(a0 - step * j) * w)
+                    vertices[iv].y = <float>(ay - sin(a0 - step * j) * w)
                     vertices[iv].s0 = 0
                     vertices[iv].t0 = 0
                     if j == 0:
                         indices[ii] = siv
-                        indices[ii + 1] = pivstart
+                        indices[ii + 1] = <unsigned short>pivstart
                         indices[ii + 2] = iv
                     else:
                         indices[ii] = siv
@@ -579,17 +579,17 @@ cdef class Line(VertexInstruction):
                     ii += 3
                 indices[ii] = siv
                 indices[ii + 1] = iv - 1
-                indices[ii + 2] = pivend
+                indices[ii + 2] = <unsigned short>pivend
                 ii += 3
 
         # caps
         if cap == LINE_CAP_SQUARE:
-            vertices[iv].x = x2 + cos(angle) * w
-            vertices[iv].y = y2 + sin(angle) * w
+            vertices[iv].x = <float>(x2 + cos(angle) * w)
+            vertices[iv].y = <float>(y2 + sin(angle) * w)
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
-            vertices[iv + 1].x = x3 + cos(angle) * w
-            vertices[iv + 1].y = y3 + sin(angle) * w
+            vertices[iv + 1].x = <float>(x3 + cos(angle) * w)
+            vertices[iv + 1].y = <float>(y3 + sin(angle) * w)
             vertices[iv + 1].s0 = 0
             vertices[iv + 1].t0 = 0
             indices[ii] = piv + 1
@@ -600,12 +600,12 @@ cdef class Line(VertexInstruction):
             indices[ii + 5] = iv + 1
             ii += 6
             iv += 2
-            vertices[iv].x = sx1 - cos(sangle) * w
-            vertices[iv].y = sy1 - sin(sangle) * w
+            vertices[iv].x = <float>(sx1 - cos(sangle) * w)
+            vertices[iv].y = <float>(sy1 - sin(sangle) * w)
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
-            vertices[iv + 1].x = sx4 - cos(sangle) * w
-            vertices[iv + 1].y = sy4 - sin(sangle) * w
+            vertices[iv + 1].x = <float>(sx4 - cos(sangle) * w)
+            vertices[iv + 1].y = <float>(sy4 - sin(sangle) * w)
             vertices[iv + 1].s0 = 0
             vertices[iv + 1].t0 = 0
             indices[ii] = 0
@@ -626,14 +626,14 @@ cdef class Line(VertexInstruction):
             siv = iv
             cx = p[0]
             cy = p[1]
-            vertices[iv].x = cx
-            vertices[iv].y = cy
+            vertices[iv].x = <float>cx
+            vertices[iv].y = <float>cy
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
             iv += 1
             for i in xrange(0, self._cap_precision - 1):
-                vertices[iv].x = cx + cos(a1 + step * i) * w
-                vertices[iv].y = cy + sin(a1 + step * i) * w
+                vertices[iv].x = <float>(cx + cos(a1 + step * i) * w)
+                vertices[iv].y = <float>(cy + sin(a1 + step * i) * w)
                 vertices[iv].s0 = 1
                 vertices[iv].t0 = 1
                 if i == 0:
@@ -658,14 +658,14 @@ cdef class Line(VertexInstruction):
             siv = iv
             cx = p[-2]
             cy = p[-1]
-            vertices[iv].x = cx
-            vertices[iv].y = cy
+            vertices[iv].x = <float>cx
+            vertices[iv].y = <float>cy
             vertices[iv].s0 = 0
             vertices[iv].t0 = 0
             iv += 1
             for i in xrange(0, self._cap_precision - 1):
-                vertices[iv].x = cx + cos(a1 + step * i) * w
-                vertices[iv].y = cy + sin(a1 + step * i) * w
+                vertices[iv].x = <float>(cx + cos(a1 + step * i) * w)
+                vertices[iv].y = <float>(cy + sin(a1 + step * i) * w)
                 vertices[iv].s0 = 0
                 vertices[iv].t0 = 0
                 if i == 0:
@@ -1132,10 +1132,10 @@ cdef class Line(VertexInstruction):
     cdef void prebuild_rounded_rectangle(self):
         cdef float a, px, py, x, y, w, h, c1, c2, c3, c4
         cdef resolution = 30
-        cdef int l = len(self._mode_args)
+        cdef int l = <int>len(self._mode_args)
 
         self._points = []
-        a = -PI
+        a = <float>-PI
         x, y, w, h = self._mode_args [:4]
 
         if l == 5:
@@ -1276,7 +1276,7 @@ cdef class SmoothLine(Line):
 
     def __init__(self, **kwargs):
         Line.__init__(self, **kwargs)
-        self._owidth = kwargs.get("overdraw_width") or 1.2
+        self._owidth = kwargs.get("overdraw_width") or <float>1.2
         self.batch.set_mode("triangles")
         self.texture = self.premultiplied_texture()
 
@@ -1312,23 +1312,23 @@ cdef class SmoothLine(Line):
     cdef void build_smooth(self):
         cdef:
             list p = self.points
-            float width = max(0, (self._width - 1.))
-            float owidth = width + self._owidth
+            double width = max(0, (self._width - 1.))
+            double owidth = width + self._owidth
             vertex_t *vertices = NULL
             unsigned short *indices = NULL
             unsigned short *tindices = NULL
             double ax, ay, bx = 0., by = 0., rx = 0., ry = 0., last_angle = 0., angle, av_angle
-            float cos1, sin1, cos2, sin2, ocos1, ocos2, osin1, osin2
-            long index, vindex, vcount, icount, iv, ii, max_vindex, count
-            unsigned short i0, i1, i2, i3, i4, i5, i6, i7
+            double cos1, sin1, cos2, sin2, ocos1, ocos2, osin1, osin2
+            long index, icount, iv, ii, max_vindex, count
+            unsigned short i0, i1, i2, i3, i4, i5, i6, i7, vindex, vcount
 
         iv = vindex = 0
-        count = len(p) / 2
+        count = <long>int(len(p) / 2.)
         if count < 2:
             self.batch.clear_data()
             return
 
-        vcount = count * 4
+        vcount = <unsigned short>(count * 4)
         icount = (count - 1) * 18
         if self._close:
             icount += 18
@@ -1413,7 +1413,7 @@ cdef class SmoothLine(Line):
                     #print 'ERROR LINE INTERSECTION 1'
                     pass
 
-                l = sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
+                l = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
 
                 if line_intersection(
                     ox + cos(ra1) * owidth,
@@ -1428,7 +1428,7 @@ cdef class SmoothLine(Line):
                     #print 'ERROR LINE INTERSECTION 2'
                     pass
 
-                ol = sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
+                ol = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
 
             last_angle = angle
 
@@ -1464,23 +1464,23 @@ cdef class SmoothLine(Line):
             ox2 = ax + ocos2
             oy2 = ay + osin2
 
-            vertices[iv].x = x1
-            vertices[iv].y = y1
+            vertices[iv].x = <float>x1
+            vertices[iv].y = <float>y1
             vertices[iv].s0 = 0.5
             vertices[iv].t0 = 0.25
             iv += 1
-            vertices[iv].x = x2
-            vertices[iv].y = y2
+            vertices[iv].x = <float>x2
+            vertices[iv].y = <float>y2
             vertices[iv].s0 = 0.5
             vertices[iv].t0 = 0.75
             iv += 1
-            vertices[iv].x = ox1
-            vertices[iv].y = oy1
+            vertices[iv].x = <float>ox1
+            vertices[iv].y = <float>oy1
             vertices[iv].s0 = 1
             vertices[iv].t0 = 0
             iv += 1
-            vertices[iv].x = ox2
-            vertices[iv].y = oy2
+            vertices[iv].x = <float>ox2
+            vertices[iv].y = <float>oy2
             vertices[iv].s0 = 1
             vertices[iv].t0 = 1
             iv += 1

--- a/kivy/lib/gstplayer/_gstplayer.h
+++ b/kivy/lib/gstplayer/_gstplayer.h
@@ -79,7 +79,7 @@ static GstFlowReturn c_on_appsink_sample(GstElement *appsink, callback_data_t *d
 	if ( width4 == width3 ) {
 		// we can directly use the buffer in memory
 		cbuffer = (gchar *)mapinfo.data;
-		size = mapinfo.size;
+		size = (gint)mapinfo.size;
 	} else {
 		// need a copy without stride :(
 		// OpenGL ES 2 doesn't support stride without an extension.  We might

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -332,17 +332,17 @@ cdef class GstPlayer:
                 g_object_set_double(self.playbin, 'volume', volume)
 
     def get_duration(self):
-        cdef float duration
+        cdef double duration
         with nogil:
-            duration = self._get_duration()
+            duration = <double>self._get_duration()
         if duration == -1:
             return -1
         return duration / float(GST_SECOND)
 
     def get_position(self):
-        cdef float position
+        cdef double position
         with nogil:
-            position = self._get_position()
+            position = <double>self._get_position()
         if position == -1:
             return -1
         return position / float(GST_SECOND)

--- a/kivy/lib/libtess2/Source/bucketalloc.c
+++ b/kivy/lib/libtess2/Source/bucketalloc.c
@@ -1,5 +1,5 @@
 /*
-** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008) 
+** SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
 ** Copyright (C) [dates of first publication] Silicon Graphics, Inc.
 ** All Rights Reserved.
 **
@@ -9,10 +9,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 ** of the Software, and to permit persons to whom the Software is furnished to do so,
 ** subject to the following conditions:
-** 
+**
 ** The above copyright notice including the dates of first publication and either this
 ** permission notice or a reference to http://oss.sgi.com/projects/FreeB/ shall be
-** included in all copies or substantial portions of the Software. 
+** included in all copies or substantial portions of the Software.
 **
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 ** INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -20,7 +20,7 @@
 ** BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 ** OR OTHER DEALINGS IN THE SOFTWARE.
-** 
+**
 ** Except as contained in this notice, the name of Silicon Graphics, Inc. shall not
 ** be used in advertising or otherwise to promote the sale, use or other dealings in
 ** this Software without prior written authorization from Silicon Graphics, Inc.
@@ -55,7 +55,7 @@ struct BucketAlloc
 
 static int CreateBucket( struct BucketAlloc* ba )
 {
-	size_t size;
+	unsigned int size;
 	Bucket* bucket;
 	void* freelist;
 	unsigned char* head;
@@ -154,8 +154,8 @@ void bucketFree( struct BucketAlloc *ba, void *ptr )
 			inBounds = 1;
 			break;
 		}
-		bucket = bucket->next;			
-	}		
+		bucket = bucket->next;
+	}
 
 	if ( inBounds )
 	{
@@ -184,7 +184,7 @@ void deleteBucketAlloc( struct BucketAlloc *ba )
 		next = bucket->next;
 		alloc->memfree( alloc->userData, bucket );
 		bucket = next;
-	}		
+	}
 	ba->freelist = 0;
 	ba->buckets = 0;
 	alloc->memfree( alloc->userData, ba );

--- a/kivy/lib/vidcore_lite/egl.pyx
+++ b/kivy/lib/vidcore_lite/egl.pyx
@@ -1,6 +1,6 @@
 
 from libc.stdlib cimport malloc, free
-from bcm cimport DISPMANX_ELEMENT_HANDLE_T, ElementHandle
+from .bcm cimport DISPMANX_ELEMENT_HANDLE_T, ElementHandle
 cimport bcm
 import bcm
 

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -296,7 +296,7 @@ cpdef float dpi2px(value, ext) except *:
         g_dpi = Metrics.dpi
         g_density = Metrics.density
         g_fontscale = Metrics.fontscale
-    cdef float rv = float(value)
+    cdef float rv = <float>float(value)
     if ext == 'in':
         return rv * g_dpi
     elif ext == 'px':
@@ -306,11 +306,11 @@ cpdef float dpi2px(value, ext) except *:
     elif ext == 'sp':
         return rv * g_density * g_fontscale
     elif ext == 'pt':
-        return rv * g_dpi / 72.
+        return rv * g_dpi / <float>72.
     elif ext == 'cm':
-        return rv * g_dpi / 2.54
+        return rv * g_dpi / <float>2.54
     elif ext == 'mm':
-        return rv * g_dpi / 25.4
+        return rv * g_dpi / <float>25.4
 
 cdef class Property:
     '''Base class for building more complex properties.
@@ -662,7 +662,7 @@ cdef class NumericProperty(Property):
         if value[-2:] in NUMERIC_FORMATS:
             return self.parse_list(obj, value[:-2], value[-2:])
         else:
-            return float(value)
+            return <float>float(value)
 
     cdef float parse_list(self, EventDispatcher obj, value, ext) except *:
         cdef PropertyStorage ps = obj.__storage[self._name]

--- a/setup.py
+++ b/setup.py
@@ -579,7 +579,10 @@ class CythonExtension(Extension):
         self.cython_directives = {
             'c_string_encoding': 'utf-8',
             'profile': 'USE_PROFILE' in environ,
-            'embedsignature': 'USE_EMBEDSIGNATURE' in environ}
+            'embedsignature': 'USE_EMBEDSIGNATURE' in environ,
+            'language_level': 3,
+            'unraisable_tracebacks': True,
+        }
         # XXX with pip, setuptools is imported before distutils, and change
         # our pyx to c, then, cythonize doesn't happen. So force again our
         # sources


### PR DESCRIPTION
The cython `language_level` setting sets whether the code is compiled under python 2 or 3 language syntax. Right now the default is 2, but in the future it'll be 3.

This sets the level to 3, explicitly, and fixes all the issues I encountered to make it compile and make all the warning go away. This should put us in a good state fr when the default changes, and also so that we can reliably use python 3 syntax in cython without having to keep track whether division returns a float etc.

Most of the warnings and compile issues was because:
* imports were `from x import y` instead of `from .x import y`, where `x` was the file next to the current file.
* In many places we use `float`, but when we do any multiplication it actually uses double arithmetic so we have to explicitly cast to the `float` type afterwards.
* `xrange` didn't cause errors, for now, so I didn't change it, except if I changed the neighboring code.