### PR TITLE
Update clock.py - Corrected typo

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -486,7 +486,7 @@ class ClockBaseBehavior(object):
 
     MIN_SLEEP = 0.005
     '''The minimum time to sleep. If the remaining time is less than this,
-    the event loop will continuo
+    the event loop will continue.
     '''
     SLEEP_UNDERSHOOT = MIN_SLEEP - 0.001
 


### PR DESCRIPTION
There was a typo in one of the descriptions. Changed "continuo" to 'continue."