### PR TITLE
Arch Linux documentation support with changes

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -184,6 +184,38 @@ Gentoo
    `gstreamer: Standard flag, kivy will be able to use audio/video streaming libraries.`
    `spell: Standard flag, provide enchant to use spelling in kivy apps.`
 
+
+Manual installation (On Arch Linux based systems)
+------------------------------------------------
+
+#. Install the dependencies::
+
+    pacman -Syu
+    pacman -S sdl2 sdl2_gfx sdl2_image sdl2_net sdl2_ttf sdl2_mixer python-setuptools python-pip
+
+    Note: python-setuptools needs to be installed through pacman or it will result with conflicts!
+
+#. Upgrading pip::
+
+    python -m pip install --upgrade --user pip
+
+#. Install a new enough version of Cython:
+
+    .. parsed-literal::
+
+        pip install -U |cython_install|
+
+#. Install Kivy globally on your system::
+
+    pip install git+https://github.com/kivy/kivy.git@master
+
+#. Or build and use kivy inplace (best for development)::
+
+    git clone https://github.com/kivy/kivy
+    cd kivy
+    python setup.py install
+
+
 Manually installing Kivy from source
 ------------------------------------
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -119,7 +119,8 @@ Manual installation (On Arch Linux ARM)
 
 #. Install pip from source::
 
-    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+    wget https://bootstrap.pypa.io/get-pip.py
+    or curl -O https://bootstrap.pypa.io/get-pip.py
     sudo python get-pip.py
 
 #. Install a new enough version of Cython:

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -107,42 +107,35 @@ Manual installation (On Raspbian Wheezy)
     echo "export PYTHONPATH=$(pwd):\$PYTHONPATH" >> ~/.profile
     source ~/.profile
 
-Manual installation (On Arch Linux ARM)
+Manual installation (On Arch Linux based systems)
 ------------------------------------------------
 
 #. Install the dependencies::
 
-    sudo pacman -Syu
-    sudo pacman -S sdl2 sdl2_gfx sdl2_image sdl2_net sdl2_ttf sdl2_mixer python-setuptools
+    pacman -Syu
+    pacman -S sdl2 sdl2_gfx sdl2_image sdl2_net sdl2_ttf sdl2_mixer python-setuptools python-pip
 
     Note: python-setuptools needs to be installed through pacman or it will result with conflicts!
 
-#. Install pip from source::
+#. Upgrading pip::
 
-    wget https://bootstrap.pypa.io/get-pip.py
-    or curl -O https://bootstrap.pypa.io/get-pip.py
-    sudo python get-pip.py
+    python -m pip install --upgrade --user pip
 
 #. Install a new enough version of Cython:
 
     .. parsed-literal::
 
-        sudo pip install -U |cython_install|
+        pip install -U |cython_install|
 
 #. Install Kivy globally on your system::
 
-    sudo pip install git+https://github.com/kivy/kivy.git@master
+    pip install git+https://github.com/kivy/kivy.git@master
 
 #. Or build and use kivy inplace (best for development)::
 
     git clone https://github.com/kivy/kivy
     cd kivy
     python setup.py install
-
-Images to use::
-
-    http://raspex.exton.se/?p=859 (recommended)  
-    https://archlinuxarm.org/
 
 .. note::
 


### PR DESCRIPTION
- Changes to the documentation and renaming (Not only targeting Arch Linux). Also added some of what matham mentioned about on Discord.
- Added the support documentation also for the Linux installation page.

Things to change: The way you install kivy (no usage of pip). I hope someone else could help me with that part.