### PR TITLE
fix pausing without app instance

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -229,11 +229,9 @@ class WindowSDL(WindowBase):
             from kivy.base import stopTouchApp
             app = App.get_running_app()
             if not app:
-                Logger.info('WindowSDL: No running App found, exit.')
-                stopTouchApp()
-                return 0
+                Logger.info('WindowSDL: No running App found, pause.')
 
-            if not app.dispatch('on_pause'):
+            elif not app.dispatch('on_pause'):
                 Logger.info(
                     'WindowSDL: App doesn\'t support pause mode, stop.')
                 stopTouchApp()
@@ -248,7 +246,8 @@ class WindowSDL(WindowBase):
             if self._pause_loop:
                 self._pause_loop = False
                 app = App.get_running_app()
-                app.dispatch('on_resume')
+                if app:
+                    app.dispatch('on_resume')
 
         elif action == 'windowresized':
             self._size = largs
@@ -707,11 +706,8 @@ class WindowSDL(WindowBase):
         from kivy.base import stopTouchApp
         app = App.get_running_app()
         if not app:
-            Logger.info('WindowSDL: No running App found, exit.')
-            stopTouchApp()
-            return
-
-        if not app.dispatch('on_pause'):
+            Logger.info('WindowSDL: No running App found, pause.')
+        elif not app.dispatch('on_pause'):
             Logger.info('WindowSDL: App doesn\'t support pause mode, stop.')
             stopTouchApp()
             return
@@ -732,8 +728,9 @@ class WindowSDL(WindowBase):
                 break
             elif action == 'windowrestored':
                 break
-
-        app.dispatch('on_resume')
+            
+        if app:
+            app.dispatch('on_resume')
 
     def _update_modifiers(self, mods=None, key=None):
         if mods is None and key is None:


### PR DESCRIPTION
On android, pause event can come in early, before the app instance is
created.

fixes #6400