### PR TITLE
Support for EGL on linux platform (GLVND)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ venv
 kivy/setupconfig.py
 
 kivy/core/clipboard/_clipboard_sdl2.c
+.eggs/
+.vscode/

--- a/kivy/core/window/window_x11_core.c
+++ b/kivy/core/window/window_x11_core.c
@@ -3,12 +3,12 @@
 #include <string.h>
 #include <math.h>
 #include <X11/Xatom.h>
-#include <X11/extensions/Xrender.h>
 #include <X11/Xutil.h>
 #include <X11/XKBlib.h>
 #include "config.h"
 
 #if __USE_EGL == 0
+	#include <X11/extensions/Xrender.h>
 	#include <GL/gl.h>
 	#include <GL/glx.h>
 	#include <GL/glxext.h>
@@ -56,15 +56,27 @@ static int g_width, g_height;
 		EGL_DEPTH_SIZE,         EGL_DONT_CARE,
 		EGL_STENCIL_SIZE,       EGL_DONT_CARE,
 
+#if __USE_OPENGL_ES2 == 1
 		EGL_RENDERABLE_TYPE,    EGL_OPENGL_ES2_BIT,
+#else
+		EGL_RENDERABLE_TYPE,    EGL_OPENGL_BIT,
+#endif
 		EGL_SURFACE_TYPE,       EGL_WINDOW_BIT | EGL_PIXMAP_BIT,
 		EGL_NONE,
 	};
 
+#if __USE_OPENGL_ES2 == 1
 	static const EGLint ctx_attribs[] = {
 	EGL_CONTEXT_CLIENT_VERSION, 2,
 	EGL_NONE
 	};
+#else
+	static const EGLint ctx_attribs[] = {
+	EGL_CONTEXT_CLIENT_VERSION,  4,
+	EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT,
+	EGL_NONE
+	};
+#endif
 #endif
 
 typedef int (*event_cb_t)(XEvent *event);
@@ -333,8 +345,15 @@ static void createTheWindow(int width, int height, int x, int y, int resizable, 
 			fatalError("Can't initialize egl\n");
 		}
 
-		eglBindAPI(EGL_OPENGL_ES_API);
-
+#if __USE_OPENGL_ES2 == 1
+		if (eglBindAPI(EGL_OPENGL_ES_API) == EGL_FALSE) {
+			fatalError("Can't bind EGL_OPENGL_ES_API\n");
+		}
+#else
+		if (eglBindAPI(EGL_OPENGL_API) == EGL_FALSE) {
+			fatalError("Can't bind EGL_OPENGL_API\n");
+		}
+#endif
 		EGLint num_configs;
 		eglChooseConfig(eglDisplay, egl_config_attribs, &eglconfig, 1, &num_configs);
 
@@ -346,9 +365,14 @@ static void createTheWindow(int width, int height, int x, int y, int resizable, 
 
 		// connect the context to the surface
 		eglcontext = eglCreateContext(eglDisplay, eglconfig, EGL_NO_CONTEXT, ctx_attribs);
+		if (eglcontext == EGL_NO_CONTEXT) {
+			fatalError("Couldn't create the context\n");
+		}
 
 		// associate the egl-context with the egl-surface
-		eglMakeCurrent(eglDisplay, eglsurface, eglsurface, eglcontext);
+		if (eglMakeCurrent(eglDisplay, eglsurface, eglsurface, eglcontext) == EGL_FALSE){
+			fatalError("Couldn't make the egl context current\n");
+		}
 
 		// print egl information
 		printf("WinX11 EGL vendor: %s\n", eglQueryString(eglDisplay, EGL_VENDOR));

--- a/kivy/graphics/cgl_backend/cgl_glew.pyx
+++ b/kivy/graphics/cgl_backend/cgl_glew.pyx
@@ -14,16 +14,12 @@ cdef extern from "gl_redirect.h":
     int GLEW_OK
     char *glewGetErrorString(int) nogil
 
-IF PLATFORM == "win32":
-    cdef extern from *:
-        void* wglGetProcAddress(const char* proc)
-
 cpdef is_backend_supported():
-    return not USE_OPENGL_MOCK and PLATFORM == "win32"
+    return not USE_OPENGL_MOCK and (PLATFORM == "win32" or PLATFORM == "linux")
 
 
 def init_backend():
-    IF USE_OPENGL_MOCK or PLATFORM != "win32":
+    IF USE_OPENGL_MOCK or (PLATFORM != "win32" and PLATFORM != "linux"):
         raise TypeError('Glew is not available. Recompile with USE_OPENGL_MOCK=0')
     ELSE:
         cdef int result
@@ -35,62 +31,3 @@ def init_backend():
         else:
             Logger.info('GL: GLEW initialization succeeded')
         link_static()
-        gl_dynamic_binding(<void *(__stdcall *)(const char *)>wglGetProcAddress)
-
-IF not USE_OPENGL_MOCK and PLATFORM == "win32":
-    cdef void gl_dynamic_binding(void *(__stdcall * f)(const char *)) except *:
-        cdef bytes gl_extensions
-        if cgl.glGetString == NULL:
-            Logger.error('glGetString is unavailable, skipping Fbo detection')
-            return
-        gl_extensions = cgl.glGetString(GL_EXTENSIONS)
-
-        # If the current opengl driver don't have framebuffers methods,
-        # Check if an extension exist
-        Logger.debug("GL: available extensions: {}".format(gl_extensions))
-        if cgl.glGenFramebuffers != NULL:
-            return
-
-        Logger.debug("GL: glGenFramebuffers is NULL, try to detect an extension")
-        if b"ARB_framebuffer_object" in gl_extensions:
-            Logger.debug("GL: ARB_framebuffer_object is supported")
-
-            cgl.glIsRenderbuffer = <GLISRENDERBUFFERPTR> f("glIsRenderbuffer")
-            cgl.glBindRenderbuffer = <GLBINDRENDERBUFFERPTR> f("glBindRenderbuffer")
-            cgl.glDeleteRenderbuffers = <GLDELETERENDERBUFFERSPTR> f("glDeleteRenderbuffers")
-            cgl.glGenRenderbuffers = <GLGENRENDERBUFFERSPTR> f("glGenRenderbuffers")
-            cgl.glRenderbufferStorage = <GLRENDERBUFFERSTORAGEPTR> f("glRenderbufferStorage")
-            cgl.glGetRenderbufferParameteriv = <GLGETRENDERBUFFERPARAMETERIVPTR> f("glGetRenderbufferParameteriv")
-            cgl.glIsFramebuffer = <GLISFRAMEBUFFERPTR> f("glIsFramebuffer")
-            cgl.glBindFramebuffer = <GLBINDFRAMEBUFFERPTR> f("glBindFramebuffer")
-            cgl.glDeleteFramebuffers = <GLDELETEFRAMEBUFFERSPTR> f("glDeleteFramebuffers")
-            cgl.glGenFramebuffers = <GLGENFRAMEBUFFERSPTR> f("glGenFramebuffers")
-            cgl.glCheckFramebufferStatus = <GLCHECKFRAMEBUFFERSTATUSPTR> f("glCheckFramebufferStatus")
-            #cgl.glFramebufferTexture1D = <GLFRAMEBUFFERTEXTURE1DPTR> f("glFramebufferTexture1D")
-            cgl.glFramebufferTexture2D = <GLFRAMEBUFFERTEXTURE2DPTR> f("glFramebufferTexture2D")
-            #cgl.glFramebufferTexture3D = <GLFRAMEBUFFERTEXTURE3DPTR> f("glFramebufferTexture3D")
-            cgl.glFramebufferRenderbuffer = <GLFRAMEBUFFERRENDERBUFFERPTR> f("glFramebufferRenderbuffer")
-            cgl.glGetFramebufferAttachmentParameteriv = <GLGETFRAMEBUFFERATTACHMENTPARAMETERIVPTR> f("glGetFramebufferAttachmentParameteriv")
-            cgl.glGenerateMipmap = <GLGENERATEMIPMAPPTR> f("glGenerateMipmap")
-        elif b"EXT_framebuffer_object" in gl_extensions:
-            Logger.debug("GL: EXT_framebuffer_object is supported\n")
-
-            cgl.glIsRenderbuffer = <GLISRENDERBUFFERPTR> f("glIsRenderbufferEXT")
-            cgl.glBindRenderbuffer = <GLBINDRENDERBUFFERPTR> f("glBindRenderbufferEXT")
-            cgl.glDeleteRenderbuffers = <GLDELETERENDERBUFFERSPTR> f("glDeleteRenderbuffersEXT")
-            cgl.glGenRenderbuffers = <GLGENRENDERBUFFERSPTR> f("glGenRenderbuffersEXT")
-            cgl.glRenderbufferStorage = <GLRENDERBUFFERSTORAGEPTR> f("glRenderbufferStorageEXT")
-            cgl.glGetRenderbufferParameteriv = <GLGETRENDERBUFFERPARAMETERIVPTR> f("glGetRenderbufferParameterivEXT")
-            cgl.glIsFramebuffer = <GLISFRAMEBUFFERPTR> f("glIsFramebufferEXT")
-            cgl.glBindFramebuffer = <GLBINDFRAMEBUFFERPTR> f("glBindFramebufferEXT")
-            cgl.glDeleteFramebuffers = <GLDELETEFRAMEBUFFERSPTR> f("glDeleteFramebuffersEXT")
-            cgl.glGenFramebuffers = <GLGENFRAMEBUFFERSPTR> f("glGenFramebuffersEXT")
-            cgl.glCheckFramebufferStatus = <GLCHECKFRAMEBUFFERSTATUSPTR> f("glCheckFramebufferStatusEXT")
-            #cgl.glFramebufferTexture1D = <GLFRAMEBUFFERTEXTURE1DPTR> f("glFramebufferTexture1DEXT")
-            cgl.glFramebufferTexture2D = <GLFRAMEBUFFERTEXTURE2DPTR> f("glFramebufferTexture2DEXT")
-            #cgl.glFramebufferTexture3D = <GLFRAMEBUFFERTEXTURE3DPTR> f("glFramebufferTexture3DEXT")
-            cgl.glFramebufferRenderbuffer = <GLFRAMEBUFFERRENDERBUFFERPTR> f("glFramebufferRenderbufferEXT")
-            cgl.glGetFramebufferAttachmentParameteriv = <GLGETFRAMEBUFFERATTACHMENTPARAMETERIVPTR> f("glGetFramebufferAttachmentParameterivEXT")
-        else:
-            Logger.info("GL: No framebuffers extension is supported")
-            Logger.debug("GL: Any call to Fbo will crash!")

--- a/kivy/graphics/opengl_utils.pyx
+++ b/kivy/graphics/opengl_utils.pyx
@@ -50,6 +50,8 @@ cpdef list gl_get_extensions():
                 for x in extensions.split()]
     return _gl_extensions
 
+cdef extern from "gl_redirect.h":
+    GLboolean glewIsSupported (const char *name) nogil
 
 cpdef int gl_has_extension(name):
     '''Check if an OpenGL extension is available. If the name starts with `GL_`,
@@ -63,6 +65,9 @@ cpdef int gl_has_extension(name):
     '''
     if cgl_get_initialized_backend_name() == "mock":
         return True
+    elif cgl_get_initialized_backend_name() == "glew":
+        return glewIsSupported(name) != GL_FALSE or glewIsSupported('GL_' + name) != GL_FALSE
+
     name = name.lower()
     if name.startswith('GL_'):
         name = name[3:]

--- a/kivy/include/gl_redirect.h
+++ b/kivy/include/gl_redirect.h
@@ -53,7 +53,11 @@
     #ifndef GL_EXT_texture_storage
     #define GL_EXT_texture_storage
     #endif
-
+#elif (__USE_EGL==1 && __USE_OPENGL_ES2==0)
+    // using EGL & X11 on platform linux
+    // requires glew to be installed (e.g. apt install libglew-dev)
+    #define GLEW_EGL
+    #include <GL/glew.h>
 #else
 
 #	if __USE_OPENGL_ES2

--- a/setup.py
+++ b/setup.py
@@ -666,7 +666,7 @@ def determine_gl_flags():
         c_options['use_x11'] = True
         c_options['use_egl'] = True
     else:
-        flags['libraries'] = ['GL']
+        flags['libraries'] = ['GL','GLEW']
     return flags, base_flags
 
 
@@ -803,7 +803,7 @@ sources = {
     'graphics/gl_instructions.pyx': merge(base_flags, gl_flags_base),
     'graphics/instructions.pyx': merge(base_flags, gl_flags_base),
     'graphics/opengl.pyx': merge(base_flags, gl_flags_base),
-    'graphics/opengl_utils.pyx': merge(base_flags, gl_flags_base),
+    'graphics/opengl_utils.pyx': merge(base_flags, gl_flags),
     'graphics/shader.pyx': merge(base_flags, gl_flags_base),
     'graphics/stencil_instructions.pyx': merge(base_flags, gl_flags_base),
     'graphics/scissor_instructions.pyx': merge(base_flags, gl_flags_base),
@@ -900,11 +900,14 @@ if c_options['use_rpi']:
         base_flags, gl_flags)
 
 if c_options['use_x11']:
-    libs = ['Xrender', 'X11']
+    libs = ['X11']
     if c_options['use_egl']:
+        if platform == 'linux':
+            # link with GLVND : libOpenGL
+            libs += ['OpenGL']
         libs += ['EGL']
     else:
-        libs += ['GL']
+        libs += ['Xrender', 'GL']
     sources['core/window/window_x11.pyx'] = merge(
         base_flags, gl_flags, {
             # FIXME add an option to depend on them but not compile them


### PR DESCRIPTION
I'm not expecting this to be merged. Mostly an example on how to make Kivy work with GLVND and allow CUDA interop to work on Ubuntu 18.04, could also be useful on the Jetson but I haven't validated this. It supports this configuration: USE_EGL=1, USE_X11=1 in platform=='linux' (and USE_OPENGL_ES_2=0).

Motivation: cudaGraphicsGLRegisterImage failed on textures id from Kivy on Ubuntu 18.04. I figured that this function only works correctly for EGL created context. 

In Ubuntu 18.04 using nvidia proprietary driver ppa, we now get the GLVND driver by default. So we can use EGL and X11 by linking with libEGL and libOpenGL. See [Linking OpenGL for Server-Side Rendering](https://devblogs.nvidia.com/linking-opengl-server-side-rendering/).

This PR is about using the full OpenGL API in the X11+EGL configuration and about using GLEW for the backend in this case. Using GLEW might not be mandatory, but it's how I go around the deprecated GL_EXTENSIONS not returning anything at some point when I was testing this. I added the compatibility bit late in my tests, so maybe GLEW was not necessary with that bit set, but supporting GLEW in platform 'linux' may be useful for someone else.