### PR TITLE
Add preliminary support for coverage for kv files.

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -176,7 +176,10 @@ class ParserRuleProperty(object):
             # if we don't detect any string/key in it, we can eval and give the
             # result
             if re.search(lang_key, tmp) is None:
-                self.co_value = eval(value)
+                value = '\n' * self.line + value
+                self.co_value = eval(
+                    compile(value, self.ctx.filename or '<string>', 'eval')
+                )
                 return
 
         # ok, we can compile.

--- a/kivy/tests/coverage_lang.kv
+++ b/kivy/tests/coverage_lang.kv
@@ -1,0 +1,17 @@
+#:import kivy kivy
+
+<SomeWidget@Widget>:
+    on_x: self.something = 42
+    height: self.width
+    width: 78
+    on_y:
+        self.another = 23
+        self.home = 78
+    canvas.before:
+        Color:
+            rgb: 1, 1, 1
+
+Widget:
+    size: 55, self.y + 10
+    SomeWidget:
+        size_hint_x: .5

--- a/kivy/tests/test_coverage.py
+++ b/kivy/tests/test_coverage.py
@@ -1,0 +1,83 @@
+import pytest
+import os
+try:
+    import coverage
+except ImportError:
+    pytestmark = pytest.mark.skip("coverage not available")
+
+
+kv_statement_lines = {4, 5, 6, 8, 9, 12, 15, 17}
+
+
+def test_coverage_base():
+    from kivy.lang.builder import Builder
+    cov = coverage.Coverage(source=[os.path.dirname(__file__)])
+    cov.start()
+
+    fname = os.path.join(os.path.dirname(__file__), 'coverage_lang.kv')
+    try:
+        widget = Builder.load_file(fname)
+    finally:
+        cov.stop()
+
+    Builder.unload_file(fname)
+    _, statements, missing, _ = cov.analysis(fname)
+    assert set(statements) == kv_statement_lines
+    assert set(missing) == {4, 8, 9}
+
+
+def test_coverage_multiline_on_event():
+    from kivy.lang.builder import Builder
+    cov = coverage.Coverage(source=[os.path.dirname(__file__)])
+    cov.start()
+
+    fname = os.path.join(os.path.dirname(__file__), 'coverage_lang.kv')
+    try:
+        widget = Builder.load_file(fname)
+        widget.children[0].y = 65
+    finally:
+        cov.stop()
+
+    Builder.unload_file(fname)
+    _, statements, missing, _ = cov.analysis(fname)
+    assert set(statements) == kv_statement_lines
+    assert set(missing) == {4, }
+
+
+def test_coverage_trigger_event():
+    from kivy.lang.builder import Builder
+    cov = coverage.Coverage(source=[os.path.dirname(__file__)])
+    cov.start()
+
+    fname = os.path.join(os.path.dirname(__file__), 'coverage_lang.kv')
+    try:
+        widget = Builder.load_file(fname)
+        widget.children[0].x = 65
+        widget.children[0].width = 97
+    finally:
+        cov.stop()
+
+    Builder.unload_file(fname)
+    _, statements, missing, _ = cov.analysis(fname)
+    assert set(statements) == kv_statement_lines
+    assert set(missing) == {8, 9}
+
+
+def test_coverage_trigger_all():
+    from kivy.lang.builder import Builder
+    cov = coverage.Coverage(source=[os.path.dirname(__file__)])
+    cov.start()
+
+    fname = os.path.join(os.path.dirname(__file__), 'coverage_lang.kv')
+    try:
+        widget = Builder.load_file(fname)
+        widget.children[0].x = 65
+        widget.children[0].width = 97
+        widget.children[0].y = 65
+    finally:
+        cov.stop()
+
+    Builder.unload_file(fname)
+    _, statements, missing, _ = cov.analysis(fname)
+    assert set(statements) == kv_statement_lines
+    assert set(missing) == set()

--- a/kivy/tools/coverage.py
+++ b/kivy/tools/coverage.py
@@ -1,0 +1,135 @@
+"""Kivy coverage plugin
+=======================
+
+This provides a coverage plugin to measure code execution in kv files. To use,
+create and add::
+
+    [run]
+    plugins =
+        kivy.tools.coverage
+
+to the ``.coveragerc`` file in the root of your project. Or::
+
+    [coverage:run]
+    plugins =
+        kivy.tools.coverage
+
+in ``setup.cfg``.
+
+Then you can test your project with e.g. ``pip install coverage`` followed by
+``coverage run --source=./ kivy_app.py`` and ``coverage report``.
+
+Or to use with pytest, ``pip install pytest-cov`` followed by something like
+``pytest --cov=./ .``
+
+TODO: Expand kv statements measured.
+
+Currently, it ignores rules such as Widget creation or graphics object
+creation from being measured. Similarly for import statements.
+
+KV code created as strings within a python file is also not measured. To
+support the above, deeper changes will be required.
+"""
+
+import os
+import coverage
+from kivy.lang.parser import Parser
+
+
+class CoverageKVParser(Parser):
+
+    def execute_directives(self):
+        # don't actually execute anything
+        pass
+
+    def get_coverage_lines(self):
+        lines = set()
+        for parser_prop in walk_parser(self):
+            for line_num, line in enumerate(
+                    parser_prop.value.splitlines(),
+                    start=parser_prop.line + 1):
+                if line.strip():
+                    lines.add(line_num)
+
+        return lines
+
+
+def walk_parser_rules(parser_rule):
+    yield parser_rule
+
+    for child in parser_rule.children:
+        for rule in walk_parser_rules(child):
+            yield rule
+
+    if parser_rule.canvas_before is not None:
+        for rule in walk_parser_rules(parser_rule.canvas_before):
+            yield rule
+        yield parser_rule.canvas_before
+    if parser_rule.canvas_root is not None:
+        for rule in walk_parser_rules(parser_rule.canvas_root):
+            yield rule
+    if parser_rule.canvas_after is not None:
+        for rule in walk_parser_rules(parser_rule.canvas_after):
+            yield rule
+
+
+def walk_parser_rules_properties(parser_rule):
+    for rule in parser_rule.properties.values():
+        yield rule
+    for rule in parser_rule.handlers:
+        yield rule
+
+
+def walk_parser(parser):
+    if parser.root is not None:
+        for rule in walk_parser_rules(parser.root):
+            for prop in walk_parser_rules_properties(rule):
+                yield prop
+
+    for _, cls_rule in parser.rules:
+        for rule in walk_parser_rules(cls_rule):
+            for prop in walk_parser_rules_properties(rule):
+                yield prop
+
+
+class KivyCoveragePlugin(coverage.plugin.CoveragePlugin):
+
+    def file_tracer(self, filename):
+        if filename.endswith('.kv'):
+            return KivyFileTracer(filename=filename)
+        return None
+
+    def file_reporter(self, filename):
+        return KivyFileReporter(filename=filename)
+
+    def find_executable_files(self, src_dir):
+        for (dirpath, dirnames, filenames) in os.walk(src_dir):
+            for filename in filenames:
+                if filename.endswith('.kv'):
+                    yield os.path.join(dirpath, filename)
+
+
+class KivyFileTracer(coverage.plugin.FileTracer):
+
+    filename = ''
+
+    def __init__(self, filename, **kwargs):
+        super(KivyFileTracer, self).__init__(**kwargs)
+        self.filename = filename
+
+    def source_filename(self):
+        return self.filename
+
+
+class KivyFileReporter(coverage.plugin.FileReporter):
+
+    def lines(self):
+        with open(self.filename) as fh:
+            source = fh.read()
+
+        parser = CoverageKVParser(content=source, filename=self.filename)
+        return parser.get_coverage_lines()
+
+
+def coverage_init(reg, options):
+    reg.add_file_tracer(KivyCoveragePlugin())

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ logging-level=DEBUG
 cython_min=0.24
 cython_max=0.29.10
 cython_exclude=0.27,0.27.2
+[coverage:run]
+plugins =
+    kivy.tools.coverage


### PR DESCRIPTION
This provides a coverage plugin to measure code execution in kv files. To use, create and add
```
    [run]
    plugins =
        kivy.tools.coverage
```

to the ``.coveragerc`` file in the root of your project. Or
```
    [coverage:run]
    plugins =
        kivy.tools.coverage
```
in ``setup.cfg``.

Then you can test your project with e.g. ``pip install coverage`` followed by ``coverage run --source=./ kivy_app.py`` and ``coverage report``. Or to use with pytest, ``pip install pytest-cov`` followed by something like ``pytest --cov=./ .``

Still todo in the future, although not in this PR: Expand kv statements measured. Currently, it ignores rule headers such as `Widget` creation or graphics object creation from being measured. Similarly for import statements. It only measures property assignments and callbacks e.g. `prop: xxx` and `on_xxx: ...`.

KV code created as strings within a python file is also not measured. To support the above, deeper changes would be required.


I did have to change builder to do an `compile` and `eval` rather than just `eval`, otherwise it wasn't able to trace when the prop is set with a simple literal as it is not executed under a filename. I measured this change with:

```
import timeit

print(timeit.timeit(stmt='c = compile("\\n" * 10 + "4 + 5", "some_file.py", "eval"); q = eval(c)', number=100000))
print(timeit.timeit(stmt='q = eval("4 + 5")', number=100000))
```
which printed:
```
0.5128765000000001
0.45291780000000004
```
which I don't think is significant enough to not be worth this.