### PR TITLE
Fixes multiline label w/ line_height < 1

### DIFF
--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -127,7 +127,10 @@ cdef class _SurfaceContainer:
         r.w = st.w
         r.h = st.h
         SDL_SetSurfaceAlphaMod(st, <int>(color[3] * 255))
-        SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_NONE)
+        if container.options['font_blended']:
+            SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_BLEND)
+        else:
+            SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_NONE)
         SDL_BlitSurface(st, NULL, self.surface, &r)
         SDL_FreeSurface(st)
 


### PR DESCRIPTION
This PR fixes a "rendering" issue that prevents the user from take advantage of the `Label` `line_height` property when`line_height` is less than `1`

I think that needs some tests from devs and users in order to check unexpected behaviors on different devices and configurations.

Testcase example:

```python
BoxLayout:
    size_hint: 1, .5
    Label:
        size_hint: 1, 1
        color: 0, 0, 0, 1
        text_size: self.size
        font_size: dp(13)
        halign: 'left'
        valign: 'top'
        max_lines: 3
        shorten_from: 'right'
        line_height: .7
        padding: 0, 0
        text: "Lorem ipsum dolor sit amet demo demo demo demo"
```

