### PR TITLE
add comment on required pip version

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -13,7 +13,7 @@ Using Precompiled Wheels
 
 Wheels are precompiled binaries for all linux platforms using the manylinux2010 tag.
 In the following, replace `python` with `python3` for Python 3.
-To install first update pip::
+To install first update pip (at least pip v19.0 is required to support a manylinux2010 wheel)::
 
     $ python -m pip install --upgrade --user pip setuptools virtualenv
 


### PR DESCRIPTION
When trying to install kivy on Linux from wheel I first ignored the hint to upgrade pip. My pip version was below 19.0 which resulted in pip ignoring the wheel (as pip before v19.0 does not understand manylinux2010). In consequence, the source version was downloaded (which resulted in a compilation error for me). After upgrading pip, everything went smoothly.

As I think that more users might fall into this trap, I added a comment on the required pip version.