### PR TITLE
Changes to fix issues on Mac, for FileChooser and Popups

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -523,7 +523,7 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center, bind=('width', 'height'), cache=True)
+    center = AliasProperty(_get_center, bind=('width', 'height'), cache=False)
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -508,7 +508,6 @@
 # Popup widget
 <Popup>:
     _container: container
-    pos_hint: { "center_x": 0.5, "center_y": 0.5 } 
     GridLayout:
         padding: '12dp'
         cols: 1

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -236,7 +236,7 @@
         Rectangle:
             source: 'atlas://data/images/defaulttheme/tree_%s' % ('opened' if self.is_open else 'closed')
             size: self.height / 2.0, self.height / 2.0
-            pos: self.x - 20, self.center_y - 8
+            pos: self.x - dp(20), self.center_y - dp(8)
     canvas.after:
         Color:
             rgba: .5, .5, .5, .2
@@ -335,7 +335,7 @@
 
     orientation: 'horizontal'
     size_hint_y: None
-    height: '48dp' if dp(1) > 1 else '24dp'
+    height: '24dp' # '48dp' if dp(1) > 1 else '24dp'
     # Don't allow expansion of the ../ node
     is_leaf: not ctx.isdir or ctx.name.endswith('..' + ctx.sep) or self.locked
     on_touch_down: self.collide_point(*args[1].pos) and ctx.controller().entry_touched(self, args[1])
@@ -508,6 +508,7 @@
 # Popup widget
 <Popup>:
     _container: container
+    pos_hint: { "center_x": 0.5, "center_y": 0.5 } 
     GridLayout:
         padding: '12dp'
         cols: 1


### PR DESCRIPTION
Changes made to fix bugs on MacOS.
Problem: Initial position of PopUps not in Center, fixed with pos_hint
Problem: FileChooser format not device independent, fixed with dp()
Problem: FileChooser format height not device independent.  fixed()

Note: It appears there are a number of additional issues in style.kv.  Borders, for example does uses explicit sizing, dp() is missing in a number of places.  I do not have a test case so I have not made the change.