### PR TITLE
Center cache problem on MacOS

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -523,7 +523,7 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center, bind=('width', 'height', '_density'),cache=True)
+    center = AliasProperty(_get_center, bind=('width', 'height', '_density'), cache=True)
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -523,7 +523,7 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center, bind=('width', 'height'), cache=True)
+    center = AliasProperty(_get_center, bind=('width', 'height'), cache=False)
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -523,7 +523,9 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center, bind=('width', 'height', '_density'), cache=True)
+    center = AliasProperty(_get_center,
+                           bind=('width', 'height', '_density'),
+                           cache=True)
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -334,9 +334,9 @@ class WindowBase(EventDispatcher):
     __instance = None
     __initialized = False
     _fake_fullscreen = False
-    _density = 1
 
     # private properties
+    _density = NumericProperty(1)
     _size = ListProperty([0, 0])
     _modifiers = ListProperty([])
     _rotation = NumericProperty(0)
@@ -523,7 +523,7 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center, bind=('width', 'height'))  # Do not cache center
+    center = AliasProperty(_get_center, bind=('width', 'height', '_density'),cache=True)
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -523,7 +523,7 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center, bind=('width', 'height'), cache=False)
+    center = AliasProperty(_get_center, bind=('width', 'height'))  # Do not cache center
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -508,7 +508,6 @@
 # Popup widget
 <Popup>:
     _container: container
-    pos_hint: { "center_x": 0.5, "center_y": 0.5 } 
     GridLayout:
         padding: '12dp'
         cols: 1

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -236,7 +236,7 @@
         Rectangle:
             source: 'atlas://data/images/defaulttheme/tree_%s' % ('opened' if self.is_open else 'closed')
             size: self.height / 2.0, self.height / 2.0
-            pos: self.x - 20, self.center_y - 8
+            pos: self.x - dp(20), self.center_y - dp(8)
     canvas.after:
         Color:
             rgba: .5, .5, .5, .2
@@ -335,7 +335,7 @@
 
     orientation: 'horizontal'
     size_hint_y: None
-    height: '48dp' if dp(1) > 1 else '24dp'
+    height: '24dp' # '48dp' if dp(1) > 1 else '24dp'
     # Don't allow expansion of the ../ node
     is_leaf: not ctx.isdir or ctx.name.endswith('..' + ctx.sep) or self.locked
     on_touch_down: self.collide_point(*args[1].pos) and ctx.controller().entry_touched(self, args[1])
@@ -508,6 +508,7 @@
 # Popup widget
 <Popup>:
     _container: container
+    pos_hint: { "center_x": 0.5, "center_y": 0.5 } 
     GridLayout:
         padding: '12dp'
         cols: 1


### PR DESCRIPTION
On MacOS, The position of PopUps was wrong prior to a resize.  After a resize, popups were in the correct position.  Removing the cache=true setting from the center alias property solved the problem.