### PR TITLE
Move proxy_ref to EventDispatcher.

### DIFF
--- a/kivy/_event.pxd
+++ b/kivy/_event.pxd
@@ -15,6 +15,7 @@ cdef class EventDispatcher(ObjectWithUid):
     cdef dict __storage
     cdef object __weakref__
     cdef public set _kwargs_applied_init
+    cdef public object _proxy_ref
     cpdef dict properties(self)
 
 

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -19,6 +19,7 @@ from libc.string cimport memset
 from functools import partial
 from collections import defaultdict
 from kivy.weakmethod import WeakMethod
+from kivy.weakproxy import WeakProxy
 from kivy.compat import string_types
 from kivy.properties cimport (Property, PropertyStorage, ObjectProperty,
     NumericProperty, StringProperty, ListProperty, DictProperty,
@@ -890,10 +891,22 @@ cdef class EventDispatcher(ObjectWithUid):
 
     @property
     def proxy_ref(self):
-        '''Default implementation of proxy_ref, returns self.
+        '''Returns a :class:`~kivy.weakproxy.WeakProxy` reference to the
+        :class:`EventDispatcher`.
+
         .. versionadded:: 1.9.0
+
+        .. versionchanged:: 2.0.0
+
+            Previously it just returned itself, now it actually returns a
+            :class:`~kivy.weakproxy.WeakProxy`.
         '''
-        return self
+        _proxy_ref = self._proxy_ref
+        if _proxy_ref is not None:
+            return _proxy_ref
+
+        self._proxy_ref = _proxy_ref = WeakProxy(self)
+        return _proxy_ref
 
 
 cdef class BoundCallback:

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -167,6 +167,7 @@ cdef class EventDispatcher(ObjectWithUid):
 
         self.__event_stack = {}
         self.__storage = {}
+        self._proxy_ref = None.
 
         __cls__ = self.__class__
 

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -167,7 +167,7 @@ cdef class EventDispatcher(ObjectWithUid):
 
         self.__event_stack = {}
         self.__storage = {}
-        self._proxy_ref = None.
+        self._proxy_ref = None
 
         __cls__ = self.__class__
 


### PR DESCRIPTION
Currently `peoxy_ref` is defined for both `EventDispatcher` and `Widget`. However, `EventDispatcher`'s `proxy_ref` just return's `self`, so it useless. This fixes it.

The problem before was that if a non-`Widget`, but `EventDispatcher` based class with properties etc, was used in kv, e.g. `prop: some_event.prop`, then the builder module would hold on to a direct reference to the object and prevent it from being garbage collected.

This fixes that.