### PR TITLE
Don't init property created in KV with given value

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -847,37 +847,25 @@ cdef class EventDispatcher(ObjectWithUid):
             True
         '''
         cdef Property prop
+        if value is None:  # shortcut
+            cls = ObjectProperty
+        elif isinstance(value, bool):
+            cls = BooleanProperty
+        elif isinstance(value, (int, float)):
+            cls = NumericProperty
+        elif isinstance(value, string_types):
+            cls = StringProperty
+        elif isinstance(value, (list, tuple)):
+            cls = ListProperty
+        elif isinstance(value, dict):
+            cls = DictProperty
+        else:
+            cls = ObjectProperty
 
         if default_value:
-            if value is None:  # shortcut
-                prop = ObjectProperty(None, *largs, **kwargs)
-            if isinstance(value, bool):
-                prop = BooleanProperty(value, *largs, **kwargs)
-            elif isinstance(value, (int, float)):
-                prop = NumericProperty(value, *largs, **kwargs)
-            elif isinstance(value, string_types):
-                prop = StringProperty(value, *largs, **kwargs)
-            elif isinstance(value, (list, tuple)):
-                prop = ListProperty(value, *largs, **kwargs)
-            elif isinstance(value, dict):
-                prop = DictProperty(value, *largs, **kwargs)
-            else:
-                prop = ObjectProperty(value, *largs, **kwargs)
+            prop = cls(value, *largs, **kwargs)
         else:
-            if value is None:  # shortcut
-                prop = ObjectProperty(*largs, **kwargs)
-            if isinstance(value, bool):
-                prop = BooleanProperty(*largs, **kwargs)
-            elif isinstance(value, (int, float)):
-                prop = NumericProperty(*largs, **kwargs)
-            elif isinstance(value, string_types):
-                prop = StringProperty(*largs, **kwargs)
-            elif isinstance(value, (list, tuple)):
-                prop = ListProperty(*largs, **kwargs)
-            elif isinstance(value, dict):
-                prop = DictProperty(*largs, **kwargs)
-            else:
-                prop = ObjectProperty(*largs, **kwargs)
+            prop = cls(*largs, **kwargs)
 
         prop.link(self, name)
         prop.link_deps(self, name)

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -975,6 +975,7 @@ Context.html#getFilesDir()>`_ is returned.
         if self._app_window:
             for child in self._app_window.children:
                 self._app_window.remove_widget(child)
+        App._running_app = None
 
     def on_start(self):
         '''Event handler for the `on_start` event which is fired after

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -281,7 +281,7 @@ class ParserRule(object):
             value = self.properties[name].co_value
             if type(value) is CodeType:
                 value = None
-            widget.create_property(name, value)
+            widget.create_property(name, value, default_value=False)
 
     def _forbid_selectors(self):
         c = self.name[0]

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -32,7 +32,7 @@ class BaseClass(object):
     def dispatch(self, event_type, *largs, **kwargs):
         pass
 
-    def create_property(self, name, value=None):
+    def create_property(self, name, value=None, default_value=True):
         pass
 
     def is_event_type(self, key):


### PR DESCRIPTION
In the case where a widget doesn't have a property (e.g. property `my_prop`), if you set this property in kv its value is stored in the property instance for the widget *class* as opposed to in the widget *instance*.

E.g.:

```
<SomeWidget>:
    my_prop: app.large_obj
    OtherWidget:
        other_prop: app.other_obj
```

Currently, both `my_prop` and `other_prop` will have a property instance created for the `SomeWidget` and `OtherWidget`, respectively because the didn't yet exist. Similarly, they will each hold a ref to `app.large_obj` and `app.other_obj`, respectively.

The problem is that this object is held indefinitely and cannot be garbage collected. This is also undesired because it's not clear from kv, that the value is saved forever as the default. Instead, this PR changes it such that the property will be initialized to the default value of that property. The property will still be set to the appropriate value, it just will be set for each widget instance, instead of as the default stored in the class.

Backward compatibility
---------------------------

If you do:

```
<SomeWidget>:
    my_prop: app.large_obj
```
Then it doesn't make a difference whether it's the class default or instance default because every instance will be set to the value. The only difference is that if it's the class default the value will of course be whatever default value is immediately, while with the changes the property will not be set to the desired value until the rule is executed (it's value until the rule is set is the default value for that property class). But this is not different than other kv rules where the property already exists so I don't think it's an issue.

For the other case, where the rule is not a class, but rather a instance rule, e.g.:

```
<SomeWidget>:
    OtherWidget:
        other_prop: app.other_obj
```

This is very similar to the previous case, except for `OtherWidget` instances created before the rule is added to `Builder` and executed the very first time. Previously, all of them would default to the given value as it's stored in the class. But with these changes, it is not stored in the class, so existing widgets would default to the default value for the property class.

However, this is not an issue because you shouldn't really access this property for widgets created before the rule is added to `Builder` because they are not properly initialized.

So I think this can be merged with little backward compat issues.


I'm planning to add tests for this stuff testing memory leaks once the other PRs I created today are merged as they are all required together to prevent memory leaks.