### PR TITLE
Move `__self__` from widget to EventDispatcher and fix tests.

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -925,6 +925,10 @@ cdef class EventDispatcher(ObjectWithUid):
         self._proxy_ref = _proxy_ref = WeakProxy(self)
         return _proxy_ref
 
+    @property
+    def __self__(self):
+        return self
+
 
 cdef class BoundCallback:
 

--- a/kivy/core/audio/audio_ffpyplayer.py
+++ b/kivy/core/audio/audio_ffpyplayer.py
@@ -125,9 +125,9 @@ class SoundFFPy(Sound):
         self._state = 'paused'
         # wait until loaded or failed, shouldn't take long, but just to make
         # sure metadata is available.
-        s = time.clock()
+        s = time.perf_counter()
         while ((not player.get_metadata()['duration']) and
-               not self.quitted and time.clock() - s < 10.):
+               not self.quitted and time.perf_counter() - s < 10.):
             time.sleep(0.005)
 
     def unload(self):

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -237,12 +237,12 @@ class VideoFFPy(VideoBase):
 
         # wait until loaded or failed, shouldn't take long, but just to make
         # sure metadata is available.
-        s = time.clock()
+        s = time.perf_counter()
         while not self._ffplayer_need_quit:
             if ffplayer.get_metadata()['src_vid_size'] != (0, 0):
                 break
             # XXX if will fail later then?
-            if time.clock() - s > 10.:
+            if time.perf_counter() - s > 10.:
                 break
             sleep(0.005)
 

--- a/kivy/tests/test_app.py
+++ b/kivy/tests/test_app.py
@@ -1,4 +1,5 @@
 import os.path
+from textwrap import dedent
 
 from kivy.app import App
 from kivy.clock import Clock
@@ -149,3 +150,54 @@ async def test_graphics_app(kivy_app):
 
     assert not g1 and not b1 and not r2 and not b2
     assert r1 > 50 and a1 > 50 and g2 > 50 and a2 > 50
+
+
+def kv_app_ref_app():
+    from kivy.app import App
+    from kivy.lang import Builder
+    from kivy.properties import ObjectProperty
+    from kivy.uix.widget import Widget
+
+    class MyWidget(Widget):
+
+        obj = ObjectProperty(None)
+
+    Builder.load_string(dedent(
+        """
+        <MyWidget>:
+            obj: app.__self__
+        """))
+
+    class TestApp(UnitKivyApp, App):
+        def build(self):
+            return MyWidget()
+
+    return TestApp()
+
+
+@async_run(app_cls_func=kv_app_ref_app)
+async def test_leak_app_kv_property(kivy_app):
+    # just tests whether the app is gc'd after the test is complete
+    pass
+
+
+def kv_app_default_ref_app():
+    from kivy.app import App
+    from kivy.lang import Builder
+
+    class TestApp(UnitKivyApp, App):
+        def build(self):
+            # create property in kv and set app to it
+            return Builder.load_string(dedent(
+                """
+                Widget:
+                    obj: app.__self__
+                """))
+
+    return TestApp()
+
+
+@async_run(app_cls_func=kv_app_default_ref_app)
+async def test_leak_app_default_kv_property(kivy_app):
+    # just tests whether the app is gc'd after the test is complete
+    pass

--- a/kivy/tests/test_urlrequest.py
+++ b/kivy/tests/test_urlrequest.py
@@ -2,163 +2,174 @@
 UrlRequest tests
 ================
 '''
+import pytest
+import threading
 
-import unittest
-
-try:
-    # py3k
-    import _thread
-except ImportError:
-    # py27
-    import thread as _thread
-
-from kivy.network.urlrequest import UrlRequest
 from time import sleep
 from base64 import b64encode
-from kivy.clock import Clock
 import os
 
 
-class UrlRequestTest(unittest.TestCase):
+class UrlRequestQueue(object):
+
+    queue = []
+
+    def __init__(self, queue):
+        super(UrlRequestQueue, self).__init__()
+        self.queue = queue
 
     def _on_success(self, req, *args):
-        self.queue.append((_thread.get_ident(), 'success', args))
+        self.queue.append((threading.get_ident(), 'success', args))
 
     def _on_redirect(self, req, *args):
-        self.queue.append((_thread.get_ident(), 'redirect', args))
+        self.queue.append((threading.get_ident(), 'redirect', args))
 
     def _on_error(self, req, *args):
-        self.queue.append((_thread.get_ident(), 'error', args))
+        self.queue.append((threading.get_ident(), 'error', args))
 
     def _on_progress(self, req, *args):
-        self.queue.append((_thread.get_ident(), 'progress', args))
-
-    def test_callbacks(self):
-        if os.environ.get('NONETWORK'):
-            return
-        self.queue = []
-        req = UrlRequest('http://google.com',
-                         on_success=self._on_success,
-                         on_progress=self._on_progress,
-                         on_error=self._on_error,
-                         on_redirect=self._on_redirect,
-                         debug=True)
-
-        # don't use wait, but maximum 10s timeout
-        for i in range(50):
-            Clock.tick()
-            sleep(.5)
-            if req.is_finished:
-                break
-
-        self.assertTrue(req.is_finished)
-
-        # we should have 2 progress minimum and one success
-        self.assertTrue(len(self.queue) >= 3)
-
-        # ensure the callback is called from this thread (main).
-        tid = _thread.get_ident()
-        self.assertEqual(self.queue[0][0], tid)
-        self.assertEqual(self.queue[-2][0], tid)
-        self.assertEqual(self.queue[-1][0], tid)
-
-        self.assertEqual(self.queue[0][1], 'progress')
-        self.assertEqual(self.queue[-2][1], 'progress')
-        self.assertIn(self.queue[-1][1], ('success', 'redirect'))
-
-        self.assertEqual(self.queue[0][2][0], 0)
-        self.assertEqual(self.queue[-2][2][0], self.queue[-2][2][1])
-
-    def test_auth_header(self):
-        if os.environ.get('NONETWORK'):
-            return
-        self.queue = []
-        head = {
-            "Authorization": "Basic {}".format(b64encode(
-                "{}:{}".format('user', 'passwd').encode('utf-8')
-            ).decode('utf-8'))
-        }
-        req = UrlRequest(
-            'http://httpbin.org/basic-auth/user/passwd',
-            on_success=self._on_success,
-            on_progress=self._on_progress,
-            on_error=self._on_error,
-            on_redirect=self._on_redirect,
-            req_headers=head,
-            debug=True
-        )
-
-        # don't use wait, but maximum 10s timeout
-        for i in range(50):
-            Clock.tick()
-            sleep(.5)
-            if req.is_finished:
-                break
-
-        self.assertTrue(req.is_finished)
-
-        # we should have 2 progress minimum and one success
-        self.assertTrue(len(self.queue) >= 3)
-
-        # ensure the callback is called from this thread (main).
-        tid = _thread.get_ident()
-        self.assertEqual(self.queue[0][0], tid)
-        self.assertEqual(self.queue[-2][0], tid)
-        self.assertEqual(self.queue[-1][0], tid)
-
-        self.assertEqual(self.queue[0][1], 'progress')
-        self.assertEqual(self.queue[-2][1], 'progress')
-        self.assertIn(self.queue[-1][1], ('success', 'redirect'))
-        self.assertEqual(
-            self.queue[-1][2],
-            ({'authenticated': True, 'user': 'user'}, )
-        )
-
-        self.assertEqual(self.queue[0][2][0], 0)
-        self.assertEqual(self.queue[-2][2][0], self.queue[-2][2][1])
-
-    def test_auth_auto(self):
-        if os.environ.get('NONETWORK'):
-            return
-        self.queue = []
-        req = UrlRequest(
-            'http://user:passwd@httpbin.org/basic-auth/user/passwd',
-            on_success=self._on_success,
-            on_progress=self._on_progress,
-            on_error=self._on_error,
-            on_redirect=self._on_redirect,
-            debug=True
-        )
-
-        # don't use wait, but maximum 10s timeout
-        for i in range(50):
-            Clock.tick()
-            sleep(.5)
-            if req.is_finished:
-                break
-
-        self.assertTrue(req.is_finished)
-
-        # we should have 2 progress minimum and one success
-        self.assertTrue(len(self.queue) >= 3)
-
-        # ensure the callback is called from this thread (main).
-        tid = _thread.get_ident()
-        self.assertEqual(self.queue[0][0], tid)
-        self.assertEqual(self.queue[-2][0], tid)
-        self.assertEqual(self.queue[-1][0], tid)
-
-        self.assertEqual(self.queue[0][1], 'progress')
-        self.assertEqual(self.queue[-2][1], 'progress')
-        self.assertIn(self.queue[-1][1], ('success', 'redirect'))
-        self.assertEqual(
-            self.queue[-1][2],
-            ({'authenticated': True, 'user': 'user'}, )
-        )
-
-        self.assertEqual(self.queue[0][2][0], 0)
-        self.assertEqual(self.queue[-2][2][0], self.queue[-2][2][1])
+        self.queue.append((threading.get_ident(), 'progress', args))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_callbacks():
+    if os.environ.get('NONETWORK'):
+        return
+    from kivy.network.urlrequest import UrlRequest
+    from kivy.clock import Clock
+
+    obj = UrlRequestQueue([])
+    queue = obj.queue
+    req = UrlRequest('http://google.com',
+                     on_success=obj._on_success,
+                     on_progress=obj._on_progress,
+                     on_error=obj._on_error,
+                     on_redirect=obj._on_redirect,
+                     debug=True)
+
+    # don't use wait, but maximum 10s timeout
+    for i in range(50):
+        Clock.tick()
+        sleep(.5)
+        if req.is_finished:
+            break
+
+    assert req.is_finished
+
+    if req.error and req.error.errno == 11001:
+        pytest.skip('Cannot connect to get address')
+
+    # we should have 2 progress minimum and one success
+    assert len(queue) >= 3
+
+    # ensure the callback is called from this thread (main).
+    tid = threading.get_ident()
+    assert queue[0][0] == tid
+    assert queue[-2][0] == tid
+    assert queue[-1][0] == tid
+
+    assert queue[0][1] == 'progress'
+    assert queue[-2][1] == 'progress'
+    assert queue[-1][1] in ('success', 'redirect')
+
+    assert queue[0][2][0] == 0
+    assert queue[-2][2][0] == queue[-2][2][1]
+
+
+def test_auth_header():
+    if os.environ.get('NONETWORK'):
+        return
+    from kivy.network.urlrequest import UrlRequest
+    from kivy.clock import Clock
+
+    obj = UrlRequestQueue([])
+    queue = obj.queue
+    head = {
+        "Authorization": "Basic {}".format(b64encode(
+            "{}:{}".format('user', 'passwd').encode('utf-8')
+        ).decode('utf-8'))
+    }
+    req = UrlRequest(
+        'http://httpbin.org/basic-auth/user/passwd',
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+        req_headers=head,
+        debug=True
+    )
+
+    # don't use wait, but maximum 10s timeout
+    for i in range(50):
+        Clock.tick()
+        sleep(.5)
+        if req.is_finished:
+            break
+
+    assert req.is_finished
+
+    if req.error and req.error.errno == 11001:
+        pytest.skip('Cannot connect to get address')
+
+    # we should have 2 progress minimum and one success
+    assert len(queue) >= 3
+
+    # ensure the callback is called from this thread (main).
+    tid = threading.get_ident()
+    assert queue[0][0] == tid
+    assert queue[-2][0] == tid
+    assert queue[-1][0] == tid
+
+    assert queue[0][1] == 'progress'
+    assert queue[-2][1] == 'progress'
+    assert queue[-1][1] in ('success', 'redirect')
+    assert queue[-1][2] == ({'authenticated': True, 'user': 'user'}, )
+
+    assert queue[0][2][0] == 0
+    assert queue[-2][2][0] == queue[-2][2][1]
+
+
+def test_auth_auto():
+    if os.environ.get('NONETWORK'):
+        return
+    from kivy.network.urlrequest import UrlRequest
+    from kivy.clock import Clock
+
+    obj = UrlRequestQueue([])
+    queue = obj.queue
+    req = UrlRequest(
+        'http://user:passwd@httpbin.org/basic-auth/user/passwd',
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+        debug=True
+    )
+
+    # don't use wait, but maximum 10s timeout
+    for i in range(50):
+        Clock.tick()
+        sleep(.5)
+        if req.is_finished:
+            break
+
+    assert req.is_finished
+
+    if req.error and req.error.errno == 11001:
+        pytest.skip('Cannot connect to get address')
+
+    # we should have 2 progress minimum and one success
+    assert len(queue) >= 3
+
+    # ensure the callback is called from this thread (main).
+    tid = threading.get_ident()
+    assert queue[0][0] == tid
+    assert queue[-2][0] == tid
+    assert queue[-1][0] == tid
+
+    assert queue[0][1] == 'progress'
+    assert queue[-2][1] == 'progress'
+    assert queue[-1][1] in ('success', 'redirect')
+    assert queue[-1][2] == ({'authenticated': True, 'user': 'user'}, )
+
+    assert queue[0][2][0] == 0
+    assert queue[-2][2][0] == queue[-2][2][1]

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -392,10 +392,6 @@ class Widget(WidgetBase):
     def __hash__(self):
         return id(self)
 
-    @property
-    def __self__(self):
-        return self
-
     def apply_class_lang_rules(
             self, root=None, ignored_consts=set(), rule_children=None):
         '''


### PR DESCRIPTION
Given that `proxy_ref` is now in `EventDispatcher`, it's helpful to also move `__self__` to it so we can get the actual object.

Also adds memory leaks tests making sure the app is gc'd after each test is done, and fixes the often failing network test to not fail due to lack of internet.