### PR TITLE
Fix "Error in sys.excepthook"

### DIFF
--- a/kivy/graphics/context.pyx
+++ b/kivy/graphics/context.pyx
@@ -49,7 +49,15 @@ cdef class Context:
         self.flush()
 
     def trigger_gl_dealloc(self):
-        Clock.schedule_del_safe(self.gl_dealloc)
+        # see https://github.com/kivy/kivy/issues/5986
+        # Somehow, the try/except fixes that issue. Calling `self.gl_dealloc()`
+        # directly also caused the `Error in sys.excepthook:`, so it's not just
+        # the Clock. Perhaps this is called after everything has been deleted
+        # and cython objects destroyed, which like a bug in cython/python
+        try:
+            Clock.schedule_del_safe(self.gl_dealloc)
+        except Exception:
+            pass
 
     cpdef void flush(self):
         gc.collect()


### PR DESCRIPTION
This fixes #5986.

As I wrote in the comment, it's not clear what exactly the issue is. However, putting a try/except around it seems to fix it.

I tried opening a file and logging the exception, but that also caused the `Error in sys.excepthook`. It seems like this is called after most things have been destroyed so we cannot call anything else cython related from other files or do c things. This is likely a bug in cython, but I'm not exactly sure how to report this.