### PR TITLE
Docs wrong highlights

### DIFF
--- a/kivy/extras/highlight.py
+++ b/kivy/extras/highlight.py
@@ -26,7 +26,8 @@ class KivyLexer(RegexLexer):
                 bygroups(Name.Class, Text, Punctuation, Text)),
             (r'(.*?)(\s*)(:)(\s*)(.*?)$',
                 bygroups(Name.Attribute, Text, Punctuation, Text,
-                using(PythonLexer)))],
+                using(PythonLexer))),
+            (r'[^:]+?$', using(PythonLexer))],
         'classList': [
             (r'(,)(\s*)([A-Z][A-Za-z0-9]*)',
                 bygroups(Punctuation, Text, Name.Class)),


### PR DESCRIPTION
Solve #4341 
Add a regular expression to treat the problematic line as python code since they seem to behave this way (cf. [Clipboard](https://kivy.org/doc/stable/api-kivy.core.clipboard.html))