### PR TITLE
Fix playing audio streams from ffpyplayer

### DIFF
--- a/kivy/core/audio/audio_ffpyplayer.py
+++ b/kivy/core/audio/audio_ffpyplayer.py
@@ -126,7 +126,7 @@ class SoundFFPy(Sound):
         # wait until loaded or failed, shouldn't take long, but just to make
         # sure metadata is available.
         s = time.perf_counter()
-        while ((not player.get_metadata()['duration']) and
+        while (player.get_metadata()['duration'] is None and
                not self.quitted and time.perf_counter() - s < 10.):
             time.sleep(0.005)
 


### PR DESCRIPTION
Everything in the title - try playing a webradio such as `http://www.tms-server.com/radio.ogg` and it will fail because duration turns from `None` to `0.0`, which doesn't trigger this condition.