### PR TITLE
Updating ModalView to improve theming

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -490,7 +490,7 @@
 
 # ModalView widget
 <ModalView>:
-    canvas.before:
+    canvas:
         Color:
             rgba: root.overlay_color[:3] + [root.overlay_color[-1] * self._anim_alpha]
         Rectangle:

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -490,14 +490,14 @@
 
 # ModalView widget
 <ModalView>:
-    canvas:
+    canvas.before:
         Color:
-            rgba: root.background_color[:3] + [root.background_color[-1] * self._anim_alpha]
+            rgba: root.overlay_color[:3] + [root.overlay_color[-1] * self._anim_alpha]
         Rectangle:
             size: self._window.size if self._window else (0, 0)
 
         Color:
-            rgb: 1, 1, 1
+            rgba: root.background_color
         BorderImage:
             source: root.background
             border: root.border

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -118,11 +118,16 @@ class ModalView(AnchorLayout):
     defaults to None.
     '''
 
-    background_color = ListProperty([0, 0, 0, .7])
-    '''Background color in the format (r, g, b, a).
+    background_color = ListProperty([1, 1, 1, 1])
+    '''Background color, in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
-    defaults to [0, 0, 0, .7].
+    This acts as a *multiplier* to the texture colour. The default
+    texture is grey, so just setting the background color will give
+    a darker result. To set a plain color, set the
+    :attr:`background_normal` to ``''``.
+
+    The :attr:`background_color` is a
+    :class:`~kivy.properties.ListProperty` and defaults to [1, 1, 1, 1].
     '''
 
     background = StringProperty(
@@ -144,6 +149,14 @@ class ModalView(AnchorLayout):
 
     :attr:`border` is a :class:`~kivy.properties.ListProperty` and defaults to
     (16, 16, 16, 16).
+    '''
+
+    overlay_color = ListProperty([0, 0, 0, .7])
+    '''Overlay color in the format (r, g, b, a).
+    Used for dimming the window behind the modal view.
+
+    :attr:`overlay_color` is a :class:`~kivy.properties.ListProperty` and
+    defaults to [0, 0, 0, .7].
     '''
 
     # Internals properties used for graphical representation.

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -99,6 +99,9 @@ class ModalView(AnchorLayout):
     .. versionchanged:: 1.11.0
         Added events `on_pre_open` and `on_pre_dismiss`.
 
+    .. versionchanged:: 2.0.0
+        Added property 'overlay_color'.
+
     '''
 
     auto_dismiss = BooleanProperty(True)
@@ -128,6 +131,10 @@ class ModalView(AnchorLayout):
 
     The :attr:`background_color` is a
     :class:`~kivy.properties.ListProperty` and defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed behavior to affect the background of the widget itself, not the overlay dimming.
+
     '''
 
     background = StringProperty(
@@ -157,6 +164,8 @@ class ModalView(AnchorLayout):
 
     :attr:`overlay_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [0, 0, 0, .7].
+
+    .. versionadded:: 2.0.0
     '''
 
     # Internals properties used for graphical representation.


### PR DESCRIPTION
Some simple proposed changes to the ModalView class to make its background_color behave more closely to the same variable in other classes in kivy.  Also, added overlay_color variable to allow independent setting of the 'fade out' color when a popup is activated.

Note that the doc string for background_color is copied from the Button class, hopefully they parse correctly, I do not know anything about the documentation format or how to test it.