### PR TITLE
Fix relative import for the egl backend

### DIFF
--- a/kivy/lib/vidcore_lite/egl.pyx
+++ b/kivy/lib/vidcore_lite/egl.pyx
@@ -1,8 +1,8 @@
 
 from libc.stdlib cimport malloc, free
 from .bcm cimport DISPMANX_ELEMENT_HANDLE_T, ElementHandle
-cimport bcm
-import bcm
+cimport kivy.lib.vidcore_lite.bcm as bcm
+import kivy.lib.vidcore_lite.bcm as bcm
 
 cdef extern from "EGL/egl.h":
     ctypedef int EGLint ###maybe wrong


### PR DESCRIPTION
`import bcm` doesn't work because it needs to be a absolute path, or the full import path. I'm writing this fix from memory from trying this a week ago.