### PR TITLE
Fix lack of white-space after ":" in pong.kv

### DIFF
--- a/examples/tutorials/pong/steps/step5/pong.kv
+++ b/examples/tutorials/pong/steps/step5/pong.kv
@@ -11,8 +11,8 @@
     size: 25, 200
     canvas:
         Rectangle:
-            pos:self.pos
-            size:self.size
+            pos: self.pos
+            size: self.size
 
 <PongGame>:
     ball: pong_ball


### PR DESCRIPTION
Line 14 and 15 in [this code](https://github.com/kivy/kivy/blob/7f0478d30a58c33a2cb9b35c6a4168e97c4f92f3/examples/tutorials/pong/steps/step5/pong.kv) lacks white-space after `:`, though other lines (for example line 7, 8) have white-space after `:`.
So I added white-space after `:`.