### PR TITLE
Made ScreenManager clear_widgets correctly iterate over screens

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1013,7 +1013,7 @@ class ScreenManager(FloatLayout):
         self.screens.remove(screen)
 
     def clear_widgets(self, screens=None):
-        if not screens:
+        if screens is None:
             screens = self.screens
 
         # iterate over a copy of screens, as self.remove_widget

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1015,9 +1015,11 @@ class ScreenManager(FloatLayout):
     def clear_widgets(self, screens=None):
         if not screens:
             screens = self.screens
-        remove_widget = self.remove_widget
-        for screen in screens:
-            remove_widget(screen)
+
+        # iterate over a copy of screens, as self.remove_widget
+        # modifies self.screens in place
+        for screen in screens[:]:
+            self.remove_widget(screen)
 
     def real_add_widget(self, screen, *args):
         # ensure screen is removed from its previous parent


### PR DESCRIPTION
Currently ScreenManager's clear_widgets iterates over self.screens while modifying it, so it misses entries doesn't actually remove everything. The fix is straightforward, this is just an oversight.