### PR TITLE
[WIP] add 'tmp_builder' fixture for more isolated unit tests

### DIFF
--- a/kivy/tests/conftest.py
+++ b/kivy/tests/conftest.py
@@ -10,6 +10,8 @@ except SyntaxError:
     # it's ok to fail here as it won't be used anyway
     pass
 
+from .fixtures import tmp_builder
+
 if kivy_eventloop != 'trio':
     @pytest.fixture()
     def nursery():

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -4,7 +4,7 @@ import weakref
 import time
 import os.path
 
-__all__ = ('kivy_app', )
+__all__ = ('kivy_app', 'tmp_builder')
 
 # keep track of all the kivy app fixtures so that we can check that it
 # properly dies
@@ -109,3 +109,16 @@ async def kivy_app(request, nursery):
     apps.append((weakref.ref(app), request))
     del app
     gc.collect()
+
+
+@pytest.fixture()
+def tmp_builder():
+    from kivy.context import get_current_context, Context
+    from kivy.factory import Factory
+    from kivy.lang import Builder
+    ctx = Context(get_current_context())
+    ctx['Factory'] = Factory.create_from(Factory)
+    ctx['Builder'] = Builder.create_from(Builder)
+    ctx.push()
+    yield Builder
+    ctx.pop()

--- a/kivy/tests/test_fixtures.py
+++ b/kivy/tests/test_fixtures.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+def rule_exists(builder, cls_name):
+    from itertools import dropwhile
+    key = cls_name.lower()
+    try:
+        next(dropwhile(lambda v: v[0].key != key, builder.rules))
+    except StopIteration:
+        return False
+    return True
+
+
+def test_rule_exists():
+    from kivy.lang import Builder
+    assert not rule_exists(Builder, 'Widget')
+    assert rule_exists(Builder, 'StencilView')
+
+    name = 'UnknownName'
+    assert not rule_exists(Builder, name)
+    Builder.load_string('<{}>'.format(name), filename=name)
+    assert rule_exists(Builder, name)
+    Builder.unload_file(name)
+    assert not rule_exists(Builder, name)
+
+
+class Test_tmp_builder:
+    '''test_load() has to be excuted before test_restored()'''
+
+    name = 'UnknownWidget'
+
+    def test_load(self, tmp_builder):
+        from kivy.factory import Factory
+        from kivy.lang import Builder
+        assert tmp_builder is Builder
+        assert rule_exists(Builder, 'StencilView')
+
+        name = self.name
+        assert not rule_exists(Builder, name)
+        Builder.load_string('<{}@Widget>:'.format(name))
+        assert rule_exists(Builder, name)
+        assert name in Factory.classes
+
+    def test_restored(self):
+        from kivy.factory import Factory
+        from kivy.lang import Builder
+        name = self.name
+        assert not rule_exists(Builder, name)
+        assert name not in Factory.classes


### PR DESCRIPTION
When writing unit tests, I have to be careful of the widget-class-name. More specifically, I have to make sure the widget-class-name I'm going to use is not used by other unit tests, which is pain. This `tmp_builder` makes the all the changes to `Builder` and  `Factory` temporary. So now we can write tests like this:

```python
def test_1(tmp_builder):
    from kivy.factory import Factory
    assert 'MyWidget' not in Factory.classes
    tmp_builder.load_string('<MyWidget>:\n\tButton')
    class MyWidget(Factory.Widget):
        pass
    w = MyWidget()
    assert len(w.children) == 1

def test_2(tmp_builder):  # same as test_1
    from kivy.factory import Factory
    assert 'MyWidget' not in Factory.classes
    tmp_builder.load_string('<MyWidget>:\n\tButton')
    class MyWidget(Factory.Widget):
        pass
    w = MyWidget()
    assert len(w.children) == 1
```

### note

- Initially, I was trying to add two fixtures, which are `tmp_builder` and `tmp_factory`, but failed. I'd be glad if someone finds the cause out. ([first attempt](https://github.com/gottadiveintopython/kivy/tree/tmp_builder))

- I feel like `@pytest.fixture(scope='function')` is over kill for this fixture. `@pytest.fixture(scope='module')` might be better.

- Your tests still affected by other tests that don't use this fixture, even if you use it.