### PR TITLE
There is no way to get event.edit.start and event.edit.length

### DIFF
--- a/examples/miscellaneous/on_textedit_event.py
+++ b/examples/miscellaneous/on_textedit_event.py
@@ -19,7 +19,7 @@ class TextInputIME(TextInput):
         super(TextInputIME, self).__init__(**kwargs)
         EventLoop.window.bind(on_textedit=self._on_textedit)
 
-    def _on_textedit(self, window, text):
+    def _on_textedit(self, window, text, start, length):
         self.testtext = text
 
 

--- a/examples/miscellaneous/on_textedit_event.py
+++ b/examples/miscellaneous/on_textedit_event.py
@@ -18,9 +18,29 @@ class TextInputIME(TextInput):
     def __init__(self, **kwargs):
         super(TextInputIME, self).__init__(**kwargs)
         EventLoop.window.bind(on_textedit=self._on_textedit)
+        self._editing = None
 
     def _on_textedit(self, window, text, start, length):
         self.testtext = text
+        if len(text):
+            self._editing = True
+        else:
+            self._editing = False
+
+        if length:
+            end = start + length
+            text = "[u]{}[/u]({})[u]{}[/u]".format(
+                text[:start], text[start:end], text[end:])
+        else:
+            text = "[u]{}[/u]".format(text)
+        self.suggestion_text = text
+
+    def keyboard_on_key_down(self, window, keycode, text, modifiers):
+        # IME consumes it all
+        if self._editing:
+            return True
+        super(TextInputIME, self).keyboard_on_key_down(
+            window, keycode, text, modifiers)
 
 
 class MainWidget(Widget):

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1806,7 +1806,7 @@ class WindowBase(EventDispatcher):
         '''
         pass
 
-    def on_textedit(self, text):
+    def on_textedit(self, text, start, length):
         '''Event called when inputting with IME.
         The string inputting with IME is set as the parameter of
         this event.

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -646,7 +646,9 @@ cdef class _WindowSDL2Storage:
             return ('textinput', s)
         elif event.type == SDL_TEXTEDITING:
             s = event.edit.text.decode('utf-8')
-            return ('textedit', s)
+            cursor = event.edit.start
+            length = event.edit.length
+            return ('textedit', s, cursor, length)
         else:
             #    print('receive unknown sdl window event', event.type)
             pass

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -690,7 +690,9 @@ class WindowSDL(WindowBase):
 
             elif action == 'textedit':
                 text = args[0]
-                self.dispatch('on_textedit', text)
+                start = args[1]
+                length = args[2]
+                self.dispatch('on_textedit', text, start, length)
 
             # unhandled event !
             else:

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -3057,8 +3057,8 @@ class TextInput(FocusBehavior, Widget):
                 eend = len(value)
             lbl = MarkupLabel(
                 text="{}[b]{}[u]{}[/u]{}[/b]{}".format(
-                    pre, value[:ebeg], value[ebeg:eend], value[eend:], suf
-                    ), **kw)
+                    pre, value[:ebeg], value[ebeg:eend], value[eend:], suf),
+                **kw)
         else:
             lbl = Label(text=txt, **kw)
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -578,10 +578,6 @@ class TextInput(FocusBehavior, Widget):
         # when the gl context is reloaded, trigger the text rendering again.
         _textinput_list.append(ref(self, TextInput._reload_remove_observer))
 
-        EventLoop.window.bind(on_textedit=self._on_textedit)
-        self._editing = False
-        self._edit_range = None
-
         if platform == 'linux':
             self._ensure_clipboard()
 
@@ -1732,15 +1728,6 @@ class TextInput(FocusBehavior, Widget):
             self._do_blink_cursor_ev.cancel()
             self._hide_handles(win)
 
-    def _on_textedit(self, window, text, start, length):
-        if len(text):
-            self._editing = True
-            self._edit_range = (start, length)
-        else:
-            self._editing = False
-            self._edit_range = None
-        self.suggestion_text = text
-
     def _ensure_clipboard(self):
         global Clipboard, CutBuffer
         if not Clipboard:
@@ -2466,10 +2453,6 @@ class TextInput(FocusBehavior, Widget):
             self._alt_r = False
 
     def keyboard_on_key_down(self, window, keycode, text, modifiers):
-        # IME consumes it all
-        if self._editing:
-            return True
-
         # Keycodes on OS X:
         ctrl, cmd = 64, 1024
         key, key_str = keycode
@@ -3049,16 +3032,8 @@ class TextInput(FocusBehavior, Widget):
 
         lbl = None
         if value:
-            if self._edit_range:
-                ebeg = self._edit_range[0]
-                eend = ebeg + self._edit_range[1]
-            else:
-                ebeg = 0
-                eend = len(value)
             lbl = MarkupLabel(
-                text="{}[b]{}[u]{}[/u]{}[/b]{}".format(
-                    pre, value[:ebeg], value[ebeg:eend], value[eend:], suf),
-                **kw)
+                text="{}[b]{}[/b]{}".format(pre, value, suf), **kw)
         else:
             lbl = Label(text=txt, **kw)
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -3049,7 +3049,7 @@ class TextInput(FocusBehavior, Widget):
 
         lbl = None
         if value:
-            if self.edit_range:
+            if self._edit_range:
                 ebeg = self._edit_range[0]
                 eend = ebeg + self._edit_range[1]
             else:


### PR DESCRIPTION
Firstly, Kivy should not ignore event.edit.start and event.edit.length.
**edit: I misunderstood them**
~~They have important meanings for Japanese IME.
They indicate the place where the user is editing.
I'll try to explain it metaphorically.
IME is like a translator.
You say "I love you," and a French translator says, "Je vous aime."
You'd think, "No, use 'te' instead of 'vous.'"
In this case, event.edit.text=="Je vous aime", event.edit.start==3, and event.edit.length==4.~~

You press space key, and the translator (IME) will give you a number of candidates (including "te" in the above case).
So secondly, this space key (and other keys while editing) should be ignored by Kivy. It's consumed by IME.

Lastly, honestly speaking, I haven't compiled Kivy myself yet.
The only thing I have really used is here:
https://osdn.net/users/tamomo/pf/MekikuViewer/scm/blobs/master/IMETextInput.py
So, I'm violating Kivy's contribution guideline.
I will install Visual C++ and other dependencies next week or later. But I'd like to give you a pull request for now.

Thanks!