### PR TITLE
fix loading of custom style.kv

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -931,7 +931,7 @@ class BuilderBase(object):
 
 #: Main instance of a :class:`BuilderBase`.
 Builder = register_context('Builder', BuilderBase)
-Builder.load_file(join(kivy_data_dir, 'style.kv'), rulesonly=True)
+Builder.load_file('style.kv', rulesonly=True)
 
 if 'KIVY_PROFILE_LANG' in environ:
     import atexit

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -40,7 +40,7 @@ import kivy
 resource_paths = ['.', dirname(sys.argv[0])]
 if platform == 'ios':
     resource_paths += [join(dirname(sys.argv[0]), 'YourApp')]
-resource_paths += [dirname(kivy.__file__), join(kivy_data_dir, '..')]
+resource_paths += [dirname(kivy.__file__), kivy_data_dir]
 
 
 def resource_find(filename):


### PR DESCRIPTION
Adding a custom resource directory using kivy.resources.resource_add_path(path) did not load the customized style.kv in the program directory because the added resource path was overwritten by the following line in kivy/lang/builder.py:
`Builder.load_file(join(kivy_data_dir, 'style.kv'), rulesonly=True)`
Here, style.kv is hardcoded to the directory of the default style.kv, bypassing the logic of kivy.resources.resource_find(filename). 

[This question](https://stackoverflow.com/questions/52812576/how-to-customize-style-kv-in-kivy) suggests to load the custom style.kv directly using kivy.lang.Builder.load_file() as a workaround. This works, but also means both, the custom and default style.kv are parsed. This can create re-decleration warnings (e.g. `[WARNING] [Factory     ] Ignored class "FileIconEntry" re-declaration.`) and potentially break popups (`kivy.uix.popup.PopupException: Popup can have only one widget as content`). 

In kivy/resources.py a default resource_paths list is created. Instead of adding the kivy_data_dir, including style.kv, the kivy module root directory is added twice. I changed that so that in case there is no custom style.kv given the default one is found by kivy.resources.resource_find(filename). 

I tested this with no custom style.kv, with the custom one in the program directory, and with a custom style.kv in an outside directory, added via kivy.resources.resource_add_path(path). Everything seems to work as expected. Only thing to note is that in the last case the call to resource_add_path() must happen before importing kivy.app which already wants to read style.kv. 
