### PR TITLE
Revert "Fixes multiline label w/ line_height < 1"

### DIFF
--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -127,10 +127,7 @@ cdef class _SurfaceContainer:
         r.w = st.w
         r.h = st.h
         SDL_SetSurfaceAlphaMod(st, <int>(color[3] * 255))
-        if container.options['font_blended']:
-            SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_BLEND)
-        else:
-            SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_NONE)
+        SDL_SetSurfaceBlendMode(st, SDL_BLENDMODE_NONE)
         SDL_BlitSurface(st, NULL, self.surface, &r)
         SDL_FreeSurface(st)
 


### PR DESCRIPTION
Reverts kivy/kivy#6422

This PR introduce issue with normal text rendering. See the attached screenshot on one app with and without it. I have the same behavior on Linux and Android. (be sure to open the original)

![kivy-issue-6422](https://user-images.githubusercontent.com/37904/64494510-2b96c180-d28e-11e9-8373-c920f02b8cb6.png)

I suggest to remove to fix the normal text rendering, and find the right way to fix the issue in the meantime. The Kivy version pinned P4A include this issue.
