### PR TITLE
Fixes positioning (valign) issue when using max_lines

### DIFF
--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -566,8 +566,10 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     if max_lines > 0 and len(lines) > max_lines:
         val = True
         if dwn:
+            h-= sum(l.h for l in lines[max_lines:])
             del lines[max_lines:]
         else:
+            h-= sum(l.h for l in lines[:max(0, <int>len(lines) - max_lines)])
             del lines[:max(0, <int>len(lines) - max_lines)]
 
     # now make sure we don't have lines outside specified height


### PR DESCRIPTION
When using `max_lines`, I noticed a inconsistency with the selection made in the `valign` property.

Demo `kv` code:
```
Label:
    size_hint: 1, .190
    text_size: self.size
    text: "Text w/ max 2 lines, Text w/ max 2 lines, Text w/ max 2 lines, Text w/ max 2 lines, Text w/ max 2 lines, Text w/ max 2 lines, "
    color: 0, 0, 0, 1
    halign: 'left'
    valign: 'middle'
    font_size: dp(15)
    max_lines: 2
```

Before this PR:

![Screenshot from 2019-09-13 15-48-55](https://user-images.githubusercontent.com/8177736/64868140-0cf24b00-d63f-11e9-93c1-7e37516c6ccf.png)

After this PR (and how is supposed o be):

![Screenshot from 2019-09-13 15-47-26](https://user-images.githubusercontent.com/8177736/64868171-18de0d00-d63f-11e9-8117-14c9f378fc14.png)

