### PR TITLE
Don't use the Window when computing dp during docs generation

### DIFF
--- a/kivy/graphics/__init__.py
+++ b/kivy/graphics/__init__.py
@@ -32,7 +32,7 @@ to the canvas object and will be used when the window is drawn.
 
 .. note::
 
-    Kivy drawing instructions are not automatically relative to the position 
+    Kivy drawing instructions are not automatically relative to the position
     or size of the widget. You, therefore, need to consider these factors when
     drawing. In order to make your drawing instructions relative to the widget,
     the instructions need either to be

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -153,6 +153,9 @@ class MetricsBase(object):
         be taken from the Window provider (Desktop mainly) or from a
         platform-specific module (like android/ios).
         '''
+        if environ.get('KIVY_DOC_INCLUDE', None):
+            return 132.
+
         custom_dpi = environ.get('KIVY_DPI')
         if custom_dpi:
             return float(custom_dpi)
@@ -193,6 +196,9 @@ class MetricsBase(object):
         '''Return the density of the screen. This value is 1 by default
         on desktops but varies on android depending on the screen.
         '''
+        if environ.get('KIVY_DOC_INCLUDE', None):
+            return 1.
+
         custom_density = environ.get('KIVY_METRICS_DENSITY')
         if custom_density:
             return float(custom_density)


### PR DESCRIPTION
In many places we use the `KIVY_DOC_INCLUDE` guard to prevent the window from being created during doc generation. If `dp` is used anywhere, then the window is still currently created in order to compute it. 

With this PR, dpi now returns a dummy value if `KIVY_DOC_INCLUDE` is defined to prevent the window from being shown.