### PR TITLE
Add a "scroll_to_index" method to the ScrollView class

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1010,7 +1010,8 @@ class ScrollView(StencilView):
 
         vp = self._viewport
         pos = (vp.default_size[1] + vp.spacing) * index
-        dsx,dsy = self.convert_distance_to_scroll(0, pos - (self.height * 0.5))
+        dsx, dsy = self.convert_distance_to_scroll(0, pos - (
+            self.height * 0.5))
         sxp = 1.0 - min(1, max(0, dsx))
         syp = 1.0 - min(1, max(0, dsy))
 

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -998,7 +998,13 @@ class ScrollView(StencilView):
             self.scroll_x = sxp
             self.scroll_y = syp
 
-    def scroll_to_index(self, index):
+    def scroll_to_index(self, index, animate=True):
+        '''Scrolls the viewport to the item at the given index,
+        while trying to place that item at the center of the viewport. 
+        If animate is True (the default), then the default animation 
+        parameters will be used. Otherwise, it should be a dict containing 
+        arguments to pass to :class:`~kivy.animation.Animation` constructor.
+        '''
         if not self.parent and self._viewport:
             return
 

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -998,6 +998,25 @@ class ScrollView(StencilView):
             self.scroll_x = sxp
             self.scroll_y = syp
 
+    def scroll_to_index(self, index):
+        if not self.parent and self._viewport:
+            return
+
+        vp = self._viewport
+        pos = (vp.default_size[1] + vp.spacing) * index
+        dsx, dsy = self.convert_distance_to_scroll(0, pos - (self.height * 0.5))
+        sxp = 1.0 - min(1, max(0, dsx))
+        syp = 1.0 - min(1, max(0, dsy))
+
+        if animate:
+            if animate is True:
+                animate = {'d': 0.2, 't': 'out_quad'}
+            Animation.stop_all(self, 'scroll_x', 'scroll_y')
+            Animation(scroll_x=sxp, scroll_y=syp, **animate).start(self)
+        else:
+            self.scroll_x = sxp
+            self.scroll_y = syp
+
     def convert_distance_to_scroll(self, dx, dy):
         '''Convert a distance in pixels to a scroll distance, depending on the
         content size and the scrollview size.

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1000,9 +1000,9 @@ class ScrollView(StencilView):
 
     def scroll_to_index(self, index, animate=True):
         '''Scrolls the viewport to the item at the given index,
-        while trying to place that item at the center of the viewport. 
-        If animate is True (the default), then the default animation 
-        parameters will be used. Otherwise, it should be a dict containing 
+        while trying to place that item at the center of the viewport.
+        If animate is True (the default), then the default animation
+        parameters will be used. Otherwise, it should be a dict containing
         arguments to pass to :class:`~kivy.animation.Animation` constructor.
         '''
         if not self.parent and self._viewport:
@@ -1010,7 +1010,7 @@ class ScrollView(StencilView):
 
         vp = self._viewport
         pos = (vp.default_size[1] + vp.spacing) * index
-        dsx, dsy = self.convert_distance_to_scroll(0, pos - (self.height * 0.5))
+        dsx,dsy = self.convert_distance_to_scroll(0, pos - (self.height * 0.5))
         sxp = 1.0 - min(1, max(0, dsx))
         syp = 1.0 - min(1, max(0, dsy))
 


### PR DESCRIPTION
I had the need to scroll to a given item in a RecycleView and could not find a simple way to do this. The \<Row\> objects didn't seem to work with the existing `scroll_to` method, so I ended up rolling my own method, taking some inspiration from what's already in the ScrollView class. While it's very likely that I've simply overlooked a better way of doing this, it seemed simple and clean enough that I thought I'd share it with you in a PR - if nothing else I might end up learning something new. 