### PR TITLE
Fixed Issue #6524

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -811,8 +811,16 @@ class FileChooserController(RelativeLayout):
         else:
             if platform == 'win':
                 is_root = splitdrive(path)[1] in (sep, altsep)
+                if not path:
+                    path = abspath(sep)
+                else:
+                    path = abspath(self.path)
             elif platform in ('macosx', 'linux', 'android', 'ios'):
                 is_root = normpath(expanduser(path)) == sep
+                if not path:
+                    path = abspath(sep)
+                else:
+                    path = abspath(self.path)
             else:
                 # Unknown fs, just always add the .. entry but also log
                 Logger.warning('Filechooser: Unsupported OS: %r' % platform)


### PR DESCRIPTION
Converts path to absolute path when first generating files for FileChooserController, preventing files from being unrecognized in the initial directory when attempting to select them.