### PR TITLE
fix erroneous check of KIVY_NO_ENV_CONFIG

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -906,7 +906,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             Logger.exception('Core: Error while saving default config file')
 
     # Load configuration from env
-    if environ.get('KIVY_NO_ENV_CONFIG', '0') != '0':
+    if environ.get('KIVY_NO_ENV_CONFIG', '0') != '1':
         for key, value in environ.items():
             if not key.startswith("KCFG_"):
                 continue


### PR DESCRIPTION
The check to see if KIVY_NO_ENV_CONFIG is set was incorrect.

Without this fix, one has to set os.environ["KIVY_NO_ENV_CONFIG"] = "1" to be able to use KCFG_KIVY_LOG_LEVEL=warning and the likes. Which is the opposite of what config.py's doc says.