### PR TITLE
remove the 'App'-less classname hack, there is no rationale

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -698,10 +698,7 @@ class App(EventDispatcher):
         '''
         if self.title is not None:
             return self.title
-        clsname = self.__class__.__name__
-        if clsname.endswith('App'):
-            clsname = clsname[:-3]
-        return clsname
+        return self.__class__.__name__
 
     def get_application_icon(self):
         '''Return the icon of the application.
@@ -907,8 +904,6 @@ Context.html#getFilesDir()>`_ is returned.
         '''
         if self._app_name is None:
             clsname = self.__class__.__name__
-            if clsname.endswith('App'):
-                clsname = clsname[:-3]
             self._app_name = clsname.lower()
         return self._app_name
 


### PR DESCRIPTION
There is hard to justify code that strips the 'App' of the classname when using it for things like the default title bar text. This stripping causes issues when the classname is just App, and looks silly in cases like MyApp. I'm sure the original author meant well, maybe for something like HelloWorldApp, but the stripping is really not needed.

The following code gives me an empty titlebar, whereas any other classname will show:
```
import kivy
import kivy.app
import kivy.uix.button

class App(kivy.app.App):
  def build(self):
    # self.title = 'App' # workaround
    return kivy.uix.button.Button(text='Hello World')

App().run()
```

Now I did not test this fix because I'm not setup nor ready at this time to invest the time having a dev setup, not knowing if Kivy is for me. I'm hoping someone else can do some sanity test. The string might be used for other things than just the title bar. Though in all honesty, right now it's pretty broken if the name of the class is just App.