### PR TITLE
Fixes TextInput cursor "rendering" issue

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2774,7 +2774,7 @@ class TextInput(FocusBehavior, Widget):
                                bind=('cursor', 'padding', 'pos', 'size',
                                      'focus', 'scroll_x', 'scroll_y',
                                      'line_height', 'line_spacing'),
-                               cache=True)
+                               cache=False)
     '''Current position of the cursor, in (x, y).
 
     :attr:`cursor_pos` is an :class:`~kivy.properties.AliasProperty`,


### PR DESCRIPTION
Due to caching, added via PR #6055 , `TextInput` **cursor** is being displayed in the wrong position when user focuses the `TextInput`. (After inserting some text the cursor is than displayed fine).

This PR simply removes caching from `cursor_pos`, fixing the issue.

Code to reproduce:
```
TextInput:
     size_hint: 1, 1/5
```