### PR TITLE
Added 'RPI' environmental variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ kivy_ios_root = environ.get('KIVYIOSROOT', None)
 if kivy_ios_root is not None:
     platform = 'ios'
 # proprietary broadcom video core drivers
-if exists('/opt/vc/include/bcm_host.h'):
+if environ.get('RPI', 1) and exists('/opt/vc/include/bcm_host.h'):
     platform = 'rpi'
 # use mesa video core drivers
 if environ.get('VIDEOCOREMESA', None):


### PR DESCRIPTION
This is used when compiling Kivy for the Raspberry Pi 4.

See: https://github.com/kivy/kivy/issues/6474#issuecomment-542679712

Please let me know if you want me to modify setup.py to autodetect the Raspberry Pi 4 instead of setting a environmental variable.