### PR TITLE
Build latest .DMG for osx app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,13 +177,13 @@ script:
           app_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))");
           git_tag=$(git rev-parse --short HEAD);
 
-          yes | ./create-osx-bundle.sh python3 master > output.txt;
+          yes | ./create-osx-bundle.sh 1.11.1 3.7.4 > output.txt;
           app_ver=$(KIVY_NO_CONSOLELOG=1 Kivy.app/Contents/Resources/script -c 'import kivy; print(kivy.__version__)');
           mv Kivy.app Kivy3.app;
           ./create-osx-dmg.sh Kivy3.app;
           mkdir app;
-          cp Kivy3.dmg app/"Kivy-$app_ver"-python3.6.5.dmg;
-          mv Kivy3.dmg app/"Kivy-$app_ver-$git_tag-$app_date"-python3.6.5.dmg;
+          cp Kivy3.dmg app/"Kivy-$app_ver"-python3.7.4.dmg;
+          mv Kivy3.dmg app/"Kivy-$app_ver-$git_tag-$app_date"-python3.7.4.dmg;
           yes | rsync -avh -e "ssh -p 2458" --include="*/" --include="*.dmg" --exclude="*" "./app/" "root@$SERVER_IP:/web/downloads/ci/osx/app/";
           popd;
       elif [ "${RUN}" == "wheels" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]  && ([ "${TRAVIS_EVENT_TYPE}" == "cron" ] || [ "${TRAVIS_TAG}" != "" ] || [[ "$TRAVIS_COMMIT_MESSAGE" =~ "[build wheel]" ]] || [[ "$TRAVIS_COMMIT_MESSAGE" =~ "[build wheel osx]" ]]); then


### PR DESCRIPTION
Update Travis to build latest .DMG for osx . 
Using Kivy 1.11.1 and Python 3.7.4