### PR TITLE
Fixed depreciated option for twisted, and sys.exc_call is only run in py2

### DIFF
--- a/examples/frameworks/twisted/twistd_app.py
+++ b/examples/frameworks/twisted/twistd_app.py
@@ -12,7 +12,7 @@ from kivy.lang import Builder
 from twisted.scripts._twistd_unix import UnixApplicationRunner, ServerOptions
 from twisted.application.service import IServiceCollection
 
-TWISTD = 'twistd web -p 8087'
+TWISTD = 'twistd web --listen=tcp:8087'
 
 
 class AndroidApplicationRunner(UnixApplicationRunner):

--- a/examples/frameworks/twisted/twistd_app.py
+++ b/examples/frameworks/twisted/twistd_app.py
@@ -48,7 +48,6 @@ class TwistedTwistd(GridLayout):
             IServiceCollection(self.app).stopService()
             self.running = False
         else:
-            sys.exc_clear()
             sys.path.insert(0, os.path.abspath(os.getcwd()))
             sys.argv = TWISTD.split(' ')
             config = ServerOptions()


### PR DESCRIPTION
Calling the twisted deamon by: `twistd web -p 8087`
with Twisted (19.7.0) raises an error
```
Traceback (most recent call last):
[...]
  File "/usr/lib64/python2.7/site-packages/twisted/internet/endpoints.py", line 1665, in _matchPluginToPrefix
    raise ValueError("Unknown endpoint type: '%s'" % (endpointType,))
ValueError: Unknown endpoint type: '8087'
```

According to the manual of twistd is the `--port` option deprecated and is to be replaced by --listen

Moreover `sys.exc_call()` has been removed in python3. To keep the script running, it is now confirmed, that python2 is running. Otherwise this call is ignored. That will maintain the script version-agnostic for now.

