### PR TITLE
Relative initial size for images

### DIFF
--- a/examples/demo/pictures/pictures.kv
+++ b/examples/demo/pictures/pictures.kv
@@ -40,8 +40,9 @@ FloatLayout:
         id: image
         source: root.source
 
-        # create initial image to be 400 pixels width
-        size: 400, 400 / self.image_ratio
+        # create initial image with relative size
+        size: win.Window.width * 0.6, win.Window.width * 0.6 / self.image_ratio
+        allow_stretch: True
 
         # add shadow background
         canvas.before:


### PR DESCRIPTION
Addressing issue #3691 regarding the `pictures` example in `example/demo/pictures`.

Replacing the fixed initial size of the images of 400px by a relative size given by `Window.width` 