### PR TITLE
Horizontal value track is offset from the center of Slider

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -60,7 +60,7 @@
             rgba: root.value_track_color if self.value_track and self.orientation == 'horizontal' else [1, 1, 1, 0]
         Line:
             width: self.value_track_width
-            points: self.x + self.padding, self.center_y - self.value_track_width / 2, self.value_pos[0], self.center_y - self.value_track_width / 2
+            points: self.x + self.padding, self.center_y, self.value_pos[0], self.center_y
         Color:
             rgba: root.value_track_color if self.value_track and self.orientation == 'vertical' else [1, 1, 1, 0]
         Line:


### PR DESCRIPTION
Horizontal value track is offset from the center of the Slider. The value track is shifted down. The issue is most noticeable whenever the background_width/value_track_width are large.