### PR TITLE
Bump max cython version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ verbosity=2
 logging-level=DEBUG
 [kivy]
 cython_min=0.24
-cython_max=0.29.10
+cython_max=0.29.14
 cython_exclude=0.27,0.27.2
 [coverage:run]
 plugins =


### PR DESCRIPTION
This should fix the manylinux building issues, as the current max cython version causes it to use a cython version that doesn't work with python 3.8.