### PR TITLE
Multiple splitters size

### DIFF
--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -368,7 +368,9 @@ class Splitter(BoxLayout):
         self.dispatch('on_release')
 
     def on_release(self):
-        pass
+        for slider in self.parent.children:
+            slider.size_hint_y = slider.height / self.parent.height
+            slider.size_hint_x = slider.width / self.parent.width
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #5714 
The problem is that once the size of a splitter is modified, its size_hint is set to None.
As a consequence, the size of the splitters cannot be controlled externally after that.