### PR TITLE
Add the ability to show statusbar on iOS

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -77,23 +77,25 @@ cdef class _WindowSDL2Storage:
                      resizable, state, gl_backend):
         self.win_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI
 
-        if USE_IOS:
-            self.win_flags |= SDL_WINDOW_BORDERLESS | SDL_WINDOW_RESIZABLE | SDL_WINDOW_FULLSCREEN_DESKTOP
-        else:
-            if resizable:
-                self.win_flags |= SDL_WINDOW_RESIZABLE
+        if resizable:
+            self.win_flags |= SDL_WINDOW_RESIZABLE
+
+        if not USE_IOS:
             if borderless:
                 self.win_flags |= SDL_WINDOW_BORDERLESS
 
-            if USE_ANDROID:
-                # Android is handled separately because it is important to create the window with
-                # the same fullscreen setting as AndroidManifest.xml.
-                if environ.get('P4A_IS_WINDOWED', 'True') == 'False':
-                    self.win_flags |= SDL_WINDOW_FULLSCREEN
-            elif fullscreen == 'auto':
-                self.win_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP
-            elif fullscreen is True:
+        if USE_ANDROID:
+            # Android is handled separately because it is important to create the window with
+            # the same fullscreen setting as AndroidManifest.xml.
+            if environ.get('P4A_IS_WINDOWED', 'True') == 'False':
                 self.win_flags |= SDL_WINDOW_FULLSCREEN
+        elif USE_IOS:
+            if environ.get('IOS_IS_WINDOWED', 'True') == 'False':
+                self.win_flags |= SDL_WINDOW_FULLSCREEN | SDL_WINDOW_BORDERLESS
+        elif fullscreen == 'auto':
+            self.win_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP
+        elif fullscreen is True:
+            self.win_flags |= SDL_WINDOW_FULLSCREEN
         if state == 'maximized':
             self.win_flags |= SDL_WINDOW_MAXIMIZED
         elif state == 'minimized':


### PR DESCRIPTION
"statusbar" availability on iOS it's always been a "TODO" in `kivy` and `kivy-ios`.
See issue: https://github.com/kivy/kivy-ios/issues/189

This PR manage some needed flags in order to implement it.

The `kivy` part it's ready, so this one could be merged. I still need to bump versions on a couple of things in `kivy-ios` in order to get it working for users on the `kivy-ios` side.

It also open the availability on iPadOS to split screen functionality. 