### PR TITLE
make GridLayout fill a column first when 'cols' is None

### DIFF
--- a/kivy/tests/test_uix_gridlayout.py
+++ b/kivy/tests/test_uix_gridlayout.py
@@ -3,6 +3,7 @@ uix.gridlayout tests
 ========================
 '''
 
+import pytest
 import unittest
 from kivy.tests.common import GraphicUnitTest
 
@@ -50,6 +51,21 @@ class UixGridLayoutTest(GraphicUnitTest):
         gl.cols_minimum = {i: 10 for i in range(10)}
         gl.add_widget(GridLayout())
         self.render(gl)
+
+
+def test_fills_a_column_first_when_cols_is_None():
+    # github issue #6538
+    from kivy.uix.gridlayout import GridLayout
+    from kivy.uix.widget import Widget
+    gl = GridLayout(rows=3, size=(300, 300), pos=(0, 0))
+    for i in range(4):
+        gl.add_widget(Widget())
+    gl.do_layout()
+    children = tuple(reversed(gl.children))
+    assert children[0].pos == [0, 200]
+    assert children[1].pos == [0, 100]
+    assert children[2].pos == [0, 0]
+    assert children[3].pos == [150, 200]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Current implementation of the `GridLayout` always fills a row first regardless `cols` is None or not. And this behavior causes #6538, the GridLayout puts `3` into the 2rd row instead of the 3rd row.

This PR changes that behavior. So the following code:

```python
from kivy.app import runTouchApp
from kivy.factory import Factory

root = Factory.GridLayout(rows=3)
for i in range(4):
    root.add_widget(Factory.Label(text=str(i)))
runTouchApp(root)
```

which produces the following result under the master branch:

![before_6538](https://user-images.githubusercontent.com/26050135/70900709-b41ac000-203c-11ea-8ee3-2426c00493ec.png)
(fills a row first)

will produce the following result under this PR.

![under_6538](https://user-images.githubusercontent.com/26050135/70900741-c3017280-203c-11ea-93ad-40fc5c4852ec.png)
(fills a column first)