### PR TITLE
Native audio support for Android

### DIFF
--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -226,7 +226,9 @@ class Sound(EventDispatcher):
 # Little trick here, don't activate gstreamer on window
 # seem to have lot of crackle or something...
 audio_libs = []
-if platform in ('macosx', 'ios'):
+if platform == 'android':
+    audio_libs += [('android', 'audio_android')]
+elif platform in ('macosx', 'ios'):
     audio_libs += [('avplayer', 'audio_avplayer')]
 try:
     from kivy.lib.gstplayer import GstPlayer  # NOQA

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -15,7 +15,8 @@ AudioManager = autoclass("android.media.AudioManager")
 class SoundAndroidPlayer(Sound):
     @staticmethod
     def extensions():
-        return ("mp3", "mp4", "aac", "3gp", "flac", "mkv", "wav", "ogg", "m4a")
+        return ("mp3", "mp4", "aac", "3gp", "flac", "mkv", "wav", "ogg", "m4a",
+                "gsm", "mid", "xmf", "mxmf", "rtttl", "rtx", "ota", "imy")
 
     def __init__(self, **kwargs):
         self._mediaplayer = None

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -30,7 +30,7 @@ class SoundAndroidPlayer(Sound):
 
     def unload(self):
         if self._mediaplayer:
-            self._mediaplayer.reset()
+            self._mediaplayer.release()
             self._mediaplayer = None
 
     def play(self):

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -1,0 +1,68 @@
+"""
+AudioAndroid: Kivy audio implementation for Android using native API
+"""
+
+__all__ = ("SoundAndroidPlayer", )
+
+from jnius import autoclass
+from kivy.core.audio import Sound, SoundLoader
+
+
+MediaPlayer = autoclass("android.media.MediaPlayer")
+FileInputStream = autoclass("java.io.FileInputStream")
+AudioManager = autoclass("android.media.AudioManager")
+
+
+class SoundAndroidPlayer(Sound):
+    @staticmethod
+    def extensions():
+        return ("mp3", "mp4", "aac", "3gp", "flac", "mkv", "wav", "ogg", "m4a")
+
+    def __init__(self, **kwargs):
+        self._mediaplayer = None
+        super(SoundAndroidPlayer, self).__init__(**kwargs)
+
+    def load(self):
+        self.unload()
+        self._mediaplayer = MediaPlayer()
+        self._mediaplayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+        self._mediaplayer.setDataSource(self.filename)
+        self._mediaplayer.prepare()
+
+    def unload(self):
+        self.stop()
+        self._mediaplayer = None
+
+    def play(self):
+        if not self._mediaplayer:
+            return
+        self._mediaplayer.start()
+        super(SoundAndroidPlayer, self).play()
+
+    def stop(self):
+        if not self._mediaplayer:
+            return
+        self._mediaplayer.reset()
+
+    def seek(self, position):
+        if not self._mediaplayer:
+            return
+        self._mediaplayer.seek(float(position))
+
+    def get_pos(self):
+        if self._mediaplayer:
+            return self._mediaplayer.getCurrentPosition() / 1000.
+        return super(SoundAndroidPlayer, self).get_pos()
+
+    def on_volume(self, instance, volume):
+        if self._mediaplayer:
+            volume = float(volume)
+            self._mediaplayer.setVolume(volume, volume)
+
+    def _get_length(self):
+        if self._mediaplayer:
+            return self._mediaplayer.getDuration() / 1000.
+        return super(SoundAndroidPlayer, self)._get_length()
+
+
+SoundLoader.register(SoundAndroidPlayer)

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -9,7 +9,6 @@ from kivy.core.audio import Sound, SoundLoader
 
 
 MediaPlayer = autoclass("android.media.MediaPlayer")
-FileInputStream = autoclass("java.io.FileInputStream")
 AudioManager = autoclass("android.media.AudioManager")
 
 
@@ -26,12 +25,13 @@ class SoundAndroidPlayer(Sound):
         self.unload()
         self._mediaplayer = MediaPlayer()
         self._mediaplayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
-        self._mediaplayer.setDataSource(self.filename)
+        self._mediaplayer.setDataSource(self.source)
         self._mediaplayer.prepare()
 
     def unload(self):
-        self.stop()
-        self._mediaplayer = None
+        if self._mediaplayer:
+            self._mediaplayer.reset()
+            self._mediaplayer = None
 
     def play(self):
         if not self._mediaplayer:
@@ -42,12 +42,13 @@ class SoundAndroidPlayer(Sound):
     def stop(self):
         if not self._mediaplayer:
             return
-        self._mediaplayer.reset()
+        self._mediaplayer.stop()
+        self._mediaplayer.prepare()
 
     def seek(self, position):
         if not self._mediaplayer:
             return
-        self._mediaplayer.seek(float(position))
+        self._mediaplayer.seekTo(float(position) * 1000)
 
     def get_pos(self):
         if self._mediaplayer:

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -5,11 +5,14 @@ AudioAndroid: Kivy audio implementation for Android using native API
 __all__ = ("SoundAndroidPlayer", )
 
 from jnius import autoclass
+from android import api_version
 from kivy.core.audio import Sound, SoundLoader
 
 
 MediaPlayer = autoclass("android.media.MediaPlayer")
 AudioManager = autoclass("android.media.AudioManager")
+if api_version >= 21:
+    AudioAttributesBuilder = autoclass("android.media.AudioAttributes$Builder")
 
 
 class SoundAndroidPlayer(Sound):
@@ -25,7 +28,13 @@ class SoundAndroidPlayer(Sound):
     def load(self):
         self.unload()
         self._mediaplayer = MediaPlayer()
-        self._mediaplayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+        if api_version >= 21:
+            self._mediaplayer.setAudioAttributes(
+                AudioAttributesBuilder()
+                .setLegacyStreamType(AudioManager.STREAM_MUSIC)
+                .build())
+        else:
+            self._mediaplayer.setAudioStreamType(AudioManager.STREAM_MUSIC)
         self._mediaplayer.setDataSource(self.source)
         self._mediaplayer.prepare()
 


### PR DESCRIPTION
This includes a new core provider that uses native MediaPlayer
on Android. It was used before when we were using Pygame,
but the support got lost during rewriting of P4A.

Unlike SDL2 native provider, this one support natively AAC (mp4/aac/m4a)