### PR TITLE
Replace deprecated stuff in audio providers' Sound classes.

### DIFF
--- a/kivy/core/audio/audio_avplayer.py
+++ b/kivy/core/audio/audio_avplayer.py
@@ -28,7 +28,7 @@ class SoundAvplayer(Sound):
 
     def load(self):
         self.unload()
-        fn = NSString.alloc().initWithUTF8String_(self.filename)
+        fn = NSString.alloc().initWithUTF8String_(self.source)
         url = NSURL.alloc().initFileURLWithPath_(fn)
         self._avplayer = AVAudioPlayer.alloc().initWithContentsOfURL_error_(
             url, None)

--- a/kivy/core/audio/audio_gstplayer.py
+++ b/kivy/core/audio/audio_gstplayer.py
@@ -90,7 +90,7 @@ class SoundGstplayer(Sound):
         self.player.set_volume(volume)
 
     def _get_uri(self):
-        uri = self.filename
+        uri = self.source
         if not uri:
             return
         if '://' not in uri:

--- a/kivy/core/audio/audio_pygame.py
+++ b/kivy/core/audio/audio_pygame.py
@@ -91,9 +91,9 @@ class SoundPygame(Sound):
 
     def load(self):
         self.unload()
-        if self.filename is None:
+        if self.source is None:
             return
-        self._data = mixer.Sound(self.filename)
+        self._data = mixer.Sound(self.source)
 
     def unload(self):
         self.stop()

--- a/kivy/core/audio/audio_sdl2.pyx
+++ b/kivy/core/audio/audio_sdl2.pyx
@@ -204,7 +204,7 @@ class SoundSDL2(Sound):
         cc.channel = Mix_PlayChannel(-1, cc.chunk, 0)
         if cc.channel == -1:
             Logger.warning('AudioSDL2: Unable to play {}: {}'.format(
-                           self.filename, Mix_GetError()))
+                           self.source, Mix_GetError()))
             return
         # schedule event to check if the sound is still playing or not
         self._check_play_ev = Clock.schedule_interval(self._check_play, 0.1)
@@ -225,18 +225,18 @@ class SoundSDL2(Sound):
     def load(self):
         cdef ChunkContainer cc = self.cc
         self.unload()
-        if self.filename is None:
+        if self.source is None:
             return
 
-        if isinstance(self.filename, bytes):
-            fn = self.filename
+        if isinstance(self.source, bytes):
+            fn = self.source
         else:
-            fn = self.filename.encode('UTF-8')
+            fn = self.source.encode('UTF-8')
 
         cc.chunk = Mix_LoadWAV(<char *><bytes>fn)
         if cc.chunk == NULL:
             Logger.warning('AudioSDL2: Unable to load {}: {}'.format(
-                           self.filename, Mix_GetError()))
+                           self.source, Mix_GetError()))
         else:
             cc.original_chunk = Mix_QuickLoad_RAW(cc.chunk.abuf, cc.chunk.alen)
             cc.chunk.volume = int(self.volume * 128)
@@ -317,7 +317,7 @@ class MusicSDL2(Sound):
         Mix_VolumeMusic(int(self.volume * 128))
         if Mix_PlayMusic(mc.music, 1) == -1:
             Logger.warning('AudioSDL2: Unable to play music {}: {}'.format(
-                           self.filename, Mix_GetError()))
+                           self.source, Mix_GetError()))
             return
         mc.playing = 1
         # schedule event to check if the sound is still playing or not
@@ -338,18 +338,18 @@ class MusicSDL2(Sound):
     def load(self):
         cdef MusicContainer mc = self.mc
         self.unload()
-        if self.filename is None:
+        if self.source is None:
             return
 
-        if isinstance(self.filename, bytes):
-            fn = self.filename
+        if isinstance(self.source, bytes):
+            fn = self.source
         else:
-            fn = self.filename.encode('UTF-8')
+            fn = self.source.encode('UTF-8')
 
         mc.music = Mix_LoadMUS(<char *><bytes>fn)
         if mc.music == NULL:
             Logger.warning('AudioSDL2: Unable to load music {}: {}'.format(
-                           self.filename, Mix_GetError()))
+                           self.source, Mix_GetError()))
         else:
             Mix_VolumeMusic(int(self.volume * 128))
 


### PR DESCRIPTION
Fixes deprecation warnings in #6602

As I exposed in #6602, I don't know if the deprecation warnings in ```kivy/core/audio/__init__.py``` should be removed too.

P.S: I'm so sorry about not naming the branch accordingly to the guidelines.