### PR TITLE
Generate 38 wheels for windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,12 @@ environment:
   - PYVER: 37
     BITTNESS: 64
     COMPILER: msvc
+  - PYVER: 38
+    BITTNESS: 86
+    COMPILER: msvc
+  - PYVER: 38
+    BITTNESS: 64
+    COMPILER: msvc
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-desktop.ps1'))
 build_script:

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -102,8 +102,8 @@ kivy release (`1.11.1`) and its dependencies.
 #. Install the dependencies (skip gstreamer (~120MB) if not needed, see
    :ref:`kivy-dependencies`). If you are upgrading Kivy, see :ref:`install-win-dist-upgrade`::
 
-     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2==0.1.22 kivy_deps.glew==0.1.12
-     python -m pip install kivy_deps.gstreamer==0.1.17
+     python -m pip install docutils pygments pypiwin32 kivy_deps.sdl2==0.1.* kivy_deps.glew==0.1.*
+     python -m pip install kivy_deps.gstreamer==0.1.*
 
    .. note::
 
@@ -113,7 +113,7 @@ kivy release (`1.11.1`) and its dependencies.
    For Python 3.5+, you can also use the angle backend instead of glew. This
    can be installed with::
 
-     python -m pip install kivy_deps.angle==0.1.9
+     python -m pip install kivy_deps.angle==0.1.*
 
    .. warning::
 


### PR DESCRIPTION
We now have kivy_deps.xxx for 3.8, so we "should" be able to compile 1.11.1.