### PR TITLE
Update filechooser.py

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -687,6 +687,7 @@ class FileChooserController(RelativeLayout):
         self._gitems_gen = self._generate_file_entries(
             path=kwargs.get('path', self.path),
             parent=self._gitems_parent)
+        self.path = abspath(self.path)
 
         # cancel any previous clock if exist
         ev = self._create_files_entries_ev


### PR DESCRIPTION
## Description
When the path attribute is set, the full path is duplicated. Here is an example:
https://github.com/kivy/kivy/blob/master/kivy/uix/filechooser.py#L615

```
self.path = ./data/images/
entry.path = data/images/minecraft/skeleton.png
```

## Example of the problem
The problem is with join. See the example here:

``` python
from os.path import abspath
print(abspath(join('./data/images/', 'data/images/minecraft/skeleton.png')))
# /home/s0h3ck/data/images/data/images/minecraft/skeleton.png
print(abspath(join('./data/images/', '/home/s0h3ck/data/images/minecraft/skeleton.png')))
# /home/s0h3ck/data/images/minecraft/skeleton.png
```

## Suggestions
### First
self.selection = abspath(entry.path)
https://github.com/kivy/kivy/blob/master/kivy/uix/filechooser.py#L615

### Second
https://github.com/kivy/kivy/blob/master/kivy/uix/filechooser.py#L690
self.path = abspath(self.path)

## Information
I applied the second suggestion because I don't know if the first suggestion can break something. on Windows or MacOS. The first would be better for performance because the second is called more than once.

