### PR TITLE
Fix Exception when device name cant be decoded (maybe because of Chinese Caracters?)

### DIFF
--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -656,8 +656,11 @@ else:
             fd = open(input_fn, 'rb')
 
             # get the controler name (EVIOCGNAME)
-            device_name = fcntl.ioctl(fd, EVIOCGNAME + (256 << 16),
-                                      " " * 256).decode().strip()
+            try:
+                device_name = fcntl.ioctl(fd, EVIOCGNAME + (256 << 16),
+                                        " " * 256).decode().strip()
+            except:
+                device_name = "unknown device"
             Logger.info('HIDMotionEvent: using <%s>' % device_name)
 
             # get abs infos


### PR DESCRIPTION
This was the traceback I got...

stderr: Traceback (most recent call last):
stderr:   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
stderr:     self.run()
stderr:   File "/usr/lib/python2.7/threading.py", line 754, in run
stderr:     self.__target(*self.__args, **self.__kwargs)
stderr:   File "/home/pi/klippy-env/local/lib/python2.7/site-packages/kivy/input/providers/hidinput.py", line 660, in _thread_run
stderr:     " " * 256).decode().strip()
stderr: UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 0: ordinal not in range(128)