### PR TITLE
Missing directory replaced in colorpicker #6599

### DIFF
--- a/examples/widgets/colorpicker.py
+++ b/examples/widgets/colorpicker.py
@@ -200,9 +200,9 @@ class MainRootWidget(BoxLayout):
 
     def on_parent(self, instance, parent):
         if parent:
-            _dir = join(dirname(__file__), 'lists/fruit_images/')
+            _dir = join(dirname(__file__), '../demo/pictures/images/')
             for image in list(walk(_dir))[0][2]:
-                if image.find('512') > -1:
+                if image.find('jpg') > -1:
                     self.client_area.add_widget(Picture(source=_dir + image))
 
 


### PR DESCRIPTION
The `lists/fruit_images` was deleted in the past during the removal of the ListView elements.
As reference see: https://github.com/kivy/kivy/pull/5968/files

Since then, `examples/widgets/colorpicker.py` seems to have failed to run because of the missing directory. This has been reported in issue #6599.

I replaced the old directory with a current directory used for other examples as well.