### PR TITLE
List kivy.weakmethod because pyinstaller doesn't see into cython files.

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -89,7 +89,8 @@ if 'KIVY_DOC' not in environ:
 
     kivy_modules = [
         'xml.etree.cElementTree',
-        'kivy.core.gl'
+        'kivy.core.gl',
+        'kivy.weakmethod',
     ] + collect_submodules('kivy.graphics')
     '''List of kivy modules that are always needed as hiddenimports of
     pyinstaller.


### PR DESCRIPTION
Tried packaging an app, and it failed to load with recent pyinstaller because `kivy.weakmethod` was missing.