### PR TITLE
Make modal and dropdown consistent

### DIFF
--- a/kivy/tests/test_uix_actionbar.py
+++ b/kivy/tests/test_uix_actionbar.py
@@ -218,6 +218,11 @@ class ActionBarTestCase(GraphicUnitTest):
         self.assertTrue(group2.is_open)
         self.assertFalse(group1.is_open)
 
+        # click away from ActionBar and wait for it to disappear
+        TouchPoint(0, 0)
+        sleep(g2dd.min_state_time)
+        self.move_frames(1)
+
         # click on Group 1
         TouchPoint(*group1.center)
 

--- a/kivy/tests/test_uix_dropdown.py
+++ b/kivy/tests/test_uix_dropdown.py
@@ -56,27 +56,35 @@ async def test_dropdown_app(kivy_app):
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
         pass
 
+    # open dropdown
     dropdown.open(kivy_app.attach_widget)
     dropdown.pos = 0, 0
     await kivy_app.wait_clock_frames(2)
     assert dropdown.attach_to is not None
 
-    # press within dropdown area
+    # press within dropdown area - should stay open
     async for _ in kivy_app.do_touch_down_up(widget=button):
         pass
     assert dropdown.attach_to is not None
-    # start in dropdown but release outside
+    # start in dropdown but release outside - should stay open
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
         pass
     assert dropdown.attach_to is not None
-    # start outside but release in dropdown
+
+    # start outside but release in dropdown - should close
     async for _ in kivy_app.do_touch_drag(
             pos=(button.center_x + button.width / 4, button.center_y),
             target_widget=button):
         pass
+    assert dropdown.attach_to is None
+
+    # open dropdown again
+    dropdown.open(kivy_app.attach_widget)
+    dropdown.pos = 0, 0
+    await kivy_app.wait_clock_frames(2)
     assert dropdown.attach_to is not None
 
-    # press outside dropdown area to close it
+    # press outside dropdown area to close it - should close
     async for _ in kivy_app.do_touch_down_up(
             pos=(button.center_x + button.width / 4, button.center_y)):
         pass

--- a/kivy/tests/test_uix_dropdown.py
+++ b/kivy/tests/test_uix_dropdown.py
@@ -1,0 +1,83 @@
+from kivy.tests import async_run, UnitKivyApp
+
+
+def dropdown_app():
+    from kivy.app import App
+    from kivy.uix.button import Button
+    from kivy.uix.dropdown import DropDown
+    from kivy.uix.label import Label
+
+    class RootButton(Button):
+
+        dropdown = None
+
+        def on_touch_down(self, touch):
+            assert self.dropdown.attach_to is None
+            return super(RootButton, self).on_touch_down(touch)
+
+        def on_touch_move(self, touch):
+            assert self.dropdown.attach_to is None
+            return super(RootButton, self).on_touch_move(touch)
+
+        def on_touch_up(self, touch):
+            assert self.dropdown.attach_to is None
+            return super(RootButton, self).on_touch_up(touch)
+
+    class TestApp(UnitKivyApp, App):
+        def build(self):
+            root = RootButton(text='Root')
+            self.attach_widget = Label(text='Attached widget')
+            root.add_widget(self.attach_widget)
+
+            root.dropdown = self.dropdown = DropDown(
+                auto_dismiss=True, min_state_time=0)
+            self.inner_widget = w = Label(
+                size_hint=(None, None), text='Dropdown')
+            root.dropdown.add_widget(w)
+            return root
+
+    return TestApp()
+
+
+@async_run(app_cls_func=dropdown_app)
+async def test_dropdown_app(kivy_app):
+    await kivy_app.wait_clock_frames(2)
+    dropdown = kivy_app.dropdown
+    button = kivy_app.root
+    assert dropdown.attach_to is None
+
+    kivy_app.attach_widget.size = button.width * 3 / 5, 2
+    kivy_app.attach_widget.top = button.height
+    kivy_app.inner_widget.size = button.width * 3 / 5, button.height
+
+    # just press button
+    async for _ in kivy_app.do_touch_down_up(widget=button):
+        pass
+    async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
+        pass
+
+    dropdown.open(kivy_app.attach_widget)
+    dropdown.pos = 0, 0
+    await kivy_app.wait_clock_frames(2)
+    assert dropdown.attach_to is not None
+
+    # press within dropdown area
+    async for _ in kivy_app.do_touch_down_up(widget=button):
+        pass
+    assert dropdown.attach_to is not None
+    # start in dropdown but release outside
+    async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
+        pass
+    assert dropdown.attach_to is not None
+    # start outside but release in dropdown
+    async for _ in kivy_app.do_touch_drag(
+            pos=(button.center_x + button.width / 4, button.center_y),
+            target_widget=button):
+        pass
+    assert dropdown.attach_to is not None
+
+    # press outside dropdown area to close it
+    async for _ in kivy_app.do_touch_down_up(
+            pos=(button.center_x + button.width / 4, button.center_y)):
+        pass
+    assert dropdown.attach_to is None

--- a/kivy/tests/test_uix_modal.py
+++ b/kivy/tests/test_uix_modal.py
@@ -1,0 +1,75 @@
+from kivy.tests import async_run, UnitKivyApp
+from math import isclose
+
+
+def modal_app():
+    from kivy.app import App
+    from kivy.uix.button import Button
+    from kivy.uix.modalview import ModalView
+
+    class ModalButton(Button):
+
+        modal = None
+
+        def on_touch_down(self, touch):
+            assert self.modal._window is None
+            return super(ModalButton, self).on_touch_down(touch)
+
+        def on_touch_move(self, touch):
+            assert self.modal._window is None
+            return super(ModalButton, self).on_touch_move(touch)
+
+        def on_touch_up(self, touch):
+            assert self.modal._window is None
+            return super(ModalButton, self).on_touch_up(touch)
+
+    class TestApp(UnitKivyApp, App):
+        def build(self):
+            root = ModalButton()
+            root.modal = self.modal_view = ModalView(
+                size_hint=(.2, .5), auto_dismiss=True)
+            return root
+
+    return TestApp()
+
+
+@async_run(app_cls_func=modal_app)
+async def test_modal_app(kivy_app):
+    await kivy_app.wait_clock_frames(2)
+    modal = kivy_app.modal_view
+    button = kivy_app.root
+    modal._anim_duration = 0
+    assert modal._window is None
+
+    # just press button
+    async for _ in kivy_app.do_touch_down_up(widget=button):
+        pass
+    async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
+        pass
+
+    modal.open()
+    await kivy_app.wait_clock_frames(2)
+    assert modal._window is not None
+    assert isclose(modal.center_x, button.center_x, abs_tol=.1)
+    assert isclose(modal.center_y, button.center_y, abs_tol=.1)
+
+    # press within modal area
+    async for _ in kivy_app.do_touch_down_up(widget=button):
+        pass
+    assert modal._window is not None
+    # start in modal but release outside
+    async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
+        pass
+    assert modal._window is not None
+    # start outside but release in modal
+    async for _ in kivy_app.do_touch_drag(
+            pos=(button.center_x + button.width / 4, button.center_y),
+            target_widget=button):
+        pass
+    assert modal._window is not None
+
+    # press outside modal area to close it
+    async for _ in kivy_app.do_touch_down_up(
+            pos=(button.center_x + button.width / 4, button.center_y)):
+        pass
+    assert modal._window is None

--- a/kivy/tests/test_uix_modal.py
+++ b/kivy/tests/test_uix_modal.py
@@ -47,28 +47,35 @@ async def test_modal_app(kivy_app):
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
         pass
 
+    # open modal
     modal.open()
     await kivy_app.wait_clock_frames(2)
     assert modal._window is not None
     assert isclose(modal.center_x, button.center_x, abs_tol=.1)
     assert isclose(modal.center_y, button.center_y, abs_tol=.1)
 
-    # press within modal area
+    # press within modal area - should stay open
     async for _ in kivy_app.do_touch_down_up(widget=button):
         pass
     assert modal._window is not None
-    # start in modal but release outside
+    # start in modal but release outside - should stay open
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
         pass
     assert modal._window is not None
-    # start outside but release in modal
+
+    # start outside but release in modal - should close
     async for _ in kivy_app.do_touch_drag(
             pos=(button.center_x + button.width / 4, button.center_y),
             target_widget=button):
         pass
+    assert modal._window is None
+
+    # open modal again
+    modal.open()
+    await kivy_app.wait_clock_frames(2)
     assert modal._window is not None
 
-    # press outside modal area to close it
+    # press outside modal area - should close
     async for _ in kivy_app.do_touch_down_up(
             pos=(button.center_x + button.width / 4, button.center_y)):
         pass

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -298,22 +298,20 @@ class DropDown(ScrollView):
 
     def on_touch_down(self, touch):
         self._touch_started_inside = self.collide_point(*touch.pos)
-        super(DropDown, self).on_touch_down(touch)
+        if not self.auto_dismiss or self._touch_started_inside:
+            super(DropDown, self).on_touch_down(touch)
         return True
 
     def on_touch_move(self, touch):
-        super(DropDown, self).on_touch_move(touch)
+        if not self.auto_dismiss or self._touch_started_inside:
+            super(DropDown, self).on_touch_move(touch)
         return True
 
     def on_touch_up(self, touch):
-        if super(DropDown, self).on_touch_up(touch):
-            return True
-        if 'button' in touch.profile and touch.button.startswith('scroll'):
-            return True
-        if self.collide_point(*touch.pos):
-            return True
         if self.auto_dismiss and not self._touch_started_inside:
             self.dismiss()
+            return True
+        super(DropDown, self).on_touch_up(touch)
         return True
 
     def _reposition(self, *largs):

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -191,6 +191,8 @@ class DropDown(ScrollView):
     list. It is a :class:`~kivy.uix.gridlayout.GridLayout` by default.
     '''
 
+    _touch_started_inside = None
+
     __events__ = ('on_select', 'on_dismiss')
 
     def __init__(self, **kwargs):
@@ -295,9 +297,10 @@ class DropDown(ScrollView):
         return super(DropDown, self).clear_widgets()
 
     def on_touch_down(self, touch):
+        inside = self._touch_started_inside = self.collide_point(*touch.pos)
         if super(DropDown, self).on_touch_down(touch):
             return True
-        if self.collide_point(*touch.pos):
+        if inside:
             return True
         if (self.attach_to and self.attach_to.collide_point(
                 *self.attach_to.to_widget(*touch.pos))):
@@ -310,7 +313,7 @@ class DropDown(ScrollView):
             return
         if self.collide_point(*touch.pos):
             return True
-        if self.auto_dismiss:
+        if self.auto_dismiss and not self._touch_started_inside:
             self.dismiss()
 
     def _reposition(self, *largs):

--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -297,24 +297,24 @@ class DropDown(ScrollView):
         return super(DropDown, self).clear_widgets()
 
     def on_touch_down(self, touch):
-        inside = self._touch_started_inside = self.collide_point(*touch.pos)
-        if super(DropDown, self).on_touch_down(touch):
-            return True
-        if inside:
-            return True
-        if (self.attach_to and self.attach_to.collide_point(
-                *self.attach_to.to_widget(*touch.pos))):
-            return True
+        self._touch_started_inside = self.collide_point(*touch.pos)
+        super(DropDown, self).on_touch_down(touch)
+        return True
+
+    def on_touch_move(self, touch):
+        super(DropDown, self).on_touch_move(touch)
+        return True
 
     def on_touch_up(self, touch):
         if super(DropDown, self).on_touch_up(touch):
             return True
         if 'button' in touch.profile and touch.button.startswith('scroll'):
-            return
+            return True
         if self.collide_point(*touch.pos):
             return True
         if self.auto_dismiss and not self._touch_started_inside:
             self.dismiss()
+        return True
 
     def _reposition(self, *largs):
         # calculate the coordinate of the attached widget in the window

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -266,22 +266,20 @@ class ModalView(AnchorLayout):
 
     def on_touch_down(self, touch):
         self._touch_started_inside = self.collide_point(*touch.pos)
-        super(ModalView, self).on_touch_down(touch)
+        if not self.auto_dismiss or self._touch_started_inside:
+            super(ModalView, self).on_touch_down(touch)
         return True
 
     def on_touch_move(self, touch):
-        super(ModalView, self).on_touch_move(touch)
+        if not self.auto_dismiss or self._touch_started_inside:
+            super(ModalView, self).on_touch_move(touch)
         return True
 
     def on_touch_up(self, touch):
-        if super(ModalView, self).on_touch_up(touch):
-            return True
-        if 'button' in touch.profile and touch.button.startswith('scroll'):
-            return True
-        if self.collide_point(*touch.pos):
-            return True
         if self.auto_dismiss and not self._touch_started_inside:
             self.dismiss()
+            return True
+        super(ModalView, self).on_touch_up(touch)
         return True
 
     def on__anim_alpha(self, instance, value):

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -177,6 +177,8 @@ class ModalView(AnchorLayout):
 
     _window = ObjectProperty(None, allownone=True, rebind=True)
 
+    _touch_started_inside = None
+
     __events__ = ('on_pre_open', 'on_open', 'on_pre_dismiss', 'on_dismiss')
 
     def __init__(self, **kwargs):
@@ -263,10 +265,7 @@ class ModalView(AnchorLayout):
             self.center = self._window.center
 
     def on_touch_down(self, touch):
-        if not self.collide_point(*touch.pos):
-            if self.auto_dismiss:
-                self.dismiss()
-                return True
+        self._touch_started_inside = self.collide_point(*touch.pos)
         super(ModalView, self).on_touch_down(touch)
         return True
 
@@ -275,7 +274,14 @@ class ModalView(AnchorLayout):
         return True
 
     def on_touch_up(self, touch):
-        super(ModalView, self).on_touch_up(touch)
+        if super(ModalView, self).on_touch_up(touch):
+            return True
+        if 'button' in touch.profile and touch.button.startswith('scroll'):
+            return True
+        if self.collide_point(*touch.pos):
+            return True
+        if self.auto_dismiss and not self._touch_started_inside:
+            self.dismiss()
         return True
 
     def on__anim_alpha(self, instance, value):


### PR DESCRIPTION
This makes the behavior of modal and dropdown consistent with respect to auto-dismissing.

Currently they behave differently, and I think buggy. One auto-dismisses on touch down if clicked outside, while the other on touch up. Also, one eats all the touch move, while the other ignores them, unlike up/down touches.

In the past, with one touch a dropdown would be closed, but the same touch could also open something else. I don't think this is right - one touch should close it and do nothing else. Another touch should be required to do something new. This is the fix required in action bar.

Is there a reason for these differences? What this does is:

* Auto-dismiss happens when the touch down start outside the modal/dropdown - even if it's released inside. Otherwise, it stays up, even if the touch starts inside but ends outside. Consequently, it auto-dismisses in touch up.
* All touches that are outside the modal/dropdown are just eaten - modal already behaved this way so I just fixed dropdown to also do this. There's no reason for a touch outside to be passed on when the popup is visible.
* Once the touch down is going to cause dismissal - the touch is eaten, even if it's inside during move/up.
* Adds gui tests to test auto-dismiss.