### PR TITLE
Compile wheels for Raspberry Pi 1-3 using the CI

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -10,11 +10,11 @@ RUN [ "cross-build-start" ]
 RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple" && \
     install_kivy_test_run_apt_deps && \
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install xorg && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg && \
     install_python && \
     install_kivy_test_run_pip_deps'
 
-# Download the Raspberry Pi firmware if we are targeting the Raspberry Pi 1-3.
+# Download the Raspberry Pi firmware, so Raspberry Pi 1-3 can use the 'egl_rpi' window provider.
 ARG KIVY_CROSS_PLATFORM=""
 ARG KIVY_CROSS_SYSROOT=""
 RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
@@ -24,6 +24,6 @@ RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
     fi
 
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" USE_X11=1 python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 RUN [ "cross-build-end" ]

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -23,6 +23,6 @@ RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
     fi
 
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 VIDEOCOREMESA=1 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 RUN [ "cross-build-end" ]

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -10,6 +10,7 @@ RUN [ "cross-build-start" ]
 RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple" && \
     install_kivy_test_run_apt_deps && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install xorg && \
     install_python && \
     install_kivy_test_run_pip_deps'
 
@@ -23,6 +24,6 @@ RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
     fi
 
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" USE_X11=1 python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 RUN [ "cross-build-end" ]

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -13,7 +13,16 @@ RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     install_python && \
     install_kivy_test_run_pip_deps'
 
+# Download the Raspberry Pi firmware if we are targeting the Raspberry Pi 1-3.
+ARG KIVY_CROSS_PLATFORM=""
+ARG KIVY_CROSS_SYSROOT=""
+RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
+        apt-get -y install git; \
+        git clone --depth=1 https://github.com/raspberrypi/firmware "$KIVY_CROSS_SYSROOT"; \
+        ln -s "$KIVY_CROSS_SYSROOT"/opt/vc "$KIVY_CROSS_SYSROOT"/usr; \
+    fi
+
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 VIDEOCOREMESA=1 python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 VIDEOCOREMESA=1 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 RUN [ "cross-build-end" ]

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -95,14 +95,6 @@ generate_armv7l_wheels() {
   docker cp "$(docker create kivy/kivy-armv7l)":/kivy-wheel .
   cp kivy-wheel/Kivy-* dist/
 
-  # Rename the special wheels for the Raspberry Pi 1-3
-  if [ "$#" -gt 1 ]; then
-    for name in dist/*.whl; do
-      new_name="${name/-cp/.rpi123-cp}"
-      mv -n "$name" "$new_name"
-    done
-  fi
-
   # Create a copy with the armv6l suffix
   for name in dist/*.whl; do
     new_name="${name/armv7l/armv6l}"
@@ -119,12 +111,12 @@ rename_wheels() {
     -c "import kivy; _, tag, n = kivy.parse_kivy_version(kivy.__version__); print(tag + n) if n is not None else print(tag or 'something')" \
     --config "kivy:log_level:error")
   echo "tag_name=$tag_name"
-  wheel_name="$tag_name.$wheel_date.$git_tag"
+  wheel_name="$tag_name.$wheel_date.$git_tag-"
   echo "wheel_name=$wheel_name"
 
   ls dist/
   for name in dist/*.whl; do
-    new_name="${name/$tag_name/$wheel_name}"
+    new_name="${name/$tag_name-/$wheel_name}"
     if [ ! -f "$new_name" ]; then
       cp -n "$name" "$new_name"
     fi

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   SERVER_IP: '159.203.106.198'
+  KIVY_CROSS_PLATFORM: 'rpi'
+  KIVY_CROSS_SYSROOT: '/rpi-firmware'
 
 jobs:
   raspberrypi:
@@ -16,13 +18,18 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
+        platform: ['rpi123', 'rpi4']
         docker_images: ['balenalib/armv7hf-debian:stretch', 'balenalib/armv7hf-debian:buster']
     steps:
     - uses: actions/checkout@v1
     - name: Make ${{ matrix.docker_images }} wheel
       run: |
         source .ci/ubuntu_ci.sh
-        generate_armv7l_wheels ${{ matrix.docker_images }}
+        if [ "${{ matrix.platform }}" == "rpi123" ]; then
+          generate_armv7l_wheels ${{ matrix.docker_images }} "$KIVY_CROSS_PLATFORM" "$KIVY_CROSS_SYSROOT"
+        else
+          generate_armv7l_wheels ${{ matrix.docker_images }}
+        fi
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
       run: |

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -18,18 +18,13 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        platform: ['rpi123', 'rpi4']
         docker_images: ['balenalib/armv7hf-debian:stretch', 'balenalib/armv7hf-debian:buster']
     steps:
     - uses: actions/checkout@v1
     - name: Make ${{ matrix.docker_images }} wheel
       run: |
         source .ci/ubuntu_ci.sh
-        if [ "${{ matrix.platform }}" == "rpi123" ]; then
-          generate_armv7l_wheels ${{ matrix.docker_images }} "$KIVY_CROSS_PLATFORM" "$KIVY_CROSS_SYSROOT"
-        else
-          generate_armv7l_wheels ${{ matrix.docker_images }}
-        fi
+        generate_armv7l_wheels ${{ matrix.docker_images }} "$KIVY_CROSS_PLATFORM" "$KIVY_CROSS_SYSROOT"
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
       run: |

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -125,12 +125,19 @@ _`Raspberry Pi 1-4 installation` on Raspbian Jessie/Stretch/Buster
     # or to recompile all files
     make force
 
-   Or on a Raspberry Pi 4 it is possible to use a precompiled wheel. The precompiled wheel can be downloaded from the latest `release <https://github.com/kivy/kivy/releases>`_. A wheel is also automatically build daily and can be downloaded here: `<https://kivy.org/downloads/ci/raspberrypi/kivy>`_.
+   It is also possible to use a precompiled wheel. The precompiled wheel can be downloaded from the latest `release <https://github.com/kivy/kivy/releases>`_. A wheel is also automatically build daily and can be downloaded here: `<https://kivy.org/downloads/ci/raspberrypi/kivy>`_. Note that the wheel for the Raspberry Pi 1-3 has `rpi123` in the filename and will only work on those devices, as it uses proprietary Broadcom drivers.
 
-   The wheel can be installed as follows::
+   First install the wheel dependency::
 
     python3 -m pip install --upgrade --user wheel
-    python3 -m pip install --user *armv7l.whl
+
+   On a Raspberry Pi 1-3 you need the `rpi123` wheel::
+
+    python3 -m pip install --user Kivy-2.0.0.dev0.rpi123-*-linux_armv7l.whl
+
+   On a Raspberry Pi 4 you need the wheel **WITHOUT** the `rpi123` included in the name::
+
+    python3 -m pip install --user Kivy-2.0.0.dev0-*-linux_armv7l.whl
 
 .. note::
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -146,6 +146,30 @@ _`Raspberry Pi 1-4 installation` on Raspbian Jessie/Stretch/Buster
     this issue, please upgrade or consult `ticket #5360.
     <https://github.com/kivy/kivy/issues/5360>`_
 
+Raspberry Pi window provider and GL backend
+-------------------------------------------
+
+By default the Raspberry Pi 1-3 will use the ``egl_rpi`` window provider and the ``gl`` GL backend.
+
+Since the ``egl_rpi`` window provider is not available on the Raspberry Pi 4 it uses the ``sdl2`` window provider and the ``sdl2`` GL backend by default.
+
+The window provider and GL backend can be changed at runtime by setting the `KIVY_WINDOW`_ and `KIVY_GL_BACKEND`_ environmental variables.
+
+The table below shows the supported combinations of window provider and GL backend on the 4 platforms:
+
++------------------------------------+-----------------------------------+-------+-------+-------+-------+
+| Window provider (`KIVY_WINDOW`_\=) | GL backend (`KIVY_GL_BACKEND`_\=) | RPi 1 | RPi 2 | RPi 3 | RPi 4 |
++====================================+===================================+=======+=======+=======+=======+
+| sdl2                               | sdl2/gl                           | y     | y     | y     | y     |
++------------------------------------+-----------------------------------+-------+-------+-------+-------+
+| x11                                | gl                                | y     | y     | y     | y     |
++------------------------------------+-----------------------------------+-------+-------+-------+-------+
+| egl_rpi                            | gl                                | y     | y     | y     | n     |
++------------------------------------+-----------------------------------+-------+-------+-------+-------+
+
+.. _KIVY_WINDOW: https://kivy.org/doc/stable/guide/environment.html#restrict-core-to-specific-implementation
+.. _KIVY_GL_BACKEND: https://kivy.org/doc/stable/guide/environment.html#restrict-core-to-specific-implementation
+
 Installation on Raspbian Wheezy
 ----------------------------------------
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -4,7 +4,7 @@ Installation on Raspberry Pi
 ============================
 
 Raspberry Pi 4 headless installation on Raspbian Buster
-------------------------------------------------
+-------------------------------------------------------
 
 #. If you have installed Raspbian with a desktop i.e. if you Raspberry Pi boot into a desktop environment, then you can skip to `Raspberry Pi 1-4 installation`_.
 
@@ -80,7 +80,7 @@ Raspberry Pi 4 headless installation on Raspbian Buster
 #. Now simply follow the `Raspberry Pi 1-4 installation`_ instructions to install Kivy.
 
 _`Raspberry Pi 1-4 installation` on Raspbian Jessie/Stretch/Buster
-------------------------------------------------
+------------------------------------------------------------------
 
 #. Install the dependencies::
 
@@ -125,19 +125,19 @@ _`Raspberry Pi 1-4 installation` on Raspbian Jessie/Stretch/Buster
     # or to recompile all files
     make force
 
-   It is also possible to use a precompiled wheel. The precompiled wheel can be downloaded from the latest `release <https://github.com/kivy/kivy/releases>`_. A wheel is also automatically build daily and can be downloaded here: `<https://kivy.org/downloads/ci/raspberrypi/kivy>`_. Note that the wheel for the Raspberry Pi 1-3 has `rpi123` in the filename and will only work on those devices, as it uses proprietary Broadcom drivers.
+   It is also possible to use a precompiled wheel. The precompiled wheel can be downloaded from the latest `release <https://github.com/kivy/kivy/releases>`_. A wheel is also automatically build daily and can be downloaded here: `<https://kivy.org/downloads/ci/raspberrypi/kivy>`_.
 
    First install the wheel dependency::
 
     python3 -m pip install --upgrade --user wheel
 
-   On a Raspberry Pi 1-3 you need the `rpi123` wheel::
+   Now simply install the wheel::
 
-    python3 -m pip install --user Kivy-2.0.0.dev0.rpi123-*-linux_armv7l.whl
+    python3 -m pip install --user *armv7l.whl
 
-   On a Raspberry Pi 4 you need the wheel **WITHOUT** the `rpi123` included in the name::
+   It is also possible to install the latest development version like so::
 
-    python3 -m pip install --user Kivy-2.0.0.dev0-*-linux_armv7l.whl
+    python3 -m pip install --pre --user --extra-index-url https://kivy.org/downloads/simple kivy[base]
 
 .. note::
 

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -10,8 +10,7 @@ per application: please don't try to create more than one.
 
 __all__ = ('Keyboard', 'WindowBase', 'Window')
 
-import re
-from os.path import join, exists, isfile
+from os.path import join, exists
 from os import getcwd
 
 from kivy.core import core_select_lib
@@ -23,7 +22,7 @@ from kivy.modules import Modules
 from kivy.event import EventDispatcher
 from kivy.properties import ListProperty, ObjectProperty, AliasProperty, \
     NumericProperty, OptionProperty, StringProperty, BooleanProperty
-from kivy.utils import platform, reify, deprecated
+from kivy.utils import platform, reify, deprecated, pi_version
 from kivy.context import get_current_context
 from kivy.uix.behaviors import FocusBehavior
 from kivy.setupconfig import USE_SDL2
@@ -2060,62 +2059,9 @@ class WindowBase(EventDispatcher):
         pass
 
 
-def pi_version():
-    """Detect the version of the Raspberry Pi by reading the revision field
-    value from '/proc/cpuinfo'.
-    See: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
-    Based on: https://github.com/adafruit/Adafruit_Python_GPIO/blob/master/Adafruit_GPIO/Platform.py
-    """  # noqa
-    # Check if file exist
-    if not isfile('/proc/cpuinfo'):
-        return None
-
-    with open('/proc/cpuinfo', 'r') as f:
-        cpuinfo = f.read()
-
-    # Match a line like 'Revision   : a01041'
-    revision = re.search(r'^Revision\s+:\s+(\w+)$', cpuinfo,
-                         flags=re.MULTILINE | re.IGNORECASE)
-    if not revision:
-        # Couldn't find the hardware revision, assume it is not a Pi
-        return None
-
-    # Determine the Pi version using the processor bits using the new-style
-    # revision format
-    revision = revision.group(1)
-    if int(revision, base=16) & 0x800000:
-        version = ((int(revision, base=16) & 0xF000) >> 12) + 1
-        print('Raspberry Pi revision: {}'.format(version))
-        return version
-
-    # Only look a the last five characters, as the first one changes if the
-    # warranty bit is set
-    revision = revision[-5:]
-    if revision in {'0002', '0003', '0004', '0005', '0006', '0007', '0008',
-                    '0009', '000d', '000e', '000f', '0010', '0012', '0013',
-                    '0015', ' 900032'}:
-        print('Raspberry Pi 1')
-        return 1
-    elif revision in {'01041', '21041', '22042'}:
-        print('Raspberry Pi 2')
-        return 2
-    elif revision in {'02082', '22082', '32082', '220a0', '02082', '020a0'}:
-        print('Raspberry Pi 3, CM3')
-        return 3
-    elif revision in {'02100'}:
-        print('Raspberry CM3+')
-        return 3
-    elif revision in {'03111'}:
-        print('Raspberry Pi 4')
-        return 4
-    else:
-        print('Not a Raspberry Pi: {}'.format(revision))
-        return None
-
-
 #: Instance of a :class:`WindowBase` implementation
 window_impl = []
-if platform == 'linux' and (pi_version() or 4) < 4:
+if platform == 'linux' and (pi_version or 4) < 4:
     window_impl += [('egl_rpi', 'window_egl_rpi', 'WindowEglRpi')]
 if USE_SDL2:
     window_impl += [('sdl2', 'window_sdl2', 'WindowSDL')]

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -10,7 +10,8 @@ per application: please don't try to create more than one.
 
 __all__ = ('Keyboard', 'WindowBase', 'Window')
 
-from os.path import join, exists
+import re
+from os.path import join, exists, isfile
 from os import getcwd
 
 from kivy.core import core_select_lib
@@ -2059,9 +2060,62 @@ class WindowBase(EventDispatcher):
         pass
 
 
+def pi_version():
+    """Detect the version of the Raspberry Pi by reading the revision field
+    value from '/proc/cpuinfo'.
+    See: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
+    Based on: https://github.com/adafruit/Adafruit_Python_GPIO/blob/master/Adafruit_GPIO/Platform.py
+    """  # noqa
+    # Check if file exist
+    if not isfile('/proc/cpuinfo'):
+        return None
+
+    with open('/proc/cpuinfo', 'r') as f:
+        cpuinfo = f.read()
+
+    # Match a line like 'Revision   : a01041'
+    revision = re.search(r'^Revision\s+:\s+(\w+)$', cpuinfo,
+                         flags=re.MULTILINE | re.IGNORECASE)
+    if not revision:
+        # Couldn't find the hardware revision, assume it is not a Pi
+        return None
+
+    # Determine the Pi version using the processor bits using the new-style
+    # revision format
+    revision = revision.group(1)
+    if int(revision, base=16) & 0x800000:
+        version = ((int(revision, base=16) & 0xF000) >> 12) + 1
+        print('Raspberry Pi revision: {}'.format(version))
+        return version
+
+    # Only look a the last five characters, as the first one changes if the
+    # warranty bit is set
+    revision = revision[-5:]
+    if revision in {'0002', '0003', '0004', '0005', '0006', '0007', '0008',
+                    '0009', '000d', '000e', '000f', '0010', '0012', '0013',
+                    '0015', ' 900032'}:
+        print('Raspberry Pi 1')
+        return 1
+    elif revision in {'01041', '21041', '22042'}:
+        print('Raspberry Pi 2')
+        return 2
+    elif revision in {'02082', '22082', '32082', '220a0', '02082', '020a0'}:
+        print('Raspberry Pi 3, CM3')
+        return 3
+    elif revision in {'02100'}:
+        print('Raspberry CM3+')
+        return 3
+    elif revision in {'03111'}:
+        print('Raspberry Pi 4')
+        return 4
+    else:
+        print('Not a Raspberry Pi: {}'.format(revision))
+        return None
+
+
 #: Instance of a :class:`WindowBase` implementation
 window_impl = []
-if platform == 'linux':
+if platform == 'linux' and (pi_version() or 4) < 4:
     window_impl += [('egl_rpi', 'window_egl_rpi', 'WindowEglRpi')]
 if USE_SDL2:
     window_impl += [('sdl2', 'window_sdl2', 'WindowSDL')]

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -508,8 +508,7 @@ class reify(object):
 
 
 def _get_pi_version():
-    """Detect the version of the Raspberry Pi by reading the revision field
-    value from '/proc/cpuinfo'.
+    """Detect the version of the Raspberry Pi by reading the revision field value from '/proc/cpuinfo'
     See: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
     Based on: https://github.com/adafruit/Adafruit_Python_GPIO/blob/master/Adafruit_GPIO/Platform.py
     """  # noqa
@@ -529,35 +528,13 @@ def _get_pi_version():
 
     # Determine the Pi version using the processor bits using the new-style
     # revision format
-    revision = revision.group(1)
-    if int(revision, base=16) & 0x800000:
-        version = ((int(revision, base=16) & 0xF000) >> 12) + 1
-        print('Raspberry Pi revision: {}'.format(version))
-        return version
+    revision = int(revision.group(1), base=16)
+    if revision & 0x800000:
+        return ((revision & 0xF000) >> 12) + 1
 
-    # Only look a the last five characters, as the first one changes if the
-    # warranty bit is set
-    revision = revision[-5:]
-    if revision in {'0002', '0003', '0004', '0005', '0006', '0007', '0008',
-                    '0009', '000d', '000e', '000f', '0010', '0012', '0013',
-                    '0015', ' 900032'}:
-        print('Raspberry Pi 1')
-        return 1
-    elif revision in {'01041', '21041', '22042'}:
-        print('Raspberry Pi 2')
-        return 2
-    elif revision in {'02082', '22082', '32082', '220a0', '02082', '020a0'}:
-        print('Raspberry Pi 3, CM3')
-        return 3
-    elif revision in {'02100'}:
-        print('Raspberry CM3+')
-        return 3
-    elif revision in {'03111'}:
-        print('Raspberry Pi 4')
-        return 4
-    else:
-        print('Not a Raspberry Pi: {}'.format(revision))
-        return None
+    # If it is not using the new style revision format,
+    # then it must be a Raspberry Pi 1
+    return 1
 
 
 pi_version = _get_pi_version()

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -18,11 +18,11 @@ __all__ = ('intersection', 'difference', 'strtotuple',
            'is_color_transparent', 'hex_colormap', 'colormap', 'boundary',
            'deprecated', 'SafeList',
            'interpolate', 'QueryDict',
-           'platform', 'escape_markup', 'reify', 'rgba')
+           'platform', 'escape_markup', 'reify', 'rgba', 'pi_version')
 
-from os import environ
+from os import environ, path
 from sys import platform as _sys_platform
-from re import match, split
+from re import match, split, search, MULTILINE, IGNORECASE
 from kivy.compat import string_types
 
 
@@ -505,3 +505,59 @@ class reify(object):
         retval = self.func(inst)
         setattr(inst, self.func.__name__, retval)
         return retval
+
+
+def _get_pi_version():
+    """Detect the version of the Raspberry Pi by reading the revision field
+    value from '/proc/cpuinfo'.
+    See: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
+    Based on: https://github.com/adafruit/Adafruit_Python_GPIO/blob/master/Adafruit_GPIO/Platform.py
+    """  # noqa
+    # Check if file exist
+    if not path.isfile('/proc/cpuinfo'):
+        return None
+
+    with open('/proc/cpuinfo', 'r') as f:
+        cpuinfo = f.read()
+
+    # Match a line like 'Revision   : a01041'
+    revision = search(r'^Revision\s+:\s+(\w+)$', cpuinfo,
+                      flags=MULTILINE | IGNORECASE)
+    if not revision:
+        # Couldn't find the hardware revision, assume it is not a Pi
+        return None
+
+    # Determine the Pi version using the processor bits using the new-style
+    # revision format
+    revision = revision.group(1)
+    if int(revision, base=16) & 0x800000:
+        version = ((int(revision, base=16) & 0xF000) >> 12) + 1
+        print('Raspberry Pi revision: {}'.format(version))
+        return version
+
+    # Only look a the last five characters, as the first one changes if the
+    # warranty bit is set
+    revision = revision[-5:]
+    if revision in {'0002', '0003', '0004', '0005', '0006', '0007', '0008',
+                    '0009', '000d', '000e', '000f', '0010', '0012', '0013',
+                    '0015', ' 900032'}:
+        print('Raspberry Pi 1')
+        return 1
+    elif revision in {'01041', '21041', '22042'}:
+        print('Raspberry Pi 2')
+        return 2
+    elif revision in {'02082', '22082', '32082', '220a0', '02082', '020a0'}:
+        print('Raspberry Pi 3, CM3')
+        return 3
+    elif revision in {'02100'}:
+        print('Raspberry CM3+')
+        return 3
+    elif revision in {'03111'}:
+        print('Raspberry Pi 4')
+        return 4
+    else:
+        print('Not a Raspberry Pi: {}'.format(revision))
+        return None
+
+
+pi_version = _get_pi_version()

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ if kivy_ios_root is not None:
 if exists('/opt/vc/include/bcm_host.h'):
     # The proprietary broadcom video core drivers are not available on the
     # Raspberry Pi 4
-    if pi_version() != 4:
+    if (pi_version() or 4) < 4:
         platform = 'rpi'
 # use mesa video core drivers
 if environ.get('VIDEOCOREMESA', None) == '1':

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ if "--build_examples" in sys.argv:
     build_examples = True
     sys.argv.remove("--build_examples")
 
+from kivy.utils import pi_version
 from copy import deepcopy
 import os
-import re
 from os.path import join, dirname, sep, exists, basename, isdir
 from os import walk, environ, makedirs
 from distutils.command.build_ext import build_ext
@@ -141,59 +141,6 @@ if sys.platform == 'darwin':
         osx_arch = 'i386'
 
 
-def pi_version():
-    """Detect the version of the Raspberry Pi by reading the revision field
-    value from '/proc/cpuinfo'.
-    See: https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
-    Based on: https://github.com/adafruit/Adafruit_Python_GPIO/blob/master/Adafruit_GPIO/Platform.py
-    """  # noqa
-    # Check if file exist
-    if not os.path.isfile('/proc/cpuinfo'):
-        return None
-
-    with open('/proc/cpuinfo', 'r') as f:
-        cpuinfo = f.read()
-
-    # Match a line like 'Revision   : a01041'
-    revision = re.search(r'^Revision\s+:\s+(\w+)$', cpuinfo,
-                         flags=re.MULTILINE | re.IGNORECASE)
-    if not revision:
-        # Couldn't find the hardware revision, assume it is not a Pi
-        return None
-
-    # Determine the Pi version using the processor bits using the new-style
-    # revision format
-    revision = revision.group(1)
-    if int(revision, base=16) & 0x800000:
-        version = ((int(revision, base=16) & 0xF000) >> 12) + 1
-        print('Raspberry Pi revision: {}'.format(version))
-        return version
-
-    # Only look a the last five characters, as the first one changes if the
-    # warranty bit is set
-    revision = revision[-5:]
-    if revision in {'0002', '0003', '0004', '0005', '0006', '0007', '0008',
-                    '0009', '000d', '000e', '000f', '0010', '0012', '0013',
-                    '0015', ' 900032'}:
-        print('Raspberry Pi 1')
-        return 1
-    elif revision in {'01041', '21041', '22042'}:
-        print('Raspberry Pi 2')
-        return 2
-    elif revision in {'02082', '22082', '32082', '220a0', '02082', '020a0'}:
-        print('Raspberry Pi 3, CM3')
-        return 3
-    elif revision in {'02100'}:
-        print('Raspberry CM3+')
-        return 3
-    elif revision in {'03111'}:
-        print('Raspberry Pi 4')
-        return 4
-    else:
-        print('Not a Raspberry Pi: {}'.format(revision))
-        return None
-
-
 # Detect Python for android project (http://github.com/kivy/python-for-android)
 ndkplatform = environ.get('NDKPLATFORM')
 if ndkplatform is not None and environ.get('LIBLINK'):
@@ -205,7 +152,7 @@ if kivy_ios_root is not None:
 if exists('/opt/vc/include/bcm_host.h'):
     # The proprietary broadcom video core drivers are not available on the
     # Raspberry Pi 4
-    if (pi_version() or 4) < 4:
+    if (pi_version or 4) < 4:
         platform = 'rpi'
 # use mesa video core drivers
 if environ.get('VIDEOCOREMESA', None) == '1':

--- a/setup.py
+++ b/setup.py
@@ -731,12 +731,12 @@ def determine_gl_flags():
                 cross_sysroot + '/usr/lib/libbrcmGLESv2.so')
 
         if all((exists(lib) for lib in brcm_lib_files)):
-            print('Found brcmEGL and brcmGLES library files'
+            print('Found brcmEGL and brcmGLES library files '
                   'for rpi platform at ' + dirname(brcm_lib_files[0]))
             gl_libs = ['brcmEGL', 'brcmGLESv2']
         else:
             print(
-                'Failed to find brcmEGL and brcmGLESv2 library files'
+                'Failed to find brcmEGL and brcmGLESv2 library files '
                 'for rpi platform, falling back to EGL and GLESv2.')
             gl_libs = ['EGL', 'GLESv2']
         flags['libraries'] = ['bcm_host'] + gl_libs


### PR DESCRIPTION
~~I have appended `rpi123` to the wheel filename, as these wheels will only work on the Raspberry Pi 1-3, as they use the proprietary Broadcom drivers.~~