### PR TITLE
Fix for crashes caused by text selection outside of TextInput area

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -611,13 +611,15 @@ class TextInput(FocusBehavior, Widget):
         '''Get the cursor x offset on the current line.
         '''
         offset = 0
-        row = self.cursor_row
-        col = self.cursor_col
+        row = int(self.cursor_row)
+        col = int(self.cursor_col)
         _lines = self._lines
         if col and row < len(_lines):
             offset = self._get_text_width(
-                _lines[row][:col], self.tab_width,
-                self._label_cached)
+                _lines[row][:col],
+                self.tab_width,
+                self._label_cached
+            )
         return offset
 
     def get_cursor_from_index(self, index):
@@ -1294,7 +1296,7 @@ class TextInput(FocusBehavior, Widget):
         '''Update selection text and order of from/to if finished is True.
         Can be called multiple times until finished is True.
         '''
-        a, b = self._selection_from, self._selection_to
+        a, b = int(self._selection_from), int(self._selection_to)
         if a > b:
             a, b = b, a
         self._selection_finished = finished
@@ -1331,8 +1333,8 @@ class TextInput(FocusBehavior, Widget):
         different behavior. Alternatively, you can bind to this
         event to provide additional functionality.
         '''
-        ci = self.cursor_index()
-        cc = self.cursor_col
+        ci = int(self.cursor_index())
+        cc = int(self.cursor_col)
         line = self._lines[self.cursor_row]
         len_line = len(line)
         start = max(0, len(line[:cc]) - line[:cc].rfind(u' ') - 1)


### PR DESCRIPTION
This may be an edge case, but worth addressing.

Changes:
- Fix for uncaught exceptions due to text selection exceeding `TextInput` area

Description:

Fix for uncaught exceptions related to slicing when list indexes are not supplied as integers. This happens for row / col in `_lines[row][:col]` and other places that use slicing for cursor position or text selection, even double tap.

Observed in:

in KivyMD's class `MDTextFieldRound` when for example
1. Created password input field of type `MDTextFieldRound` with a right side icon (no left side icon) enabled in the text field
2. Populated the field with text
3. Resized (downsized) the window until the icon pushes the text beyond the text field area (overflow text is hidden underneath the visible layer)
4. Selected the text by clicking in a way that:

   - Targeted the beginning of the overflow or an invisible part of the text (obstructed by a part of the input field if it is rounded or partly rounded)
   - 'Double tapped' the text, selecting the entire text (overflow as well)