### PR TITLE
Test generated wheels and sdist

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -13,7 +13,7 @@ env:
   DOCKER_IMAGE: 'quay.io/pypa/manylinux2010_x86_64'
 
 jobs:
-  manylinux2010:
+  manylinux:
     runs-on: ubuntu-18.04
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel linux]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel linux]')
     steps:
@@ -40,7 +40,6 @@ jobs:
         upload_file_to_server "$SERVER_IP" "linux/kivy/"
     - name: Upload wheels as artifact
       uses: actions/upload-artifact@master
-      if: github.event_name == 'pull_request'
       with:
         name: manylinux_wheels
         path: dist
@@ -59,11 +58,68 @@ jobs:
         files: dist/*
         draft: true
 
-  always_job:
-    name: Always run job
+  manylinux_wheel_test:
     runs-on: ubuntu-18.04
+    needs: manylinux
+    env:
+      DISPLAY: ':99.0'
     steps:
-      - name: Always run
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - uses: actions/download-artifact@master
+        with:
+          name: manylinux_wheels
+      - name: Install dependencies
         run: |
-          echo "This is run to prevent the workflow from showing an error if the wheels job is not run and no jobs run is an error."
-          echo "See https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38085"
+          mv manylinux_wheels dist
+          source .ci/ubuntu_ci.sh
+          install_kivy_test_run_apt_deps
+          install_kivy_test_wheel_run_pip_deps
+      - name: Setup env
+        run: |
+          source .ci/ubuntu_ci.sh
+          prepare_env_for_unittest
+      - name: Install Kivy
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_manylinux_wheel
+      - name: Test Kivy
+        run: |
+          source .ci/ubuntu_ci.sh
+          test_kivy_install
+
+  sdist_test:
+    runs-on: ubuntu-18.04
+    env:
+      DISPLAY: ':99.0'
+      KIVY_SPLIT_EXAMPLES: 0
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - name: Generate sdist
+        run: |
+          source .ci/ubuntu_ci.sh
+          generate_sdist
+      - name: Install dependencies
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_test_run_apt_deps
+          install_kivy_test_wheel_run_pip_deps
+      - name: Setup env
+        run: |
+          source .ci/ubuntu_ci.sh
+          prepare_env_for_unittest
+      - name: Install Kivy
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_sdist
+      - name: Test Kivy
+        run: |
+          source .ci/ubuntu_ci.sh
+          test_kivy_install

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -70,7 +70,6 @@ jobs:
         upload_file_to_server "$SERVER_IP" "osx/kivy/"
     - name: Upload wheels as artifact
       uses: actions/upload-artifact@master
-      if: github.event_name == 'pull_request'
       with:
         name: osx_wheels
         path: dist
@@ -88,6 +87,32 @@ jobs:
       with:
         files: dist/*
         draft: true
+
+  osx_wheel_test:
+    runs-on: macOS-latest
+    needs: osx_wheels
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - uses: actions/download-artifact@master
+        with:
+          name: osx_wheels
+      - name: Install dependencies
+        run: |
+          mv osx_wheels dist
+          source .ci/ubuntu_ci.sh
+          install_kivy_test_wheel_run_pip_deps
+      - name: Install Kivy
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_manylinux_wheel
+      - name: Test Kivy
+        run: |
+          source .ci/ubuntu_ci.sh
+          test_kivy_install
 
   osx_app:
     runs-on: macOS-latest

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -3,8 +3,6 @@ name: Windows Unittests
 on: [push, pull_request]
 
 env:
-  USE_SDL2: 1
-  USE_GSTREAMER: 1
   GST_REGISTRY: '~/registry.bin'
   KIVY_GL_BACKEND: 'angle_sdl2'
   KIVY_SPLIT_EXAMPLES: 1

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -10,8 +10,8 @@ on:
 env:
   KIVY_SPLIT_EXAMPLES: 1
   SERVER_IP: '159.203.106.198'
-  USE_SDL2: 1
-  USE_GSTREAMER: 1
+  GST_REGISTRY: '~/registry.bin'
+  KIVY_GL_BACKEND: 'angle_sdl2'
 
 jobs:
   windows_wheels:
@@ -64,7 +64,6 @@ jobs:
         Upload-windows-wheels-to-server -ip "$env:SERVER_IP"
     - name: Upload wheels as artifact
       uses: actions/upload-artifact@master
-      if: github.event_name == 'pull_request'
       with:
         name: windows_wheels
         path: dist
@@ -82,6 +81,52 @@ jobs:
       with:
         files: dist/*
         draft: true
+
+  windows_wheel_test:
+    runs-on: windows-latest
+    needs: windows_wheels
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - uses: actions/download-artifact@v1
+        with:
+          name: windows_wheels
+      - name: Install Kivy Wheel
+        run: |
+          mv windows_wheels dist
+          . .\.ci\windows_ci.ps1
+          Install-kivy-wheel
+      - name: Test Kivy Wheel
+        run: |
+          . .\.ci\windows_ci.ps1
+          Test-kivy-installed
+
+  windows_sdist_test:
+    runs-on: windows-latest
+    needs: windows_wheels
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - uses: actions/download-artifact@v1
+        with:
+          name: windows_wheels
+      - name: Install Kivy sdist
+        env:
+          KIVY_SPLIT_EXAMPLES: 0
+        run: |
+          mv windows_wheels dist
+          . .\.ci\windows_ci.ps1
+          Install-kivy-sdist
+      - name: Test Kivy sdist
+        run: |
+          . .\.ci\windows_ci.ps1
+          Test-kivy-installed
 
   always_job:
     name: Always run job

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include *AUTHORS *LICENSE *README.md
+include *AUTHORS *LICENSE *README.md *pyproject.toml
 recursive-include doc *
 recursive-include examples *
 recursive-include kivy/data *.png *.jpg *.ttf *.kv *.fs *.vs *.json *.gif *.atlas *.ico

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -68,7 +68,7 @@ release = kivy.__version__
 base = 'autobuild.py-done'
 if not os.path.exists(os.path.join(os.path.dirname(base_dir), base)):
     import autobuild
-import gallery
+from kivy.tools import gallery
 gallery.write_all_rst_pages()
 
 # There are two options for replacing |today|: either, you set today to some

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -25,7 +25,7 @@ __all__ = (
     'kivy_options', 'kivy_base_dir',
     'kivy_modules_dir', 'kivy_data_dir', 'kivy_shader_dir',
     'kivy_icons_dir', 'kivy_home_dir',
-    'kivy_config_fn', 'kivy_usermodules_dir',
+    'kivy_config_fn', 'kivy_usermodules_dir', 'kivy_examples_dir'
 )
 
 import sys
@@ -266,6 +266,17 @@ kivy_home_dir = ''
 kivy_config_fn = ''
 #: Kivy user modules directory
 kivy_usermodules_dir = ''
+#: Kivy examples directory
+kivy_examples_dir = ''
+for examples_dir in (
+        join(dirname(dirname(__file__)), 'examples'),
+        join(sys.exec_prefix, 'share', 'kivy-examples'),
+        join(sys.prefix, 'share', 'kivy-examples'),
+        '/usr/share/kivy-examples', '/usr/local/share/kivy-examples',
+        expanduser('~/.local/share/kivy-examples')):
+    if exists(examples_dir):
+        kivy_examples_dir = examples_dir
+        break
 
 # if there are deps, import them so they can do their magic.
 _packages = []

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -16,6 +16,7 @@ import unittest
 import logging
 import pytest
 import sys
+from functools import partial
 import os
 import threading
 from kivy.graphics.cgl import cgl_get_backend_name
@@ -35,23 +36,27 @@ http_server_ready = threading.Event()
 kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
 
 
-def ensure_web_server():
+def ensure_web_server(root=None):
     if http_server is not None:
         return True
 
+    if not root:
+        root = os.path.join(os.path.dirname(__file__), "..", "..")
+    need_chdir = sys.version_info.major == 3 and sys.version_info.minor <= 6
+    curr_dir = os.getcwd()
+
     def _start_web_server():
         global http_server
-        try:
-            from SimpleHTTPServer import SimpleHTTPRequestHandler
-            from SocketServer import TCPServer
-        except ImportError:
-            from http.server import SimpleHTTPRequestHandler
-            from socketserver import TCPServer
+        from http.server import SimpleHTTPRequestHandler
+        from socketserver import TCPServer
 
         try:
-            handler = SimpleHTTPRequestHandler
-            handler.directory = os.path.join(
-                os.path.dirname(__file__), "..", "..")
+            if need_chdir:
+                os.chdir(root)
+                handler = SimpleHTTPRequestHandler
+            else:
+                handler = partial(SimpleHTTPRequestHandler, directory=root)
+
             http_server = TCPServer(
                 ("", 8000), handler, bind_and_activate=False)
             http_server.daemon_threads = True
@@ -66,6 +71,9 @@ def ensure_web_server():
         finally:
             http_server = None
             http_server_ready.set()
+
+            if need_chdir:
+                os.chdir(curr_dir)
 
     th = threading.Thread(target=_start_web_server)
     th.daemon = True

--- a/kivy/tests/pyinstaller/test_pyinstaller.py
+++ b/kivy/tests/pyinstaller/test_pyinstaller.py
@@ -101,15 +101,15 @@ class TestVideoWidget(PyinstallerBase):
     @classmethod
     def get_env(cls):
         env = super(TestVideoWidget, cls).get_env()
+        import kivy
         env['__KIVY_VIDEO_TEST_FNAME'] = os.path.abspath(os.path.join(
-            os.path.dirname(__file__), "..", "..", "..", "examples",
-            "widgets", "cityCC0.mpg"))
+            kivy.kivy_examples_dir, "widgets", "cityCC0.mpg"))
         return env
 
     @classmethod
     def get_run_env(cls):
         env = super(TestVideoWidget, cls).get_run_env()
+        import kivy
         env['__KIVY_VIDEO_TEST_FNAME'] = os.path.abspath(os.path.join(
-            os.path.dirname(__file__), "..", "..", "..", "examples",
-            "widgets", "cityCC0.mpg"))
+            kivy.kivy_examples_dir, "widgets", "cityCC0.mpg"))
         return env

--- a/kivy/tests/test_audio.py
+++ b/kivy/tests/test_audio.py
@@ -5,6 +5,9 @@ Audio tests
 
 import unittest
 import os
+import pytest
+if os.environ.get('KIVY_TEST_AUDIO') == '0':
+    pytestmark = pytest.mark.skip("Audio is not available")
 
 SAMPLE_FILE = os.path.join(os.path.dirname(__file__), 'sample1.ogg')
 SAMPLE_LENGTH = 1.402

--- a/kivy/tests/test_doc_gallery.py
+++ b/kivy/tests/test_doc_gallery.py
@@ -1,4 +1,4 @@
-from doc.gallery import *
+from kivy.tools.gallery import *
 
 
 def test_parse_docstring_info():

--- a/kivy/tests/test_uix_asyncimage.py
+++ b/kivy/tests/test_uix_asyncimage.py
@@ -2,6 +2,7 @@ from kivy.tests.common import GraphicUnitTest, ensure_web_server
 
 from kivy.uix.image import AsyncImage
 from kivy.config import Config
+from kivy import kivy_examples_dir
 
 from zipfile import ZipFile
 from os.path import join, dirname, abspath
@@ -16,7 +17,7 @@ except ImportError:
 class AsyncImageTestCase(GraphicUnitTest):
     @classmethod
     def setUpClass(cls):
-        ensure_web_server()
+        ensure_web_server(kivy_examples_dir)
 
     def setUp(self):
         self.maxfps = Config.getint('graphics', 'maxfps')
@@ -59,7 +60,7 @@ class AsyncImageTestCase(GraphicUnitTest):
     def test_remote_zipsequence(self):
         # cube ZIP has 63 PNGs used for animation
         ZIP = (
-            'http://localhost:8000/examples/widgets/'
+            'http://localhost:8000/widgets/'
             'sequenced_images/data/images/cube.zip'
         )
 
@@ -79,9 +80,7 @@ class AsyncImageTestCase(GraphicUnitTest):
     def test_local_zipsequence(self):
         # cube ZIP has 63 PNGs used for animation
         ZIP = join(
-            # kivy/examples/.../cube.zip
-            dirname(dirname(dirname(abspath(__file__)))),
-            'examples', 'widgets', 'sequenced_images',
+            kivy_examples_dir, 'widgets', 'sequenced_images',
             'data', 'images', 'cube.zip'
         )
         ZIP_pngs = self.zip_frames(ZIP)

--- a/kivy/tests/test_video.py
+++ b/kivy/tests/test_video.py
@@ -10,10 +10,9 @@ class VideoTestCase(unittest.TestCase):
         from kivy.uix.video import Video
         from kivy.clock import Clock
         from kivy.base import runTouchApp, stopTouchApp
+        from kivy import kivy_examples_dir
         from os.path import join, dirname, abspath
-        here = dirname(__file__)
-        source = abspath(join(
-            here, "..", "..", "examples", "widgets", "cityCC0.mpg"))
+        source = abspath(join(kivy_examples_dir, "widgets", "cityCC0.mpg"))
         video = Video(source=source, play=True)
         Clock.schedule_once(lambda x: stopTouchApp(), 1)
 

--- a/kivy/tools/gallery.py
+++ b/kivy/tools/gallery.py
@@ -13,11 +13,12 @@ import re
 from os.path import sep
 from os.path import join as slash  # just like that name better
 from os.path import dirname, abspath
+import kivy
 from kivy.logger import Logger
 import textwrap
 
 # from here to the kivy top
-base_dir = dirname(dirname(abspath(__file__)))
+base_dir = dirname(dirname(abspath(kivy.__file__)))
 examples_dir = slash(base_dir, 'examples')
 screenshots_dir = slash(base_dir, 'doc/sources/images/examples')
 generation_dir = slash(base_dir, 'doc/sources/examples')
@@ -28,7 +29,7 @@ gallery_filename = slash(generation_dir, 'gallery.rst')
 
 # Info is a dict built up from
 # straight filename information, more from reading the docstring,
-# and more from parsing the description text.  Errors are often
+# and more from parsing the description text. Errors are often
 # shown by setting the key 'error' with the value being the error message.
 #
 # It doesn't quite meet the requirements for a class, but is a vocabulary
@@ -37,7 +38,7 @@ gallery_filename = slash(generation_dir, 'gallery.rst')
 def iter_filename_info(dir_name):
     """
     Yield info (dict) of each matching screenshot found walking the
-    directory dir_name.  A matching screenshot uses double underscores to
+    directory dir_name. A matching screenshot uses double underscores to
     separate fields, i.e. path__to__filename__py.png as the screenshot for
     examples/path/to/filename.py.
 
@@ -66,7 +67,7 @@ def iter_filename_info(dir_name):
 
 def parse_docstring_info(text):
     ''' parse docstring from text (normal string with '\n's) and return an info
-    dict.  A docstring should the first triple quoted string, have a title
+    dict. A docstring should the first triple quoted string, have a title
     followed by a line of equal signs, and then a description at
     least one sentence long.
 
@@ -87,7 +88,7 @@ def parse_docstring_info(text):
 
 def iter_docstring_info(dir_name):
     ''' Iterate over screenshots in directory, yield info from the file
-     name and initial parse of the docstring.  Errors are logged, but
+     name and initial parse of the docstring. Errors are logged, but
      files with errors are skipped.
     '''
     for file_info in iter_filename_info(dir_name):
@@ -116,12 +117,12 @@ def enhance_info_description(info, line_length=79):
 
     info['files'] is the source filename and any filenames referenced by the
     magic words in the description, e.g. 'the file xxx.py' or
-    'The image this.png'.  These are as written in the description, do
+    'The image this.png'. These are as written in the description, do
     not allow ../dir notation, and are relative to the source directory.
 
     info['enhanced_description'] is the description, as an array of
     paragraphs where each paragraph is an array of lines wrapped to width
-    line_length.  This enhanced description include the rst links to
+    line_length. This enhanced description include the rst links to
     the files of info['files'].
     '''
 
@@ -223,7 +224,7 @@ We hope your journey into learning Kivy is exciting and fun!
         a("\n.. |link{num}|  replace:: :doc:`{source}<gen__{dunder}>`")
         a("\n.. |pic{num}| image:: ../images/examples/{dunder}.png"
           "\n    :width:  216pt"
-          "\n    :align:  middle"
+          "\n    :align: " " middle"
           "\n    :target: gen__{dunder}.html")
         a("\n.. |title{num}|  replace:: **{title}**")
 
@@ -274,14 +275,14 @@ def make_detail_page(info):
         a('\n.. _`' + full_name.replace(sep, '_') + '`:')
         # double separator if building on windows (sphinx skips backslash)
         if '\\' in full_name:
-            full_name = full_name.replace(sep, sep*2)
+            full_name = full_name.replace(sep, sep * 2)
 
         if ext in ['.png', '.jpg', '.jpeg']:
             title = 'Image **' + full_name + '**'
             a('\n' + title)
             a('~' * len(title))
             a('\n.. image:: ../../../examples/' + full_name)
-            a('    :align:  center')
+            a('    :align: ' ' center')
         else:  # code
             title = 'File **' + full_name + '**'
             a('\n' + title)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 requires = [
     "setuptools", "wheel",
     "cython>=0.24,<=0.29.14,!=0.27,!=0.27.2",
-    'kivy_deps.gstreamer_dev==0.1.*; sys_platform == "win32"',
-    'kivy_deps.sdl2_dev==0.1.*; sys_platform == "win32"',
-    'kivy_deps.glew_dev==0.1.*; sys_platform == "win32"',
-    'kivy_deps.gstreamer==0.1.*; sys_platform == "win32"',
-    'kivy_deps.sdl2==0.1.*; sys_platform == "win32"',
-    'kivy_deps.glew==0.1.*; sys_platform == "win32"',
+    'kivy_deps.gstreamer_dev~=0.1.18; sys_platform == "win32"',
+    'kivy_deps.sdl2_dev~=0.1.23; sys_platform == "win32"',
+    'kivy_deps.glew_dev~=0.1.12; sys_platform == "win32"',
+    'kivy_deps.gstreamer~=0.1.18; sys_platform == "win32"',
+    'kivy_deps.sdl2~=0.1.23; sys_platform == "win32"',
+    'kivy_deps.glew~=0.1.12; sys_platform == "win32"',
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,16 +37,16 @@ base =
     pillow
     docutils
     pygments
-    kivy_deps.angle==0.1.*; sys_platform == "win32"
-    kivy_deps.sdl2==0.1.*; sys_platform == "win32"
-    kivy_deps.glew==0.1.*; sys_platform == "win32"
+    kivy_deps.angle~=0.1.10; sys_platform == "win32"
+    kivy_deps.sdl2~=0.1.23; sys_platform == "win32"
+    kivy_deps.glew~=0.1.12; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 full =
     pillow
     docutils
     pygments
-    kivy_deps.gstreamer==0.1.*; sys_platform == "win32"
-    kivy_deps.angle==0.1.*; sys_platform == "win32"
-    kivy_deps.sdl2==0.1.*; sys_platform == "win32"
-    kivy_deps.glew==0.1.*; sys_platform == "win32"
+    kivy_deps.gstreamer~=0.1.18; sys_platform == "win32"
+    kivy_deps.angle~=0.1.10; sys_platform == "win32"
+    kivy_deps.sdl2~=0.1.23; sys_platform == "win32"
+    kivy_deps.glew~=0.1.12; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"

--- a/setup.py
+++ b/setup.py
@@ -542,6 +542,9 @@ if platform not in ('ios', 'android') and (c_options['use_gstreamer']
 # detect SDL2, only on desktop and iOS, or android if explicitly enabled
 # works if we forced the options or in autodetection
 sdl2_flags = {}
+if platform == 'win32' and c_options['use_sdl2'] is None:
+    c_options['use_sdl2'] = True
+
 if c_options['use_sdl2'] or (
         platform not in ('android',) and c_options['use_sdl2'] is None):
 


### PR DESCRIPTION
* This tests on the CI in a clean environment the installation both from the CI generated wheel as well as the sdist - exactly like a user would.
* It also changes the tests slightly so we can run the tests in an existing kivy install, installed from a wheel - as long as the kivy_examples were installed also.

  This is so that it would be easy to install and test kivy (from source) `pip install github_kivy_url`, without having to clone it etc. This would make it easier to test whether kivy still works after updating any of the `kivy_deps.xxx` directly on the CI for kivy-sdk-packager. 
