### PR TITLE
Create all the wheels before doing any uploads

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -13,7 +13,7 @@ env:
   DOCKER_IMAGE: 'quay.io/pypa/manylinux2010_x86_64'
 
 jobs:
-  manylinux:
+  manylinux_wheel_create:
     runs-on: ubuntu-18.04
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel linux]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel linux]')
     steps:
@@ -26,6 +26,28 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         generate_manylinux2010_wheels $DOCKER_IMAGE
+    - name: Upload wheels as artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: manylinux_wheels
+        path: dist
+
+  manylinux_wheel_upload_test:
+    runs-on: ubuntu-18.04
+    needs: manylinux_wheel_create
+    env:
+      DISPLAY: ':99.0'
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+    - uses: actions/download-artifact@master
+      with:
+        name: manylinux_wheels
+    - name: Fix wheel path
+      run: mv manylinux_wheels dist
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
       run: |
@@ -38,18 +60,6 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         upload_file_to_server "$SERVER_IP" "linux/kivy/"
-    - name: Upload wheels as artifact
-      uses: actions/upload-artifact@master
-      with:
-        name: manylinux_wheels
-        path: dist
-    - name: Publish to PyPI
-      if: github.event_name == 'create' && github.event.ref_type == 'tag'
-      env:
-        TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        twine upload dist/*
     - name: Upload to GitHub Release
       uses: softprops/action-gh-release@78c309ef59fdb9557cd6574f2e0be552936ed728
       if: startsWith(github.ref, 'refs/tags/')
@@ -58,39 +68,30 @@ jobs:
       with:
         files: dist/*
         draft: true
-
-  manylinux_wheel_test:
-    runs-on: ubuntu-18.04
-    needs: manylinux
-    env:
-      DISPLAY: ':99.0'
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.x
-      - uses: actions/download-artifact@master
-        with:
-          name: manylinux_wheels
-      - name: Install dependencies
-        run: |
-          mv manylinux_wheels dist
-          source .ci/ubuntu_ci.sh
-          install_kivy_test_run_apt_deps
-          install_kivy_test_wheel_run_pip_deps
-      - name: Setup env
-        run: |
-          source .ci/ubuntu_ci.sh
-          prepare_env_for_unittest
-      - name: Install Kivy
-        run: |
-          source .ci/ubuntu_ci.sh
-          install_kivy_manylinux_wheel
-      - name: Test Kivy
-        run: |
-          source .ci/ubuntu_ci.sh
-          test_kivy_install
+    - name: Publish to PyPI
+      if: github.event_name == 'create' && github.event.ref_type == 'tag'
+      env:
+        TWINE_USERNAME: "__token__"
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+      run: |
+        twine upload dist/*
+    - name: Install dependencies
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_test_run_apt_deps
+        install_kivy_test_wheel_run_pip_deps
+    - name: Setup env
+      run: |
+        source .ci/ubuntu_ci.sh
+        prepare_env_for_unittest
+    - name: Install Kivy
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_manylinux_wheel
+    - name: Test Kivy
+      run: |
+        source .ci/ubuntu_ci.sh
+        test_kivy_install
 
   sdist_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -18,7 +18,7 @@ env:
   USE_GSTREAMER: 1
 
 jobs:
-  osx_wheels:
+  osx_wheels_create:
     runs-on: macOS-latest
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
     strategy:
@@ -56,6 +56,26 @@ jobs:
         source .ci/osx_versions.sh
         source .ci/osx_ci.sh
         generate_osx_wheels
+    - name: Upload wheels as artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: osx_wheels
+        path: dist
+
+  osx_wheel_upload_test:
+    runs-on: macOS-latest
+    needs: osx_wheels_create
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+    - uses: actions/download-artifact@master
+      with:
+        name: osx_wheels
+    - name: Fix wheel path
+      run: mv osx_wheels dist
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
       run: |
@@ -68,18 +88,6 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         upload_file_to_server "$SERVER_IP" "osx/kivy/"
-    - name: Upload wheels as artifact
-      uses: actions/upload-artifact@master
-      with:
-        name: osx_wheels
-        path: dist
-    - name: Publish to PyPI
-      if: github.event_name == 'create' && github.event.ref_type == 'tag'
-      env:
-        TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        twine upload dist/*
     - name: Upload to GitHub Release
       uses: softprops/action-gh-release@78c309ef59fdb9557cd6574f2e0be552936ed728
       if: startsWith(github.ref, 'refs/tags/')
@@ -88,32 +96,24 @@ jobs:
       with:
         files: dist/*
         draft: true
-
-  osx_wheel_test:
-    runs-on: macOS-latest
-    needs: osx_wheels
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.x
-      - uses: actions/download-artifact@master
-        with:
-          name: osx_wheels
-      - name: Install dependencies
-        run: |
-          mv osx_wheels dist
-          source .ci/ubuntu_ci.sh
-          install_kivy_test_wheel_run_pip_deps
-      - name: Install Kivy
-        run: |
-          source .ci/ubuntu_ci.sh
-          install_kivy_manylinux_wheel
-      - name: Test Kivy
-        run: |
-          source .ci/ubuntu_ci.sh
-          test_kivy_install
+    - name: Publish to PyPI
+      if: github.event_name == 'create' && github.event.ref_type == 'tag'
+      env:
+        TWINE_USERNAME: "__token__"
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+      run: twine upload dist/*
+    - name: Install test dependencies
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_test_wheel_run_pip_deps
+    - name: Install Kivy wheel
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_manylinux_wheel
+    - name: Test Kivy wheel
+      run: |
+        source .ci/ubuntu_ci.sh
+        test_kivy_install
 
   osx_app:
     runs-on: macOS-latest

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -14,7 +14,7 @@ env:
   KIVY_GL_BACKEND: 'angle_sdl2'
 
 jobs:
-  windows_wheels:
+  windows_wheels_create:
     runs-on: windows-latest
     strategy:
       matrix:
@@ -46,46 +46,15 @@ jobs:
       run: |
         . .\.ci\windows_ci.ps1
         Generate-windows-wheels
-    - name: Fix wheel names
-      if: github.event.ref_type != 'tag'
-      run: |
-        . .\.ci\windows_ci.ps1
-        Rename-windows-wheels
-    - name: Install MSYS2
-      run: choco install msys2
-    - name: Upload wheels to server
-      if: github.event_name != 'pull_request'
-      env:
-        UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
-        MSYSTEM: MINGW64
-        CHERE_INVOKING: 1
-      run: |
-        . .\.ci\windows_ci.ps1
-        Upload-windows-wheels-to-server -ip "$env:SERVER_IP"
     - name: Upload wheels as artifact
       uses: actions/upload-artifact@master
       with:
         name: windows_wheels
         path: dist
-    - name: Publish to PyPI
-      if: github.event_name == 'create' && github.event.ref_type == 'tag'
-      env:
-        TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        twine upload dist/*
-    - name: Upload to GitHub Release
-      uses: softprops/action-gh-release@78c309ef59fdb9557cd6574f2e0be552936ed728
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        GITHUB_TOKEN: ${{ secrets.github_release }}
-      with:
-        files: dist/*
-        draft: true
 
-  windows_wheel_test:
+  windows_wheel_upload_test:
     runs-on: windows-latest
-    needs: windows_wheels
+    needs: windows_wheels_create
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
@@ -95,9 +64,41 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: windows_wheels
+      - name: Fix wheel path
+        run: mv windows_wheels dist
+      - name: Fix wheel names
+        if: github.event.ref_type != 'tag'
+        run: |
+          . .\.ci\windows_ci.ps1
+          Rename-windows-wheels
+      - name: Install MSYS2
+        run: choco install msys2
+      - name: Upload wheels to server
+        if: github.event_name != 'pull_request'
+        env:
+          UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
+          MSYSTEM: MINGW64
+          CHERE_INVOKING: 1
+        run: |
+          . .\.ci\windows_ci.ps1
+          Upload-windows-wheels-to-server -ip "$env:SERVER_IP"
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@78c309ef59fdb9557cd6574f2e0be552936ed728
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_release }}
+        with:
+          files: dist/*
+          draft: true
+      - name: Publish to PyPI
+        if: github.event_name == 'create' && github.event.ref_type == 'tag'
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        run: |
+          twine upload dist/*
       - name: Install Kivy Wheel
         run: |
-          mv windows_wheels dist
           . .\.ci\windows_ci.ps1
           Install-kivy-wheel
       - name: Test Kivy Wheel
@@ -107,7 +108,7 @@ jobs:
 
   windows_sdist_test:
     runs-on: windows-latest
-    needs: windows_wheels
+    needs: windows_wheels_create
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
@@ -117,11 +118,12 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: windows_wheels
+      - name: Fix wheel path
+        run: mv windows_wheels dist
       - name: Install Kivy sdist
         env:
           KIVY_SPLIT_EXAMPLES: 0
         run: |
-          mv windows_wheels dist
           . .\.ci\windows_ci.ps1
           Install-kivy-sdist
       - name: Test Kivy sdist


### PR DESCRIPTION
In the pre-release, during a matrix build, if e.g. something fails in any python version in the matrix, the whole matrix is canceled. So if we upload in the build jobs, if one upload fails, all the uploads fails.

Instead, all wheels are now simply built and uploaded as artifacts. Then, in the next stage we upload all of them together to server/pypi/release. And even if that fails, we at least can download it from the artifact page. Finally, after that, we test the wheels.