### PR TITLE
Adding support for non-file SVGs

### DIFF
--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -366,7 +366,7 @@ cdef class Svg(RenderContext):
     """Svg class. See module for more informations about the usage.
     """
 
-    def __init__(self, source, anchor_x=0, anchor_y=0,
+    def __init__(self, source=None, anchor_x=0, anchor_y=0,
                  bezier_points=BEZIER_POINTS, circle_points=CIRCLE_POINTS,
                  color=None):
         '''
@@ -420,7 +420,8 @@ cdef class Svg(RenderContext):
                 b"\xff\xff\xff\xff\xff\xff\xff\x00", colorfmt="rgba")
 
         self._source = None
-        self.source = source
+        if source:
+            self.source = source
 
 
     @property
@@ -510,13 +511,16 @@ cdef class Svg(RenderContext):
             fd = open(filename, 'rb')
         try:
             #save the tree for later reloading
-            self.tree = parse(fd)
-            self.reload()
+            self.set_tree(parse(fd))
             end = time()
             Logger.debug("Svg: Loaded {} in {:.2f}s".format(filename, end - start))
         finally:
             self._source = filename
             fd.close()
+
+    def set_tree(self, tree):
+        self.tree = tree
+        self.reload()
 
     cdef void reload(self) except *:
             # parse tree

--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -386,12 +386,12 @@ cdef class Svg(RenderContext):
         :param color the default color to use for Svg elements that specify "currentColor"
 
         .. note:: if you want to use SVGs from string, you can parse the source yourself
-            using `from xml.etree.cElementTree import fromstring` and pass the result it to 
+            using `from xml.etree.cElementTree import fromstring` and pass the result to 
             Svg().set_tree(). This will trigger the rendering of the Svg - as an alternative
             to assigning a filepath to Svg.source. This is also viable to trigger reloading.
 
         .. versionchanged:: 2.0.0
-            Parameter `filename` changed to `source`, and its optional now.
+            Parameter `filename` changed to `source` and made optional.
         '''
 
         super(Svg, self).__init__(fs=SVG_FS, vs=SVG_VS,
@@ -527,7 +527,7 @@ cdef class Svg(RenderContext):
         '''
         sets the tree used to render the Svg and triggers reloading.
 	
-	:param xml.etree.cElementTree tree: the tree parsed from the SVG source
+        :param xml.etree.cElementTree tree: the tree parsed from the SVG source
 
         .. versionadded:: 2.0.0
         '''

--- a/kivy/graphics/svg.pyx
+++ b/kivy/graphics/svg.pyx
@@ -385,8 +385,13 @@ cdef class Svg(RenderContext):
             subdivide circular and elliptic arcs. Defaults to 10.
         :param color the default color to use for Svg elements that specify "currentColor"
 
+        .. note:: if you want to use SVGs from string, you can parse the source yourself
+            using `from xml.etree.cElementTree import fromstring` and pass the result it to 
+            Svg().set_tree(). This will trigger the rendering of the Svg - as an alternative
+            to assigning a filepath to Svg.source. This is also viable to trigger reloading.
+
         .. versionchanged:: 2.0.0
-            Parameter `filename` changed to `source`.
+            Parameter `filename` changed to `source`, and its optional now.
         '''
 
         super(Svg, self).__init__(fs=SVG_FS, vs=SVG_VS,
@@ -519,6 +524,13 @@ cdef class Svg(RenderContext):
             fd.close()
 
     def set_tree(self, tree):
+        '''
+        sets the tree used to render the Svg and triggers reloading.
+	
+	:param xml.etree.cElementTree tree: the tree parsed from the SVG source
+
+        .. versionadded:: 2.0.0
+        '''
         self.tree = tree
         self.reload()
 


### PR DESCRIPTION
source.setter now uses Svg.set_tree() to set the tree and execute .reload()
Svg() can now reloaded/initiated using set_tree(tree) when source is not a file.
Svg() Constructor therefore does not require source parameter - which now defaults to None.
source.setter is only executed during __init__ when parameter is given.