### PR TITLE
Fix https in python3.x

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -42,6 +42,7 @@ from kivy.cache import Cache
 from kivy.core.image import ImageLoader, Image
 from kivy.compat import PY2, string_types
 from kivy.config import Config
+from kivy.utils import platform
 
 from collections import deque
 from time import sleep
@@ -49,6 +50,7 @@ from os.path import join
 from os import write, close, unlink, environ
 import threading
 import mimetypes
+import certifi
 
 # Register a cache for loader
 Cache.register('kv.loader', limit=500, timeout=60)
@@ -121,6 +123,12 @@ class LoaderBase(object):
         self._running = False
         self._start_wanted = False
         self._trigger_update = Clock.create_trigger(self._update)
+
+        try:
+            assert platform == 'android'
+            environ['SSL_CERT_FILE'] = certifi.where()
+        except AssertionError as ok:
+            pass
 
     def __del__(self):
         if self._trigger_update is not None:

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -124,12 +124,9 @@ class LoaderBase(object):
         self._start_wanted = False
         self._trigger_update = Clock.create_trigger(self._update)
 
-        try:
-            assert platform == 'android'
+        if platform == 'android':
             import certifi
             environ['SSL_CERT_FILE'] = certifi.where()
-        except AssertionError as ok:
-            pass
 
     def __del__(self):
         if self._trigger_update is not None:

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -50,7 +50,7 @@ from os.path import join
 from os import write, close, unlink, environ
 import threading
 import mimetypes
-import certifi
+
 
 # Register a cache for loader
 Cache.register('kv.loader', limit=500, timeout=60)
@@ -126,6 +126,7 @@ class LoaderBase(object):
 
         try:
             assert platform == 'android'
+            import certifi
             environ['SSL_CERT_FILE'] = certifi.where()
         except AssertionError as ok:
             pass

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -126,7 +126,7 @@ class LoaderBase(object):
 
         if platform == 'android':
             import certifi
-            environ['SSL_CERT_FILE'] = certifi.where()
+            environ.setdefault('SSL_CERT_FILE', certifi.where())
 
     def __del__(self):
         if self._trigger_update is not None:

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -88,7 +88,6 @@ from kivy.clock import Clock
 from kivy.weakmethod import WeakMethod
 from kivy.logger import Logger
 from kivy.utils import platform
-import certifi
 
 
 # list to save UrlRequest and prevent GC on un-referenced objects
@@ -211,13 +210,18 @@ class UrlRequest(Thread):
         self._chunk_size = chunk_size
         self._timeout = timeout
         self._method = method
-        self.ca_file = ca_file if (platform != 'android') else (
-                ca_file or certifi.where())
         self.verify = verify
         self._proxy_host = proxy_host
         self._proxy_port = proxy_port
         self._proxy_headers = proxy_headers
         self._cancel_event = Event()
+
+        try:
+            assert platform == 'android'
+            import certifi
+            self.ca_file = ca_file or certifi.where()
+        except AssertionError as ok:
+            self.ca_file = ca_file
 
         #: Url of the request
         self.url = url

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -216,11 +216,10 @@ class UrlRequest(Thread):
         self._proxy_headers = proxy_headers
         self._cancel_event = Event()
 
-        try:
-            assert platform == 'android'
+        if platform == 'android':
             import certifi
             self.ca_file = ca_file or certifi.where()
-        except AssertionError as ok:
+        else:
             self.ca_file = ca_file
 
         #: Url of the request

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -87,6 +87,8 @@ except ImportError:
 from kivy.clock import Clock
 from kivy.weakmethod import WeakMethod
 from kivy.logger import Logger
+from kivy.utils import platform
+import certifi
 
 
 # list to save UrlRequest and prevent GC on un-referenced objects
@@ -209,7 +211,8 @@ class UrlRequest(Thread):
         self._chunk_size = chunk_size
         self._timeout = timeout
         self._method = method
-        self.ca_file = ca_file
+        self.ca_file = ca_file if (platform != 'android') else (
+                ca_file or certifi.where())
         self.verify = verify
         self._proxy_host = proxy_host
         self._proxy_port = proxy_port


### PR DESCRIPTION
Added code to set the operating system environmental variable SSL_CERT_FILE to cacert.pem for Android.

Solving an extremely nasty bug for HTTPS on Android deployments effecting UrlRequest and AsyncImage.


COMMENTS:

Non-invasive global solution for a nasty HTTPS request bug on Android
physical deployments using python 3.x.

This solution is required to enable Android functionality for both:
   kivy.network.urlrequest     
   kivy.uix.image.AsyncImage
                                                                                                   
                                                         
Notes about testing:
                                                                                                   
Solution implementation was manually verified for correctness in Python 3.7
on Xubuntu (Linux-Lite) 18.04, and for deployment on Android Slim 6 (ROM.)
                                                                                                   
Solution implementation, and integration was manually verified for                 
correctness in Python 3.8 on Xubuntu (Linux-Lite) 18.04 and deployment on
Android Slim 6 (ROM.)
                                                                                                   
(Solution was not verified for Python 2.x, and does not suppose to support
2.x, nor has it been verified as correct for iOS deployment (hence, the                   
conditional prefix.))