### PR TITLE
[WIP] Fix input type on android using SDL2 as window provider

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1907,7 +1907,9 @@ class WindowBase(EventDispatcher):
             if keyboard:
                 keyboard.release()
 
-    def request_keyboard(self, callback, target, input_type='text'):
+    def request_keyboard(
+        self, callback, target, input_type='text', keyboard_suggestions=True
+    ):
         '''.. versionadded:: 1.0.4
 
         Internal widget method to request the keyboard. This method is rarely
@@ -1940,6 +1942,11 @@ class WindowBase(EventDispatcher):
                     `input_type` is currently only honored on mobile devices.
 
                 .. versionadded:: 1.8.0
+
+            `keyboard_suggestions`: bool
+                If True provides auto suggestions on top of keyboard.
+                This will only work if input_type is set to `text`, `url`,
+                `mail` or `address`.
 
         :Return:
             An instance of :class:`Keyboard` containing the callback, target,

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -562,7 +562,7 @@ cdef class _WindowSDL2Storage:
                 text_keyboards = {"text", "url", "mail", "address"}
 
                 if not keyboard_suggestions and input_type in text_keyboards:
-                    input_types |= TYPE_TEXT_FLAG_NO_SUGGESTIONS
+                    input_type_value |= TYPE_TEXT_FLAG_NO_SUGGESTIONS
 
                 mActivity.changeKeyboard(input_type_value)
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -771,10 +771,17 @@ class WindowSDL(WindowBase):
         self._modifiers = list(modifiers)
         return
 
-    def request_keyboard(self, callback, target, input_type='text'):
+    def request_keyboard(
+        self, callback, target, input_type="text", keyboard_suggestions=True
+    ):
         self._sdl_keyboard = super(WindowSDL, self).\
-            request_keyboard(callback, target, input_type)
-        self._win.show_keyboard(self._system_keyboard, self.softinput_mode)
+            request_keyboard(callback, target, input_type, keyboard_suggestions)
+        self._win.show_keyboard(
+            self._system_keyboard,
+            self.softinput_mode,
+            input_type,
+            keyboard_suggestions,
+        )
         Clock.schedule_interval(self._check_keyboard_shown, 1 / 5.)
         return self._sdl_keyboard
 

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -237,6 +237,16 @@ class FocusBehavior(object):
         2.0.0.
     '''
 
+    keyboard_suggestions = BooleanProperty(True)
+    '''If True provides auto suggestions on top of keyboard.
+    This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
+    `address`.
+
+    .. versionadded:: 1.8.0
+    :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to True
+    '''
+
     def _set_on_focus_next(self, instance, value):
         ''' If changing code, ensure following code is not infinite loop:
         widget.focus_next = widget
@@ -388,9 +398,12 @@ class FocusBehavior(object):
     def _ensure_keyboard(self):
         if self._keyboard is None:
             self._requested_keyboard = True
-            keyboard = self._keyboard =\
-                EventLoop.window.request_keyboard(
-                    self._keyboard_released, self, input_type=self.input_type)
+            keyboard = self._keyboard = EventLoop.window.request_keyboard(
+                self._keyboard_released,
+                self,
+                input_type=self.input_type,
+                keyboard_suggestions=self.keyboard_suggestions,
+            )
             keyboards = FocusBehavior._keyboards
             if keyboard not in keyboards:
                 keyboards[keyboard] = None

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -242,7 +242,7 @@ class FocusBehavior(object):
     This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
     `address`.
 
-    .. versionadded:: 1.8.0
+    .. versionadded:: 2.0.0
     :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to True
     '''

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -454,6 +454,10 @@ class TextInput(FocusBehavior, Widget):
 
     .. versionchanged:: 1.7.0
         `on_double_tap`, `on_triple_tap` and `on_quad_touch` events added.
+
+    .. versionchanged:: 2.0.0
+        :attr:`~kivy.uix.behaviors.FocusBehavior.keyboard_suggestions`
+        is now inherited from :class:`~kivy.uix.behaviors.FocusBehavior`.
     '''
 
     __events__ = ('on_text_validate', 'on_double_tap', 'on_triple_tap',
@@ -2668,16 +2672,6 @@ class TextInput(FocusBehavior, Widget):
 
     :attr:`password_mask` is a :class:`~kivy.properties.StringProperty` and
     defaults to `'*'`.
-    '''
-
-    keyboard_suggestions = BooleanProperty(True)
-    '''If True provides auto suggestions on top of keyboard.
-    This will only work if :attr:`input_type` is set to `text`.
-
-    .. versionadded:: 1.8.0
-
-    :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
-    and defaults to True.
     '''
 
     cursor_blink = BooleanProperty(True)


### PR DESCRIPTION
This pull request allows the use of `input_type` and `keyboard_suggestions` properties to modify the keyboard displayed on Android. In summary, it uses the `changeKeyboard` function in PythonActivity.java (see kivy/python-for-android#2057). Additionally, `keyboard_suggestions` was moved from kivy/uix/textinput.py to kivy/uix/behaviors/focus.py, so it's more accesible to send to the  `request_keyboard` method.

This is ready to review. Note that you may encounter some bugs with these changes:
- Inserting any emoji will crash the app in older Android versions, and a tofu will appear in latest versions.
- Keyboard suggestions have a weird behavior. You won't see anything you type until you select the suggestion.

The details are in (kivy/python-for-android#2015).  Unless those bugs are solved, this PR shouldn't be merged.