### PR TITLE
[WIP] fix the layout calculation on GridLayout

### DIFF
--- a/kivy/tests/test_uix_gridlayout.py
+++ b/kivy/tests/test_uix_gridlayout.py
@@ -2,7 +2,7 @@
 uix.gridlayout tests
 ========================
 '''
-
+import pytest
 import unittest
 from kivy.tests.common import GraphicUnitTest
 
@@ -50,6 +50,25 @@ class UixGridLayoutTest(GraphicUnitTest):
         gl.cols_minimum = {i: 10 for i in range(10)}
         gl.add_widget(GridLayout())
         self.render(gl)
+
+
+@pytest.mark.parametrize("cols, rows", [(2, None), (None, 2), (2, 2)])
+@pytest.mark.parametrize("index_of_small_child", range(4))
+def test_one_small_child_as_a_part_of_2x2_does_not_affect_the_entire_layout(
+        cols, rows, index_of_small_child):
+    from kivy.uix.widget import Widget
+    from kivy.uix.gridlayout import GridLayout
+    gl = GridLayout(size=(800, 600), pos=(0, 0), rows=rows, cols=cols)
+    for i in range(4):
+        gl.add_widget(Widget())
+    c = gl.children[index_of_small_child]
+    c.size_hint = (None, None)
+    c.size = (100, 100)
+    gl.do_layout()
+    assert {tuple(c.pos) for c in gl.children} == \
+        {(0, 0), (400, 0), (0, 300), (400, 300)}
+    assert sorted(c.size for c in gl.children) == \
+        [[100, 100], [400, 300], [400, 300], [400, 300]]
 
 
 if __name__ == '__main__':

--- a/kivy/tests/test_uix_recycleview.py
+++ b/kivy/tests/test_uix_recycleview.py
@@ -1,0 +1,32 @@
+import pytest
+
+KV_CODE_1 = '''
+RecycleView:
+    pos: 0, 0
+    size: 800, 600
+    viewclass: 'Widget'
+    data: ({} for __ in range(4))
+    RecycleGridLayout:
+        default_size_hint: 1, 1
+'''
+
+
+class TestRecycleGridLayout:
+    @pytest.mark.parametrize("cols, rows", [(2, None), (None, 2), (2, 2)])
+    @pytest.mark.parametrize("index_of_small_child", range(4))
+    def test_one_small_child_as_a_part_of_2x2_doesnt_affect_the_entire_layout(
+            self, cols, rows, index_of_small_child):
+        from kivy.clock import Clock
+        from kivy.lang import Builder
+        rv = Builder.load_string(KV_CODE_1)
+        gl = rv.children[0]
+        gl.cols = cols
+        gl.rows = rows
+        rv.data[index_of_small_child] = {
+            'size_hint': (None, None), 'size': (100, 100), }
+        Clock.tick()
+        Clock.tick()
+        assert {tuple(c.pos) for c in gl.children} == \
+            {(0, 0), (400, 0), (0, 300), (400, 300)}
+        assert sorted(c.size for c in gl.children) == \
+            [[100, 100], [400, 300], [400, 300], [400, 300]]

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -439,9 +439,8 @@ class GridLayout(Layout):
                     itertools_compress(cols, (sh is None for sh in cols_sh))
                 ) - self._spacing_and_padding_width)
             cols_sh_min = tuple(
-                None if sh is None else
-                max(col, 0 if sh_min is None else sh_min)
-                for col, sh, sh_min in zip(cols, cols_sh, self._cols_sh_min))
+                None if sh_min is None else max(col, sh_min)
+                for col, sh_min in zip(cols, self._cols_sh_min))
 
             if stretch_w > 1e-9:
                 self.layout_hint_with_bounds(
@@ -470,9 +469,8 @@ class GridLayout(Layout):
                     itertools_compress(rows, (sh is None for sh in rows_sh))
                 ) - self._spacing_and_padding_height)
             rows_sh_min = tuple(
-                None if sh is None else
-                max(row, 0 if sh_min is None else sh_min)
-                for row, sh, sh_min in zip(rows, rows_sh, self._rows_sh_min)
+                None if sh_min is None else max(row, sh_min)
+                for row, sh_min in zip(rows, self._rows_sh_min)
             )
 
             if stretch_h > 1e-9:

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -453,9 +453,7 @@ class GridLayout(Layout):
                     # if the col don't have stretch information, nothing to do
                     if not col_stretch:
                         continue
-                    cols[index] = max(
-                        cols[index],
-                        stretch_w * col_stretch / cols_weight)
+                    cols[index] = stretch_w * col_stretch / cols_weight
 
         # same algo for rows
         if self.row_force_default:
@@ -487,9 +485,7 @@ class GridLayout(Layout):
                     # if the row don't have stretch information, nothing to do
                     if not row_stretch:
                         continue
-                    rows[index] = max(
-                        rows[index],
-                        stretch_h * row_stretch / rows_weight)
+                    rows[index] = stretch_h * row_stretch / rows_weight
 
     def _iterate_layout(self, count):
         selfx = self.x

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -95,7 +95,7 @@ from kivy.properties import NumericProperty, BooleanProperty, DictProperty, \
     BoundedNumericProperty, ReferenceListProperty, VariableListProperty, \
     ObjectProperty, StringProperty
 from math import ceil
-from itertools import compress as itertools_compress, chain as itertools_chain
+from itertools import compress as itertools_compress
 
 
 def nmax(*args):


### PR DESCRIPTION
In some situations, having a different-sized widget in a GridLayout produces a weird result, for example:

```python
from kivy.config import Config
Config.set('graphics', 'width', 200)
Config.set('graphics', 'height', 200)
from kivy.app import runTouchApp
from kivy.lang import Builder

runTouchApp(Builder.load_string('''
GridLayout:
    cols: 2
    Button:
        text: '1'
    Button:
        text: '2'
    Button:
        text: '3'
        size_hint_x: None
        width: 80
    Button:
        text: '4'
'''))
```

![Screenshot at 2020-02-13 12-29-50](https://user-images.githubusercontent.com/26050135/74398982-9ad79980-4e5c-11ea-8f15-43eb210a2df6.png)

which should be

![Screenshot at 2020-02-13 12-32-10](https://user-images.githubusercontent.com/26050135/74399070-e25e2580-4e5c-11ea-9b93-ec91ae1459a1.png)

I believe. And this kinda bugs need to be fixed in order to make #6490 truely usable.

### Another cases

Here are another cases that I considered as bug.

#### No.1

```yaml
GridLayout:
    cols: 2
    Button:
        text: '1'
    Button:
        text: '2'
    Button:
        text: '3'
        size_hint_x: .5
    Button:
        text: '4'
```

![Screenshot at 2020-02-14 14-33-03](https://user-images.githubusercontent.com/26050135/74504333-2cb3d500-4f37-11ea-96d2-cf33421b5501.png)

which should be

![Screenshot at 2020-02-14 14-33-50](https://user-images.githubusercontent.com/26050135/74504340-33dae300-4f37-11ea-9618-c71956db5d98.png)

#### No.2

```yaml
GridLayout:
    cols: 2
    Button:
        text: '1'
    Button:
        text: '2'
    Button:
        text: '3'
        size_hint_max_x: 50
    Button:
        text: '4'
```

![Screenshot at 2020-02-14 14-36-44](https://user-images.githubusercontent.com/26050135/74504517-ce3b2680-4f37-11ea-8c0f-3e36e212721a.png)

which should be

![Screenshot at 2020-02-14 14-33-50](https://user-images.githubusercontent.com/26050135/74504340-33dae300-4f37-11ea-9618-c71956db5d98.png)

#### No.3

```yaml
GridLayout:
    cols: 2
    Button:
        text: '1'
        size_hint_x: None
        width: 80
    Button:
        text: '2'
    Button:
        text: '3'
        size_hint_min_x: 120
    Button:
        text: '4'
```

![Screenshot at 2020-02-14 15-01-30](https://user-images.githubusercontent.com/26050135/74505589-e82a3880-4f3a-11ea-84c0-b73c9b05d4d6.png)

Button3 and Button4 are overlapping each other.
