### PR TITLE
ddsfile.py fix for string/bytes comparing for py3

### DIFF
--- a/kivy/lib/ddsfile.py
+++ b/kivy/lib/ddsfile.py
@@ -196,6 +196,9 @@ class DDSFile(object):
             data = fd.read()
 
         # ensure magic
+        magic_header = data[:4]
+        if isinstance(magic_header, bytes):
+            magic_header = magic_header.decode()
         if data[:4] != 'DDS ':
             raise DDSException('Invalid magic header')
 


### PR DESCRIPTION
I used `bytes.decode()`, that should work on py2 and py3 but on py2 it's probably string anyway. Comparing to `b'DDS '` could have also worked(?).