### PR TITLE
img_dds.py fix for upside down dds files.

### DIFF
--- a/kivy/core/image/img_dds.py
+++ b/kivy/core/image/img_dds.py
@@ -25,7 +25,7 @@ class ImageLoaderDDS(ImageLoaderBase):
         self.filename = filename
         width, height = dds.size
         im = ImageData(width, height, dds.dxt, dds.images[0], source=filename,
-                       flip_vertical=False)
+                       flip_vertical=True)
         if len(dds.images) > 1:
             images = dds.images
             images_size = dds.images_size


### PR DESCRIPTION
All DDS files I tested where loaded upside down, but to be honest I'm not sure if some tools save the data inside dds file in some other arrangement - OpenGL and Direct3D use different conventions for where up and down is in a texture.