### PR TITLE
xclip less verbose Kivy startup

### DIFF
--- a/kivy/core/clipboard/clipboard_xclip.py
+++ b/kivy/core/clipboard/clipboard_xclip.py
@@ -14,7 +14,8 @@ if platform != 'linux':
 try:
     import subprocess
 
-    p = subprocess.Popen(['xclip', '-version'], stdout=subprocess.PIPE)
+    p = subprocess.Popen(['xclip', '-version'], stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL)
     p.communicate()
 except:
     raise


### PR DESCRIPTION
if using xclip, even if the Kivy logger is set to log_level='warning' only, Kivy startup always displays just this:
   xclip version 0.13
   Copyright (C) 2001-2008 Kim Saunders et al.
   Distributed under the terms of the GNU GPL

This is due to using 'xclip -version' (otherwise, without -version it would block)

SOLUTION: by ignoring this informative xclip stderr we get a cleaner Kivy startup and still except when xclip is not present