### PR TITLE
Extend certifi usage to ios

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -124,7 +124,7 @@ class LoaderBase(object):
         self._start_wanted = False
         self._trigger_update = Clock.create_trigger(self._update)
 
-        if platform == 'android':
+        if platform in ['android', 'ios']:
             import certifi
             environ.setdefault('SSL_CERT_FILE', certifi.where())
 

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -216,7 +216,7 @@ class UrlRequest(Thread):
         self._proxy_headers = proxy_headers
         self._cancel_event = Event()
 
-        if platform == 'android':
+        if platform in ['android', 'ios']:
             import certifi
             self.ca_file = ca_file or certifi.where()
         else:


### PR DESCRIPTION
Needs `kivy-ios` to be updated, but doesn't break it cause `kivy` version in `kivy-ios` is targeting a specific hash.