### PR TITLE
Kivy now works on the Raspberry Pi 4 without X11

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -24,6 +24,6 @@ RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
     fi
 
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 RUN [ "cross-build-end" ]

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -59,33 +59,7 @@ Raspberry Pi 4 headless installation on Raspbian Buster
 
     sudo ldconfig -v
 
-#. Create a small test app::
-
-    cat <<EOF > ~/app.py
-    import os
-    os.environ['KIVY_SDL_GL_ALPHA_SIZE'] = '0'
-
-    from kivy.app import App
-    from kivy.uix.button import Button
-
-
-    class TestApp(App):
-
-        def build(self):
-            return Button(text='hello world')
-
-
-    if __name__ == '__main__':
-        TestApp().run()
-    EOF
-
-   Note that you need to set the ``KIVY_SDL_GL_ALPHA_SIZE`` environmental variable to 0, which is needed in order to use SDL2 without X11.
-
 #. Now simply follow the `Raspberry Pi 1-4 installation`_ instructions to install Kivy.
-
-#. Now run your app::
-
-    python3 ~/app.py
 
 _`Raspberry Pi 1-4 installation` on Raspbian Jessie/Stretch/Buster
 ------------------------------------------------------------------

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -135,7 +135,7 @@ cdef class _WindowSDL2Storage:
         SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8)
-        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, int(environ.get('KIVY_SDL_GL_ALPHA_SIZE', '8')))
+        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, KIVY_SDL_GL_ALPHA_SIZE)
         SDL_GL_SetAttribute(SDL_GL_RETAINED_BACKING, 0)
         SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1)
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -135,7 +135,7 @@ cdef class _WindowSDL2Storage:
         SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8)
-        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8)
+        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, int(environ.get('KIVY_SDL_GL_ALPHA_SIZE', '8')))
         SDL_GL_SetAttribute(SDL_GL_RETAINED_BACKING, 0)
         SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1)
 

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,10 @@ c_options['use_avfoundation'] = platform in ['darwin', 'ios']
 c_options['use_osx_frameworks'] = platform == 'darwin'
 c_options['debug_gl'] = False
 
+# Set the alpha size, this will be 0 on the Raspberry Pi and 8 on all other
+# platforms, so SDL2 works without X11
+c_options['kivy_sdl_gl_alpha_size'] = 8 if pi_version is None else 0
+
 # now check if environ is changing the default values
 for key in list(c_options.keys()):
     ukey = key.upper()

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,10 @@ c_options['kivy_sdl_gl_alpha_size'] = 8 if pi_version is None else 0
 for key in list(c_options.keys()):
     ukey = key.upper()
     if ukey in environ:
-        value = bool(int(environ[ukey]))
+        # kivy_sdl_gl_alpha_size should be an integer, the rest are booleans
+        value = int(environ[ukey])
+        if key != 'kivy_sdl_gl_alpha_size':
+            value = bool(value)
         print('Environ change {0} -> {1}'.format(key, value))
         c_options[key] = value
 
@@ -283,7 +286,9 @@ class KivyBuildExt(build_ext, object):
         # generate content
         print('Build configuration is:')
         for opt, value in c_options.items():
-            value = int(bool(value))
+            # kivy_sdl_gl_alpha_size is already an integer
+            if opt != 'kivy_sdl_gl_alpha_size':
+                value = int(bool(value))
             print(' * {0} = {1}'.format(opt, value))
             opt = opt.upper()
             config_h += '#define __{0} {1}\n'.format(opt, value)


### PR DESCRIPTION
Thanks to @ddimensia for figuring out the missing piece in getting SDL2 to work without X11 i.e. setting `SDL_GL_ALPHA_SIZE` to 0.

The SDL2 instructions are more or less copied from the following site: https://github.com/midwan/amiberry/wiki/Compile-SDL2-from-source.