### PR TITLE
window_info is not included in x86 pyinstaller.

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -91,6 +91,7 @@ if 'KIVY_DOC' not in environ:
         'xml.etree.cElementTree',
         'kivy.core.gl',
         'kivy.weakmethod',
+        'kivy.core.window.window_info',
     ] + collect_submodules('kivy.graphics')
     '''List of kivy modules that are always needed as hiddenimports of
     pyinstaller.


### PR DESCRIPTION
Somehow, `kivy.core.window.window_info` is not packaged automatically with pyinstaller, but only on x86!? This adds it explicitly.