### PR TITLE
add correct value of CLOCK_MONOTONIC for OpenBSD

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -446,6 +446,8 @@ try:
                     # 12: CLOCK_MONOTONIC_FAST (FreeBSD specific)
                     Logger.debug('clock.py: {{{:s}}} clock ID {:d}'.format(
                         platform, _clockid))
+                elif 'openbsd' in platform:
+                    _clockid = 3  # CLOCK_MONOTONIC
                 else:
                     _clockid = 1  # CLOCK_MONOTONIC
 


### PR DESCRIPTION
current version of kivy fails to start on OpenBSD -current due to invalid `clock_id` value passed to `clock_gettime()`.

This small fix does the trick in the same way as for FreeBSD.