### PR TITLE
points property sets _mode to LINE_MODE_POINTS

### DIFF
--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -723,6 +723,7 @@ cdef class Line(VertexInstruction):
             else:
                 self._points = list(points)
 
+            self._mode = LINE_MODE_POINTS
             self.flag_update()
 
     property dash_length:


### PR DESCRIPTION
To be consistent with ellipse, circle, rectangle, rounded_rectangle, and bezier properties, the points property should change `_mode` to LINE_MODE_POINTS.