### PR TITLE
Add ImageButton to style.kv

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -27,6 +27,8 @@
             size: self.texture_size
             pos: int(self.center_x - self.texture_size[0] / 2.), int(self.center_y - self.texture_size[1] / 2.)
 
+<ImageButton@ButtonBehavior+Image>:
+
 <BubbleContent>
     opacity: .7 if self.disabled else 1
     rows: 1


### PR DESCRIPTION
I essentially use this in ALL my projects. It would be a shame not to include it out of the box.
The only drawback in making it a dynamic class, is the lack of documentation/discoverability... If you think it should be a full-blown class then so be it!

More to the point of the "why" - I remember my early Kivy days (when behaviors weren't even a thing), I used the normal Button, set border to `(0, 0, 0, 0)` and changed `background_normal` and `background_down` to the SAME image. On all my buttons (until I discovered dynamic classes). You can see how it "feels" like excessive boilerplate for a framework like Kivy.
How hard can it be to make "an image as button" for a beginner who doesn't know about behaviors or dynamic classes?
How do you think they feel when their image is totally distorted because they didn't realize the Button background is a BorderImage and they need to set all borders to zero?
How do you think they feel when they find out the "complex" case (having a border image) takes as many lines to address as the simple one (just an image as button)?
When giving support to such users, wouldn't it be easier and faster to say "just use ImageButton, set the source, and do what you want in on_press"? :-)

Thanks for reading! Let's improve our QoL as Kivy coders, line by line :-)