### PR TITLE
Fixes for Image and AsyncImage

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -61,7 +61,6 @@ from kivy.resources import resource_find
 from kivy.properties import StringProperty, ObjectProperty, ListProperty, \
     AliasProperty, BooleanProperty, NumericProperty
 from kivy.logger import Logger
-from kivy.compat import PY2
 
 # delayed imports
 Loader = None
@@ -257,7 +256,7 @@ class Image(Widget):
         self._loops = 0
         source = resource_find(self.source)
         if not source:
-            Logger.error('Image: Image not found at %s' % self.source)
+            Logger.error('Image: Not found <%s>' % self.source)
             self._clear_core_image()
             return
         mipmap = self.mipmap
@@ -272,7 +271,7 @@ class Image(Widget):
                 nocache=self.nocache
             )
         except Exception:
-            Logger.error('Image: Error loading texture %s' % self.source)
+            Logger.error('Image: Error loading <%s>' % self.source)
             self._clear_core_image()
             ci = self._coreimage
         if ci:
@@ -368,7 +367,7 @@ class AsyncImage(Image):
         if not self.is_uri(source):
             source = resource_find(source)
             if not source:
-                Logger.error('AsyncImage: Image not found at %s' % self.source)
+                Logger.error('AsyncImage: Not found <%s>' % self.source)
                 self._clear_core_image()
                 return
         self._coreimage = image = Loader.image(

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -344,6 +344,12 @@ class AsyncImage(Image):
         want to refer to the :mod:`~kivy.loader` documentation and in
         particular, the :class:`~kivy.loader.ProxyImage` for more detail
         on how to handle events around asynchronous image loading.
+
+    .. note::
+
+        AsyncImage currently does not support properties
+        :attr:`anim_loop` and :attr:`mipmap` and setting those properties will
+        have no effect.
     '''
 
     __events__ = ('on_error', 'on_load')

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -318,15 +318,11 @@ class Image(Widget):
             # image will be re-loaded from disk
 
         '''
-        try:
+        if self._coreimage:
             self._coreimage.remove_from_cache()
-
-        except AttributeError:
-            pass
-
-        oldsource = self.source
+        old_source = self.source
         self.source = ''
-        self.source = oldsource
+        self.source = old_source
 
     def on_nocache(self, *args):
         if self.nocache and self._coreimage:

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -201,7 +201,7 @@ class Image(Widget):
 
     def get_norm_image_size(self):
         if not self.texture:
-            return self.size
+            return list(self.size)
         ratio = self.image_ratio
         w, h = self.size
         tw, th = self.texture.size
@@ -209,7 +209,7 @@ class Image(Widget):
         # ensure that the width is always maximized to the containter width
         if self.allow_stretch:
             if not self.keep_ratio:
-                return w, h
+                return [w, h]
             iw = w
         else:
             iw = min(w, tw)
@@ -223,7 +223,7 @@ class Image(Widget):
             else:
                 ih = min(h, th)
             iw = ih * ratio
-        return iw, ih
+        return [iw, ih]
 
     norm_image_size = AliasProperty(get_norm_image_size,
                                     bind=('texture', 'size', 'allow_stretch',

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -287,8 +287,7 @@ class Image(Widget):
             self._coreimage.anim_reset(False)
 
     def on_texture(self, instance, value):
-        if value is not None:
-            self.texture_size = list(value.size)
+        self.texture_size = value.size if value else [0, 0]
 
     def _clear_core_image(self):
         if self._coreimage:

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -250,19 +250,17 @@ class Image(Widget):
         if not self.source:
             self._clear_core_image()
             return
-        self._loops = 0
         source = resource_find(self.source)
         if not source:
             Logger.error('Image: Not found <%s>' % self.source)
             self._clear_core_image()
             return
-        mipmap = self.mipmap
         if self._coreimage:
             self._coreimage.unbind(on_texture=self._on_tex_change)
         try:
-            self._coreimage = ci = CoreImage(
+            self._coreimage = image = CoreImage(
                 source,
-                mipmap=mipmap,
+                mipmap=self.mipmap,
                 anim_delay=self.anim_delay,
                 keep_data=self.keep_data,
                 nocache=self.nocache
@@ -270,10 +268,10 @@ class Image(Widget):
         except Exception:
             Logger.error('Image: Error loading <%s>' % self.source)
             self._clear_core_image()
-            ci = self._coreimage
-        if ci:
-            ci.bind(on_texture=self._on_tex_change)
-            self.texture = ci.texture
+            image = self._coreimage
+        if image:
+            image.bind(on_texture=self._on_tex_change)
+            self.texture = image.texture
 
     def on_anim_delay(self, instance, value):
         if self._coreimage is None:
@@ -290,6 +288,7 @@ class Image(Widget):
             self._coreimage.unbind(on_texture=self._on_tex_change)
         self.texture = None
         self._coreimage = None
+        self._loops = 0
 
     def _on_tex_change(self, *largs):
         # update texture from core image

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -244,7 +244,7 @@ class Image(Widget):
         fbind = self.fbind
         fbind('source', update)
         fbind('mipmap', update)
-        super(Image, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def texture_update(self, *largs):
         if not self.source:
@@ -355,7 +355,7 @@ class AsyncImage(Image):
         if not Loader:
             from kivy.loader import Loader
         self.fbind('source', self._load_source)
-        super(AsyncImage, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _load_source(self, *args):
         source = self.source

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -280,7 +280,6 @@ class Image(Widget):
             self.texture = ci.texture
 
     def on_anim_delay(self, instance, value):
-        self._loop = 0
         if self._coreimage is None:
             return
         self._coreimage.anim_delay = value

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -240,14 +240,11 @@ class Image(Widget):
     def __init__(self, **kwargs):
         self._coreimage = None
         self._loops = 0
-        super(Image, self).__init__(**kwargs)
-        fbind = self.fbind
         update = self.texture_update
+        fbind = self.fbind
         fbind('source', update)
         fbind('mipmap', update)
-        if self.source:
-            update()
-        self.on_anim_delay(self, kwargs.get('anim_delay', .25))
+        super(Image, self).__init__(**kwargs)
 
     def texture_update(self, *largs):
         if not self.source:
@@ -354,14 +351,11 @@ class AsyncImage(Image):
 
     def __init__(self, **kwargs):
         self._coreimage = None
-        super(AsyncImage, self).__init__(**kwargs)
         global Loader
         if not Loader:
             from kivy.loader import Loader
         self.fbind('source', self._load_source)
-        if self.source:
-            self._load_source()
-        self.on_anim_delay(self, kwargs.get('anim_delay', .25))
+        super(AsyncImage, self).__init__(**kwargs)
 
     def _load_source(self, *args):
         source = self.source

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -419,10 +419,10 @@ class AsyncImage(Image):
         pass
 
     def reload(self):
-        if Loader:
+        if Loader and self.source:
             source = self.source
             if not self.is_uri(source):
                 source = resource_find(source)
-            Loader.remove_from_cache(source)
-
+            if source:
+                Loader.remove_from_cache(source)
         super(AsyncImage, self).reload()


### PR DESCRIPTION
Fixes summary:

1. If `source` property of `AsyncImage` is set to path which does not exist on disk, then error will be logged and `texture` will be set to `None`. This prevents passing of `None` value as `filename` to `Loader.image` method which is internally used to asynchronously load image. This also could be a possible fix for https://github.com/kivy/kivy/issues/6103  and https://github.com/kivy/kivy/issues/6609.
2. Added `remove_from_cache` method to Image and override it in AsyncImage to add better cache removal. 
3. Ensured that type 'list' is always returned for property 'norm_image_size' of Image class. This adds consistency and fixes case where `self.size` returned without making a copy of it (`texture` is `None`) thus not triggering dispatch of `norm_image_size` and as a consequence not updating canvas.
4. Fixed `texture_size` so that its value be `[0, 0]` when `texture` is `None`. 
5. Removed try/except clause from `reload` method of `Image` class and removed `reload` from `AsyncImage` class.
6. Better log messages and consistent with image loaders.
7. Removed unused `_loop` attribute from `Image` class.