### PR TITLE
Use GLES context when ES2 is forced

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -143,6 +143,8 @@ cdef class _WindowSDL2Storage:
             Logger.info("Window: Activate GLES2/ANGLE context")
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 4)
             SDL_SetHint(SDL_HINT_VIDEO_WIN_D3DCOMPILER, "none")
+        elif kivy_opengl_es2:
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES)
 
         if x is None:
             x = SDL_WINDOWPOS_UNDEFINED

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -59,6 +59,11 @@ cdef extern from "SDL.h":
         SDL_GL_CONTEXT_FLAGS
         SDL_GL_CONTEXT_PROFILE_MASK
 
+    ctypedef enum SDL_GLprofile:
+        SDL_GL_CONTEXT_PROFILE_CORE = 0x0001
+        SDL_GL_CONTEXT_PROFILE_COMPATIBILITY = 0x0002
+        SDL_GL_CONTEXT_PROFILE_ES = 0x0004
+
     ctypedef enum SDL_SystemCursor:
         SDL_SYSTEM_CURSOR_ARROW
         SDL_SYSTEM_CURSOR_IBEAM


### PR DESCRIPTION
On the desktop, multiple context types are generally available,
including full OpenGL with core and compatibility contexts, in addition
to ES contexts.

Certain extensions, such as GL_OES_EGL_image_external require a GLES
context, but SDL2 defaults to a core or compatibility context when
available.

This patch forces a GLES context when ES2 is forced using KIVY_GRAPHICS.