### PR TITLE
Adding allow_stretch to Slider in style.kv:

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -72,6 +72,8 @@
         pos: (root.value_pos[0] - root.cursor_width / 2, root.center_y - root.cursor_height / 2) if root.orientation == 'horizontal' else (root.center_x - root.cursor_width / 2, root.value_pos[1] - root.cursor_height / 2)
         size: root.cursor_size
         source: root.cursor_disabled_image if root.disabled else root.cursor_image
+        allow_stretch: True
+        keep_ratio: False
 
 <ProgressBar>:
     canvas:


### PR DESCRIPTION
The slider cursor image is currently ignoring the cursor size properties
(cursor_size, cursor_width and cursor_height) of the built-in Slider widget.

By adding allow_stretch: True and keep_ratio: False the slider cursor
image will be stretched/shrink to the size specified by the cursor
size properties of the Slider widget.

IOW: changing/setting the Slider properties cursor_size, cursor_width and cursor_height
have no effect on the displayed size of the cursor image.

So these properties would make only sense for to read/get the size of the used image and should therefore implemented and documented as read-only properties!