### PR TITLE
No need to import Properties when sub-classing Widget!

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -289,8 +289,9 @@ class WidgetMetaclass(type):
         return ChainMap({}, all_properties)
 
     def __new__(metas, name, bases, methods):
-        # Remove Properties from __dict__
-        methods = methods.maps[0]
+        if hasattr(methods, 'maps'):
+            # Remove Properties from __dict__
+            methods = methods.maps[0]
         return super(WidgetMetaclass, metas).__new__(metas, name, bases, methods)
 
     def __init__(cls, name, bases, attrs):

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -249,12 +249,12 @@ from kivy.base import EventLoop
 from kivy.lang import Builder
 from kivy.context import get_current_context
 from kivy.weakproxy import WeakProxy
-from collections import ChainMap           
+from collections import ChainMap
 from functools import partial
-from inspect import getfile                
+from inspect import getfile           
 from itertools import islice
-from os.path import dirname, join, exists  
-from textwrap import dedent                
+from os.path import dirname, join, exists
+from textwrap import dedent  
 
 all_properties = {name: getattr(properties, name) for name in properties.__all__}
 

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -280,6 +280,7 @@ class WidgetException(Exception):
 class WidgetMetaclass(type):
     '''Metaclass to automatically register new widgets for the
     :class:`~kivy.factory.Factory`.
+
     .. warning::
         This metaclass is used by the Widget. Do not use it directly!
     '''

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -251,10 +251,10 @@ from kivy.context import get_current_context
 from kivy.weakproxy import WeakProxy
 from collections import ChainMap
 from functools import partial
-from inspect import getfile           
+from inspect import getfile
 from itertools import islice
 from os.path import dirname, join, exists
-from textwrap import dedent  
+from textwrap import dedent
 
 all_properties = {name: getattr(properties, name) for name in properties.__all__}
 


### PR DESCRIPTION
We add all properties to a Widgets dict in `__prepare__` with a ChainMap.  This allows, in the context of a Widget class def, to avoid importing any properties at all -- as property imports can get rather lengthy.  We also added a proof-of-concept auto-loader of kv lang which could be provided either in a special class attribute, `__KV__`, or a file in the same directory with the same name (in lowercase) as the widget.

Alternatively, auto-loading could be passed as a kwarg in class def, e.g.:
```py
class MyWidget(Widget, autoload_kv=True):
```

The end result is simpler widget creation, e.g.:
```py
from kivy.uix.label import Label


class TestMeta(Label):
    __KV__ = """
    <TestMeta>:
        text: self.name
    """
    name = StringProperty()


if __name__ == '__main__':
    from kivy.app import App

    class MyApp(App):
        def build(self):
            return TestMeta(name='Hello world!')

    MyApp().run()
```