### PR TITLE
Fix key_background_color property is not used

### DIFF
--- a/kivy/uix/vkeyboard.py
+++ b/kivy/uix/vkeyboard.py
@@ -562,10 +562,9 @@ class VKeyboard(Scatter):
         texture = Image(background, mipmap=True).texture
 
         with self.active_keys_layer:
-            Color(1, 1, 1)
+            Color(*self.key_background_color)
             for line_nb, index in active_keys.values():
                 pos, size = layout_geometry['LINE_%d' % line_nb][index]
-                Color(*self.key_background_color)
                 BorderImage(texture=texture, pos=pos, size=size,
                             border=self.key_border)
 
@@ -665,9 +664,9 @@ class VKeyboard(Scatter):
                                    self.key_background_normal)
         texture = Image(key_normal, mipmap=True).texture
         with self.background_key_layer:
+            Color(*self.key_background_color)
             for line_nb in range(1, layout_rows + 1):
                 for pos, size in layout_geometry['LINE_%d' % line_nb]:
-                    Color(*self.key_background_color)
                     BorderImage(texture=texture, pos=pos, size=size,
                                 border=self.key_border)
 

--- a/kivy/uix/vkeyboard.py
+++ b/kivy/uix/vkeyboard.py
@@ -565,6 +565,7 @@ class VKeyboard(Scatter):
             Color(1, 1, 1)
             for line_nb, index in active_keys.values():
                 pos, size = layout_geometry['LINE_%d' % line_nb][index]
+                Color(*self.key_background_color)
                 BorderImage(texture=texture, pos=pos, size=size,
                             border=self.key_border)
 
@@ -666,6 +667,7 @@ class VKeyboard(Scatter):
         with self.background_key_layer:
             for line_nb in range(1, layout_rows + 1):
                 for pos, size in layout_geometry['LINE_%d' % line_nb]:
+                    Color(*self.key_background_color)
                     BorderImage(texture=texture, pos=pos, size=size,
                                 border=self.key_border)
 


### PR DESCRIPTION
When trying to style the VKeyboard Widget I came across the key_background_color property that is also described in the [docs](https://kivy.org/doc/stable/api-kivy.uix.vkeyboard.html#kivy.uix.vkeyboard.VKeyboard.key_background_color).

It however wasn't used when rendering the keys. This PR tries to fix this and applies the color when drawing the keys.