### PR TITLE
Use utf-8 encoding by default on reading .kv files. Fixes #5154

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -285,7 +285,7 @@ class BuilderBase(object):
 
         return obj
 
-    def load_file(self, filename, **kwargs):
+    def load_file(self, filename, encoding='utf8', **kwargs):
         '''Insert a file into the language builder and return the root widget
         (if defined) of the kv file.
 
@@ -293,14 +293,16 @@ class BuilderBase(object):
             `rulesonly`: bool, defaults to False
                 If True, the Builder will raise an exception if you have a root
                 widget inside the definition.
+
+            `encoding`: File charcter encoding. Defaults to utf-8,
         '''
         filename = resource_find(filename) or filename
         if __debug__:
-            trace('Lang: load file %s' % filename)
-        with open(filename, 'r') as fd:
-            kwargs['filename'] = filename
-            data = fd.read()
+            trace('Lang: load file %s, using %s encoding', filename, encoding)
 
+        kwargs['filename'] = filename
+        with open(filename, 'r', encoding=encoding) as fd:
+            data = fd.read()
             return self.load_string(data, **kwargs)
 
     def unload_file(self, filename):

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -4,6 +4,7 @@ Language tests
 '''
 
 import unittest
+import os
 from weakref import proxy
 from functools import partial
 
@@ -293,6 +294,19 @@ class LangTestCase(unittest.TestCase):
         self.assertIsNone(wid.obj)
         Builder.apply_rules(wid, 'TLangClassCustom')
         self.assertEqual(wid.obj, 42)
+
+    def test_load_utf8(self):
+        from tempfile import mkstemp
+        from kivy.lang import Builder
+        fd, name = mkstemp()
+        os.write(fd, '''
+
+Label:
+    text: 'é 😊'
+'''.encode('utf8'))
+        root = Builder.load_file(name)
+        assert root.text == 'é 😊'
+        os.close(fd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add optional 'encoding' parameter loading .kv files, defaulting
to None. If not passed, also tries native system encoding
if file fails loading as utf-8.

rebasing of #5649 