### PR TITLE
Wait for ffpyplayer to fully load a video before playing to prevent a/v desync

### DIFF
--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -218,6 +218,12 @@ class VideoFFPy(VideoBase):
         did_dispatch_eof = False
         seek_queue = self._seek_queue
 
+        # Wait for first frame to load before playing so audio doesnt get out of sync too badly
+        frame = None
+        while frame is None:
+            frame, value = ffplayer.get_frame(force_refresh=True)
+            sleep(0.1)
+
         # fast path, if the source video is yuv420p, we'll use a glsl shader
         # for buffer conversion to rgba
         while not self._ffplayer_need_quit:


### PR DESCRIPTION
Videos (especially obvious with uhd videos) played with ffpyplayer would start the audio playback before the video is ready causing a desync and severe stuttering in the video.  This commit helps prevent that by waiting for ffpyplayer to load the first frame.

Note that the sleep is at the end of the last while loop is for a good reason too - if the video starts playing immediately after the frame is gotten, it will still stutter a decent amount, delaying by .1 second helps that significantly.