### PR TITLE
file chooser font property

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -352,12 +352,13 @@
             halign: 'left'
             shorten: True
             text: ctx.name
+            font_name: ctx.controller().font_name
         Label:
             text_size: self.width, None
             size_hint_x: None
             halign: 'right'
             text: '{}'.format(ctx.get_nice_size())
-
+            font_name: ctx.controller().font_name
 
 <FileChooserIconLayout>:
     on_entry_added: stacklayout.add_widget(args[1])
@@ -413,14 +414,15 @@
         pos: root.x + dp(24), root.y + dp(40)
     Label:
         text: ctx.name
+        font_name: ctx.controller().font_name
         text_size: (root.width, self.height)
         halign: 'center'
         shorten: True
         size: '100dp', '16dp'
         pos: root.x, root.y + dp(16)
-
     Label:
         text: '{}'.format(ctx.get_nice_size())
+        font_name: ctx.controller().font_name
         font_size: '11sp'
         color: .8, .8, .8, 1
         size: '100dp', '16sp'

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -87,6 +87,8 @@ __all__ = ('FileChooserListView', 'FileChooserIconView',
 
 from weakref import ref
 from time import time
+
+from kivy.core.text import DEFAULT_FONT
 from kivy.compat import string_types
 from kivy.factory import Factory
 from kivy.clock import Clock
@@ -510,6 +512,16 @@ class FileChooserController(RelativeLayout):
     :class:`FileSystemLocal()`
 
     .. versionadded:: 1.8.0
+    '''
+
+    font_name = StringProperty(DEFAULT_FONT)
+    '''Filename of the font to use in UI components. The path can be
+    absolute or relative.  Relative paths are resolved by the
+    :func:`~kivy.resources.resource_find` function.
+
+    :attr:`font_name` is a :class:`~kivy.properties.StringProperty` and
+    defaults to 'Roboto'. This value is taken
+    from :class:`~kivy.config.Config`.
     '''
 
     _update_files_ev = None


### PR DESCRIPTION
This adds a `font_name` property to `FileChooserController`, which helps avoid characters in file names not being in the default font.
Probably there are other places in the files code this could be used as well.