### PR TITLE
Use ColorProperty instead of ListProperty for color property

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1208,8 +1208,12 @@ class WindowBase(EventDispatcher):
 
     .. versionadded:: 1.10.1
 
-    :attr:`shape_color_key` is a :class:`~kivy.properties.ColorProperty`
+    :attr:`shape_color_key` is a :class:`~kivy.properties.ListProperty`
     instance and defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
     def on_shape_color_key(self, instane, value):
         self._set_shape(

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -21,7 +21,8 @@ from kivy.base import EventLoop, stopTouchApp
 from kivy.modules import Modules
 from kivy.event import EventDispatcher
 from kivy.properties import ListProperty, ObjectProperty, AliasProperty, \
-    NumericProperty, OptionProperty, StringProperty, BooleanProperty
+    NumericProperty, OptionProperty, StringProperty, BooleanProperty, \
+    ColorProperty
 from kivy.utils import platform, reify, deprecated, pi_version
 from kivy.context import get_current_context
 from kivy.uix.behaviors import FocusBehavior
@@ -1201,13 +1202,13 @@ class WindowBase(EventDispatcher):
     :attr:`shape_mode` is an :class:`~kivy.properties.AliasProperty`.
     '''
 
-    shape_color_key = ListProperty([1, 1, 1, 1])
+    shape_color_key = ColorProperty([1, 1, 1, 1])
     '''Color key of the shaped window - sets which color will be hidden from
     the window :attr:`shape_image` (only works for sdl2 window provider).
 
     .. versionadded:: 1.10.1
 
-    :attr:`shape_color_key` is a :class:`~kivy.properties.ListProperty`
+    :attr:`shape_color_key` is a :class:`~kivy.properties.ColorProperty`
     instance and defaults to [1, 1, 1, 1].
     '''
     def on_shape_color_key(self, instane, value):

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -215,8 +215,12 @@ class ActionPrevious(BoxLayout, ActionItem):
     '''
     Text color, in the format (r, g, b, a)
 
-    :attr:`color` is a :class:`~kivy.properties.ColorProperty` and defaults
+    :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults
     to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     previous_image = StringProperty(
@@ -526,8 +530,12 @@ class ActionView(BoxLayout):
     '''
     Background color in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     background_image = StringProperty(
@@ -794,8 +802,12 @@ class ActionBar(BoxLayout):
     '''
     Background color, in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     background_image = StringProperty(

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -48,7 +48,7 @@ from kivy.uix.spinner import Spinner
 from kivy.uix.label import Label
 from kivy.config import Config
 from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty, \
-    StringProperty, ListProperty, OptionProperty, AliasProperty
+    StringProperty, ListProperty, OptionProperty, AliasProperty, ColorProperty
 from kivy.metrics import sp
 from kivy.lang import Builder
 from functools import partial
@@ -211,11 +211,11 @@ class ActionPrevious(BoxLayout, ActionItem):
     and defaults to 0.
     '''
 
-    color = ListProperty([1, 1, 1, 1])
+    color = ColorProperty([1, 1, 1, 1])
     '''
     Text color, in the format (r, g, b, a)
 
-    :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty` and defaults
     to [1, 1, 1, 1].
     '''
 
@@ -522,11 +522,11 @@ class ActionView(BoxLayout):
     and defaults to None.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''
     Background color in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
     '''
 
@@ -790,11 +790,11 @@ class ActionBar(BoxLayout):
     defaults to None or the last ActionView instance added to the ActionBar.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''
     Background color, in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
     '''
 

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -95,8 +95,12 @@ class Bubble(GridLayout):
     '''Background color, in the format (r, g, b, a). To use it you have to set
     either :attr:`background_image` or :attr:`arrow_image` first.
 
-    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     border = ListProperty([16, 16, 16, 16])

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -66,7 +66,7 @@ from kivy.uix.gridlayout import GridLayout
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
 from kivy.properties import ObjectProperty, StringProperty, OptionProperty, \
-    ListProperty, BooleanProperty
+    ListProperty, BooleanProperty, ColorProperty
 from kivy.clock import Clock
 from kivy.base import EventLoop
 from kivy.metrics import dp
@@ -91,11 +91,11 @@ class Bubble(GridLayout):
     '''Bubble class. See module documentation for more information.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a). To use it you have to set
     either :attr:`background_image` or :attr:`arrow_image` first.
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
     '''
 

--- a/kivy/uix/button.py
+++ b/kivy/uix/button.py
@@ -47,7 +47,7 @@ Kv Example::
 __all__ = ('Button', )
 
 from kivy.uix.label import Label
-from kivy.properties import StringProperty, ListProperty
+from kivy.properties import StringProperty, ListProperty, ColorProperty
 from kivy.uix.behaviors import ButtonBehavior
 
 
@@ -60,7 +60,7 @@ class Button(ButtonBehavior, Label):
 
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a).
 
     This acts as a *multiplier* to the texture colour. The default
@@ -71,7 +71,7 @@ class Button(ButtonBehavior, Label):
     .. versionadded:: 1.0.8
 
     The :attr:`background_color` is a
-    :class:`~kivy.properties.ListProperty` and defaults to [1, 1, 1, 1].
+    :class:`~kivy.properties.ColorProperty` and defaults to [1, 1, 1, 1].
     '''
 
     background_normal = StringProperty(

--- a/kivy/uix/button.py
+++ b/kivy/uix/button.py
@@ -71,7 +71,11 @@ class Button(ButtonBehavior, Label):
     .. versionadded:: 1.0.8
 
     The :attr:`background_color` is a
-    :class:`~kivy.properties.ColorProperty` and defaults to [1, 1, 1, 1].
+    :class:`~kivy.properties.ListProperty` and defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     background_normal = StringProperty(

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -30,7 +30,7 @@ An example usage::
 
 __all__ = ('CheckBox', )
 
-from kivy.properties import AliasProperty, StringProperty, ListProperty
+from kivy.properties import AliasProperty, StringProperty, ColorProperty
 from kivy.uix.behaviors import ToggleButtonBehavior
 from kivy.uix.widget import Widget
 
@@ -155,7 +155,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
     'atlas://data/images/defaulttheme/checkbox_radio_disabled_on'.
     '''
 
-    color = ListProperty([1, 1, 1, 1])
+    color = ColorProperty([1, 1, 1, 1])
     '''Color is used for tinting the default graphical representation
     of checkbox and radio button (images).
 
@@ -164,7 +164,7 @@ class CheckBox(ToggleButtonBehavior, Widget):
     .. versionadded:: 1.10.0
 
     :attr:`color` is a
-    :class:`~kivy.properties.ListProperty` and defaults to
+    :class:`~kivy.properties.ColorProperty` and defaults to
     '[1, 1, 1, 1]'.
     '''
 

--- a/kivy/uix/checkbox.py
+++ b/kivy/uix/checkbox.py
@@ -164,8 +164,12 @@ class CheckBox(ToggleButtonBehavior, Widget):
     .. versionadded:: 1.10.0
 
     :attr:`color` is a
-    :class:`~kivy.properties.ColorProperty` and defaults to
+    :class:`~kivy.properties.ListProperty` and defaults to
     '[1, 1, 1, 1]'.
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     def __init__(self, **kwargs):

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -59,7 +59,7 @@ from kivy.uix.widget import Widget
 from kivy.core.image import Image as CoreImage
 from kivy.resources import resource_find
 from kivy.properties import StringProperty, ObjectProperty, ListProperty, \
-    AliasProperty, BooleanProperty, NumericProperty
+    AliasProperty, BooleanProperty, NumericProperty, ColorProperty
 from kivy.logger import Logger
 
 # delayed imports
@@ -123,14 +123,14 @@ class Image(Widget):
     read-only.
     '''
 
-    color = ListProperty([1, 1, 1, 1])
+    color = ColorProperty([1, 1, 1, 1])
     '''Image color, in the format (r, g, b, a). This attribute can be used to
     'tint' an image. Be careful: if the source image is not gray/white, the
     color will not really work as expected.
 
     .. versionadded:: 1.0.6
 
-    :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults to
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty` and defaults to
     [1, 1, 1, 1].
     '''
 

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -130,8 +130,12 @@ class Image(Widget):
 
     .. versionadded:: 1.0.6
 
-    :attr:`color` is a :class:`~kivy.properties.ColorProperty` and defaults to
+    :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults to
     [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     allow_stretch = BooleanProperty(False)

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -287,7 +287,7 @@ from kivy.core.text import Label as CoreLabel, DEFAULT_FONT
 from kivy.core.text.markup import MarkupLabel as CoreMarkupLabel
 from kivy.properties import StringProperty, OptionProperty, \
     NumericProperty, BooleanProperty, ReferenceListProperty, \
-    ListProperty, ObjectProperty, DictProperty
+    ListProperty, ObjectProperty, DictProperty, ColorProperty
 from kivy.utils import get_hex_from_color
 
 
@@ -441,13 +441,13 @@ class Label(Widget):
     # Properties
     #
 
-    disabled_color = ListProperty([1, 1, 1, .3])
+    disabled_color = ColorProperty([1, 1, 1, .3])
     '''The color of the text when the widget is disabled, in the (r, g, b, a)
     format.
 
     .. versionadded:: 1.8.0
 
-    :attr:`disabled_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`disabled_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, .3].
     '''
 
@@ -755,10 +755,10 @@ class Label(Widget):
         or set a :attr:`text_size` to change this behavior.
     '''
 
-    color = ListProperty([1, 1, 1, 1])
+    color = ColorProperty([1, 1, 1, 1])
     '''Text color, in the format (r, g, b, a).
 
-    :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults to
+    :attr:`color` is a :class:`~kivy.properties.ColorProperty` and defaults to
     [1, 1, 1, 1].
     '''
 

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -447,8 +447,12 @@ class Label(Widget):
 
     .. versionadded:: 1.8.0
 
-    :attr:`disabled_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`disabled_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, .3].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     text = StringProperty('')
@@ -758,8 +762,12 @@ class Label(Widget):
     color = ColorProperty([1, 1, 1, 1])
     '''Text color, in the format (r, g, b, a).
 
-    :attr:`color` is a :class:`~kivy.properties.ColorProperty` and defaults to
+    :attr:`color` is a :class:`~kivy.properties.ListProperty` and defaults to
     [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     outline_width = NumericProperty(None, allownone=True)

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -130,12 +130,13 @@ class ModalView(AnchorLayout):
     :attr:`background_normal` to ``''``.
 
     The :attr:`background_color` is a
-    :class:`~kivy.properties.ColorProperty` and defaults to [1, 1, 1, 1].
+    :class:`~kivy.properties.ListProperty` and defaults to [1, 1, 1, 1].
 
     .. versionchanged:: 2.0.0
         Changed behavior to affect the background of the widget itself, not
         the overlay dimming.
-
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     background = StringProperty(

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -78,7 +78,7 @@ from kivy.logger import Logger
 from kivy.animation import Animation
 from kivy.uix.anchorlayout import AnchorLayout
 from kivy.properties import StringProperty, BooleanProperty, ObjectProperty, \
-    NumericProperty, ListProperty
+    NumericProperty, ListProperty, ColorProperty
 
 
 class ModalView(AnchorLayout):
@@ -121,7 +121,7 @@ class ModalView(AnchorLayout):
     defaults to None.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a).
 
     This acts as a *multiplier* to the texture colour. The default
@@ -130,7 +130,7 @@ class ModalView(AnchorLayout):
     :attr:`background_normal` to ``''``.
 
     The :attr:`background_color` is a
-    :class:`~kivy.properties.ListProperty` and defaults to [1, 1, 1, 1].
+    :class:`~kivy.properties.ColorProperty` and defaults to [1, 1, 1, 1].
 
     .. versionchanged:: 2.0.0
         Changed behavior to affect the background of the widget itself, not
@@ -159,11 +159,11 @@ class ModalView(AnchorLayout):
     (16, 16, 16, 16).
     '''
 
-    overlay_color = ListProperty([0, 0, 0, .7])
+    overlay_color = ColorProperty([0, 0, 0, .7])
     '''Overlay color in the format (r, g, b, a).
     Used for dimming the window behind the modal view.
 
-    :attr:`overlay_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`overlay_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [0, 0, 0, .7].
 
     .. versionadded:: 2.0.0

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -176,8 +176,12 @@ class Popup(ModalView):
 
     .. versionadded:: 1.8.0
 
-    :attr:`title_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`title_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     separator_color = ColorProperty([47 / 255., 167 / 255., 212 / 255., 1.])
@@ -185,8 +189,12 @@ class Popup(ModalView):
 
     .. versionadded:: 1.1.0
 
-    :attr:`separator_color` is a :class:`~kivy.properties.ColorProperty` and
-    defaults to [47 / 255., 167 / 255., 212 / 255., 1.]
+    :attr:`separator_color` is a :class:`~kivy.properties.ListProperty` and
+    defaults to [47 / 255., 167 / 255., 212 / 255., 1.].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     separator_height = NumericProperty('2dp')

--- a/kivy/uix/popup.py
+++ b/kivy/uix/popup.py
@@ -106,7 +106,7 @@ __all__ = ('Popup', 'PopupException')
 from kivy.core.text import DEFAULT_FONT
 from kivy.uix.modalview import ModalView
 from kivy.properties import (StringProperty, ObjectProperty, OptionProperty,
-                             NumericProperty, ListProperty)
+                             NumericProperty, ColorProperty)
 
 
 class PopupException(Exception):
@@ -171,21 +171,21 @@ class Popup(ModalView):
     to None.
     '''
 
-    title_color = ListProperty([1, 1, 1, 1])
+    title_color = ColorProperty([1, 1, 1, 1])
     '''Color used by the Title.
 
     .. versionadded:: 1.8.0
 
-    :attr:`title_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`title_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
     '''
 
-    separator_color = ListProperty([47 / 255., 167 / 255., 212 / 255., 1.])
+    separator_color = ColorProperty([47 / 255., 167 / 255., 212 / 255., 1.])
     '''Color used by the separator between title and content.
 
     .. versionadded:: 1.1.0
 
-    :attr:`separator_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`separator_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [47 / 255., 167 / 255., 212 / 255., 1.]
     '''
 

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -197,7 +197,7 @@ from kivy.clock import Clock
 from kivy.uix.floatlayout import FloatLayout
 from kivy.properties import (StringProperty, ObjectProperty, AliasProperty,
                              NumericProperty, ListProperty, OptionProperty,
-                             BooleanProperty)
+                             BooleanProperty, ColorProperty)
 from kivy.animation import Animation, AnimationTransition
 from kivy.uix.relativelayout import RelativeLayout
 from kivy.lang import Builder
@@ -460,12 +460,12 @@ class ShaderTransition(TransitionBase):
     :attr:`vs` is a :class:`~kivy.properties.StringProperty` and defaults to
     None.'''
 
-    clearcolor = ListProperty([0, 0, 0, 1])
+    clearcolor = ColorProperty([0, 0, 0, 1])
     '''Sets the color of Fbo ClearColor.
 
     .. versionadded:: 1.9.0
 
-    :attr:`clearcolor` is a :class:`~kivy.properties.ListProperty`
+    :attr:`clearcolor` is a :class:`~kivy.properties.ColorProperty`
     and defaults to [0, 0, 0, 1].'''
 
     def make_screen_fbo(self, screen):

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -465,8 +465,13 @@ class ShaderTransition(TransitionBase):
 
     .. versionadded:: 1.9.0
 
-    :attr:`clearcolor` is a :class:`~kivy.properties.ColorProperty`
-    and defaults to [0, 0, 0, 1].'''
+    :attr:`clearcolor` is a :class:`~kivy.properties.ListProperty`
+    and defaults to [0, 0, 0, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
+    '''
 
     def make_screen_fbo(self, screen):
         fbo = Fbo(size=screen.size, with_stencilbuffer=True)

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -340,8 +340,12 @@ class ScrollView(StencilView):
 
     .. versionadded:: 1.2.0
 
-    :attr:`bar_color` is a :class:`~kivy.properties.ColorProperty` and defaults
+    :attr:`bar_color` is a :class:`~kivy.properties.ListProperty` and defaults
     to [.7, .7, .7, .9].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     bar_inactive_color = ColorProperty([.7, .7, .7, .2])
@@ -351,7 +355,11 @@ class ScrollView(StencilView):
     .. versionadded:: 1.9.0
 
     :attr:`bar_inactive_color` is a
-    :class:`~kivy.properties.ColorProperty` and defaults to [.7, .7, .7, .2].
+    :class:`~kivy.properties.ListProperty` and defaults to [.7, .7, .7, .2].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     bar_width = NumericProperty('2dp')

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -151,7 +151,8 @@ from kivy.uix.stencilview import StencilView
 from kivy.metrics import sp, dp
 from kivy.effects.dampedscroll import DampedScrollEffect
 from kivy.properties import NumericProperty, BooleanProperty, AliasProperty, \
-    ObjectProperty, ListProperty, ReferenceListProperty, OptionProperty
+    ObjectProperty, ListProperty, ReferenceListProperty, OptionProperty, \
+    ColorProperty
 from kivy.uix.behaviors import FocusBehavior
 
 
@@ -334,23 +335,23 @@ class ScrollView(StencilView):
     :attr:`vbar` is a :class:`~kivy.properties.AliasProperty`, readonly.
     '''
 
-    bar_color = ListProperty([.7, .7, .7, .9])
+    bar_color = ColorProperty([.7, .7, .7, .9])
     '''Color of horizontal / vertical scroll bar, in RGBA format.
 
     .. versionadded:: 1.2.0
 
-    :attr:`bar_color` is a :class:`~kivy.properties.ListProperty` and defaults
+    :attr:`bar_color` is a :class:`~kivy.properties.ColorProperty` and defaults
     to [.7, .7, .7, .9].
     '''
 
-    bar_inactive_color = ListProperty([.7, .7, .7, .2])
+    bar_inactive_color = ColorProperty([.7, .7, .7, .2])
     '''Color of horizontal / vertical scroll bar (in RGBA format), when no
     scroll is happening.
 
     .. versionadded:: 1.9.0
 
     :attr:`bar_inactive_color` is a
-    :class:`~kivy.properties.ListProperty` and defaults to [.7, .7, .7, .2].
+    :class:`~kivy.properties.ColorProperty` and defaults to [.7, .7, .7, .2].
     '''
 
     bar_width = NumericProperty('2dp')

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -42,7 +42,8 @@ __all__ = ('Slider', )
 from kivy.uix.widget import Widget
 from kivy.properties import (NumericProperty, AliasProperty, OptionProperty,
                              ReferenceListProperty, BoundedNumericProperty,
-                             StringProperty, ListProperty, BooleanProperty)
+                             StringProperty, ListProperty, BooleanProperty,
+                             ColorProperty)
 
 
 class Slider(Widget):
@@ -244,12 +245,12 @@ class Slider(Widget):
     and defaults to False.
     """
 
-    value_track_color = ListProperty([1, 1, 1, 1])
+    value_track_color = ColorProperty([1, 1, 1, 1])
     """Color of the :attr:`value_line` in rgba format.
 
     .. versionadded 1.10.0
 
-    :attr:`value_track_color` is a :class:`~kivy.properties.ListProperty`
+    :attr:`value_track_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to [1, 1, 1, 1].
     """
 

--- a/kivy/uix/slider.py
+++ b/kivy/uix/slider.py
@@ -250,8 +250,12 @@ class Slider(Widget):
 
     .. versionadded 1.10.0
 
-    :attr:`value_track_color` is a :class:`~kivy.properties.ColorProperty`
+    :attr:`value_track_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     """
 
     value_track_width = NumericProperty('3dp')

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -270,8 +270,12 @@ class TabbedPanel(GridLayout):
     background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     border = ListProperty([16, 16, 16, 16])

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -136,7 +136,8 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.logger import Logger
 from kivy.metrics import dp
 from kivy.properties import ObjectProperty, StringProperty, OptionProperty, \
-    ListProperty, NumericProperty, AliasProperty, BooleanProperty
+    ListProperty, NumericProperty, AliasProperty, BooleanProperty, \
+    ColorProperty
 
 
 class TabbedPanelException(Exception):
@@ -266,10 +267,10 @@ class TabbedPanel(GridLayout):
     '''The TabbedPanel class. See module documentation for more information.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a).
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
     '''
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2787,8 +2787,12 @@ class TextInput(FocusBehavior, Widget):
 
     .. versionadded:: 1.9.0
 
-    :attr:`cursor_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`cursor_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 0, 0, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     cursor_width = NumericProperty('1sp')
@@ -2906,8 +2910,12 @@ class TextInput(FocusBehavior, Widget):
         The color should always have an "alpha" component less than 1
         since the selection is drawn after the text.
 
-    :attr:`selection_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`selection_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [0.1843, 0.6549, 0.8313, .5].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     border = ListProperty([4, 4, 4, 4])
@@ -2961,8 +2969,12 @@ class TextInput(FocusBehavior, Widget):
 
     .. versionadded:: 1.2.0
 
-    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty`
+    :attr:`background_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to [1, 1, 1, 1] (white).
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     foreground_color = ColorProperty([0, 0, 0, 1])
@@ -2970,8 +2982,12 @@ class TextInput(FocusBehavior, Widget):
 
     .. versionadded:: 1.2.0
 
-    :attr:`foreground_color` is a :class:`~kivy.properties.ColorProperty`
+    :attr:`foreground_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to [0, 0, 0, 1] (black).
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     disabled_foreground_color = ColorProperty([0, 0, 0, .5])
@@ -2980,8 +2996,12 @@ class TextInput(FocusBehavior, Widget):
     .. versionadded:: 1.8.0
 
     :attr:`disabled_foreground_color` is a
-    :class:`~kivy.properties.ColorProperty` and
+    :class:`~kivy.properties.ListProperty` and
     defaults to [0, 0, 0, 5] (50% transparent black).
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     use_bubble = BooleanProperty(not _is_desktop)
@@ -3264,8 +3284,12 @@ class TextInput(FocusBehavior, Widget):
 
     .. versionadded:: 1.6.0
 
-    :attr:`hint_text_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`hint_text_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [0.5, 0.5, 0.5, 1.0] (grey).
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     auto_indent = BooleanProperty(False)

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -170,7 +170,7 @@ from kivy.uix.image import Image
 
 from kivy.properties import StringProperty, NumericProperty, \
     BooleanProperty, AliasProperty, OptionProperty, \
-    ListProperty, ObjectProperty, VariableListProperty
+    ListProperty, ObjectProperty, VariableListProperty, ColorProperty
 
 Cache_register = Cache.register
 Cache_append = Cache.append
@@ -2782,12 +2782,12 @@ class TextInput(FocusBehavior, Widget):
     read-only.
     '''
 
-    cursor_color = ListProperty([1, 0, 0, 1])
+    cursor_color = ColorProperty([1, 0, 0, 1])
     '''Current color of the cursor, in (r, g, b, a) format.
 
     .. versionadded:: 1.9.0
 
-    :attr:`cursor_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`cursor_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 0, 0, 1].
     '''
 
@@ -2898,7 +2898,7 @@ class TextInput(FocusBehavior, Widget):
     defaults to 0.
     '''
 
-    selection_color = ListProperty([0.1843, 0.6549, 0.8313, .5])
+    selection_color = ColorProperty([0.1843, 0.6549, 0.8313, .5])
     '''Current color of the selection, in (r, g, b, a) format.
 
     .. warning::
@@ -2906,7 +2906,7 @@ class TextInput(FocusBehavior, Widget):
         The color should always have an "alpha" component less than 1
         since the selection is drawn after the text.
 
-    :attr:`selection_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`selection_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [0.1843, 0.6549, 0.8313, .5].
     '''
 
@@ -2956,31 +2956,31 @@ class TextInput(FocusBehavior, Widget):
     defaults to 'atlas://data/images/defaulttheme/textinput_active'.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''Current color of the background, in (r, g, b, a) format.
 
     .. versionadded:: 1.2.0
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty`
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to [1, 1, 1, 1] (white).
     '''
 
-    foreground_color = ListProperty([0, 0, 0, 1])
+    foreground_color = ColorProperty([0, 0, 0, 1])
     '''Current color of the foreground, in (r, g, b, a) format.
 
     .. versionadded:: 1.2.0
 
-    :attr:`foreground_color` is a :class:`~kivy.properties.ListProperty`
+    :attr:`foreground_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to [0, 0, 0, 1] (black).
     '''
 
-    disabled_foreground_color = ListProperty([0, 0, 0, .5])
+    disabled_foreground_color = ColorProperty([0, 0, 0, .5])
     '''Current color of the foreground when disabled, in (r, g, b, a) format.
 
     .. versionadded:: 1.8.0
 
     :attr:`disabled_foreground_color` is a
-    :class:`~kivy.properties.ListProperty` and
+    :class:`~kivy.properties.ColorProperty` and
     defaults to [0, 0, 0, 5] (50% transparent black).
     '''
 
@@ -3259,12 +3259,12 @@ class TextInput(FocusBehavior, Widget):
     to ''.
     '''
 
-    hint_text_color = ListProperty([0.5, 0.5, 0.5, 1.0])
+    hint_text_color = ColorProperty([0.5, 0.5, 0.5, 1.0])
     '''Current color of the hint_text text, in (r, g, b, a) format.
 
     .. versionadded:: 1.6.0
 
-    :attr:`hint_text_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`hint_text_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [0.5, 0.5, 0.5, 1.0] (grey).
     '''
 

--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -115,7 +115,7 @@ from kivy.clock import Clock
 from kivy.uix.label import Label
 from kivy.uix.widget import Widget
 from kivy.properties import BooleanProperty, ListProperty, ObjectProperty, \
-    AliasProperty, NumericProperty, ReferenceListProperty
+    AliasProperty, NumericProperty, ReferenceListProperty, ColorProperty
 
 
 class TreeViewException(Exception):
@@ -214,10 +214,10 @@ class TreeViewNode(object):
     to -1.
     '''
 
-    color_selected = ListProperty([.3, .3, .3, 1.])
+    color_selected = ColorProperty([.3, .3, .3, 1.])
     '''Background color of the node when the node is selected.
 
-    :attr:`color_selected` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`color_selected` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [.1, .1, .1, 1].
     '''
 
@@ -229,17 +229,17 @@ class TreeViewNode(object):
     False.
     '''
 
-    odd_color = ListProperty([1., 1., 1., .0])
+    odd_color = ColorProperty([1., 1., 1., .0])
     '''Background color of odd nodes when the node is not selected.
 
-    :attr:`odd_color` is a :class:`~kivy.properties.ListProperty` and defaults
+    :attr:`odd_color` is a :class:`~kivy.properties.ColorProperty` and defaults
     to [1., 1., 1., 0.].
     '''
 
-    even_color = ListProperty([0.5, 0.5, 0.5, 0.1])
+    even_color = ColorProperty([0.5, 0.5, 0.5, 0.1])
     '''Background color of even nodes when the node is not selected.
 
-    :attr:`bg_color` is a :class:`~kivy.properties.ListProperty` ans defaults
+    :attr:`bg_color` is a :class:`~kivy.properties.ColorProperty` ans defaults
     to [.5, .5, .5, .1].
     '''
 

--- a/kivy/uix/treeview.py
+++ b/kivy/uix/treeview.py
@@ -217,8 +217,12 @@ class TreeViewNode(object):
     color_selected = ColorProperty([.3, .3, .3, 1.])
     '''Background color of the node when the node is selected.
 
-    :attr:`color_selected` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`color_selected` is a :class:`~kivy.properties.ListProperty` and
     defaults to [.1, .1, .1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     odd = BooleanProperty(False)
@@ -232,15 +236,23 @@ class TreeViewNode(object):
     odd_color = ColorProperty([1., 1., 1., .0])
     '''Background color of odd nodes when the node is not selected.
 
-    :attr:`odd_color` is a :class:`~kivy.properties.ColorProperty` and defaults
+    :attr:`odd_color` is a :class:`~kivy.properties.ListProperty` and defaults
     to [1., 1., 1., 0.].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     even_color = ColorProperty([0.5, 0.5, 0.5, 0.1])
     '''Background color of even nodes when the node is not selected.
 
-    :attr:`bg_color` is a :class:`~kivy.properties.ColorProperty` ans defaults
+    :attr:`bg_color` is a :class:`~kivy.properties.ListProperty` ans defaults
     to [.5, .5, .5, .1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
 

--- a/kivy/uix/vkeyboard.py
+++ b/kivy/uix/vkeyboard.py
@@ -117,7 +117,7 @@ from kivy.config import Config
 from kivy.uix.scatter import Scatter
 from kivy.uix.label import Label
 from kivy.properties import ObjectProperty, NumericProperty, StringProperty, \
-    BooleanProperty, DictProperty, OptionProperty, ListProperty
+    BooleanProperty, DictProperty, OptionProperty, ListProperty, ColorProperty
 from kivy.logger import Logger
 from kivy.graphics import Color, BorderImage, Canvas
 from kivy.core.image import Image
@@ -236,11 +236,11 @@ class VKeyboard(Scatter):
     defaults to 20.
     '''
 
-    background_color = ListProperty([1, 1, 1, 1])
+    background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a). If a background is
     set, the color will be combined with the background texture.
 
-    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
     '''
 
@@ -264,11 +264,11 @@ class VKeyboard(Scatter):
 
     '''
 
-    key_background_color = ListProperty([1, 1, 1, 1])
+    key_background_color = ColorProperty([1, 1, 1, 1])
     '''Key background color, in the format (r, g, b, a). If a key background is
     set, the color will be combined with the key background texture.
 
-    :attr:`key_background_color` is a :class:`~kivy.properties.ListProperty`
+    :attr:`key_background_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to [1, 1, 1, 1].
     '''
 

--- a/kivy/uix/vkeyboard.py
+++ b/kivy/uix/vkeyboard.py
@@ -240,8 +240,12 @@ class VKeyboard(Scatter):
     '''Background color, in the format (r, g, b, a). If a background is
     set, the color will be combined with the background texture.
 
-    :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
+    :attr:`background_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     background = StringProperty(
@@ -268,8 +272,12 @@ class VKeyboard(Scatter):
     '''Key background color, in the format (r, g, b, a). If a key background is
     set, the color will be combined with the key background texture.
 
-    :attr:`key_background_color` is a :class:`~kivy.properties.ColorProperty`
+    :attr:`key_background_color` is a :class:`~kivy.properties.ListProperty`
     and defaults to [1, 1, 1, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`.
     '''
 
     key_background_normal = StringProperty(


### PR DESCRIPTION
For all color properties except:
- `GestureSurface.color`
- `Label.outline_color`
- `Label.disabled_outline_color`

as for those properties format `rgb` is used and additional changes are needed to enable using of `ColorProperty`