### PR TITLE
Cleanup WeakMethod

### DIFF
--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -82,10 +82,7 @@ cdef class ClockEvent(object):
         cdef object callback = self.callback
         if callback is not None:
             return callback
-        callback = self.weak_callback
-        if callback.is_dead():
-            return None
-        return callback()
+        return self.weak_callback()
 
     @property
     def is_triggered(self):

--- a/kivy/graphics/context.pyx
+++ b/kivy/graphics/context.pyx
@@ -155,7 +155,8 @@ cdef class Context:
         '''
         lst = self.observers_before if before else self.observers
         for cb in lst[:]:
-            if cb.is_dead() or cb() is callback:
+            method = cb()
+            if method is None or method is callback:
                 lst.remove(cb)
                 continue
 
@@ -169,10 +170,11 @@ cdef class Context:
         # call reload observers that want to do something after a whole gpu
         # reloading.
         for callback in self.observers_before[:]:
-            if callback.is_dead():
+            method = callback()
+            if method is None:
                 self.observers_before.remove(callback)
                 continue
-            callback()(self)
+            method(self)
 
         # mark all the texture to not delete from the previous reload as to
         # delete now.
@@ -265,10 +267,11 @@ cdef class Context:
         # call reload observers that want to do something after a whole gpu
         # reloading.
         for callback in self.observers[:]:
-            if callback.is_dead():
+            method = callback()
+            if method is None:
                 self.observers.remove(callback)
                 continue
-            callback()(self)
+            method(self)
 
         cgl.glFinish()
         dt = time() - start

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -398,11 +398,12 @@ cdef class Fbo(RenderContext):
         self.create_fbo()
         self.flag_update()
         # notify observers
-        for callback in self.observers:
-            if callback.is_dead():
+        for callback in self.observers[:]:
+            method = callback()
+            if method is None:
                 self.observers.remove(callback)
                 continue
-            callback()(self)
+            method(self)
 
     def add_reload_observer(self, callback):
         '''Add a callback to be called after the whole graphics context has
@@ -424,7 +425,8 @@ cdef class Fbo(RenderContext):
 
         '''
         for cb in self.observers[:]:
-            if cb.is_dead() or cb() is callback:
+            method = cb()
+            if method is None or method is callback:
                 self.observers.remove(cb)
                 continue
 

--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -684,7 +684,8 @@ cdef class Texture:
 
         '''
         for cb in self.observers[:]:
-            if cb.is_dead() or cb() is callback:
+            method = cb()
+            if method is None or method is callback:
                 self.observers.remove(cb)
                 continue
 
@@ -1120,10 +1121,11 @@ cdef class Texture:
 
         # then update content again
         for callback in self.observers[:]:
-            if callback.is_dead():
+            method = callback()
+            if method is None:
                 self.observers.remove(callback)
                 continue
-            callback()(self)
+            method(self)
 
     def save(self, filename, flipped=True, fmt=None):
         '''Save the texture content to a file. Check
@@ -1352,10 +1354,11 @@ cdef class TextureRegion(Texture):
         # then update content again
         self.bind()
         for callback in self.observers[:]:
-            if callback.is_dead():
+            method = callback()
+            if method is None:
                 self.observers.remove(callback)
                 continue
-            callback()(self)
+            method(self)
 
     def ask_update(self, callback):
         # redirect to owner

--- a/kivy/tests/test_weakmethod.py
+++ b/kivy/tests/test_weakmethod.py
@@ -1,0 +1,44 @@
+import gc
+
+
+def test_weak_method_on_obj():
+    from kivy.weakmethod import WeakMethod
+
+    class SomeClass:
+
+        def do_something(self):
+            pass
+
+    obj = SomeClass()
+    weak_method = WeakMethod(obj.do_something)
+
+    assert not weak_method.is_dead()
+    assert weak_method() == obj.do_something
+    assert weak_method == WeakMethod(obj.do_something)
+    assert weak_method != WeakMethod(SomeClass().do_something)
+
+    del obj
+    gc.collect()
+
+    assert weak_method.is_dead()
+    assert weak_method() is None
+    assert weak_method != WeakMethod(SomeClass().do_something)
+
+
+def test_weak_method_func():
+    from kivy.weakmethod import WeakMethod
+
+    def do_something():
+        pass
+
+    weak_method = WeakMethod(do_something)
+
+    assert not weak_method.is_dead()
+    assert weak_method() == do_something
+    assert weak_method == WeakMethod(do_something)
+
+    del do_something
+    gc.collect()
+
+    assert not weak_method.is_dead()
+    assert weak_method() is not None

--- a/kivy/weakmethod.py
+++ b/kivy/weakmethod.py
@@ -1,4 +1,4 @@
-'''
+"""
 Weak Method
 ===========
 
@@ -10,121 +10,63 @@ be garbage collected. Please refer to
 This WeakMethod class is taken from the recipe
 http://code.activestate.com/recipes/81253/, based on the nicodemus version.
 Many thanks nicodemus!
-'''
+"""
 
 import weakref
-import sys
 
-if sys.version > '3':
 
-    class WeakMethod:
-        '''Implementation of a
-        `weakref <http://en.wikipedia.org/wiki/Weak_reference>`_
-        for functions and bound methods.
-        '''
-        def __init__(self, method):
-            self.method = None
-            self.method_name = None
-            try:
-                if method.__self__ is not None:
-                    self.method_name = method.__func__.__name__
-                    self.proxy = weakref.proxy(method.__self__)
-                else:
-                    self.method = method
-                    self.proxy = None
-            except AttributeError:
+class WeakMethod:
+    """Implementation of a
+    `weakref <http://en.wikipedia.org/wiki/Weak_reference>`_
+    for functions and bound methods.
+    """
+    def __init__(self, method):
+        self.method = None
+        self.method_name = None
+        try:
+            if method.__self__ is not None:
+                self.method_name = method.__func__.__name__
+                self.proxy = weakref.proxy(method.__self__)
+            else:
                 self.method = method
                 self.proxy = None
+        except AttributeError:
+            self.method = method
+            self.proxy = None
 
-        def __call__(self):
-            '''Return a new bound-method like the original, or the
-            original function if it was just a function or unbound
-            method.
-            Returns None if the original object doesn't exist.
-            '''
+    def __call__(self):
+        """Return a new bound-method like the original, or the
+        original function if it was just a function or unbound
+        method.
+        Returns None if the original object doesn't exist.
+        """
+        if self.proxy is not None:
             try:
-                if self.proxy:
-                    return getattr(self.proxy, self.method_name)
+                return getattr(self.proxy, self.method_name)
             except ReferenceError:
-                pass
-            return self.method
-
-        def is_dead(self):
-            '''Returns True if the referenced callable was a bound method and
-            the instance no longer exists. Otherwise, return False.
-            '''
-            try:
-                return self.proxy is not None and not bool(dir(self.proxy))
-            except ReferenceError:
-                return True
-
-        def __eq__(self, other):
-            try:
-                if type(self) is not type(other):
-                    return False
-                s = self()
-                return s is not None and s == other()
-            except:
-                return False
-
-        def __repr__(self):
-            return '<WeakMethod proxy={} method={} method_name={}>'.format(
-                   self.proxy, self.method, self.method_name)
-
-else:
-
-    import new
-
-    class WeakMethod(object):
-        '''Implementation of a
-        `weakref <http://en.wikipedia.org/wiki/Weak_reference>`_
-        for functions and bound methods.
-        '''
-
-        def __init__(self, method):
-            try:
-                if method.__self__ is not None:
-                    # bound method
-                    self._obj = weakref.ref(method.im_self)
-                else:
-                    # unbound method
-                    self._obj = None
-                self._func = method.im_func
-                self._class = method.im_class
-            except AttributeError:
-                # not a method
-                self._obj = None
-                self._func = method
-                self._class = None
-
-        def __call__(self):
-            '''Return a new bound-method like the original, or the
-            original function if it was just a function or unbound
-            method.
-            Returns None if the original object doesn't exist.
-            '''
-            if self.is_dead():
                 return None
-            if self._obj is not None:
-                return new.instancemethod(self._func, self._obj(), self._class)
-            else:
-                # we don't have an instance: return just the function
-                return self._func
 
-        def is_dead(self):
-            '''Returns True if the referenced callable was a bound method and
-            the instance no longer exists. Otherwise, return False.
-            '''
-            return self._obj is not None and self._obj() is None
+        return self.method
 
-        def __eq__(self, other):
-            try:
-                if type(self) is not type(other):
-                    return False
-                s = self()
-                return s is not None and s == other()
-            except:
-                return False
+    def is_dead(self):
+        """Returns True if the referenced callable was a bound method and
+        the instance no longer exists. Otherwise, return False.
+        """
+        if self.proxy is None:
+            return False
 
-        def __ne__(self, other):
-            return not self == other
+        try:
+            getattr(self.proxy, self.method_name)
+            return False
+        except ReferenceError:
+            return True
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+        s = self()
+        return s is not None and s == other()
+
+    def __repr__(self):
+        return '<WeakMethod proxy={} method={} method_name={}>'.format(
+               self.proxy, self.method, self.method_name)


### PR DESCRIPTION
This cleans up WeakMethod a bit. Specifically

* Removes py2 code.
* `is_dead` called `dir`, which is super slow.
* Doing a comparison needlessly caught all exceptions.
* Added tests
* Replaced all the code that first checked whether the callback is dead and then called it. That pays the de-referencing cost twice. Instead, I changed it to simply call it once by de-referencing it and inspecting the result to see whether it is dead.
* Also caught a bug in context that did `for callback in self.observers:` instead of `for callback in self.observers[:]:`.