### PR TITLE
Add clock lifecycle, better exception handling and other cleanup

### DIFF
--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -96,11 +96,15 @@ cdef class CyClockBase(object):
     cdef public object _lock_release
 
     cdef public int has_ended
+    cdef public object _del_safe_lock
+    cdef public int _del_safe_done
 
     cpdef get_resolution(self)
-    cpdef create_trigger(
-        self, callback, timeout=*, interval=*, clock_ended_callback=*, release_ref=*)
-    cpdef schedule_del_safe(self, callback, clock_ended_callback=*)
+    cpdef create_lifecycle_aware_trigger(
+        self, callback, clock_ended_callback, timeout=*, interval=*, release_ref=*)
+    cpdef create_trigger(self, callback, timeout=*, interval=*, release_ref=*)
+    cpdef schedule_lifecycle_aware_del_safe(self, callback, clock_ended_callback)
+    cpdef schedule_del_safe(self, callback)
     cpdef schedule_once(self, callback, timeout=*)
     cpdef schedule_interval(self, callback, timeout)
     cpdef unschedule(self, callback, all=*)
@@ -116,8 +120,9 @@ cdef class CyClockBase(object):
 
 cdef class CyClockBaseFree(CyClockBase):
 
-    cpdef create_trigger_free(
-        self, callback, timeout=*, interval=*, clock_ended_callback=*, release_ref=*)
+    cpdef create_lifecycle_aware_trigger_free(
+        self, callback, clock_ended_callback, timeout=*, interval=*, release_ref=*)
+    cpdef create_trigger_free(self, callback, timeout=*, interval=*, release_ref=*)
     cpdef schedule_once_free(self, callback, timeout=*)
     cpdef schedule_interval_free(self, callback, timeout)
     cpdef _process_free_events(self, double last_tick)

--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -24,7 +24,19 @@ cdef class ClockEvent(object):
     cdef public double _dt
     cdef public list _del_queue
 
+    cdef public object clock_ended_callback
+    """A Optional callback for this event, which if provided is called by the clock
+    when the clock is stopped and the event was not ticked.
+    """
+    cdef public object weak_clock_ended_callback
+
+    cdef public int release_ref
+    """If True, the event should never release the reference to the callbacks.
+    If False, a weakref may be created instead.
+    """
+
     cpdef get_callback(self)
+    cpdef get_clock_ended_callback(self)
     cpdef cancel(self)
     cpdef release(self)
     cpdef tick(self, double curtime)
@@ -83,22 +95,29 @@ cdef class CyClockBase(object):
     cdef public object _lock_acquire
     cdef public object _lock_release
 
+    cdef public int has_ended
+
     cpdef get_resolution(self)
-    cpdef create_trigger(self, callback, timeout=*, interval=*)
-    cpdef schedule_del_safe(self, callback)
+    cpdef create_trigger(
+        self, callback, timeout=*, interval=*, clock_ended_callback=*, release_ref=*)
+    cpdef schedule_del_safe(self, callback, clock_ended_callback=*)
     cpdef schedule_once(self, callback, timeout=*)
     cpdef schedule_interval(self, callback, timeout)
     cpdef unschedule(self, callback, all=*)
     cpdef _release_references(self)
+    cpdef _process_del_safe_events(self)
     cpdef _process_events(self)
     cpdef _process_events_before_frame(self)
     cpdef get_min_timeout(self)
     cpdef get_events(self)
+    cpdef _process_clock_ended_del_safe_events(self)
+    cpdef _process_clock_ended_callbacks(self)
 
 
 cdef class CyClockBaseFree(CyClockBase):
 
-    cpdef create_trigger_free(self, callback, timeout=*, interval=*)
+    cpdef create_trigger_free(
+        self, callback, timeout=*, interval=*, clock_ended_callback=*, release_ref=*)
     cpdef schedule_once_free(self, callback, timeout=*)
     cpdef schedule_interval_free(self, callback, timeout)
     cpdef _process_free_events(self, double last_tick)

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -271,8 +271,12 @@ cdef class CyClockBase(object):
         """
         self._lock_acquire()
         try:
-            if self.has_ended:
-                raise TypeError('Clock already ended. Cannot re-start the Clock')
+            pass
+            # for now don't raise an exception when restarting because kivy's
+            # graphical tests are not setup to handle clock isolation so they try
+            # to restart the clock
+            # if self.has_ended:
+            #     raise TypeError('Clock already ended. Cannot re-start the Clock')
         finally:
             self._lock_release()
 

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -40,20 +40,24 @@ class ExceptionHandler(object):
 
         class E(ExceptionHandler):
             def handle_exception(self, inst):
-                Logger.exception('Exception catched by ExceptionHandler')
+                Logger.exception('Exception caught by ExceptionHandler')
                 return ExceptionManager.PASS
 
         ExceptionManager.add_handler(E())
 
-    All exceptions will be set to PASS, and logged to the console!
+    Then, all exceptions will be set to PASS, and logged to the console!
     '''
 
-    def __init__(self):
-        pass
-
     def handle_exception(self, exception):
-        '''Handle one exception, defaults to returning
-        `ExceptionManager.RAISE`.
+        '''Called by :class:`ExceptionManagerBase` to handle a exception.
+
+        Defaults to returning :attr:`ExceptionManager.RAISE` that re-raises the
+        exception. Return :attr:`ExceptionManager.PASS` to indicate that the
+        exception was handled and should be ignored.
+
+        This may be called multiple times with the same exception, if
+        :attr:`ExceptionManager.RAISE` is returned as the exception bubbles
+        through multiple kivy exception handling levels.
         '''
         return ExceptionManager.RAISE
 
@@ -62,7 +66,11 @@ class ExceptionManagerBase:
     '''ExceptionManager manages exceptions handlers.'''
 
     RAISE = 0
+    """The exception should be re-raised.
+    """
     PASS = 1
+    """The exception should be ignored as it was handled by the handler.
+    """
 
     def __init__(self):
         self.handlers = []
@@ -74,7 +82,7 @@ class ExceptionManagerBase:
             self.handlers.append(cls)
 
     def remove_handler(self, cls):
-        '''Remove a exception handler from the stack.'''
+        '''Remove the exception handler from the stack.'''
         if cls in self.handlers:
             self.handlers.remove(cls)
 
@@ -92,6 +100,8 @@ class ExceptionManagerBase:
 #: Instance of a :class:`ExceptionManagerBase` implementation.
 ExceptionManager: ExceptionManagerBase = register_context(
     'ExceptionManager', ExceptionManagerBase)
+"""The :class:`ExceptionManagerBase` instance that handles kivy exceptions.
+"""
 
 
 class EventLoopBase(EventDispatcher):
@@ -164,6 +174,7 @@ class EventLoopBase(EventDispatcher):
         This starts all configured input providers.'''
         self.status = 'started'
         self.quit = False
+        Clock.start_clock()
         for provider in self.input_providers:
             provider.start()
         self.dispatch('on_start')
@@ -192,6 +203,7 @@ class EventLoopBase(EventDispatcher):
         # ensure any restart will not break anything later.
         self.input_events = []
 
+        Clock.stop_clock()
         self.stopping = False
         self.status = 'stopped'
         self.dispatch('on_stop')

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -56,8 +56,8 @@ to write a short function that does accept dt. For Example::
 
 .. important::
 
-    The callback is weak-referenced: you are responsible for keeping a
-    reference to your original object/callback. If you don't keep a
+    The class method callback is weak-referenced: you are responsible for
+    keeping a reference to your original object/callback. If you don't keep a
     reference, the ClockBase will never execute your callback. For
     example::
 
@@ -115,12 +115,13 @@ Triggered Events
 
 .. versionadded:: 1.0.5
 
-A triggered event is a way to defer a callback. It functions exactly like
-schedule_once() and schedule_interval() except that it doesn't immediately
+:meth:`CyClockBase.create_trigger` is an advanced method way to defer a
+callback. It functions exactly like :meth:`CyClockBase.schedule_once` and
+:meth:`CyClockBase.schedule_interval` except that it doesn't immediately
 schedule the callback. Instead, one schedules the callback using the
 :class:`ClockEvent` returned by it. This ensures that you can call the event
 multiple times but it won't be scheduled more than once. This is not the case
-with :meth:`Clock.schedule_once`::
+with :meth:`CyClockBase.schedule_once`::
 
     # will run the callback twice before the next frame
     Clock.schedule_once(my_callback)
@@ -137,7 +138,8 @@ with :meth:`Clock.schedule_once`::
     event()
 
 In addition, it is more convenient to create and bind to
-the triggered event than using :meth:`Clock.schedule_once` in a function::
+the triggered event than using :meth:`CyClockBase.schedule_once` in a
+function::
 
     from kivy.clock import Clock
     from kivy.uix.widget import Widget
@@ -152,16 +154,6 @@ the triggered event than using :meth:`Clock.schedule_once` in a function::
             pass
 
 Even if x and y changes within one frame, the callback is only run once.
-
-:meth:`CyClockBase.create_trigger` has a timeout parameter that
-behaves exactly like :meth:`CyClockBase.schedule_once`.
-
-.. versionchanged:: 1.10.0
-
-    :meth:`CyClockBase.create_trigger` now has a ``interval`` parameter.
-    If False, the default, it'll create an event similar to
-    :meth:`CyClockBase.schedule_once`. Otherwise it'll create an event
-    similar to :meth:`CyClockBase.schedule_interval`.
 
 Unscheduling
 -------------
@@ -197,11 +189,77 @@ The best way to unschedule a callback is with :meth:`ClockEvent.cancel`.
 :meth:`CyClockBase.unschedule` is mainly an alias for that for that function.
 However, if the original callback itself is passed to
 :meth:`CyClockBase.unschedule`, it'll unschedule all instances of that
-callback (provided ``all`` is True, the default, other just the first match is
-removed).
+callback (provided ``all`` is True, the default, otherwise only the first match
+is removed).
 
 Calling :meth:`CyClockBase.unschedule` on the original callback is highly
 discouraged because it's significantly slower than when using the event.
+
+Clock Lifecycle
+---------------
+
+Kivy's clock has a lifecycle - scheduling callbacks after the clock has ended
+will raise a :class:`ClockNotRunningError` because otherwise the callback
+will never be called. By default, events can be scheduled before the clock
+is started because it is assumed the clock will eventually be started when the
+app starts
+.
+:meth:`CyClockBase.create_trigger` accepts a ``clock_ended_callback``
+parameter. If provided and the application exits normally (and the app was
+started), the event wasn't
+canceled, and the callbacks are not garbage collected, it guarantees that
+either the ``callback`` or the ``clock_ended_callback`` will be called.
+
+That is, given these conditions, if :class:`ClockNotRunningError` was not
+raised when the event was scheduled, then one of these callbacks will be
+called - either ``callback`` if the event executed normally, or
+``clock_ended_callback`` if the clock is stopped while the event is scheduled.
+
+.. versionadded:: 2.0.0
+    The lifecycle was added in 2.0.0
+
+Exception Handling
+------------------
+
+Kivy provides a exception handling manager,
+:attr:`~kivy.base.ExceptionManager`, to handle its internal exceptions
+including exceptions raised by clock callbacks, without crashing the
+application. By default when an exception is raised, the app will crash.
+But, if a handler is registered with the exception manager and the handler
+handles the exception, the app will not crash and will continue as normal.::
+
+    from kivy.base import ExceptionHandler, ExceptionManager
+    class MyHandler(ExceptionHandler):
+        def handle_exception(self, inst):
+            if isinstance(inst, ValueError):
+                Logger.exception('ValueError caught by MyHandler')
+                return ExceptionManager.PASS
+            return ExceptionManager.RAISE
+
+    ExceptionManager.add_handler(MyHandler())
+
+Then, all ValueError exceptions will be logged to the console and ignored.
+
+If an event's callback raises an exception, before the exception handler is
+executed, the callback is immediately canceled.
+
+.. versionchanged:: 2.0.0
+    Prior to Kivy 2.0.0, an exception raised in a event's callback would
+    cause the clock to crash and subsequent events may or may not be executed.
+    Even if the exception was handled by an
+    :class:`~kivy.base.ExceptionHandler`, there was no guarantee that some
+    scheduled events would not be skipped.
+
+    From 2.0.0 onward, if a event's exception is handled by an
+    :class:`~kivy.base.ExceptionHandler`, other events will be shielded from
+    the exception and will execute normally.
+
+Scheduling from ``__del__``
+---------------------------
+
+It is not safe to schedule Clock events from a object's ``__del__`` or
+``__dealloc__`` method. If you must schedule a Clock call from this method, use
+:meth:`CyClockBase.schedule_del_safe` instead.
 
 Threading and Callback Order
 -----------------------------
@@ -364,7 +422,8 @@ See :mod:`~kivy.app` for example usage.
 '''
 
 __all__ = (
-    'Clock', 'ClockEvent', 'FreeClockEvent', 'CyClockBase', 'CyClockBaseFree',
+    'Clock', 'ClockNotRunningError', 'ClockEvent', 'FreeClockEvent',
+    'CyClockBase', 'CyClockBaseFree',
     'ClockBaseBehavior', 'ClockBaseInterruptBehavior',
     'ClockBaseInterruptFreeBehavior', 'ClockBase', 'ClockBaseInterrupt',
     'ClockBaseFreeInterruptAll', 'ClockBaseFreeInterruptOnly', 'mainthread')
@@ -379,7 +438,7 @@ from kivy.compat import clock as _default_time
 import time
 try:
     from kivy._clock import CyClockBase, ClockEvent, FreeClockEvent, \
-        CyClockBaseFree
+        CyClockBaseFree, ClockNotRunningError
 except ImportError:
     Logger.error(
         'Clock: Unable to import kivy._clock. Have you perhaps forgotten to '
@@ -722,6 +781,12 @@ class ClockBaseBehavior(object):
         return self._last_tick - self._start_tick
 
     time = staticmethod(partial(_default_time))
+
+    def handle_exception(self, e):
+        from kivy.base import ExceptionManager
+
+        if ExceptionManager.handle_exception(e) == ExceptionManager.RAISE:
+            raise
 
 
 ClockBaseBehavior.time.__doc__ = \

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -631,12 +631,14 @@ if __name__ == '__main__':
         pprint('Got an error:')
         pprint(error)
 
+    Clock.start_clock()
     req = UrlRequest('https://en.wikipedia.org/w/api.php?format'
         '=json&action=query&titles=Kivy&prop=revisions&rvprop=content',
         on_success, on_error)
     while not req.is_finished:
         sleep(1)
         Clock.tick()
+    Clock.stop_clock()
 
     print('result =', req.result)
     print('error =', req.error)

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -290,6 +290,7 @@ class GraphicUnitTest(_base):
         '''
         from kivy.base import stopTouchApp
         from kivy.core.window import Window
+        from kivy.clock import Clock
         Window.unbind(on_flip=self.on_window_flip)
         stopTouchApp()
 

--- a/kivy/tests/conftest.py
+++ b/kivy/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
 
 try:
-    from .fixtures import kivy_app
+    from .fixtures import kivy_app, kivy_clock, kivy_exception_manager
 except SyntaxError:
     # async app tests would be skipped due to async_run forcing it to skip so
     # it's ok to fail here as it won't be used anyway

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -4,7 +4,43 @@ import weakref
 import time
 import os.path
 
-__all__ = ('kivy_app', )
+__all__ = ('kivy_clock', 'kivy_exception_manager', 'kivy_app', )
+
+
+@pytest.fixture()
+def kivy_clock():
+    from kivy.context import Context
+    from kivy.clock import ClockBase
+
+    context = Context(init=False)
+    context['Clock'] = ClockBase()
+    context.push()
+
+    from kivy.clock import Clock
+    Clock._max_fps = 0
+
+    try:
+        Clock.start_clock()
+        yield Clock
+        Clock.stop_clock()
+    finally:
+        context.pop()
+
+
+@pytest.fixture()
+def kivy_exception_manager():
+    from kivy.context import Context
+    from kivy.base import ExceptionManagerBase, ExceptionManager
+
+    context = Context(init=False)
+    context['ExceptionManager'] = ExceptionManagerBase()
+    context.push()
+
+    try:
+        yield ExceptionManager
+    finally:
+        context.pop()
+
 
 # keep track of all the kivy app fixtures so that we can check that it
 # properly dies

--- a/kivy/tests/test_clock.py
+++ b/kivy/tests/test_clock.py
@@ -2,37 +2,21 @@
 Clock tests
 ===========
 '''
-
+import gc
+import weakref
 import pytest
 
 
-@pytest.fixture
-def kivy_clock():
-    from kivy.context import Context
-    from kivy.clock import ClockBase
+class ClockCounter:
 
-    context = Context(init=False)
-    context['Clock'] = ClockBase()
-    context.push()
+    counter = 0
 
-    from kivy.clock import Clock
-    Clock._max_fps = 0
-
-    try:
-        yield Clock
-    finally:
-        context.pop()
+    def __call__(self, *args, **kwargs):
+        self.counter += 1
 
 
-@pytest.fixture
+@pytest.fixture()
 def clock_counter():
-    class ClockCounter:
-
-        counter = 0
-
-        def __call__(self, *args, **kwargs):
-            self.counter += 1
-
     yield ClockCounter()
 
 
@@ -145,3 +129,126 @@ def test_trigger_decorator_cancel(kivy_clock, clock_counter):
     triggered_callback.cancel()
     kivy_clock.tick()
     assert clock_counter.counter == 0
+
+
+def test_exception_caught(kivy_clock, clock_counter):
+    exception = None
+
+    def handle_test_exception(e):
+        nonlocal exception
+        exception = str(e)
+
+    # monkey patch to ignore exception
+    kivy_clock.handle_exception = handle_test_exception
+
+    def raise_exception(*args):
+        raise ValueError('Stooooop')
+
+    kivy_clock.schedule_once(raise_exception)
+    kivy_clock.schedule_once(clock_counter)
+    kivy_clock.tick()
+
+    assert clock_counter.counter == 1
+    assert exception == 'Stooooop'
+
+
+def test_exception_ignored(kivy_clock, clock_counter):
+    def raise_exception(*args):
+        raise ValueError('Stooooop')
+
+    kivy_clock.schedule_once(raise_exception)
+    kivy_clock.schedule_once(clock_counter)
+
+    with pytest.raises(ValueError):
+        kivy_clock.tick()
+
+    assert clock_counter.counter == 0
+
+
+def test_exception_caught_handler(
+        kivy_clock, clock_counter, kivy_exception_manager):
+    from kivy.base import ExceptionHandler
+    exception = None
+
+    class KivyHandler(ExceptionHandler):
+
+        def handle_exception(self, e):
+            nonlocal exception
+            exception = str(e)
+            return kivy_exception_manager.PASS
+    kivy_exception_manager.add_handler(KivyHandler())
+
+    def raise_exception(*args):
+        raise ValueError('Stooooop')
+
+    kivy_clock.schedule_once(raise_exception)
+    kivy_clock.schedule_once(clock_counter)
+    kivy_clock.tick()
+
+    assert clock_counter.counter == 1
+    assert exception == 'Stooooop'
+
+
+def test_clock_ended_callback(kivy_clock, clock_counter):
+    counter2 = ClockCounter()
+    event = kivy_clock.create_trigger(
+        clock_counter, clock_ended_callback=counter2)
+    event()
+    kivy_clock.stop_clock()
+    assert clock_counter.counter == 0
+    assert counter2.counter == 1
+
+
+def test_clock_ended_raises(kivy_clock, clock_counter):
+    from kivy.clock import ClockNotRunningError
+    kivy_clock.stop_clock()
+    with pytest.raises(ClockNotRunningError):
+        kivy_clock.schedule_once(clock_counter)
+    assert clock_counter.counter == 0
+
+
+def test_clock_stop_twice(kivy_clock, clock_counter):
+    counter2 = ClockCounter()
+    event = kivy_clock.create_trigger(
+        clock_counter, clock_ended_callback=counter2)
+    event()
+
+    kivy_clock.stop_clock()
+    assert clock_counter.counter == 0
+    assert counter2.counter == 1
+
+    kivy_clock.stop_clock()
+    assert clock_counter.counter == 0
+    assert counter2.counter == 1
+
+
+def test_clock_restart(kivy_clock):
+    kivy_clock.stop_clock()
+    with pytest.raises(TypeError):
+        kivy_clock.start_clock()
+
+
+def test_clock_event_trigger_ref(kivy_clock):
+    value = None
+
+    class Counter:
+        def call(self, *args, **kwargs):
+            nonlocal value
+            value = 42
+
+    event = kivy_clock.create_trigger(Counter().call)
+    gc.collect()
+    event()
+    kivy_clock.tick()
+    assert value is None
+
+    kivy_clock.schedule_once(Counter().call)
+    event()
+    kivy_clock.tick()
+    assert value is None
+
+    event = kivy_clock.create_trigger(Counter().call, release_ref=False)
+    gc.collect()
+    event()
+    kivy_clock.tick()
+    assert value == 42

--- a/kivy/tests/test_clock.py
+++ b/kivy/tests/test_clock.py
@@ -260,8 +260,10 @@ def test_clock_stop_twice(kivy_clock, clock_counter):
 
 def test_clock_restart(kivy_clock):
     kivy_clock.stop_clock()
-    with pytest.raises(TypeError):
-        kivy_clock.start_clock()
+    # with pytest.raises(TypeError):
+    #     kivy_clock.start_clock()
+    # for now it doesn't yet raise a error
+    kivy_clock.start_clock()
 
 
 def test_clock_event_trigger_ref(kivy_clock):

--- a/kivy/tests/test_filechooser_unicode.py
+++ b/kivy/tests/test_filechooser_unicode.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # XXX: please be careful to only save this file with an utf-8 editor
 import unittest
-from kivy.compat import PY2
+import pytest
 from kivy import platform
 unicode_char = chr
 
@@ -39,7 +39,7 @@ class FileChooserUnicodeTestCase(unittest.TestCase):
         \xc3\xa0\xc2\xa4\xc2\xb5\xc3\xa0\xc2\xa5\xe2\x82\xactestb',
         b'oor\xff\xff\xff\xff\xee\xfe\xef\x81\x8D\x99testb']
         self.ufiles = [join(basepathu, f) for f in ufiles]
-        self.bfiles = [join(basepathb, f) for f in bfiles] if PY2 else []
+        self.bfiles = []
         if not os.path.isdir(basepathu):
             os.mkdir(basepathu)
         for f in self.ufiles:
@@ -56,6 +56,10 @@ class FileChooserUnicodeTestCase(unittest.TestCase):
             myzip.extractall(path=basepathu)
         for f in self.exitsfiles:
             open(f, 'rb').close()
+
+    @pytest.fixture(autouse=True)
+    def set_clock(self, kivy_clock):
+        self.kivy_clock = kivy_clock
 
     def test_filechooserlistview_unicode(self):
         if self.skip_test:
@@ -74,13 +78,6 @@ class FileChooserUnicodeTestCase(unittest.TestCase):
         # unicode encoding to be able to compare to returned unicode
         for f in self.exitsfiles:
             self.assertIn(f, files)
-
-        if PY2:
-            wid = FileChooserListView(path=self.basepathb)
-            Clock.tick()
-            files = [join(self.basepathb, f) for f in wid.files]
-            for f in self.bfiles:
-                self.assertIn(f, files)
 
     def tearDown(self):
         if self.skip_test:

--- a/kivy/tests/test_multistroke.py
+++ b/kivy/tests/test_multistroke.py
@@ -1,3 +1,4 @@
+import pytest
 import unittest
 import kivy.multistroke
 from kivy.multistroke import Recognizer, MultistrokeGesture
@@ -54,6 +55,10 @@ class MultistrokeTestCase(unittest.TestCase):
             orientation_sensitive=False)
         self.Nbound = MultistrokeGesture('N', [NGesture],
             orientation_sensitive=True)
+
+    @pytest.fixture(autouse=True)
+    def set_clock(self, kivy_clock):
+        self.kivy_clock = kivy_clock
 
 # -----------------------------------------------------------------------------
 # Recognizer scheduling

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -3,6 +3,7 @@ Test properties attached to a widget
 '''
 
 import unittest
+import pytest
 from kivy.event import EventDispatcher
 from functools import partial
 
@@ -15,6 +16,10 @@ wid = _TestProperty()
 
 
 class PropertiesTestCase(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def set_clock(self, kivy_clock):
+        self.kivy_clock = kivy_clock
 
     def test_base(self):
         from kivy.properties import Property

--- a/kivy/tests/test_uix_translate_coordinates.py
+++ b/kivy/tests/test_uix_translate_coordinates.py
@@ -24,29 +24,27 @@ def is_relative_type(widget):
 
 
 @pytest.mark.parametrize('widget_cls_name', relative_type_widget_cls_names)
-def test_to_local_and_to_parent__relative(widget_cls_name):
-    from kivy.clock import Clock
+def test_to_local_and_to_parent__relative(widget_cls_name, kivy_clock):
     from kivy.factory import Factory
     widget = Factory.get(widget_cls_name)(pos=(100, 100))
-    Clock.tick()
+    kivy_clock.tick()
     assert widget.to_local(0, 0) == (-100, -100)
     assert widget.to_parent(0, 0) == (100, 100)
 
 
 @pytest.mark.parametrize('widget_cls_name', non_relative_type_widget_cls_names)
-def test_to_local_and_to_parent__not_relative(widget_cls_name):
-    from kivy.clock import Clock
+def test_to_local_and_to_parent__not_relative(widget_cls_name, kivy_clock):
     from kivy.factory import Factory
     widget = Factory.get(widget_cls_name)(pos=(100, 100))
-    Clock.tick()
+    kivy_clock.tick()
     assert widget.to_local(0, 0) == (0, 0)
     assert widget.to_parent(0, 0) == (0, 0)
 
 
 @pytest.mark.parametrize('root_widget_cls_name', all_widget_cls_names)
 @pytest.mark.parametrize('target_widget_cls_name', all_widget_cls_names)
-def test_to_window_and_to_widget(root_widget_cls_name, target_widget_cls_name):
-    from kivy.clock import Clock
+def test_to_window_and_to_widget(
+        root_widget_cls_name, target_widget_cls_name, kivy_clock):
     from textwrap import dedent
     from kivy.lang import Builder
     root = Builder.load_string(dedent('''
@@ -62,7 +60,7 @@ def test_to_window_and_to_widget(root_widget_cls_name, target_widget_cls_name):
                     id: target
                     pos: 0, 100
         ''').format(root_widget_cls_name, target_widget_cls_name))
-    Clock.tick()
+    kivy_clock.tick()
     target = root.ids.target
     if is_relative_type(root):
         assert target.to_window(*target.pos) == (100, 100)

--- a/kivy/tests/test_urlrequest.py
+++ b/kivy/tests/test_urlrequest.py
@@ -31,7 +31,7 @@ class UrlRequestQueue(object):
         self.queue.append((threading.get_ident(), 'progress', args))
 
 
-def test_callbacks():
+def test_callbacks(kivy_clock):
     if os.environ.get('NONETWORK'):
         return
     from kivy.network.urlrequest import UrlRequest

--- a/kivy/tools/benchmark.py
+++ b/kivy/tools/benchmark.py
@@ -168,6 +168,7 @@ if __name__ == '__main__':
 
     report = []
     report_newline = True
+    Clock.start_clock()
 
     def log(s, newline=True):
         global report_newline
@@ -252,6 +253,7 @@ if __name__ == '__main__':
     log('')
     log('Result: %.6f' % clock_total)
     log('')
+    Clock.stop_clock()
 
 try:
     reply = input(


### PR DESCRIPTION
This adds some features to clock as well as some docs cleanup.

The overall goal is to make Clock more reliable when interfacing with other threads. Specifically, to make sure that we don't end up in deadlock when the thread is waiting for something to be executed in the kivy thread, but the kivy thread has stopped because the app stopped and clock events are not executed anymore so the second thread gets stuck.

What it adds:

* A better defined clock lifecycle with a clock start and stop function that us called by the event loop.
  * If a event created with `create_lifecycle_aware_trigger` is triggered after the clock is stopped, a exception is raised because it would never be executed.
  * `create_lifecycle_aware_trigger` has an additional `clock_ended_callback` parameter. If the app exited normally, then either the `callback` or `clock_ended_callback` will have been called. The latter is called if the clock is stopped while the event is scheduled. 

    This allows e.g. a the other thread to be notified that the clock was stopped and the callback won't happen so that it can exit. That is, if triggering the event didn't raise a error, then we guarantee that either one of `callback` or `clock_ended_callback` will have been called by the time the clock stops.
 * A `release_ref` parameter that defaults to True was similarly added to `create_trigger` and `create_lifecycle_aware_trigger`. This allows more control, by preventing the callback from being garbage collected, if that's not desired.

    These ware only added to `create_trigger`/`create_lifecycle_aware_trigger` because it seemed better to leave the schedule_xxx methods simpler.

* Previously, an exception raised in a event's callback would cause the clock to crash and subsequent events may or may not be executed. Even if the exception was handled by the `ExceptionManager`, there was no guarantee that some scheduled events would not be skipped. This fixes it so that if a event's exception is handled by the `ExceptionManager`, other events will be shielded from the exception and will execute normally.
  We do it by adding `handle_exception` to clock that calls into the `ExceptionManager`.
* Fixed clock tests to use pytest and added more tests. Also fixed other tests that use the clock to use the new clock lifecycle.
* Adds better docs for the clock and for the `ExceptionManager`.