### PR TITLE
Fix and improve vim syntax highlighting for kv lang

### DIFF
--- a/kivy/tools/highlight/kivy.vim
+++ b/kivy/tools/highlight/kivy.vim
@@ -11,29 +11,30 @@ syn include @pyth $VIMRUNTIME/syntax/python.vim
 
 syn match kivyComment       /#.*\n/ display contains=pythonTodo,Spell
 syn match kivyPreProc       /^\s*#:.*/
-syn match kivyAttribute     /\I\i*/ nextgroup=kivyValue
-syn match kivyBind          /on_\I\i*:/ nextgroup=kivyValue
-syn match kivyRule          /<-*\I\i*\%([,@]s*\I\i*\)*>:/
+syn match kivyAttribute     /\I\i*/ nextgroup=kivyValue skipwhite
+syn match kivyBind          /on_\I\i*:/
+syn match kivyRule          /<-*\I\i*\%([,@+]\I\i*\)*>:/
+syn match kivyRule          /\[-*\I\i*\%([,@+]\I\i*\)*]:/
 syn match kivyRootRule      /^\I\i*:\s*$/
-syn match kivyInstruction   /^\s\+\u\i*:/ nextgroup=kivyValue
+syn match kivyInstruction   /^\s\+\u\i*:\s*/ contained nextgroup=kivyValue skipwhite skipempty
 syn match kivyWidget        /^\s\+\u\i*:/
 
-syn region kivyAttribute    start=/^\(\z(\s\+\)\)\l\+:\n\1\s\{4\}/ skip=/^\z1\s\{4\}.*$/ end=/^$/ contains=@pyth
+syn region kivyBindBlock    start=/^\(\z(\s\+\)\)on_\I\i*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth,kivyBind
+syn match kivyBindBlock     /on_\i\+:.*$/ contains=@pyth,kivyBind
 
-syn region kivyBind         start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4\}/ skip=/^\z1\s\{4\}.*$/ end=/^$/ contains=@pyth
-syn region kivyBind         start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4\}/ skip="^\s*$\|^\z1\s\{4\}" end="^\%(\z1\s\{4\}\)\@!"me=e-9999 contains=@pyth
-syn region kivyBind         start=/on_\i\+:\s/ end=/$/ contains=@pyth
+syn match kivyValue         /:.*$/ contained contains=@pyth
 
-syn match kivyValue         /\%(id\s*\)\@<!:\s*.*$/ contains=@pyth
-syn match kivyId            /\%(id:\s*\)\@<=\w\+/
+syn match kivyIdLine        /^\s\+id\s*:\s*\w\+\s*/ contains=kivyIdStart
+syn match kivyIdStart       /id\s*:/he=s+2 contained nextgroup=kivyId skipwhite
+syn match kivyId            /\w\+/ contained
 
-syn match kivyCanvas        /^\s*canvas.*:\s*$/ nextgroup=kivyInstruction
-syn region kivyCanvas       start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$\|^\z1\s\{4\}" end="^\%(\z1\s\{4\}\)\@!"me=e-9999 contains=kivyInstruction,kivyValue,kivyPreProc
+syn region kivyCanvas       start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=kivyInstruction,kivyPreProc,kivyComment
 
 hi def link kivyPreproc     PreProc
 hi def link kivyComment     Comment
 hi def link kivyRule        Type
 hi def link kivyRootRule    Function
+hi def link kivyIdStart     kivyAttribute
 hi def link kivyAttribute   Label
 hi def link kivyBind        Function
 hi def link kivyWidget      Function

--- a/kivy/tools/highlight/kivy.vim
+++ b/kivy/tools/highlight/kivy.vim
@@ -10,7 +10,7 @@ syntax clear
 syn include @pyth $VIMRUNTIME/syntax/python.vim
 
 syn match kivyComment       /#.*\n/ display contains=pythonTodo,Spell
-syn match kivyPreProc       /^#:.*/
+syn match kivyPreProc       /^\s*#:.*/
 syn match kivyAttribute     /\I\i*/ nextgroup=kivyValue
 syn match kivyBind          /on_\I\i*:/ nextgroup=kivyValue
 syn match kivyRule          /<-*\I\i*\([,@]s*\I\i*\)*>:/
@@ -18,17 +18,17 @@ syn match kivyRootRule      /^\I\i*:$/
 syn match kivyInstruction   /^\s\+\u\i*:/ nextgroup=kivyValue
 syn match kivyWidget        /^\s\+\u\i*:/
 
-syn region kivyAttribute start=/^\z(\s\+\)\l\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
+syn region kivyAttribute start=/^\(\z(\s\+\)\)\l\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
 
-syn region kivyBind start=/^\z(\s\+\)on_\i\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
-syn region kivyBind start=/^\z(\s\+\)on_\i\+:\n\1\s\{4}/ skip="^$\|^\z1\s{4}" end="^\z1\I"me=e-9999 contains=@pyth
+syn region kivyBind start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
+syn region kivyBind start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4}/ skip="^$\|^\z1\s{4}" end="^\z1\S"me=e-9999 contains=@pyth
 syn region kivyBind start=/on_\i\+:\s/ end=/$/ contains=@pyth
 
 syn match kivyValue /\(id\s*\)\@<!:\s*.*$/ contains=@pyth skipwhite
 syn match kivyId   /\(id:\s*\)\@<=\w\+/
 
 syn match kivyCanvas         /^\s*canvas.*:$/ nextgroup=kivyInstruction
-syn region kivyCanvas        start=/^\z(\s*\)canvas.*:$/ skip="^$\|^\z1\s{4}" end="^\z1\I"me=e-9999 contains=kivyInstruction,kivyValue
+syn region kivyCanvas        start=/^\z(\s*\)canvas.*:$/ skip="^$\|^\z1\s{4}" end="^\z1\S\|^\S"me=e-9999 keepend contains=kivyInstruction,kivyValue,kivyPreProc
 
 hi def link kivyPreproc      PreProc
 hi def link kivyComment      Comment

--- a/kivy/tools/highlight/kivy.vim
+++ b/kivy/tools/highlight/kivy.vim
@@ -16,16 +16,15 @@ syn match kivyRule          /\[-*\I\i*\%([,@+]\I\i*\)*]:/
 syn match kivyRootRule      /^\I\i*:\s*$/
 
 syn region kivyAttrBlock    matchgroup=kivyAttribute start=/^\z(\s\+\)\I\i*\s*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth
-syn region kivyAttrBlock    matchgroup=kivyAttribute start=/^\s\+\I\i*\s*:\%(\s*\S\)\@=/ end="$" oneline contains=@pyth
+syn region kivyAttrBlock    matchgroup=kivyAttribute start=/^\s\+\I\i*\s*:\%(\s*\S\)\@=/ end="$" keepend oneline contains=@pyth
 
-syn match kivyId            /\w\+/ contained
-syn region kivyIdBlock      matchgroup=kivyAttribute start=/^\s\+id\s*:/ end="$" oneline contains=kivyId
+syn region kivyId           matchgroup=kivyAttribute start=/^\s\+id\s*:\s*/ end="\w\+\zs" oneline
 
 syn region kivyBindBlock    matchgroup=kivyBind start=/^\z(\s\+\)on_\I\i*\s*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth
-syn region kivyBindBlock    matchgroup=kivyBind start=/^\s\+on_\i\+\s*:\%(\s*\S\)\@=/ end="$" oneline contains=@pyth
+syn region kivyBindBlock    matchgroup=kivyBind start=/^\s\+on_\i\+\s*:\%(\s*\S\)\@=/ end="$" keepend oneline contains=@pyth
 
 syn region kivyCanvasValue  matchgroup=kivyCanvas start=/^\z(\s\+\)\I\i*\s*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth contained
-syn region kivyCanvasValue  matchgroup=kivyCanvas start=/^\s\+\I\i*\s*:\%(\s*\S\)\@=/ end="$" oneline contains=@pyth contained
+syn region kivyCanvasValue  matchgroup=kivyCanvas start=/^\s\+\I\i*\s*:\%(\s*\S\)\@=/ end="$" keepend oneline contains=@pyth contained
 syn region kivyCanvas       matchgroup=kivyCanvas start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!"
                             \   contains=kivyInstruction,kivyPreProc,kivyComment,kivyCanvasValue
 

--- a/kivy/tools/highlight/kivy.vim
+++ b/kivy/tools/highlight/kivy.vim
@@ -3,7 +3,7 @@
 " Vim syntax file
 " Language:	Kivy
 " Maintainer:	Gabriel Pettier <gabriel.pettier@gmail.com>
-" Last Change:	2017 august 26
+" Last Change:	2020 June 23
 
 syntax clear
 
@@ -11,30 +11,31 @@ syn include @pyth $VIMRUNTIME/syntax/python.vim
 
 syn match kivyComment       /#.*\n/ display contains=pythonTodo,Spell
 syn match kivyPreProc       /^\s*#:.*/
-syn match kivyAttribute     /\I\i*/ nextgroup=kivyValue skipwhite
-syn match kivyBind          /on_\I\i*:/
 syn match kivyRule          /<-*\I\i*\%([,@+]\I\i*\)*>:/
 syn match kivyRule          /\[-*\I\i*\%([,@+]\I\i*\)*]:/
 syn match kivyRootRule      /^\I\i*:\s*$/
-syn match kivyInstruction   /^\s\+\u\i*:\s*/ contained
-syn match kivyWidget        /^\s\+\u\i*:/
 
-syn region kivyBindBlock    start=/^\(\z(\s\+\)\)on_\I\i*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth,kivyBind
-syn match kivyBindBlock     /on_\i\+:.*$/ contains=@pyth,kivyBind
+syn region kivyAttrBlock    matchgroup=kivyAttribute start=/^\z(\s\+\)\I\i*\s*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth
+syn region kivyAttrBlock    matchgroup=kivyAttribute start=/^\s\+\I\i*\s*:\%(\s*\S\)\@=/ end="$" oneline contains=@pyth
 
-syn match kivyValue         /:.*$/ contained contains=@pyth
-
-syn match kivyIdLine        /^\s\+id\s*:\s*\w\+\s*/ contains=kivyIdStart
-syn match kivyIdStart       /id\s*:/he=s+2 contained nextgroup=kivyId skipwhite
 syn match kivyId            /\w\+/ contained
+syn region kivyIdBlock      matchgroup=kivyAttribute start=/^\s\+id\s*:/ end="$" oneline contains=kivyId
 
-syn region kivyCanvas       start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=kivyInstruction,kivyValue,kivyPreProc,kivyComment
+syn region kivyBindBlock    matchgroup=kivyBind start=/^\z(\s\+\)on_\I\i*\s*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth
+syn region kivyBindBlock    matchgroup=kivyBind start=/^\s\+on_\i\+\s*:\%(\s*\S\)\@=/ end="$" oneline contains=@pyth
+
+syn region kivyCanvasValue  matchgroup=kivyCanvas start=/^\z(\s\+\)\I\i*\s*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth contained
+syn region kivyCanvasValue  matchgroup=kivyCanvas start=/^\s\+\I\i*\s*:\%(\s*\S\)\@=/ end="$" oneline contains=@pyth contained
+syn region kivyCanvas       matchgroup=kivyCanvas start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!"
+                            \   contains=kivyInstruction,kivyPreProc,kivyComment,kivyCanvasValue
+
+syn match kivyInstruction   /^\s\+\u\i*\s*:/ contained
+syn match kivyWidget        /^\s\+\u\i*\s*:/
 
 hi def link kivyPreproc     PreProc
 hi def link kivyComment     Comment
 hi def link kivyRule        Type
 hi def link kivyRootRule    Function
-hi def link kivyIdStart     kivyAttribute
 hi def link kivyAttribute   Label
 hi def link kivyBind        Function
 hi def link kivyWidget      Function
@@ -43,3 +44,5 @@ hi def link kivyInstruction Statement
 
 hi KivyId cterm=underline
 hi KivyPreproc cterm=bold
+
+let b:current_syntax = "kivy"

--- a/kivy/tools/highlight/kivy.vim
+++ b/kivy/tools/highlight/kivy.vim
@@ -16,7 +16,7 @@ syn match kivyBind          /on_\I\i*:/
 syn match kivyRule          /<-*\I\i*\%([,@+]\I\i*\)*>:/
 syn match kivyRule          /\[-*\I\i*\%([,@+]\I\i*\)*]:/
 syn match kivyRootRule      /^\I\i*:\s*$/
-syn match kivyInstruction   /^\s\+\u\i*:\s*/ contained nextgroup=kivyValue skipwhite skipempty
+syn match kivyInstruction   /^\s\+\u\i*:\s*/ contained
 syn match kivyWidget        /^\s\+\u\i*:/
 
 syn region kivyBindBlock    start=/^\(\z(\s\+\)\)on_\I\i*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=@pyth,kivyBind
@@ -28,7 +28,7 @@ syn match kivyIdLine        /^\s\+id\s*:\s*\w\+\s*/ contains=kivyIdStart
 syn match kivyIdStart       /id\s*:/he=s+2 contained nextgroup=kivyId skipwhite
 syn match kivyId            /\w\+/ contained
 
-syn region kivyCanvas       start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=kivyInstruction,kivyPreProc,kivyComment
+syn region kivyCanvas       start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$" end="^\%(\z1\s\{4}\)\@!" contains=kivyInstruction,kivyValue,kivyPreProc,kivyComment
 
 hi def link kivyPreproc     PreProc
 hi def link kivyComment     Comment

--- a/kivy/tools/highlight/kivy.vim
+++ b/kivy/tools/highlight/kivy.vim
@@ -13,32 +13,32 @@ syn match kivyComment       /#.*\n/ display contains=pythonTodo,Spell
 syn match kivyPreProc       /^\s*#:.*/
 syn match kivyAttribute     /\I\i*/ nextgroup=kivyValue
 syn match kivyBind          /on_\I\i*:/ nextgroup=kivyValue
-syn match kivyRule          /<-*\I\i*\([,@]s*\I\i*\)*>:/
-syn match kivyRootRule      /^\I\i*:$/
+syn match kivyRule          /<-*\I\i*\%([,@]s*\I\i*\)*>:/
+syn match kivyRootRule      /^\I\i*:\s*$/
 syn match kivyInstruction   /^\s\+\u\i*:/ nextgroup=kivyValue
 syn match kivyWidget        /^\s\+\u\i*:/
 
-syn region kivyAttribute start=/^\(\z(\s\+\)\)\l\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
+syn region kivyAttribute    start=/^\(\z(\s\+\)\)\l\+:\n\1\s\{4\}/ skip=/^\z1\s\{4\}.*$/ end=/^$/ contains=@pyth
 
-syn region kivyBind start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
-syn region kivyBind start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4}/ skip="^$\|^\z1\s{4}" end="^\z1\S"me=e-9999 contains=@pyth
-syn region kivyBind start=/on_\i\+:\s/ end=/$/ contains=@pyth
+syn region kivyBind         start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4\}/ skip=/^\z1\s\{4\}.*$/ end=/^$/ contains=@pyth
+syn region kivyBind         start=/^\(\z(\s\+\)\)on_\i\+:\n\1\s\{4\}/ skip="^\s*$\|^\z1\s\{4\}" end="^\%(\z1\s\{4\}\)\@!"me=e-9999 contains=@pyth
+syn region kivyBind         start=/on_\i\+:\s/ end=/$/ contains=@pyth
 
-syn match kivyValue /\(id\s*\)\@<!:\s*.*$/ contains=@pyth skipwhite
-syn match kivyId   /\(id:\s*\)\@<=\w\+/
+syn match kivyValue         /\%(id\s*\)\@<!:\s*.*$/ contains=@pyth
+syn match kivyId            /\%(id:\s*\)\@<=\w\+/
 
-syn match kivyCanvas         /^\s*canvas.*:$/ nextgroup=kivyInstruction
-syn region kivyCanvas        start=/^\z(\s*\)canvas.*:$/ skip="^$\|^\z1\s{4}" end="^\z1\S\|^\S"me=e-9999 keepend contains=kivyInstruction,kivyValue,kivyPreProc
+syn match kivyCanvas        /^\s*canvas.*:\s*$/ nextgroup=kivyInstruction
+syn region kivyCanvas       start=/^\z(\s\+\)canvas.*:\s*$/ skip="^\s*$\|^\z1\s\{4\}" end="^\%(\z1\s\{4\}\)\@!"me=e-9999 contains=kivyInstruction,kivyValue,kivyPreProc
 
-hi def link kivyPreproc      PreProc
-hi def link kivyComment      Comment
-hi def link kivyRule         Type
-hi def link kivyRootRule     Function
-hi def link kivyAttribute    Label
-hi def link kivyBind         Function
-hi def link kivyWidget       Function
-hi def link kivyCanvas       special
-hi def link kivyInstruction  Statement
+hi def link kivyPreproc     PreProc
+hi def link kivyComment     Comment
+hi def link kivyRule        Type
+hi def link kivyRootRule    Function
+hi def link kivyAttribute   Label
+hi def link kivyBind        Function
+hi def link kivyWidget      Function
+hi def link kivyCanvas      special
+hi def link kivyInstruction Statement
 
 hi KivyId cterm=underline
 hi KivyPreproc cterm=bold


### PR DESCRIPTION
Due to some errors and inconsistencies I've experienced with the vim syntax highlighting plugin I looked into that file and made the following changes. I tested it with vim 8.2.

* Fix back reference error (E65) in lines 21, 23, 24
* Reliably close kivyCanvas region when a widget block ends with a canvas block
* Be more generous to trailing whitespaces
* Highlight PreProc commands (`#:set ...`) below top-level

However there are still a few problems left that I can see where I'm not really sure what the best behavior would be or what the original intention was:

* Line 21: This assumes that attributes can have multiline expressions, which is not currently possible as far as I understand.
* Multiline expressions in kivyBind are currrently really wanky (you have to insert and delete a whitespace directly after `on_event:` to trigger it) as it clashes with line 25 for single line expressions. 
* Does line 23 add anything that's not covered by line 24?
* Also regarding kivyBind: the Function highlighting style doesn't work well with the python highlighting in longer expressions. 
* A _very_ minor issue: comments in a line after `#:set...` commands are still highlighted as kivyPreProc. Comments in the same line as `#:import...` fail the parser though, so maybe this should stay the way it is. 