### PR TITLE
Let ColorProperty accept arbitrary list types.

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -2005,20 +2005,23 @@ cdef class ColorProperty(Property):
     cdef convert(self, EventDispatcher obj, x):
         if x is None:
             return x
-        tp = type(x)
-        if tp is list or tp is tuple:
-            if len(x) == 4:
-                return ObservableList(self, obj, x)
-            if len(x) == 3:
-                return ObservableList(self, obj, list(x) + [1])
-            raise ValueError(
-                '{}.{} must have 3 or 4 components (got {!r})'
-                .format(obj.__class__.__name__, self.name, x)
-            )
-        elif isinstance(x, string_types):
+        if isinstance(x, string_types):
             return ObservableList(self, obj, self.parse_str(obj, x))
+
+        try:
+            count = len(x)
+        except TypeError as e:
+            raise ValueError(
+                '{}.{} has an invalid format (got {!r})'
+                .format(obj.__class__.__name__, self.name, x)
+            ) from e
+
+        if count == 4:
+            return ObservableList(self, obj, x)
+        if count == 3:
+            return ObservableList(self, obj, list(x) + [1])
         raise ValueError(
-            '{}.{} has an invalid format (got {!r})'
+            '{}.{} must have 3 or 4 components (got {!r})'
             .format(obj.__class__.__name__, self.name, x)
         )
 

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -435,6 +435,11 @@ class PropertiesTestCase(unittest.TestCase):
         color.link_deps(wid, 'color')
         self.assertEqual(color.get(wid), [1, 1, 1, 1])
 
+        color2 = ColorProperty()
+        color2.link(wid, 'color2')
+        color2.link_deps(wid, 'color2')
+        self.assertEqual(color2.get(wid), [1, 1, 1, 1])
+
         color.set(wid, "#00ff00")
         self.assertEqual(color.get(wid), [0, 1, 0, 1])
 
@@ -453,6 +458,10 @@ class PropertiesTestCase(unittest.TestCase):
         color_value = color.get(wid)
         color_value[0] = 0.5
         self.assertEqual(color.get(wid), [0.5, 1, 1, 1])
+
+        self.assertEqual(color2.get(wid), [1, 1, 1, 1])
+        color2.set(wid, color.get(wid))
+        self.assertEqual(color2.get(wid), [0.5, 1, 1, 1])
 
         color.set(wid, [1, 1, 1, 1])
         color_value = color.get(wid)


### PR DESCRIPTION
Previously it seemed to fail when we set a color property with the value of another color property because we specifically checked if it's a list or tuple. But there are other list types (e.g. ObservableList).