### PR TITLE
Remove 'img_gif' entry from image_libs

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -987,8 +987,7 @@ else:
     image_libs += [('pygame', 'img_pygame')]
 image_libs += [
     ('ffpy', 'img_ffpyplayer'),
-    ('pil', 'img_pil'),
-    ('gif', 'img_gif')]
+    ('pil', 'img_pil')]
 
 libs_loaded = core_register_libs('image', image_libs)
 


### PR DESCRIPTION
Module `kivy/core/image/img_gif.py` got remove by https://github.com/kivy/kivy/pull/6721 and this pr removes "img_gif" from `kivy/core/image/__init__.py`.