### PR TITLE
Raise KeyError if None is used as key in Cache

### DIFF
--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -88,9 +88,10 @@ class Cache(object):
         if key is None:
             # This check is added because of the case when None is used key and
             # one of purge methods gets called. Then loop in purge method will
-            # call Cache.remove with key None which then removes entire
+            # call Cache.remove with key None which then clears entire
             # category from Cache making next iteration of loop to raise a
             # KeyError.
+            # See: https://github.com/kivy/kivy/pull/6950
             raise ValueError('"None" cannot be used as key in Cache')
         try:
             cat = Cache._categories[category]

--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -74,10 +74,24 @@ class Cache(object):
             `timeout`: double (optional)
                 Time after which to delete the object if it has not been used.
                 If None, no timeout is applied.
+
+        :raises:
+            `ValueError`: If `None` is used as `key`.
+
+        .. versionchanged:: 2.0.0
+            Raises `ValueError` if `None` is used as `key`.
+
         '''
         # check whether obj should not be cached first
         if getattr(obj, '_nocache', False):
             return
+        if key is None:
+            # This check is added because of the case when None is used key and
+            # one of purge methods gets called. Then loop in purge method will
+            # call Cache.remove with key None which then removes entire
+            # category from Cache making next iteration of loop to raise a
+            # KeyError.
+            raise ValueError('"None" cannot be used as key in Cache')
         try:
             cat = Cache._categories[category]
         except KeyError:

--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -86,11 +86,11 @@ class Cache(object):
         if getattr(obj, '_nocache', False):
             return
         if key is None:
-            # This check is added because of the case when None is used key and
+            # This check is added because of the case when key is None and
             # one of purge methods gets called. Then loop in purge method will
             # call Cache.remove with key None which then clears entire
             # category from Cache making next iteration of loop to raise a
-            # KeyError.
+            # KeyError because next key will not exist.
             # See: https://github.com/kivy/kivy/pull/6950
             raise ValueError('"None" cannot be used as key in Cache')
         try:


### PR DESCRIPTION
Continuation of point (1) from https://github.com/kivy/kivy/pull/6815.
Request ensures that `None` cannot be used as key in Cache and avoids KeyError when purging of Cache occurs. 
If `None` is set as key then loop in `_purge_by_timeout` or `_purge_oldest` will call `Cache.remove` with `None` as key and clear entire category which will result in `KeyError` be raised in next iteration of the loop.