### PR TITLE
Ignore ca_file on http scheme, fixes #6946

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -334,7 +334,8 @@ class UrlRequest(Thread):
         if timeout is not None:
             args['timeout'] = timeout
 
-        if ca_file is not None and hasattr(ssl, 'create_default_context'):
+        if (ca_file is not None and hasattr(ssl, 'create_default_context') and
+                parse.scheme == 'https'):
             ctx = ssl.create_default_context(cafile=ca_file)
             ctx.verify_mode = ssl.CERT_REQUIRED
             args['context'] = ctx


### PR DESCRIPTION
Don't pass a `context` keyword argument for `HTTPConnection`.
The error was:
```
 TypeError: __init__() got an unexpected keyword argument 'context'
 ```