### PR TITLE
Issue #6932: Correct comments to use proportion, not percent

### DIFF
--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -175,7 +175,8 @@ class VideoBase(EventDispatcher):
         pass
 
     def seek(self, percent, precise=True):
-        '''Move to position as percentage (strictly, a proportion from 0 - 1) of the duration'''
+        '''Move to position as percentage (strictly, a proportion from
+            0 - 1) of the duration'''
         pass
 
     def stop(self):

--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -175,7 +175,7 @@ class VideoBase(EventDispatcher):
         pass
 
     def seek(self, percent, precise=True):
-        '''Move on percent position'''
+        '''Move to position as percentage (strictly, a proportion from 0 - 1) of the duration'''
         pass
 
     def stop(self):

--- a/kivy/uix/layout.py
+++ b/kivy/uix/layout.py
@@ -25,10 +25,10 @@ layouts to manage the sizes of their children. It indicates the size
 relative to the layout's size instead of an absolute size (in
 pixels/points/cm/etc). The format is::
 
-    widget.size_hint = (width_percent, height_percent)
+    widget.size_hint = (width_proportion, height_proportion)
 
-The percent is specified as a floating point number in the range 0-1. For
-example, 0.5 is 50%, 1 is 100%.
+The proportions are specified as floating point numbers in the range 0-1. For
+example, 0.5 represents 50%, 1 represents 100%.
 
 If you want a widget's width to be half of the parent's width and the
 height to be identical to the parent's height, you would do::

--- a/kivy/uix/pagelayout.py
+++ b/kivy/uix/pagelayout.py
@@ -63,7 +63,7 @@ class PageLayout(Layout):
     '''
 
     swipe_threshold = NumericProperty(.5)
-    '''The thresold used to trigger swipes as percentage of the widget
+    '''The threshold used to trigger swipes as ratio of the widget
     size.
 
     :data:`swipe_threshold` is a :class:`~kivy.properties.NumericProperty`

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -317,7 +317,7 @@ class ScrollView(StencilView):
     .. versionadded:: 1.2.0
 
     The position and size are normalized between 0-1, and represent a
-    percentage of the current scrollview height. This property is used
+    proportion of the current scrollview height. This property is used
     internally for drawing the little vertical bar when you're scrolling.
 
     :attr:`vbar` is a :class:`~kivy.properties.AliasProperty`, readonly.
@@ -346,7 +346,7 @@ class ScrollView(StencilView):
     .. versionadded:: 1.2.0
 
     The position and size are normalized between 0-1, and represent a
-    percentage of the current scrollview height. This property is used
+    proportion of the current scrollview height. This property is used
     internally for drawing the little horizontal bar when you're scrolling.
 
     :attr:`vbar` is a :class:`~kivy.properties.AliasProperty`, readonly.

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -140,11 +140,13 @@ class Video(Image):
             self._trigger_video_load()
 
     def seek(self, percent, precise=True):
-        '''Change the position to a percentage (strictly, a proportion) of duration.
+        '''Change the position to a percentage (strictly, a proportion)
+           of duration.
 
         :Parameters:
             `percent`: float or int
-                Position to seek as a proportion of the total duration, must be between 0-1.
+                Position to seek as a proportion of the total duration,
+                must be between 0-1.
             `precise`: bool, defaults to True
                 Precise seeking is slower, but seeks to exact requested
                 percent.

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -140,11 +140,11 @@ class Video(Image):
             self._trigger_video_load()
 
     def seek(self, percent, precise=True):
-        '''Change the position to a percentage of duration.
+        '''Change the position to a percentage (strictly, a proportion) of duration.
 
         :Parameters:
             `percent`: float or int
-                Position to seek, must be between 0-1.
+                Position to seek as a proportion of the total duration, must be between 0-1.
             `precise`: bool, defaults to True
                 Precise seeking is slower, but seeks to exact requested
                 percent.

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -587,11 +587,11 @@ class VideoPlayer(GridLayout):
                 self.container.add_widget(label)
 
     def seek(self, percent, precise=True):
-        '''Change the position to a percentage of duration.
+        '''Change the position to a percentage (strictly, a proportion) of duration.
 
         :Parameters:
             `percent`: float or int
-                Position to seek, must be between 0-1.
+                Position to seek as a proportion of total duration, must be between 0-1.
             `precise`: bool, defaults to True
                 Precise seeking is slower, but seeks to exact requested
                 percent.

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -587,11 +587,13 @@ class VideoPlayer(GridLayout):
                 self.container.add_widget(label)
 
     def seek(self, percent, precise=True):
-        '''Change the position to a percentage (strictly, a proportion) of duration.
+        '''Change the position to a percentage (strictly, a proportion)
+           of duration.
 
         :Parameters:
             `percent`: float or int
-                Position to seek as a proportion of total duration, must be between 0-1.
+                Position to seek as a proportion of total duration, must
+                be between 0-1.
             `precise`: bool, defaults to True
                 Precise seeking is slower, but seeks to exact requested
                 percent.


### PR DESCRIPTION
A number of comments refer to numbers in the range of 0-1 as "percent" or "percentages". These are ratios, or proportions, not percentages.

Did NOT correct parameter names in interfaces for fear of breaking existing clients. Just made the comments clearer.