### PR TITLE
graphics: fix ignored alpha value in hsv mode

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -243,7 +243,7 @@ cdef class Color(ContextInstruction):
         cdef long vec_size = <long>len(args)
         if kwargs.get('mode', '') == 'hsv':
             if vec_size == 4:
-                self.rgba = [0, 0, 0, 1.]
+                self.rgba = [0, 0, 0, args[3]]
                 self.hsv = args[:3]
             elif vec_size == 3:
                 self.rgba = [0, 0, 0, 1.]


### PR DESCRIPTION
In the issue #6590 was reported that the alpha value was being ignored
when using the hsv mode in the Color instruction. After inspecting the
code, I realised it was because the `a` value was defined as 1.0, no
matter which value was provided by the user.

To solve it, I set the `a` value to what the user provides, or 1.0 if
`a` is not provided.

I tested with the code in #6590 and the following:

```py
from kivy.app import App
from kivy.uix.widget import Widget
from kivy.lang import Builder

KV = """
<Rectangles>:
    canvas:
        Color:
            hsv: 0.0, 0.0, 0.0
        Rectangle:
            size: 800, 800

        Color:
            hsv: 0.0, 1.0, 0.0
            a: 0.1
        Rectangle:
            size: 400, 400
"""


class Rectangles(Widget):
    pass


class MyApp(App):
    def build(self):
        Builder.load_string(KV)
        return Rectangles()


if __name__ == "__main__":
    MyApp().run()

```

In this code, if you define `a: 1.0` in the smallest rectangle, its
color should be "light red". With `a: 0.1`, the rectangle's color
becomes "dark red".

Fixes #6590.
