### PR TITLE
Accept numeric instances in NumericProperty

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -635,18 +635,16 @@ cdef class NumericProperty(Property):
     cdef check(self, EventDispatcher obj, value):
         if Property.check(self, obj, value):
             return True
-        if type(value) not in (int, float, long):
-            raise ValueError('%s.%s accept only int/float/long (got %r)' % (
+        if not isinstance(value, (int, float, long)):
+            raise ValueError('%s.%s accept only instances of int/float/long'
+                             '(got %r)' % (
                 obj.__class__.__name__,
                 self.name, value))
 
     cdef convert(self, EventDispatcher obj, x):
-        if x is None:
+        if x is None or isinstance(x, (int, float, long)):
             return x
-        tp = type(x)
-        if tp is int or tp is float or tp is long:
-            return x
-        if tp is tuple or tp is list:
+        if isinstance(x, (tuple, list)):
             if len(x) != 2:
                 raise ValueError('%s.%s must have 2 components (got %r)' % (
                     obj.__class__.__name__,


### PR DESCRIPTION
NumericProperty class only accepts int, float, long, tuple and list
types. Because of that, numeric instances like numpy's float64 raise a
ValueError exception. For example, this code will crash (it is
simplified to focus on the error only):

```py
import numpy as np
from kivy.uix.widget import Widget
from kivy.properties import NumericProperty


class CrashWidget(Widget):
    array_of_numbers = np.array([1.0])
    numeric_value = NumericProperty(array_of_numbers[0])


if __name__ == "__main__":
    CrashWidget()
```

For the NumericProperty class, array_of_numbers[0] is not a valid type
because it is not one of int, float, long, tuple or list. However, it is
an instance of float (`isinstance(array_of_numbers[0], float)` is True).
That said, the proposed solution is to check for the instance of the
accepted NumericProperty types instead of checking for specific types
only.

Fixes #6982