### PR TITLE
Fix scrollview scroll/effect recursion

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -140,6 +140,7 @@ All the effects are located in the :mod:`kivy.effects`.
 '''
 
 __all__ = ('ScrollView', )
+
 from functools import partial
 from kivy.animation import Animation
 from kivy.compat import string_types

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -568,8 +568,6 @@ class ScrollView(StencilView):
         fbind('scroll_y', trigger_update_from_scroll)
         fbind('pos', trigger_update_from_scroll)
         fbind('size', trigger_update_from_scroll)
-        fbind('scroll_y', self._update_effect_bounds)
-        fbind('scroll_x', self._update_effect_bounds)
 
         trigger_update_from_scroll()
         update_effect_widget()
@@ -751,6 +749,8 @@ class ScrollView(StencilView):
                 e = self.effect_y if ud['in_bar_y'] else self.effect_x
 
             if e:
+                # make sure the effect's value is synced to scroll value
+                self._update_effect_bounds()
                 if btn in ('scrolldown', 'scrollleft'):
                     if self.smooth_scroll_end:
                         e.velocity -= m * self.smooth_scroll_end
@@ -803,12 +803,18 @@ class ScrollView(StencilView):
 
         if (self.do_scroll_x and self.effect_x and not ud['in_bar_x']
                 and not ud['in_bar_y']):
+            # make sure the effect's value is synced to scroll value
+            self._update_effect_bounds()
+
             self._effect_x_start_width = self.width
             self.effect_x.start(touch.x)
             self._scroll_x_mouse = self.scroll_x
 
         if (self.do_scroll_y and self.effect_y and not ud['in_bar_x']
                 and not ud['in_bar_y']):
+            # make sure the effect's value is synced to scroll value
+            self._update_effect_bounds()
+
             self._effect_y_start_height = self.height
             self.effect_y.start(touch.y)
             self._scroll_y_mouse = self.scroll_y

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -140,7 +140,7 @@ All the effects are located in the :mod:`kivy.effects`.
 '''
 
 __all__ = ('ScrollView', )
-
+from typing import Optional, Type
 from functools import partial
 from kivy.animation import Animation
 from kivy.compat import string_types
@@ -149,6 +149,7 @@ from kivy.clock import Clock
 from kivy.factory import Factory
 from kivy.uix.stencilview import StencilView
 from kivy.metrics import sp, dp
+from kivy.effects.scroll import ScrollEffect
 from kivy.effects.dampedscroll import DampedScrollEffect
 from kivy.properties import NumericProperty, BooleanProperty, AliasProperty, \
     ObjectProperty, ListProperty, ReferenceListProperty, OptionProperty, \
@@ -428,7 +429,8 @@ class ScrollView(StencilView):
     to 0
     '''
 
-    effect_cls = ObjectProperty(DampedScrollEffect, allownone=True)
+    effect_cls: Optional[Type[ScrollEffect]] = ObjectProperty(
+        DampedScrollEffect, allownone=True)
     '''Class effect to instantiate for X and Y axis.
 
     .. versionadded:: 1.7.0
@@ -442,7 +444,7 @@ class ScrollView(StencilView):
 
     '''
 
-    effect_x = ObjectProperty(None, allownone=True)
+    effect_x: Optional[ScrollEffect] = ObjectProperty(None, allownone=True)
     '''Effect to apply for the X axis. If None is set, an instance of
     :attr:`effect_cls` will be created.
 
@@ -452,7 +454,7 @@ class ScrollView(StencilView):
     defaults to None.
     '''
 
-    effect_y = ObjectProperty(None, allownone=True)
+    effect_y: Optional[ScrollEffect] = ObjectProperty(None, allownone=True)
     '''Effect to apply for the Y axis. If None is set, an instance of
     :attr:`effect_cls` will be created.
 
@@ -799,12 +801,14 @@ class ScrollView(StencilView):
             'time': touch.time_start,
         }
 
-        if self.do_scroll_x and self.effect_x and not ud['in_bar_x']:
+        if (self.do_scroll_x and self.effect_x and not ud['in_bar_x']
+                and not ud['in_bar_y']):
             self._effect_x_start_width = self.width
             self.effect_x.start(touch.x)
             self._scroll_x_mouse = self.scroll_x
 
-        if self.do_scroll_y and self.effect_y and not ud['in_bar_y']:
+        if (self.do_scroll_y and self.effect_y and not ud['in_bar_x']
+                and not ud['in_bar_y']):
             self._effect_y_start_height = self.height
             self.effect_y.start(touch.y)
             self._scroll_y_mouse = self.scroll_y

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -140,7 +140,6 @@ All the effects are located in the :mod:`kivy.effects`.
 '''
 
 __all__ = ('ScrollView', )
-from typing import Optional, Type
 from functools import partial
 from kivy.animation import Animation
 from kivy.compat import string_types
@@ -149,7 +148,6 @@ from kivy.clock import Clock
 from kivy.factory import Factory
 from kivy.uix.stencilview import StencilView
 from kivy.metrics import sp, dp
-from kivy.effects.scroll import ScrollEffect
 from kivy.effects.dampedscroll import DampedScrollEffect
 from kivy.properties import NumericProperty, BooleanProperty, AliasProperty, \
     ObjectProperty, ListProperty, ReferenceListProperty, OptionProperty, \
@@ -429,8 +427,7 @@ class ScrollView(StencilView):
     to 0
     '''
 
-    effect_cls: Optional[Type[ScrollEffect]] = ObjectProperty(
-        DampedScrollEffect, allownone=True)
+    effect_cls = ObjectProperty(DampedScrollEffect, allownone=True)
     '''Class effect to instantiate for X and Y axis.
 
     .. versionadded:: 1.7.0
@@ -444,7 +441,7 @@ class ScrollView(StencilView):
 
     '''
 
-    effect_x: Optional[ScrollEffect] = ObjectProperty(None, allownone=True)
+    effect_x = ObjectProperty(None, allownone=True)
     '''Effect to apply for the X axis. If None is set, an instance of
     :attr:`effect_cls` will be created.
 
@@ -454,7 +451,7 @@ class ScrollView(StencilView):
     defaults to None.
     '''
 
-    effect_y: Optional[ScrollEffect] = ObjectProperty(None, allownone=True)
+    effect_y = ObjectProperty(None, allownone=True)
     '''Effect to apply for the Y axis. If None is set, an instance of
     :attr:`effect_cls` will be created.
 


### PR DESCRIPTION
Fixes #5638 fixes #1078

Starting with https://github.com/kivy/kivy/commit/dce021f9d6d4b20f32e93876302c89e27e1b3f44 (which appears to be a fix for https://github.com/kivy/kivy/issues/1078), whenever `scroll_x` or `scroll_y` changed, the `value` of the effect was also updated. IMO this is a buggy change because it may lead to recursion.

Normally, there's no recursion because the effect's `value` and the scroll value in the scrollview are synchronized so they are identical. The problem is that while the scroll effect is active, if the `viewport` size when the effect is started is different from the current size they go out of sync. That's because while the affect is active we use the original widget size (`sw = vp.width - self._effect_x_start_width`), not the current widget size (https://github.com/kivy/kivy/blob/master/kivy/uix/scrollview.py#L630).

This leads to the recursion issue when resizing while the scroll effect is active. Still, why does the linked issue crash even after the effect should have stopped? Because if dragging in one of the bars, the effect is never stopped, so once you drag, it always executes the bad recursive scroll update path.

This fixes that problem by disabling the effect when scrolling on the bars as originally intended (first commit).

But, this wouldn't fix the larger problem because if you were to resize it while the effect is active you'd likely get the same recursion problem. Instead, this recursion problem is fixed by removing the binding `fbind('scroll_x', self._update_effect_bounds)` and `fbind('scroll_y', self._update_effect_bounds)` that causes recursion. Instead, to fix the original issue demonstrated in the following example, we simply make sure the effect is initialized to the current scroll value when the effect is started (second commit).

Ah, and I also added some typing that was useful while debugging to help my IDE.

(copied from https://github.com/kivy/kivy/commit/dce021f9d6d4b20f32e93876302c89e27e1b3f44)
```py
from kivy.uix.scrollview import ScrollView
from kivy.app import App
from kivy.uix.button import Button
from kivy.uix.gridlayout import GridLayout
from kivy.clock import Clock


class Root(ScrollView):
    def __init__(self, **kwargs):
        super(Root, self).__init__(**kwargs)

    def after_init(self):
        grid = GridLayout(cols=1, size_hint_y=None)
        grid.bind(minimum_height=lambda w,v: setattr(grid, 'height', v))
        self.add_widget(grid)
        for i in range(200):
            new = Button(text=str(i), size_hint_y=None, height=100)
            grid.add_widget(new)


class Test(App):
    def build(self):
        root = Root()
        root.after_init()
        Clock.schedule_once(lambda *a: setattr(root, 'scroll_y', 0.5), 0)
        return root


app = Test()
app.run()
```