### PR TITLE
Add kwargs to 'sort' method of ObservableList

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -771,8 +771,8 @@ class ObservableList(list):
         self.last_op = 'extend', None
         observable_list_dispatch(self)
 
-    def sort(self, *largs):
-        list.sort(self, *largs)
+    def sort(self, *largs, **kwargs):
+        list.sort(self, *largs, **kwargs)
         self.last_op = 'sort', None
         observable_list_dispatch(self)
 


### PR DESCRIPTION
Makes passing of `reverse` and `key` arguments possible to `sort` method of `ListProperty` which uses `ObserbableList` as internal storage. 

Fixes https://github.com/kivy/kivy/issues/5694. 