### PR TITLE
Use ColorProperty for remaining color properites

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -262,7 +262,7 @@ class LabelBase(object):
 
         kwargs_get = kwargs.get
         options['color'] = color or (1, 1, 1, 1)
-        options['outline_color'] = outline_color or (0, 0, 0)
+        options['outline_color'] = outline_color or (0, 0, 0, 1)
         options['padding'] = kwargs_get('padding', (0, 0))
         if not isinstance(options['padding'], (list, tuple)):
             options['padding'] = (options['padding'], options['padding'])

--- a/kivy/uix/gesturesurface.py
+++ b/kivy/uix/gesturesurface.py
@@ -22,7 +22,7 @@ from kivy.vector import Vector
 from kivy.uix.floatlayout import FloatLayout
 from kivy.graphics import Color, Line, Rectangle
 from kivy.properties import (NumericProperty, BooleanProperty,
-                             DictProperty, ListProperty)
+                             DictProperty, ColorProperty)
 from colorsys import hsv_to_rgb
 
 # Clock undershoot margin, FIXME: this is probably too high?
@@ -238,9 +238,13 @@ class GestureSurface(FloatLayout):
             Color used to draw the gesture, in RGB. This option does not
             have an effect if :attr:`use_random_color` is True.
 
-            :attr:`draw_timeout` is a
-            :class:`~kivy.properties.ListProperty` and defaults to
-            [1, 1, 1] (white)
+            :attr:`color` is a
+            :class:`~kivy.properties.ColorProperty` and defaults to
+            [1, 1, 1, 1] (white)
+
+            .. versionchanged:: 2.0.0
+                Changed from :class:`~kivy.properties.ListProperty` to
+                :class:`~kivy.properties.ColorProperty`.
 
         `use_random_color`
             Set to True to pick a random color for each gesture, if you do
@@ -310,7 +314,7 @@ class GestureSurface(FloatLayout):
     bbox_margin = NumericProperty(30)
 
     line_width = NumericProperty(2)
-    color = ListProperty([1., 1., 1.])
+    color = ColorProperty([1., 1., 1., 1.])
     use_random_color = BooleanProperty(False)
     draw_bbox = BooleanProperty(False)
     bbox_alpha = NumericProperty(0.1)

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -783,7 +783,7 @@ class Label(Widget):
     defaults to None.
     '''
 
-    outline_color = ListProperty([0, 0, 0])
+    outline_color = ColorProperty([0, 0, 0, 1])
     '''The color of the text outline, in the (r, g, b) format.
 
     .. note::
@@ -791,11 +791,16 @@ class Label(Widget):
 
     .. versionadded:: 1.10.0
 
-    :attr:`outline_color` is a :class:`~kivy.properties.ListProperty` and
-    defaults to [0, 0, 0].
+    :attr:`outline_color` is a :class:`~kivy.properties.ColorProperty` and
+    defaults to [0, 0, 0, 1].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`. Alpha component is ignored
+        and assigning value to it has no effect.
     '''
 
-    disabled_outline_color = ListProperty([0, 0, 0])
+    disabled_outline_color = ColorProperty([0, 0, 0, 1])
     '''The color of the text outline when the widget is disabled, in the
     (r, g, b) format.
 
@@ -804,8 +809,13 @@ class Label(Widget):
 
     .. versionadded:: 1.10.0
 
-    :attr:`disabled_outline_color` is a :class:`~kivy.properties.ListProperty`
+    :attr:`disabled_outline_color` is a :class:`~kivy.properties.ColorProperty`
     and defaults to [0, 0, 0].
+
+    .. versionchanged:: 2.0.0
+        Changed from :class:`~kivy.properties.ListProperty` to
+        :class:`~kivy.properties.ColorProperty`. Alpha component is ignored
+        and assigning value to it has no effect.
     '''
 
     texture = ObjectProperty(None, allownone=True)


### PR DESCRIPTION
Continuation of https://github.com/kivy/kivy/pull/6918

Use ColorProperty for:
- GestureSurface.color
- Label.outline_color
- Label.disabled_outline_color