### PR TITLE
Fix GI camera provider crash when no texture is available after loading

### DIFF
--- a/kivy/uix/camera.py
+++ b/kivy/uix/camera.py
@@ -90,7 +90,9 @@ class Camera(Image):
         fbind('resolution', on_index)
         on_index()
 
-    def on_tex(self, *l):
+    def on_tex(self, camera):
+        self.texture = texture = camera.texture
+        self.texture_size = list(texture.size)
         self.canvas.ask_update()
 
     def _on_index(self, *largs):
@@ -102,14 +104,9 @@ class Camera(Image):
         else:
             self._camera = CoreCamera(index=self.index,
                                   resolution=self.resolution, stopped=True)
-        self._camera.bind(on_load=self._camera_loaded)
         if self.play:
             self._camera.start()
             self._camera.bind(on_texture=self.on_tex)
-
-    def _camera_loaded(self, *largs):
-        self.texture = self._camera.texture
-        self.texture_size = list(self.texture.size)
 
     def on_play(self, instance, value):
         if not self._camera:


### PR DESCRIPTION
Traceback:

```
   File "/home/cheaterman/Dev/Kivy/kivy/core/camera/camera_gi.py", line 137, in _update
     self.dispatch('on_load')
   File "kivy/_event.pyx", line 705, in kivy._event.EventDispatcher.dispatch
   File "kivy/_event.pyx", line 1248, in kivy._event.EventObservers.dispatch
   File "kivy/_event.pyx", line 1172, in kivy._event.EventObservers._dispatch
   File "/home/cheaterman/Dev/Kivy/kivy/uix/camera.py", line 112, in _camera_loaded
     self.texture_size = list(self.texture.size)
 AttributeError: 'NoneType' object has no attribute 'size'
```

Also see #6971.