### PR TITLE
Added support for the mouse4 and mouse5 buttons

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -539,6 +539,10 @@ class WindowSDL(WindowBase):
                     btn = 'right'
                 elif button == 2:
                     btn = 'middle'
+                elif button == 4:
+                    btn = "mouse4"
+                elif button == 5:
+                    btn = "mouse5"
                 eventname = 'on_mouse_down'
                 self._mouse_buttons_down.add(button)
                 if action == 'mousebuttonup':


### PR DESCRIPTION
I added support to kivy for the mouse4 and mouse5 buttons that some mice have. I simply check for them just like how the right and middle buttons are checked.