### PR TITLE
Horizontal scrolling disabled if no overflow

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -895,7 +895,7 @@ class ScrollView(StencilView):
                     and self.effect_x:
                 width = self.width
                 if touch.ud.get('in_bar_x', False):
-                    if self.hbar[1]!=1:
+                    if self.hbar[1] != 1:
                         dx = touch.dx / float(width - width * self.hbar[1])
                         self.scroll_x = min(max(self.scroll_x + dx, 0.), 1.)
                         self._trigger_update_from_scroll()

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -895,9 +895,10 @@ class ScrollView(StencilView):
                     and self.effect_x:
                 width = self.width
                 if touch.ud.get('in_bar_x', False):
-                    dx = touch.dx / float(width - width * self.hbar[1])
-                    self.scroll_x = min(max(self.scroll_x + dx, 0.), 1.)
-                    self._trigger_update_from_scroll()
+                    if self.hbar[1]!=1:
+                        dx = touch.dx / float(width - width * self.hbar[1])
+                        self.scroll_x = min(max(self.scroll_x + dx, 0.), 1.)
+                        self._trigger_update_from_scroll()
                 else:
                     if self.scroll_type != ['bars']:
                         self.effect_x.update(touch.x)


### PR DESCRIPTION
When no overflow, scrolling gave **division by zero error**. This was because the width of scroll bar became 1, and that multiplied by window width became equal to window width. Subtraction of the two gave zero, where Python gave an error. A simple **if statement** is added so that **scrolling is disabled if scroll bar width is 1**.