### PR TITLE
Fix: Splitter handling offset.

### DIFF
--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -291,6 +291,20 @@ class Splitter(BoxLayout):
         else:
             self.height = max(self.min_size, min(self.height, self.max_size))
 
+    @staticmethod
+    def _is_moving(sz_frm, diff, pos, minpos, maxpos):
+        if sz_frm in ('l', 'b'):
+            cmp = minpos
+        else:
+            cmp = maxpos
+        if diff == 0:
+            return False
+        elif diff > 0 and pos <= cmp:
+            return False
+        elif diff < 0 and pos >= cmp:
+            return False
+        return True
+
     def strip_move(self, instance, touch):
         if touch.grab_current is not instance:
             return False
@@ -300,11 +314,15 @@ class Splitter(BoxLayout):
 
         if sz_frm in ('t', 'b'):
             diff_y = (touch.dy)
+            self_y = self.y
+            self_top = self.top
+            if not self._is_moving(sz_frm, diff_y, touch.y, self_y, self_top):
+                return
             if self.keep_within_parent:
-                if sz_frm == 't' and (self.top + diff_y) > self.parent.top:
-                    diff_y = self.parent.top - self.top
-                elif sz_frm == 'b' and (self.y + diff_y) < self.parent.y:
-                    diff_y = self.parent.y - self.y
+                if sz_frm == 't' and (self_top + diff_y) > self.parent.top:
+                    diff_y = self.parent.top - self_top
+                elif sz_frm == 'b' and (self_y + diff_y) < self.parent.y:
+                    diff_y = self.parent.y - self_y
             if sz_frm == 'b':
                 diff_y *= -1
             if self.size_hint_y:
@@ -320,12 +338,16 @@ class Splitter(BoxLayout):
             self._parent_proportion = self.height / self.parent.height
         else:
             diff_x = (touch.dx)
+            self_x = self.x
+            self_right = self.right
+            if not self._is_moving(sz_frm, diff_x, touch.x, self_x, self_right):
+                return
             if self.keep_within_parent:
-                if sz_frm == 'l' and (self.x + diff_x) < self.parent.x:
-                    diff_x = self.parent.x - self.x
+                if sz_frm == 'l' and (self_x + diff_x) < self.parent.x:
+                    diff_x = self.parent.x - self_x
                 elif (sz_frm == 'r' and
-                      (self.right + diff_x) > self.parent.right):
-                    diff_x = self.parent.right - self.right
+                      (self_right + diff_x) > self.parent.right):
+                    diff_x = self.parent.right - self_right
             if sz_frm == 'l':
                 diff_x *= -1
             if self.size_hint_x:


### PR DESCRIPTION
Hi

There is an offset problem when moving the splitter bar beyond its limit position in parent. The offset of the pointer isn't calculated and gets visual displacement. The method _is_moving in the patch is a refactored version of the following example (that is only for the fist if branch in Splitter.strip_move):

```python
if diff_y == 0:
    return
elif diff_y > 0:
    if sz_frm == 't' and touch.y <= self.top:
        return
    elif sz_frm == 'b' and touch.y <= self.y:
        return
elif diff_y < 0:
    if sz_frm == 't' and touch.y >= self.top:
        return True
    elif sz_frm == 'b' and touch.y >= self.y:
        return
```
Note this check don't keep pointer's on_touch_down position within the widget because that requires to add instance variables.