### PR TITLE
Generate Kivy.app on the CI

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -159,10 +159,6 @@ mount_osx_app() {
 activate_osx_app_venv() {
   pushd app/Kivy.app/Contents/Resources/venv/bin
   source activate
+  source kivy_activate
   popd
-
-  export GST_PLUGIN_SCANNER="$(pwd)/app/Kivy.app/Contents/Resources/gst-plugin-scanner"
-  export GTK_PATH="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current"
-  export GST_PLUGIN_SYSTEM_PATH="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0"
-  export GIO_EXTRA_MODULES="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -85,19 +85,26 @@ generate_osx_wheels() {
   rm dist/$zip_dir/kivy/.dylibs/libg*
   rm dist/$zip_dir/kivy/.dylibs/GStreamer
 
+  cp /Library/Frameworks/SDL2.framework/Versions/A/Frameworks/hidapi.framework/Versions/A/hidapi dist/$zip_dir/kivy/.dylibs/
+  cp /Library/Frameworks/SDL2_image.framework/Versions/A/Frameworks/webp.framework/Versions/A/webp dist/$zip_dir/kivy/.dylibs/
   cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/FLAC.framework/Versions/A/FLAC dist/$zip_dir/kivy/.dylibs/
   cp /Library/Frameworks/SDL2_ttf.framework/Versions/A/Frameworks/FreeType.framework/Versions/A/FreeType dist/$zip_dir/kivy/.dylibs/
   cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/Ogg.framework/Versions/A/Ogg dist/$zip_dir/kivy/.dylibs/
   cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/Vorbis.framework/Versions/A/Vorbis dist/$zip_dir/kivy/.dylibs/
   cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/modplug.framework/Versions/A/modplug dist/$zip_dir/kivy/.dylibs/
   cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/mpg123.framework/Versions/A/mpg123 dist/$zip_dir/kivy/.dylibs/
+  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/Opus.framework/Versions/A/Opus dist/$zip_dir/kivy/.dylibs/
+  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/OpusFile.framework/Versions/A/OpusFile dist/$zip_dir/kivy/.dylibs/
 
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/SDL2.framework/Versions/A/SDL2 @loader_path/SDL2
+  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/hidapi.framework/Versions/A/hidapi @loader_path/hidapi
+  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/webp.framework/Versions/A/webp @loader_path/webp
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/FLAC.framework/Versions/A/FLAC @loader_path/FLAC
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/modplug.framework/Versions/A/modplug @loader_path/modplug
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/mpg123.framework/Versions/A/mpg123 @loader_path/mpg123
+  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Opus.framework/Versions/A/Opus @loader_path/Opus
+  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/OpusFile.framework/Versions/A/OpusFile @loader_path/OpusFile
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/FreeType.framework/Versions/A/FreeType @loader_path/FreeType
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/webp.framework/Versions/A/webp @loader_path/webp
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Vorbis.framework/Versions/A/Vorbis @loader_path/Vorbis
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/../../../../SDL2.framework/Versions/A/SDL2 @loader_path/SDL2
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Ogg.framework/Versions/A/Ogg @loader_path/Ogg

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -154,12 +154,8 @@ activate_osx_app_venv() {
   source activate
   popd
 
-  export DYLD_FALLBACK_LIBRARY_PATH="$(pwd)/app/Kivy.app/Contents/lib"
-  export LD_PRELOAD_PATH="$(pwd)/app/Kivy.app/Contents/lib"
-  export GST_REGISTRY="$(pwd)/app/Kivy.app/Contents/Resources/gst.registry"
   export GST_PLUGIN_SCANNER="$(pwd)/app/Kivy.app/Contents/Resources/gst-plugin-scanner"
   export GTK_PATH="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current"
   export GST_PLUGIN_SYSTEM_PATH="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0"
   export GIO_EXTRA_MODULES="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules"
-  export KIVY_HOME="$(pwd)/app/Kivy.app/Contents/Resources/.kivy"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -150,7 +150,16 @@ mount_osx_app() {
 }
 
 activate_osx_app_venv() {
-  pushd app/Kivy.app/Contents/Resources
-  source script
+  pushd app/Kivy.app/Contents/Resources/venv/bin
+  source activate
   popd
+
+  export DYLD_FALLBACK_LIBRARY_PATH="$(pwd)/app/Kivy.app/Contents/lib"
+  export LD_PRELOAD_PATH="$(pwd)/app/Kivy.app/Contents/lib"
+  export GST_REGISTRY="$(pwd)/app/Kivy.app/Contents/Resources/gst.registry"
+  export GST_PLUGIN_SCANNER="$(pwd)/app/Kivy.app/Contents/Resources/gst-plugin-scanner"
+  export GTK_PATH="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current"
+  export GST_PLUGIN_SYSTEM_PATH="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0"
+  export GIO_EXTRA_MODULES="$(pwd)/app/Kivy.app/Contents/Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules"
+  export KIVY_HOME="$(pwd)/app/Kivy.app/Contents/Resources/.kivy"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -60,19 +60,7 @@ install_kivy_test_run_sys_deps() {
 }
 
 install_platypus() {
-  # download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
-
-  # we need to build platypus because of https://github.com/sveinbjornt/Platypus/pull/180.
-  pushd ../
-  git clone https://github.com/sveinbjornt/Platypus.git
-  cd Platypus
-
-  sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
-  sed -E -i '.bak' 's#IBTOOL_PATH.*#IBTOOL_PATH               @"/usr/bin/ibtool"#' Common.h
-  cat build_release.sh
-  ./build_release.sh
-  popd
-  cp "../Platypus/products/platypus$PLATYPUS.zip" .
+  download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
 
   unzip "platypus$PLATYPUS.zip"
   gunzip Platypus.app/Contents/Resources/platypus_clt.gz

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -109,6 +109,8 @@ generate_osx_wheels() {
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/../../../../SDL2.framework/Versions/A/SDL2 @loader_path/SDL2
   python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Ogg.framework/Versions/A/Ogg @loader_path/Ogg
 
+  codesign -fs - "dist/$zip_dir/kivy/.dylibs/hidapi"
+
   rm dist/$zip_dir.whl
   pushd dist
   python3 -c "from delocate import delocating; delocating.dir2zip('$zip_dir', '$zip_dir.whl')"

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -114,6 +114,7 @@ generate_osx_wheels() {
 generate_osx_app() {
   py_version="$1"
   branch_name="$2"
+
   git clone https://github.com/kivy/kivy-sdk-packager
   pushd kivy-sdk-packager/osx
   app_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))")
@@ -123,8 +124,9 @@ generate_osx_app() {
   app_ver=$(KIVY_NO_CONSOLELOG=1 Kivy.app/Contents/Resources/script -c 'import kivy; print(kivy.__version__)')
   mv Kivy.app Kivy3.app
   ./create-osx-dmg.sh Kivy3.app
-  mkdir app
-  cp Kivy3.dmg "app/Kivy-$app_ver-python$py_version.dmg"
-  mv Kivy3.dmg "app/Kivy-$app_ver-$git_tag-$app_date-python$py_version.dmg"
+
   popd
+  mkdir app
+  cp kivy-sdk-packager/osx/Kivy3.dmg "app/Kivy-$app_ver-python$py_version.dmg"
+  mv kivy-sdk-packager/osx/Kivy3.dmg "app/Kivy-$app_ver-$git_tag-$app_date-python$py_version.dmg"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -115,18 +115,19 @@ generate_osx_app() {
   py_version="$1"
   branch_name="$2"
 
-  git clone https://github.com/kivy/kivy-sdk-packager
+  git clone -b osx https://github.com/kivy/kivy-sdk-packager.git
   pushd kivy-sdk-packager/osx
   app_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))")
   git_tag=$(git rev-parse --short HEAD)
 
-  ./create-osx-bundle.sh "$branch_name" "$py_version"
-  app_ver=$(KIVY_NO_CONSOLELOG=1 Kivy.app/Contents/Resources/script -c 'import kivy; print(kivy.__version__)')
-  mv Kivy.app Kivy3.app
-  ./create-osx-dmg.sh Kivy3.app
+  ./create-osx-bundle.sh ../../ "$py_version" Kivy "$branch_name" "Kivy Developers" "org.kivy.osxlauncher" data/icon.icns data/script
+  ./create-osx-dmg.sh Kivy.app Kivy
 
   popd
+
   mkdir app
-  cp kivy-sdk-packager/osx/Kivy3.dmg "app/Kivy-$app_ver-python$py_version.dmg"
-  mv kivy-sdk-packager/osx/Kivy3.dmg "app/Kivy-$app_ver-$git_tag-$app_date-python$py_version.dmg"
+
+  py_version=${py_version:0:3}
+  cp kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$branch_name-python$py_version.dmg"
+  mv kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$branch_name-$git_tag-$app_date-python$py_version.dmg"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -62,6 +62,7 @@ install_kivy_test_run_sys_deps() {
 install_platypus() {
   download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
 
+  sudo security create-keypair -d 2 -A "Developer ID Application"
   pushd ../
   git clone https://github.com/sveinbjornt/Platypus.git
   cd Platypus

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -66,7 +66,7 @@ install_platypus() {
   git clone https://github.com/sveinbjornt/Platypus.git
   cd Platypus
 
-  sed -i '.bak' 's#\#2>&1 /dev/null#CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
+  sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
   cat build_release.sh
   ./build_release.sh
   find . -name '*.zip'

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -116,7 +116,7 @@ generate_osx_app_bundle() {
   app_ver=$(PYTHONPATH=. KIVY_NO_CONSOLELOG=1 python3 -c 'import kivy; print(kivy.__version__)')
 
   cd ../
-  git clone -b osx https://github.com/kivy/kivy-sdk-packager.git
+  git clone https://github.com/kivy/kivy-sdk-packager.git
   cd kivy-sdk-packager/osx
 
   ./create-osx-bundle.sh -k ../../kivy -p "$py_version" -v "$app_ver"
@@ -124,7 +124,7 @@ generate_osx_app_bundle() {
 
 generate_osx_app_dmg_from_bundle() {
   pushd ../kivy-sdk-packager/osx
-  ./create-osx-dmg.sh Kivy.app Kivy -s 1
+  ./create-osx-dmg.sh Kivy.app Kivy
   popd
 
   mkdir app

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -72,6 +72,7 @@ install_platypus() {
   cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
   cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
   chmod -R 755 /usr/local/share/platypus
+  chmod 755 /usr/local/bin/platypus
 }
 
 generate_osx_wheels() {

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -62,16 +62,16 @@ install_kivy_test_run_sys_deps() {
 install_platypus() {
   download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
 
-  pushd ../
-  git clone https://github.com/sveinbjornt/Platypus.git
-  cd Platypus
-
-  sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
-  sed -E -i '.bak' 's#IBTOOL_PATH.*#IBTOOL_PATH               @"/usr/bin/ibtool"#' Common.h
-  cat build_release.sh
-  ./build_release.sh
-  popd
-  cp "../Platypus/products/platypus$PLATYPUS.zip" .
+#  pushd ../
+#  git clone https://github.com/sveinbjornt/Platypus.git
+#  cd Platypus
+#
+#  sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
+#  sed -E -i '.bak' 's#IBTOOL_PATH.*#IBTOOL_PATH               @"/usr/bin/ibtool"#' Common.h
+#  cat build_release.sh
+#  ./build_release.sh
+#  popd
+#  cp "../Platypus/products/platypus$PLATYPUS.zip" .
 
   unzip "platypus$PLATYPUS.zip"
   gunzip Platypus.app/Contents/Resources/platypus_clt.gz

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -150,7 +150,7 @@ mount_osx_app() {
 }
 
 activate_osx_app_venv() {
-  pushd app/Kivy.app/Contents/Resources/venv/bin
-  source activate
+  pushd app/Kivy.app/Contents/Resources
+  source script
   popd
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -60,18 +60,19 @@ install_kivy_test_run_sys_deps() {
 }
 
 install_platypus() {
-  download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
+  # download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
 
-#  pushd ../
-#  git clone https://github.com/sveinbjornt/Platypus.git
-#  cd Platypus
-#
-#  sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
-#  sed -E -i '.bak' 's#IBTOOL_PATH.*#IBTOOL_PATH               @"/usr/bin/ibtool"#' Common.h
-#  cat build_release.sh
-#  ./build_release.sh
-#  popd
-#  cp "../Platypus/products/platypus$PLATYPUS.zip" .
+  # we need to build platypus because of https://github.com/sveinbjornt/Platypus/pull/180.
+  pushd ../
+  git clone https://github.com/sveinbjornt/Platypus.git
+  cd Platypus
+
+  sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
+  sed -E -i '.bak' 's#IBTOOL_PATH.*#IBTOOL_PATH               @"/usr/bin/ibtool"#' Common.h
+  cat build_release.sh
+  ./build_release.sh
+  popd
+  cp "../Platypus/products/platypus$PLATYPUS.zip" .
 
   unzip "platypus$PLATYPUS.zip"
   gunzip Platypus.app/Contents/Resources/platypus_clt.gz

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -144,7 +144,7 @@ rename_osx_app() {
 mount_osx_app() {
   pushd app
   hdiutil attach Kivy.dmg -mountroot .
-  cp -r Kivy/Kivy.app Kivy.app
+  cp -rP Kivy/Kivy.app Kivy.app
   popd
 }
 

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -67,6 +67,7 @@ install_platypus() {
   cd Platypus
 
   sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
+  sed -E -i '.bak' 's#IBTOOL_PATH.*#IBTOOL_PATH               @"/usr/bin/ibtool"#' Common.h
   cat build_release.sh
   ./build_release.sh
   popd

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -114,20 +114,23 @@ generate_osx_wheels() {
 generate_osx_app() {
   py_version="$1"
 
-  git clone -b osx https://github.com/kivy/kivy-sdk-packager.git
-  pushd kivy-sdk-packager/osx
   app_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))")
   git_tag=$(git rev-parse --short HEAD)
-  app_ver=$(KIVY_NO_CONSOLELOG=1 Kivy.app/Contents/Resources/script -c 'import kivy; print(kivy.__version__)')
+  app_ver=$(PYTHONPATH=. KIVY_NO_CONSOLELOG=1 python3 -c 'import kivy; print(kivy.__version__)')
 
-  ./create-osx-bundle.sh ../../ "$py_version" Kivy "$app_ver" "Kivy Developers" "org.kivy.osxlauncher" data/icon.icns data/script
+  pushd ../
+  git clone -b osx https://github.com/kivy/kivy-sdk-packager.git
+  pushd kivy-sdk-packager/osx
+
+  ./create-osx-bundle.sh -k ../../kivy -p "$py_version" -v "$app_ver"
   ./create-osx-dmg.sh Kivy.app Kivy
 
+  popd
   popd
 
   mkdir app
 
   py_version=${py_version:0:3}
-  cp kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$app_ver-python$py_version.dmg"
-  mv kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$app_ver-$git_tag-$app_date-python$py_version.dmg"
+  cp ../kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$app_ver-python$py_version.dmg"
+  mv ../kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$app_ver-$git_tag-$app_date-python$py_version.dmg"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -111,19 +111,20 @@ generate_osx_wheels() {
   delocate-addplat --rm-orig -x 10_9 -x 10_10 dist/*.whl
 }
 
-generate_osx_app() {
+generate_osx_app_bundle() {
   py_version="$1"
-
   app_ver=$(PYTHONPATH=. KIVY_NO_CONSOLELOG=1 python3 -c 'import kivy; print(kivy.__version__)')
 
-  pushd ../
+  cd ../
   git clone -b osx https://github.com/kivy/kivy-sdk-packager.git
-  pushd kivy-sdk-packager/osx
+  cd kivy-sdk-packager/osx
 
   ./create-osx-bundle.sh -k ../../kivy -p "$py_version" -v "$app_ver"
-  ./create-osx-dmg.sh Kivy.app Kivy -s 1
+}
 
-  popd
+generate_osx_app_dmg_from_bundle() {
+  pushd ../kivy-sdk-packager/osx
+  ./create-osx-dmg.sh Kivy.app Kivy -s 1
   popd
 
   mkdir app
@@ -144,7 +145,7 @@ rename_osx_app() {
 mount_osx_app() {
   pushd app
   hdiutil attach Kivy.dmg -mountroot .
-  cp -rP Kivy/Kivy.app Kivy.app
+  cp -R Kivy/Kivy.app Kivy.app
   popd
 }
 

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -113,14 +113,14 @@ generate_osx_wheels() {
 
 generate_osx_app() {
   py_version="$1"
-  branch_name="$2"
 
   git clone -b osx https://github.com/kivy/kivy-sdk-packager.git
   pushd kivy-sdk-packager/osx
   app_date=$(python3 -c "from datetime import datetime; print(datetime.utcnow().strftime('%Y%m%d'))")
   git_tag=$(git rev-parse --short HEAD)
+  app_ver=$(KIVY_NO_CONSOLELOG=1 Kivy.app/Contents/Resources/script -c 'import kivy; print(kivy.__version__)')
 
-  ./create-osx-bundle.sh ../../ "$py_version" Kivy "$branch_name" "Kivy Developers" "org.kivy.osxlauncher" data/icon.icns data/script
+  ./create-osx-bundle.sh ../../ "$py_version" Kivy "$app_ver" "Kivy Developers" "org.kivy.osxlauncher" data/icon.icns data/script
   ./create-osx-dmg.sh Kivy.app Kivy
 
   popd
@@ -128,6 +128,6 @@ generate_osx_app() {
   mkdir app
 
   py_version=${py_version:0:3}
-  cp kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$branch_name-python$py_version.dmg"
-  mv kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$branch_name-$git_tag-$app_date-python$py_version.dmg"
+  cp kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$app_ver-python$py_version.dmg"
+  mv kivy-sdk-packager/osx/Kivy.dmg "app/Kivy-$app_ver-$git_tag-$app_date-python$py_version.dmg"
 }

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -69,18 +69,19 @@ install_platypus() {
   sed -i '.bak' 's#            build#            build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
   cat build_release.sh
   ./build_release.sh
-  find . -name '*.zip'
+  popd
+  cp "../Platypus/products/platypus$PLATYPUS.zip" .
 
-#  unzip platypus$PLATYPUS.zip
-#  gunzip Platypus.app/Contents/Resources/platypus_clt.gz
-#  gunzip Platypus.app/Contents/Resources/ScriptExec.gz
-#
-#  mkdir -p /usr/local/bin
-#  mkdir -p /usr/local/share/platypus
-#  cp Platypus.app/Contents/Resources/platypus_clt /usr/local/bin/platypus
-#  cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
-#  cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
-#  chmod -R 755 /usr/local/share/platypus
+  unzip "platypus$PLATYPUS.zip"
+  gunzip Platypus.app/Contents/Resources/platypus_clt.gz
+  gunzip Platypus.app/Contents/Resources/ScriptExec.gz
+
+  mkdir -p /usr/local/bin
+  mkdir -p /usr/local/share/platypus
+  cp Platypus.app/Contents/Resources/platypus_clt /usr/local/bin/platypus
+  cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
+  cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
+  chmod -R 755 /usr/local/share/platypus
 }
 
 generate_osx_wheels() {

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -153,15 +153,3 @@ activate_osx_app_venv() {
   source activate
   popd
 }
-
-install_kivy_osx_app_deps() {
-  root="$(pwd)"
-  python3 -m pip install cython
-  python setup.py bdist_wheel --build_examples --universal
-  pushd ~
-  python3 -m pip install "$(ls "$root"/dist/Kivy_examples-*.whl)"
-  python3 -m pip uninstall cython -y
-  popd
-
-  python3 -m pip install ".[full,dev]"
-}

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -62,11 +62,12 @@ install_kivy_test_run_sys_deps() {
 install_platypus() {
   download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
 
-  sudo security create-keypair -d 2 -A "Developer ID Application"
   pushd ../
   git clone https://github.com/sveinbjornt/Platypus.git
   cd Platypus
 
+  sed -i '.bak' 's#\#2>&1 /dev/null#CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO#' build_release.sh
+  cat build_release.sh
   ./build_release.sh
   find . -name '*.zip'
 

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -72,7 +72,6 @@ install_platypus() {
   cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
   cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
   chmod -R 755 /usr/local/share/platypus
-  chmod 755 /usr/local/bin/platypus
 }
 
 generate_osx_wheels() {

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -62,16 +62,23 @@ install_kivy_test_run_sys_deps() {
 install_platypus() {
   download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
 
-  unzip platypus$PLATYPUS.zip
-  gunzip Platypus.app/Contents/Resources/platypus_clt.gz
-  gunzip Platypus.app/Contents/Resources/ScriptExec.gz
+  pushd ../
+  git clone https://github.com/sveinbjornt/Platypus.git
+  cd Platypus
 
-  mkdir -p /usr/local/bin
-  mkdir -p /usr/local/share/platypus
-  cp Platypus.app/Contents/Resources/platypus_clt /usr/local/bin/platypus
-  cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
-  cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
-  chmod -R 755 /usr/local/share/platypus
+  ./build_release.sh
+  find . -name '*.zip'
+
+#  unzip platypus$PLATYPUS.zip
+#  gunzip Platypus.app/Contents/Resources/platypus_clt.gz
+#  gunzip Platypus.app/Contents/Resources/ScriptExec.gz
+#
+#  mkdir -p /usr/local/bin
+#  mkdir -p /usr/local/share/platypus
+#  cp Platypus.app/Contents/Resources/platypus_clt /usr/local/bin/platypus
+#  cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
+#  cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
+#  chmod -R 755 /usr/local/share/platypus
 }
 
 generate_osx_wheels() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -27,8 +27,8 @@ install_kivy_test_run_pip_deps() {
   python3 -m pip install --upgrade pip setuptools wheel
   CYTHON_INSTALL=$(
     KIVY_NO_CONSOLELOG=1 python3 -c \
-    "from kivy.tools.packaging.cython_cfg import get_cython_versions; print(get_cython_versions()[0])" \
-    --config "kivy:log_level:error"
+      "from kivy.tools.packaging.cython_cfg import get_cython_versions; print(get_cython_versions()[0])" \
+      --config "kivy:log_level:error"
   )
   python3 -m pip install -I "$CYTHON_INSTALL" coveralls
   if [ $(python3 -c 'import sys; print("{}{}".format(*sys.version_info))') -le "35" ]; then
@@ -47,7 +47,7 @@ install_kivy_test_wheel_run_pip_deps() {
 
 prepare_env_for_unittest() {
   /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background \
-  --exec /usr/bin/Xvfb -- :99 -screen 0 1280x720x24 -ac +extension GLX
+    --exec /usr/bin/Xvfb -- :99 -screen 0 1280x720x24 -ac +extension GLX
 }
 
 install_kivy() {
@@ -63,12 +63,12 @@ install_kivy_manylinux_wheel() {
   python3 -m pip install cython
   python setup.py bdist_wheel --build_examples --universal
   cd ~
-  python3 -m pip install $(ls $root/dist/Kivy_examples-*.whl)
+  python3 -m pip install "$(ls "$root"/dist/Kivy_examples-*.whl)"
   python3 -m pip uninstall cython -y
 
   version=$(python3 -c "import sys; print('{}{}'.format(sys.version_info.major, sys.version_info.minor))")
-  kivy_fname=$(ls $root/dist/Kivy-*$version*.whl | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | head -n1)
-  python3 -m pip install "$kivy_fname[full,dev]"
+  kivy_fname=$(ls "$root"/dist/Kivy-*$version*.whl | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | head -n1)
+  python3 -m pip install "${kivy_fname}[full,dev]"
 }
 
 install_kivy_sdist() {
@@ -87,10 +87,10 @@ test_kivy() {
 test_kivy_install() {
   cd ~
   python3 -c 'import kivy'
-  test_path=$(KIVY_NO_CONSOLELOG=1 python3 -c 'import kivy.tests as tests; print(tests.__path__[0])'  --config "kivy:log_level:error")
+  test_path=$(KIVY_NO_CONSOLELOG=1 python3 -c 'import kivy.tests as tests; print(tests.__path__[0])' --config "kivy:log_level:error")
   cd "$test_path"
 
-  cat > .coveragerc << 'EOF'
+  cat >.coveragerc <<'EOF'
 [run]
   plugins = kivy.tools.coverage
 
@@ -119,13 +119,13 @@ upload_docs_to_server() {
   if [ ! -d ~/.ssh ]; then
     mkdir ~/.ssh
   fi
-  printf "%s" "$UBUNTU_UPLOAD_KEY" > ~/.ssh/id_rsa
+  printf "%s" "$UBUNTU_UPLOAD_KEY" >~/.ssh/id_rsa
   chmod 600 ~/.ssh/id_rsa
   echo -e "Host $ip\n\tStrictHostKeyChecking no\n" >>~/.ssh/config
 
   for version in $versions; do
     if [ "$version" == "${branch}" ]; then
-      echo "[$(echo $versions | tr ' ' ', ' | sed -s 's/\([^,]\+\)/"\1"/g')]" > versions.json
+      echo "[$(echo $versions | tr ' ' ', ' | sed -s 's/\([^,]\+\)/"\1"/g')]" >versions.json
       rsync --force -e "ssh -p 2457" versions.json root@$ip:/web/doc/
       rsync --delete --force -r -e "ssh -p 2457" ./doc/build/html/ root@$ip:/web/doc/$version
     fi
@@ -190,13 +190,12 @@ upload_file_to_server() {
     mkdir ~/.ssh
   fi
 
-  printf "%s" "$UBUNTU_UPLOAD_KEY" > ~/.ssh/id_rsa
+  printf "%s" "$UBUNTU_UPLOAD_KEY" >~/.ssh/id_rsa
   chmod 600 ~/.ssh/id_rsa
 
   echo -e "Host $ip\n\tStrictHostKeyChecking no\n" >>~/.ssh/config
   rsync -avh -e "ssh -p 2458" --include="*/" --include="$file_pat" --exclude="*" "$file_path/" "root@$ip:/web/downloads/ci/$server_path"
 }
-
 
 upload_artifacts_to_pypi() {
   python3 -m pip install twine

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -58,13 +58,21 @@ install_kivy() {
   cd "$path"
 }
 
-install_kivy_manylinux_wheel() {
-  root="$(pwd)"
-  python3 -m pip install cython
+
+create_kivy_examples_wheel() {
   python setup.py bdist_wheel --build_examples --universal
+}
+
+install_kivy_examples_wheel() {
+  root="$(pwd)"
   cd ~
-  python3 -m pip install "$(ls "$root"/dist/Kivy_examples-*.whl)"
-  python3 -m pip uninstall cython -y
+  python3 -m pip install --pre --no-index --no-deps -f "$root/dist" "kivy_examples"
+  python3 -m pip install --pre -f "$root/dist" "kivy_examples[full,dev]"
+}
+
+install_kivy_wheel() {
+  root="$(pwd)"
+  cd ~
 
   version=$(python3 -c "import sys; print('{}{}'.format(sys.version_info.major, sys.version_info.minor))")
   kivy_fname=$(ls "$root"/dist/Kivy-*$version*.whl | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | head -n1)

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -60,7 +60,7 @@ install_kivy() {
 
 
 create_kivy_examples_wheel() {
-  python setup.py bdist_wheel --build_examples --universal
+  KIVY_BUILD_EXAMPLES=1 python3 -m pip wheel . -w dist/
 }
 
 install_kivy_examples_wheel() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -86,7 +86,7 @@ install_kivy_sdist() {
 
 test_kivy() {
   rm -rf kivy/tests/build || true
-  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch -x "$(pwd)/kivy/tests"
 }
 
 test_kivy_install() {
@@ -100,7 +100,7 @@ test_kivy_install() {
   plugins = kivy.tools.coverage
 
 EOF
-  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 .
+  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300  -x .
 }
 
 upload_coveralls() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -39,9 +39,6 @@ install_kivy_test_run_pip_deps() {
 }
 
 install_kivy_test_wheel_run_pip_deps() {
-  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python3 get-pip.py --user
-
   python3 -m pip install --upgrade pip setuptools wheel
 }
 

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -86,7 +86,7 @@ install_kivy_sdist() {
 
 test_kivy() {
   rm -rf kivy/tests/build || true
-  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch -x "$(pwd)/kivy/tests"
+  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
 }
 
 test_kivy_install() {
@@ -100,7 +100,7 @@ test_kivy_install() {
   plugins = kivy.tools.coverage
 
 EOF
-  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300  -x .
+  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 .
 }
 
 upload_coveralls() {

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -13,6 +13,29 @@ env:
   DOCKER_IMAGE: 'quay.io/pypa/manylinux2010_x86_64'
 
 jobs:
+  kivy_examples_create:
+    # we need examples wheel for tests, but only windows actually uploads kivy-examples to pypi/server
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_test_wheel_run_pip_deps
+      - name: Create wheel
+        run: |
+          source .ci/ubuntu_ci.sh
+          create_kivy_examples_wheel
+      - name: Upload kivy-examples wheel as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux_examples_wheel
+          path: dist
+
   manylinux_wheel_create:
     runs-on: ubuntu-18.04
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel linux]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel linux]')
@@ -34,7 +57,7 @@ jobs:
 
   manylinux_wheel_upload_test:
     runs-on: ubuntu-18.04
-    needs: manylinux_wheel_create
+    needs: [manylinux_wheel_create, kivy_examples_create]
     env:
       DISPLAY: ':99.0'
     steps:
@@ -87,7 +110,15 @@ jobs:
     - name: Install Kivy
       run: |
         source .ci/ubuntu_ci.sh
-        install_kivy_manylinux_wheel
+        install_kivy_wheel
+    - uses: actions/download-artifact@v2
+      with:
+        name: linux_examples_wheel
+        path: dist
+    - name: Install kivy-examples wheel
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_examples_wheel
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -49,7 +49,7 @@ jobs:
         python: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
     - name: Switch Xcode version
-      run: xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
+      run: sudo xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -156,7 +156,7 @@ jobs:
       KIVY_SPLIT_EXAMPLES: 0
     steps:
       - name: Switch Xcode version
-        run: xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -148,10 +148,9 @@ jobs:
           REF_NAME: ${{ github.ref }}
         run: |
           py_version=$(python3 -c "import platform; print(platform.python_version())")
-          branch_name=$(python3 -c "print('$REF_NAME'.split('/')[-1])")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          generate_osx_app "$py_version" "$branch_name"
+          generate_osx_app "$py_version"
       - name: Upload app to server
         env:
           UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -180,7 +180,6 @@ jobs:
           install_kivy_test_run_sys_deps
           install_platypus
           install_kivy_test_run_pip_deps
-          exit 1
       - name: Make app bundle
         run: |
           py_version=$(python3 -c "import platform; print(platform.python_version())")

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -147,8 +147,6 @@ jobs:
     - name: Test Kivy wheel
       run: |
         source .ci/ubuntu_ci.sh
-        DYLD_PRINT_LIBRARIES=1 python3 -c 'from kivy.uix.widget import Widget; Widget()'
-        exit 1
         test_kivy_install
 
   osx_app_create:
@@ -252,7 +250,4 @@ jobs:
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh
           activate_osx_app_venv
-          echo "testing video"
-          DYLD_PRINT_LIBRARIES=1 KIVY_NO_ARGS=1 python3 -m pytest -k test_video_unload "$(pwd)/kivy/tests"
-          exit 1
           test_kivy_install

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -188,7 +188,7 @@ jobs:
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
           generate_osx_app_dmg_from_bundle
-      - name: Upload wheels as artifact
+      - name: Upload dmg as artifact
         uses: actions/upload-artifact@v2
         with:
           name: osx_app
@@ -243,6 +243,8 @@ jobs:
           install_kivy_test_wheel_run_pip_deps
           install_kivy_examples_wheel
       - name: Test Kivy wheel
+        env:
+          GST_REGISTRY: /Applications/Kivy.app/Contents/Resources/gst.registry
         run: |
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -19,6 +19,29 @@ env:
   # DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
 
 jobs:
+  kivy_examples_create:
+    # we need examples wheel for tests, but only windows actually uploads kivy-examples to pypi/server
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_test_wheel_run_pip_deps
+    - name: Create wheel
+      run: |
+        source .ci/ubuntu_ci.sh
+        create_kivy_examples_wheel
+    - name: Upload kivy-examples wheel as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: osx_examples_wheel
+        path: dist
+
   osx_wheels_create:
     runs-on: macOS-latest
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
@@ -65,7 +88,7 @@ jobs:
 
   osx_wheel_upload_test:
     runs-on: macOS-latest
-    needs: osx_wheels_create
+    needs: [osx_wheels_create, kivy_examples_create]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x
@@ -111,7 +134,15 @@ jobs:
     - name: Install Kivy wheel
       run: |
         source .ci/ubuntu_ci.sh
-        install_kivy_manylinux_wheel
+        install_kivy_wheel
+    - uses: actions/download-artifact@v2
+      with:
+        name: osx_examples_wheel
+        path: dist
+    - name: Install kivy-examples wheel
+      run: |
+        source .ci/ubuntu_ci.sh
+        install_kivy_examples_wheel
     - name: Test Kivy wheel
       run: |
         source .ci/ubuntu_ci.sh
@@ -160,7 +191,7 @@ jobs:
 
   osx_app_upload_test:
     runs-on: macOS-latest
-    needs: osx_app_create
+    needs: [osx_app_create, kivy_examples_create]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.x
@@ -195,25 +226,20 @@ jobs:
         run: |
           source .ci/osx_ci.sh
           mount_osx_app
+      - uses: actions/download-artifact@v2
+        with:
+          name: osx_examples_wheel
+          path: dist
       - name: Install test dependencies
         run: |
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh
           activate_osx_app_venv
           install_kivy_test_wheel_run_pip_deps
-          install_kivy_osx_app_deps
+          install_kivy_examples_wheel
       - name: Test Kivy wheel
         run: |
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh
           activate_osx_app_venv
           test_kivy_install
-
-  always_job:
-    name: Always run job
-    runs-on: macOS-latest
-    steps:
-      - name: Always run
-        run: |
-          echo "This is run to prevent the workflow from showing an error if the wheels job is not run and no jobs run is an error."
-          echo "See https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38085"

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,7 +16,7 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
-  DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
+  # DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
 
 jobs:
   osx_wheels_create:
@@ -147,8 +147,6 @@ jobs:
           install_platypus
           install_kivy_test_run_pip_deps
       - name: Make app
-        env:
-          REF_NAME: ${{ github.ref }}
         run: |
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -185,7 +185,6 @@ jobs:
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          sudo ln -s /Applications/Xcode_11.3.1.app /Applications/Xcode.app
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -143,10 +143,6 @@ jobs:
           install_kivy_test_run_sys_deps
           install_platypus
           install_kivy_test_run_pip_deps
-      - name: Install Kivy
-        run: |
-          source .ci/ubuntu_ci.sh
-          install_kivy
       - name: Make app
         env:
           REF_NAME: ${{ github.ref }}

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -15,7 +15,7 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
-  GST_REGISTRY: 'registry.bin'
+  GST_REGISTRY: '~/registry.bin'
 
 jobs:
   kivy_examples_create:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,6 +16,7 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
+  DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
 
 jobs:
   osx_wheels_create:
@@ -116,7 +117,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         test_kivy_install
 
-  osx_app:
+  osx_app_create:
     runs-on: macOS-latest
     if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
     env:
@@ -153,6 +154,31 @@ jobs:
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
           generate_osx_app "$py_version"
+      - name: Upload wheels as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: osx_app
+          path: app
+
+  osx_app_upload_test:
+    runs-on: macOS-latest
+    needs: osx_app_create
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - uses: actions/download-artifact@v2
+        with:
+          name: osx_app
+          path: app
+      - name: Rename app
+        if: github.event.ref_type != 'tag'
+        run: |
+          py_version=$(python3 -c "import platform; print(platform.python_version())")
+          source .ci/osx_ci.sh
+          rename_osx_app "$py_version"
       - name: Upload app to server
         env:
           UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
@@ -167,6 +193,23 @@ jobs:
         with:
           files: app/*
           draft: true
+      - name: Mount Kivy.app
+        run: |
+          source .ci/osx_ci.sh
+          mount_osx_app
+      - name: Install test dependencies
+        run: |
+          source .ci/osx_ci.sh
+          source .ci/ubuntu_ci.sh
+          activate_osx_app_venv
+          install_kivy_test_wheel_run_pip_deps
+          install_kivy_osx_app_deps
+      - name: Test Kivy wheel
+        run: |
+          source .ci/osx_ci.sh
+          source .ci/ubuntu_ci.sh
+          activate_osx_app_venv
+          test_kivy_install
 
   always_job:
     name: Always run job

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -180,16 +180,12 @@ jobs:
           install_kivy_test_run_sys_deps
           install_platypus
           install_kivy_test_run_pip_deps
+          exit 1
       - name: Make app bundle
         run: |
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          sudo bash -c 'find /Applications/Xcode_*.app/Contents/Developer/usr/bin -name ibtool -print0 | xargs -0 ls -l'
-          sudo rm /usr/bin/ibtool
-          sudo cp /Applications/Xcode_11.3.1.app/Contents/Developer/usr/bin/ibtool /usr/bin
-          ls -l /usr/bin/ibtool
-          chmod +x /usr/bin/ibtool
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -185,6 +185,10 @@ jobs:
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
+          sudo bash -c 'find /Applications/Xcode_*.app/Contents/Developer/usr/bin -name ibtool -print0 | xargs -0 ls -l'
+          ls -l /usr/bin/ibtool
+          file /usr/bin/ibtool
+          readlink /usr/bin/ibtool
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -182,7 +182,8 @@ jobs:
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          sudo find / -name ibtool 2>/dev/null
+          sudo bash -c 'find /Applications/Xcode_*.app/Contents/Developer/usr/bin -name ibtool -print0 | xargs -0 chmod 755'
+          sudo chmod 755 /usr/bin/ibtool
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -10,7 +10,6 @@ on:
 env:
   KIVY_SPLIT_EXAMPLES: 1
   SERVER_IP: '159.203.106.198'
-  KIVY_GL_BACKEND: 'mock'
   CC: clang
   CXX: clang
   FFLAGS: '-ff2c'
@@ -91,6 +90,8 @@ jobs:
   osx_wheel_upload_test:
     runs-on: macOS-latest
     needs: [osx_wheels_create, kivy_examples_create]
+    env:
+      KIVY_GL_BACKEND: 'mock'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x
@@ -201,6 +202,8 @@ jobs:
   osx_app_upload_test:
     runs-on: macOS-latest
     needs: [osx_app_create, kivy_examples_create]
+    env:
+      KIVY_GL_BACKEND: 'mock'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.x

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,6 +16,7 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
+  DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
 
 jobs:
   kivy_examples_create:
@@ -49,9 +50,6 @@ jobs:
         python: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
     - uses: actions/checkout@v2
-    - uses: maxim-lobanov/setup-xcode@v1.1
-      with:
-        xcode-version: 11.3.1
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -157,9 +155,6 @@ jobs:
       KIVY_SPLIT_EXAMPLES: 0
     steps:
       - uses: actions/checkout@v2
-      - uses: maxim-lobanov/setup-xcode@v1.1
-        with:
-          xcode-version: 11.3.1
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -187,6 +182,7 @@ jobs:
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
+          sudo find / -name ibtool 2>/dev/null
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,7 +16,6 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
-  DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
 
 jobs:
   kivy_examples_create:
@@ -50,7 +49,7 @@ jobs:
         python: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
     - name: Switch Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_11.3.1.app
+      run: xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -157,7 +156,7 @@ jobs:
       KIVY_SPLIT_EXAMPLES: 0
     steps:
       - name: Switch Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_11.3.1.app
+        run: xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -49,6 +49,8 @@ jobs:
       matrix:
         python: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
+    - name: Switch Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_11.3.1.app
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -154,6 +156,8 @@ jobs:
     env:
       KIVY_SPLIT_EXAMPLES: 0
     steps:
+      - name: Switch Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_11.3.1.app
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -182,8 +186,6 @@ jobs:
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          sudo bash -c 'find /Applications/Xcode_*.app/Contents/Developer/usr/bin -name ibtool -print0 | xargs -0 chmod 755'
-          sudo chmod 755 /usr/bin/ibtool
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -185,6 +185,7 @@ jobs:
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
+          sudo ln -s /Applications/Xcode_11.3.1.app /Applications/Xcode.app
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,7 +16,6 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
-  DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
 
 jobs:
   kivy_examples_create:
@@ -50,6 +49,9 @@ jobs:
         python: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
     - uses: actions/checkout@v2
+    - uses: maxim-lobanov/setup-xcode@v1.1
+      with:
+        xcode-version: 11.3.1
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -155,6 +157,9 @@ jobs:
       KIVY_SPLIT_EXAMPLES: 0
     steps:
       - uses: actions/checkout@v2
+      - uses: maxim-lobanov/setup-xcode@v1.1
+        with:
+          xcode-version: 11.3.1
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -119,6 +119,8 @@ jobs:
   osx_app:
     runs-on: macOS-latest
     if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
+    env:
+      KIVY_SPLIT_EXAMPLES: 0
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -56,12 +56,12 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Cache OSX deps
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: osx-cache
         key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}
     - name: Cache OSX gst-devel deps
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: osx-cache-gst-devel
         key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
@@ -163,12 +163,12 @@ jobs:
         with:
           python-version: 3.x
       - name: Cache OSX deps
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: osx-cache
           key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}
       - name: Cache OSX gst-devel deps
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: osx-cache-gst-devel
           key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
@@ -186,9 +186,10 @@ jobs:
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
           sudo bash -c 'find /Applications/Xcode_*.app/Contents/Developer/usr/bin -name ibtool -print0 | xargs -0 ls -l'
+          sudo rm /usr/bin/ibtool
+          sudo cp /Applications/Xcode_11.3.1.app/Contents/Developer/usr/bin/ibtool /usr/bin
           ls -l /usr/bin/ibtool
-          file /usr/bin/ibtool
-          readlink /usr/bin/ibtool
+          chmod +x /usr/bin/ibtool
           generate_osx_app_bundle "$py_version"
       - name: Create dmg from bundle
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -177,12 +177,17 @@ jobs:
           install_kivy_test_run_sys_deps
           install_platypus
           install_kivy_test_run_pip_deps
-      - name: Make app
+      - name: Make app bundle
         run: |
           py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          generate_osx_app "$py_version"
+          generate_osx_app_bundle "$py_version"
+      - name: Create dmg from bundle
+        run: |
+          source .ci/osx_versions.sh
+          source .ci/osx_ci.sh
+          generate_osx_app_dmg_from_bundle
       - name: Upload wheels as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -147,6 +147,8 @@ jobs:
     - name: Test Kivy wheel
       run: |
         source .ci/ubuntu_ci.sh
+        DYLD_PRINT_LIBRARIES=1 python3 -c 'from kivy.uix.widget import Widget; Widget()'
+        exit 1
         test_kivy_install
 
   osx_app_create:
@@ -250,4 +252,7 @@ jobs:
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh
           activate_osx_app_venv
+          echo "testing video"
+          DYLD_PRINT_LIBRARIES=1 KIVY_NO_ARGS=1 python3 -m pytest -k test_video_unload "$(pwd)/kivy/tests"
+          exit 1
           test_kivy_install

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -118,7 +118,7 @@ jobs:
 
   osx_app:
     runs-on: macOS-latest
-    if: false && github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
+    if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,6 +16,7 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
+  GST_REGISTRY: '~/registry.bin'
 
 jobs:
   kivy_examples_create:
@@ -245,9 +246,7 @@ jobs:
           activate_osx_app_venv
           install_kivy_test_wheel_run_pip_deps
           install_kivy_examples_wheel
-      - name: Test Kivy wheel
-        env:
-          GST_REGISTRY: /Applications/Kivy.app/Contents/Resources/gst.registry
+      - name: Test Kivy app
         run: |
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -16,7 +16,7 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
-  # DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
 
 jobs:
   kivy_examples_create:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -15,12 +15,12 @@ env:
   FFLAGS: '-ff2c'
   USE_SDL2: 1
   USE_GSTREAMER: 1
-  GST_REGISTRY: '~/registry.bin'
+  GST_REGISTRY: 'registry.bin'
 
 jobs:
   kivy_examples_create:
     # we need examples wheel for tests, but only windows actually uploads kivy-examples to pypi/server
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -42,14 +42,12 @@ jobs:
         path: dist
 
   osx_wheels_create:
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
     strategy:
       matrix:
         python: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
-    - name: Switch Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -88,7 +86,7 @@ jobs:
         path: dist
 
   osx_wheel_upload_test:
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     needs: [osx_wheels_create, kivy_examples_create]
     env:
       KIVY_GL_BACKEND: 'mock'
@@ -152,13 +150,11 @@ jobs:
         test_kivy_install
 
   osx_app_create:
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
     env:
       KIVY_SPLIT_EXAMPLES: 0
     steps:
-      - name: Switch Xcode version
-        run: sudo xcode-select -switch /Applications/Xcode_11.3.1.app/Contents/Developer
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -200,7 +196,7 @@ jobs:
           path: app
 
   osx_app_upload_test:
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     needs: [osx_app_create, kivy_examples_create]
     env:
       KIVY_GL_BACKEND: 'mock'

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -44,4 +44,8 @@ jobs:
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh
+        DYLD_PRINT_LIBRARIES=1 python3 -c 'from kivy.uix.widget import Widget; Widget()'
+        echo "testing video"
+        DYLD_PRINT_LIBRARIES=1 KIVY_NO_ARGS=1 python3 -m pytest -k test_video_unload "$(pwd)/kivy/tests"
+        exit 1
         test_kivy

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -44,8 +44,4 @@ jobs:
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh
-        DYLD_PRINT_LIBRARIES=1 python3 -c 'from kivy.uix.widget import Widget; Widget()'
-        echo "testing video"
-        DYLD_PRINT_LIBRARIES=1 KIVY_NO_ARGS=1 python3 -m pytest -k test_video_unload "$(pwd)/kivy/tests"
-        exit 1
         test_kivy

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -21,12 +21,12 @@ jobs:
       with:
         python-version: 3.x
     - name: Cache OSX deps
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: osx-cache
         key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}
     - name: Cache OSX gst-devel deps
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: osx-cache-gst-devel
         key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   unit_test:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -35,6 +35,7 @@ jobs:
         Install-kivy-test-run-pip-deps
     - name: Generate sdist/kivy-examples
       if: matrix.arch == 'x64' && matrix.python == '3.8'
+      # only windows kivy-examples is uploaded
       run: |
         . .\.ci\windows_ci.ps1
         Generate-sdist

--- a/doc/sources/guide/packaging-osx.rst
+++ b/doc/sources/guide/packaging-osx.rst
@@ -13,7 +13,14 @@ Using the Kivy SDK
 
     These instructions apply only from Kivy v2.0.0 onwards.
 
-For OS X 10.14.4+ and later, we provide a Kivy DMG with all dependencies
+.. note::
+
+    Kivy.app is built on the `current GitHub Action macOS version (10.15)
+    <https://github.com/actions/virtual-environments#available-environments>`_ and will typically
+    not work on older OS X versions. For older OS X versions, you need to build Kivy.app
+    on the oldest machine you wish to support. See below.
+
+For OS X 10.15+ and later, we provide a Kivy DMG with all dependencies
 bundled in a **virtual environment**, including a Python interpreter that can be used as
 a base to package kivy apps.
 

--- a/doc/sources/guide/packaging-osx.rst
+++ b/doc/sources/guide/packaging-osx.rst
@@ -6,11 +6,32 @@ Creating packages for OS X
     This guide describes multiple ways for packaging Kivy applications.
     Packaging with PyInstaller is recommended for general use.
 
+Using the Kivy SDK
+------------------
+
+.. note::
+
+    These instructions apply only from Kivy v2.0.0 onwards.
+
+For OS X 10.14.4+ and later, we provide a Kivy DMG with all dependencies
+bundled in a **virtual environment**, including a Python interpreter that can be used as
+a base to package kivy apps.
+
+This is the safest approach because it packages the binaries without references to
+any binaries on the system on which the app is packaged. Because all references are
+to frameworks included in the dmg or to binaries with the dmg. As opposed to
+e.g. pyinstaller which copies binaries from your local python installation.
+
+You can find complete instructions to build and package apps with Kivy.app, starting either
+with Kivy.app or building from scratch, in the readme
+of the `kivy-sdk-packager repo <https://github.com/kivy/kivy-sdk-packager/tree/master/osx>`_.
+
 .. _osx_pyinstaller:
 
 Using PyInstaller and Homebrew
 ------------------------------
 .. note::
+
     Package your app on the oldest OS X version you want to support.
 
 Complete guide
@@ -230,126 +251,3 @@ Buildozer right now uses the Kivy SDK to package your app.
 If you want to control more details about your app than buildozer
 currently offers then you can use the SDK directly, as detailed in the
 section below.
-
-Using the Kivy SDK
-------------------
-
-.. note::
-    Kivy.app is not available for download at the moment. For details,
-    see `this <https://github.com/kivy/kivy/issues/5211>`_ issue.
-
-.. note::
-    Packaging Kivy applications with the following method must be done inside
-    OS X, 32-bit platforms are no longer supported.
-
-Since version 1.9.0, Kivy is released for the OS X platform in a
-self-contained, portable distribution.
-
-Apps can be packaged and distributed with the Kivy SDK using the method
-described below, making it easier to include frameworks like SDL2 and
-GStreamer.
-
-1. Make sure you have the unmodified Kivy SDK (Kivy.app) from the download page.
-
-2. Run the following commands::
-
-    > mkdir packaging
-    > cd packaging
-    packaging> git clone https://github.com/kivy/kivy-sdk-packager
-    packaging> cd kivy-sdk-packager/osx
-    osx> cp -a /Applications/Kivy.app ./Kivy.App
-
-  .. note::
-    This step above is important, you have to make sure to preserve the paths
-    and permissions. A command like ``cp -rf`` will copy but make the app
-    unusable and lead to error later on.
-
-3. Now all you need to do is to include your compiled app in the Kivy.app
-   by running the following command::
-
-    osx> ./package-app.sh /path/to/your/<app_folder_name>/
-
-  Where <app_folder_name> is the name of your app.
-
-  This copies Kivy.app to `<app_folder_name>.app` and includes a compiled copy
-  of your app into this package.
-
-4. That's it, your self-contained package is ready to be deployed!
-   You can now further customize your app as described bellow.
-
-Installing modules
-~~~~~~~~~~~~~~~~~~
-
-Kivy package on osx uses its own virtual env that is activated when you run
-your app using `kivy` command.
-To install any module you need to install the module like so::
-
-    $ kivy -m pip install <modulename>
-
-Where are the modules/files installed?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Inside the portable venv within the app at::
-
-    Kivy.app/Contents/Resources/venv/
-
-If you install a module that installs a binary for example like kivy-garden
-That binary will be only available from the venv above, as in after you do::
-
-    kivy -m pip install kivy-garden
-
-The garden lib will be only available when you activate this env.
-
-    source /Applications/Kivy.app/Contents/Resources/venv/bin/activate
-    garden install mapview
-    deactivate
-
-To install binary files
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Just copy the binary to the Kivy.app/Contents/Resources/venv/bin/ directory.
-
-To include other frameworks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Kivy.app comes with SDL2 and Gstreamer frameworks provided.
-To include frameworks other than the ones provided do the following::
-
-    git clone http://github.com/tito/osxrelocator
-    export PYTHONPATH=~/path/to/osxrelocator
-    cd Kivy.app
-    python -m osxrelocator -r . /Library/Frameworks/<Framework_name>.framework/ \
-    @executable_path/../Frameworks/<Framework_name>.framework/
-
-Do not forget to replace <Framework_name> with your framework.
-This tool `osxrelocator` essentially changes the path for the
-libs in the framework such that they are relative to the executable
-within the .app, making the Framework portable with the .app.
-
-
-Shrinking the app size
-^^^^^^^^^^^^^^^^^^^^^^
-The app has a considerable size right now, however the unneeded parts can be
-removed from the package.
-
-For example if you don't use GStreamer, simply remove it from
-YourApp.app/Contents/Frameworks.
-Similarly you can remove the examples folder from
-/Applications/Kivy.app/Contents/Resources/kivy/examples/ or kivy/tools,
-kivy/docs etc.
-
-This way the package can be made to only include the parts that are needed for
-your app.
-
-Adjust settings
-^^^^^^^^^^^^^^^
-Icons and other settings of your app can be changed by editing
-YourApp/Contents/info.plist to suit your needs.
-
-Create a DMG
-^^^^^^^^^^^^
-To make a DMG of your app use the following command::
-
-    osx> ./create-osx-dmg.sh YourApp.app
-
-Note the lack of `/` at the end.
-This should give you a compressed dmg that will further shrink the size of your
-distributed app.

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -94,10 +94,14 @@ To activate it so you can use python, like any normal virtualenv, do::
 
         pushd /Applications/Kivy.app/Contents/Resources/venv/bin
         source activate
+        source kivy_activate
         popd
 
 On the default mac (zsh) shell you **must** be in the bin directory containing ``activate`` to be
 able to ``activate`` the virtualenv, hence why we changed the directory temporarily.
+
+``kivy_activate`` sets up the environment to be able to run Kivy, by setting the kivy home,
+gstreamer, and other variables.
 
 Start any Kivy Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -25,38 +25,15 @@ Make sure to set `KIVY_VIDEO=ffpyplayer` env variable before running the app.
 Nightly wheel installation
 --------------------------
 
-.. |cp35_osx| replace:: Python 3.5
-.. _cp35_osx: https://kivy.org/downloads/ci/osx/kivy/Kivy-2.0.0.dev0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-.. |cp36_osx| replace:: Python 3.6
-.. _cp36_osx: https://kivy.org/downloads/ci/osx/kivy/Kivy-2.0.0.dev0-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-.. |cp37_osx| replace:: Python 3.7
-.. _cp37_osx: https://kivy.org/downloads/ci/osx/kivy/Kivy-2.0.0.dev0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-.. |examples_whl_osx| replace:: Kivy examples
-.. _examples_whl_osx: https://kivy.org/downloads/appveyor/kivy/Kivy_examples-2.0.0.dev0-py2.py3-none-any.whl
-
 .. warning::
 
     Using the latest development version can be risky and you might encounter
     issues during development. If you encounter any bugs, please report them.
 
 Snapshot wheels of current Kivy master are created daily on the
-`master` branch of kivy repository. They can be found
-`here <https://kivy.org/downloads/ci/osx/kivy/>`_. To use them, instead of
-doing ``python -m pip install kivy`` we'll install one of these wheels as
-follows.
+``master`` branch of kivy repository. You can install wheels with::
 
-- |cp35_osx|_
-- |cp36_osx|_
-- |cp37_osx|_
-
-#. Download the appropriate wheel for your Python version.
-#. Install it with ``python -m pip install wheel-name`` where ``wheel-name``
-   is the name of the file.
-
-Kivy examples are separated from the core because of their size. The examples
-can be installed separately on all Python versions with this single wheel:
-
-- |examples_whl_osx|_
+    pip install kivy[base] kivy_examples --pre --extra-index-url https://kivy.org/downloads/simple/
 
 Using Conda
 -----------
@@ -65,120 +42,61 @@ If you use Anaconda, you can simply install kivy using::
 
    $ conda install kivy -c conda-forge
 
+.. _osx-run-app:
+
 Using The Kivy.app
 ------------------
 
 .. note::
 
-    This method has only been tested on OS X 10.7 and above (64-bit).
-    For versions prior to 10.7 or 10.7 32-bit, you have to install the
-    components yourself.
+    These instructions apply only from Kivy v2.0.0 onwards.
 
-For OS X > 10.13.5 and later, we provide packages with all dependencies
-bundled in a virtual environment, including a Python interpreter for
-python3 version. These bundles are primarily used for rapid prototyping,
-and currently serve as containers for packaging Kivy apps with Buildozer.
+For OS X 10.14.4+ and later, we provide a Kivy DMG with all dependencies
+bundled in a **virtual environment**, including a Python interpreter. This is
+primarily useful for packaging Kivy applications.
 
-To install Kivy, you must:
+You can find complete instructions to build and package apps with Kivy.app in the readme
+of the `kivy-sdk-packager repo <https://github.com/kivy/kivy-sdk-packager/tree/master/osx>`_.
 
-    1. Navigate to the latest Kivy release at
-       https://kivy.org/downloads/ and download `Kivy-*-osx-python*.dmg`.
+To install the Kivy virtualenv, you must:
+
+    1. Navigate to the latest Kivy release on Kivy's `website <https://kivy.org/downloads/>`_ or
+       `GitHub <https://github.com/kivy/kivy/releases>`_ and download ``Kivy.dmg``.
+       You can also download a nightly snapshot of
+       `Kivy.app <https://kivy.org/downloads/ci/osx/app/Kivy.dmg>`_.
     2. Open the dmg
-    3. Copy the Kivy.app to /Applications.
-    4. Create a symlink by running the `makesymlinks` in the window that opens when you open the dmg.
+    3. In the GUI copy the Kivy.app to /Applications by dragging the folder icon to the right.
+    4. Optionally create a symlink by running the following command::
 
-    If you have trouble running this script, you can try right-click->Open or just add the link manually
-    by running the following command::
-        `sudo ln -s /Applications/Kivy<version>/Contents/Resources/script /usr/local/bin/kivy<version>`
-    version is either 2/3 based on which version of the app did you download.
+           ``ln -s /Applications/Kivy.app/Contents/Resources/script /usr/local/bin/kivy``
 
-    5. Examples and all the normal kivy tools are present in the Kivy.app/Contents/Resources/kivy directory.
+       This creates the ``kivy`` binary that you can use instead of python to run scripts.
+       I.e. instead of doing ``python my_script.py`` or ``python -m pip install <module name>``, write
+       ``kivy my_script.py`` or ``kivy -m pip install <module name>`` to run it using the kivy
+       bundled Python interpreter with the kivy environment.
 
-You should now have a `kivy` script that you can use to launch your kivy app from the terminal.
-You might need to add `/usr/local/bin` to your path::
+       As opposed to activating the virtualenv below, running with ``kivy`` will use the virtualenv
+       but also properly configure the script environment required to run a Kivy app (i.e. setting
+       kivy's home path etc.).
 
-    export PATH=/usr/local/bin:$PATH
+Using the App Virtual environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can just drag and drop your main.py onto the kivy icon to run your app too.
+The path to the underlying virtualenv is ``/Applications/Kivy.app/Contents/Resources/venv``.
+To activate it so you can use python, like any normal virtualenv, do::
 
+        pushd /Applications/Kivy.app/Contents/Resources/venv/bin
+        source activate
+        popd
 
-Installing modules
-~~~~~~~~~~~~~~~~~~
-
-The Kivy SDK on OS X uses its own virtual env that is activated when you run your app using the `kivy` command.
-To install any module you need to install the module like so::
-
-    $ kivy -m pip install <modulename>
-
-Where are the modules/files installed?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Inside the portable venv within the app at::
-
-    Kivy.app/Contents/Resources/venv/
-
-If you install a module that installs a binary for example like kivy-garden.
-That binary will be only available from the venv above, as in after you do::
-
-    kivy -m pip install kivy-garden
-
-The garden lib will be only available when you activate this env::
-
-    source /Applications/Kivy.app/Contents/Resources/venv/bin/activate
-    garden install mapview
-    deactivate
-
-To install binary files
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Just copy the binary to the /Applications/Kivy.app/Contents/Resources/venv/bin/ directory.
-
-To include other frameworks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Kivy.app comes with SDL2 and Gstreamer frameworks provided.
-To include frameworks other than the ones provided do the following::
-
-    git clone http://github.com/tito/osxrelocator
-    export PYTHONPATH=~/path/to/osxrelocator
-    cd /Applications/Kivy.app
-    python -m osxrelocator -r . /Library/Frameworks/<Framework_name>.framework/ \
-    @executable_path/../Frameworks/<Framework_name>.framework/
-
-Do not forget to replace <Framework_name> with your framework.
-This tool `osxrelocator` essentially changes the path for the
-libs in the framework such that they are relative to the executable
-within the .app, making the Framework portable with the .app.
+On the default mac (zsh) shell you **must** be in the bin directory containing ``activate`` to be
+able to ``activate`` the virtualenv, hence why we changed the directory temporarily.
 
 Start any Kivy Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can run any Kivy application by simply dragging the application's main file
-onto the Kivy.app icon. Just try this with any python file in the examples folder.
-
-.. _osx-run-app:
-
-
-Start from the Command Line
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you want to use Kivy from the command line, double-click the ``Make Symlinks`` script
-after you have dragged the Kivy.app into the Applications folder. To test if it worked:
-
-    #. Open Terminal.app and enter::
-
-           $ kivy
-
-       You should get a Python prompt.
-
-    #. In there, type::
-
-           >>> import kivy
-
-       If it just goes to the next line without errors, it worked.
-
-    #. Running any Kivy application from the command line is now simply a matter
-       of executing a command like the following::
-
-           $ kivy yourapplication.py
+onto the Kivy.app icon.
 
 
 Using Homebrew with pip
@@ -188,18 +106,15 @@ You can install Kivy with Homebrew and pip using the following steps:
 
     1. Install the requirements using `homebrew <http://brew.sh>`_::
 
-        $ brew install pkg-config sdl2 sdl2_image sdl2_ttf sdl2_mixer gstreamer
+        $ brew install pkg-config sdl2 sdl2_image sdl2_ttf sdl2_mixer gstreamer python3
 
-    2. Install Cython and Kivy using pip:
+    2. Install Kivy using pip::
 
-        .. parsed-literal::
+           $ python3 -m pip install --no-binary kivy kivy[base]
 
-            $ pip install |cython_install|
-            $ pip install kivy
+       To install the development version, use this in the second step::
 
-    - To install the development version, use this in the second step::
-
-        $ pip install https://github.com/kivy/kivy/archive/master.zip
+           $ python3 -m pip install "kivy[base] @ https://github.com/kivy/kivy/archive/master.zip"
 
 Using MacPorts with pip
 -----------------------
@@ -210,45 +125,28 @@ Using MacPorts with pip
     support video playback in your Kivy App. The latest port documents show the
     following `py-gst-python port <https://trac.macports.org/ticket/44813>`_.
 
-You can install Kivy with macports only:
-
-    1. Install `Macports <https://www.macports.org>`_
-
-    2. Choose python versions for Kivy, available version 2.7, 3.5, 3.6
-
-        $ port install py35-kivy  # for python 3.5
-        $ port install py36-kivy  # for python 3.6
-
-    3. Check if kivy is available
-
-        $ python3.5
-        $ >>> import kivy
-
 You can install Kivy with Macports and pip using the following steps:
 
     1. Install `Macports <https://www.macports.org>`_
 
-    2. Install and set Python 3.4 as the default::
+    2. Install and set Python 3.8 as the default::
 
-        $ port install python34
-        $ port select --set python python34
+        $ port install python38
+        $ port select --set python python38
 
     3. Install and set pip as the default::
 
-        $ port install pip-34
-        $ port select --set pip pip-34
+        $ port install py38-pip
+        $ port select --set pip py38-pip
 
     4. Install the requirements using `Macports <https://www.macports.org>`_::
 
         $ port install libsdl2 libsdl2_image libsdl2_ttf libsdl2_mixer
 
-    5. Install Cython and Kivy using pip:
+    2. Install Kivy using pip::
 
-        .. parsed-literal::
+           $ python3 -m pip install --no-binary kivy kivy[base]
 
-            $ pip install |cython_install|
-            $ pip install kivy
+       To install the development version, use this in the second step::
 
-    - To install the development version, use this in the second step::
-
-        $ pip install https://github.com/kivy/kivy/archive/master.zip
+           $ python3 -m pip install "kivy[base] @ https://github.com/kivy/kivy/archive/master.zip"

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -23,7 +23,7 @@ you should install `ffpyplayer` like so ::
 Make sure to set `KIVY_VIDEO=ffpyplayer` env variable before running the app.
 
 Nightly wheel installation
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
 
@@ -50,6 +50,13 @@ Using The Kivy.app
 .. note::
 
     These instructions apply only from Kivy v2.0.0 onwards.
+
+.. note::
+
+    Kivy.app is built on the `current GitHub Action macOS version
+    <https://github.com/actions/virtual-environments#available-environments>`_ and will typically
+    not work on older OS X versions. For older OS X versions, you need to build Kivy.app
+    on the oldest machine you wish to support. See below.
 
 For OS X 10.14.4+ and later, we provide a Kivy DMG with all dependencies
 bundled in a **virtual environment**, including a Python interpreter. This is

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -10,7 +10,9 @@ The screenshots live in the 'kivy/tests/results' folder and are in PNG format,
 320x240 pixels.
 '''
 
-__all__ = ('GraphicUnitTest', 'UnitTestTouch', 'UTMotionEvent', 'async_run')
+__all__ = (
+    'GraphicUnitTest', 'UnitTestTouch', 'UTMotionEvent', 'async_run',
+    'requires_graphics')
 
 import unittest
 import logging
@@ -34,6 +36,13 @@ make_screenshots = os.environ.get('KIVY_UNITTEST_SCREENSHOTS')
 http_server = None
 http_server_ready = threading.Event()
 kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
+
+
+def requires_graphics(func):
+    if 'mock' == cgl_get_backend_name():
+        return pytest.mark.skip(
+            reason='Skipping because gl backend is set to mock')(func)
+    return func
 
 
 def ensure_web_server(root=None):

--- a/kivy/tests/test_fonts.py
+++ b/kivy/tests/test_fonts.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+from .common import requires_graphics
 
 
 class FontTestCase(unittest.TestCase):
@@ -23,6 +24,7 @@ class FontTestCase(unittest.TestCase):
 
         print(self.font_name)
 
+    @requires_graphics
     def test_unicode_name(self):
         from kivy.core.text import Label
         lbl = Label(font_name=self.font_name)

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,9 @@ def get_isolated_env_paths():
 # -----------------------------------------------------------------------------
 # Determine on which platform we are
 
+build_examples = build_examples or \
+    os.environ.get('KIVY_BUILD_EXAMPLES', '0') == '1'
+
 platform = sys.platform
 
 # Detect 32/64bit for OSX (http://stackoverflow.com/a/1405971/798575)


### PR DESCRIPTION
This PR includes a re-work of kivy-sdk-packager for osx so that we can generate a kivy bundle and dmg more incrementally and fixes a bunch of issues there that prevented it to work on the CI. You can see the full readme at https://github.com/kivy/kivy-sdk-packager/tree/master/osx.

With these changes we can now generate a Kivy.dmg for use in packaging. Additionally, we're now also testing the generated Kivy.dmg in a separate clean environment. The only test failure is with gstreamer, but that can be fixed later.

Finally, I also updated the osx docs to make it simpler and point directly to kivy-sdk-packager for more complete docs.

An unrelated issue is that osx wheels tests fail, but it doesn't fail for osx unittests that are built in place. It makes me wonder if the osx wheels are safe to use in a clean environment.