### PR TITLE
Add _version.py and move updating version metadata to the CI

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -e -x
 
+update_version_metadata() {
+  current_time=$(python -c "from time import time; from os import environ; print(int(environ.get('SOURCE_DATE_EPOCH', time())))")
+  date=$(python -c "from datetime import datetime; print(datetime.utcfromtimestamp($current_time).strftime('%Y%m%d'))")
+  echo "Version date is: $date"
+  git_tag=$(git rev-parse HEAD)
+  echo "Git tag is: $git_tag"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/_kivy_git_hash = ''/_kivy_git_hash = '$git_tag'/" kivy/_version.py
+    sed -i '' "s/_kivy_build_date = ''/_kivy_build_date = '$date'/" kivy/_version.py
+  else
+    sed -i "s/_kivy_git_hash = ''/_kivy_git_hash = '$git_tag'/" kivy/_version.py
+    sed -i "s/_kivy_build_date = ''/_kivy_build_date = '$date'/" kivy/_version.py
+  fi
+}
+
 generate_sdist() {
   python3 -m pip install cython
   python3 setup.py sdist --formats=gztar

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -12,6 +12,17 @@ function raise-only-error{
     }
 }
 
+function Update-version-metadata {
+    $current_time = python -c "from time import time; from os import environ; print(int(environ.get('SOURCE_DATE_EPOCH', time())))"
+    $date = python -c "from datetime import datetime; print(datetime.utcfromtimestamp($current_time).strftime('%Y%m%d'))"
+    echo "Version date is: $date"
+    $git_tag = git rev-parse HEAD
+    echo "Git tag is: $git_tag"
+
+    (Get-Content .\kivy\_version.py -Raw) -replace "_kivy_git_hash = ''","_kivy_git_hash = '$git_tag'" `
+        -replace "_kivy_build_date = ''","_kivy_build_date = '$date'" | Out-File -filepath .\kivy\_version.py
+}
+
 function Generate-sdist {
     python -m pip install cython
     python setup.py sdist --formats=gztar

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.x
+    - name: Generate version metadata
+      run: |
+        source .ci/ubuntu_ci.sh
+        update_version_metadata
     - name: Make wheels
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -40,6 +40,10 @@ jobs:
       with:
         path: osx-cache-gst-devel
         key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
+    - name: Generate version metadata
+      run: |
+        source .ci/ubuntu_ci.sh
+        update_version_metadata
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
@@ -135,6 +139,10 @@ jobs:
         with:
           path: osx-cache-gst-devel
           key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
+      - name: Generate version metadata
+        run: |
+          source .ci/ubuntu_ci.sh
+          update_version_metadata
       - name: Install dependencies
         run: |
           source .ci/ubuntu_ci.sh

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -21,6 +21,10 @@ jobs:
         docker_images: ['balenalib/armv7hf-debian:stretch', 'balenalib/armv7hf-debian:buster']
     steps:
     - uses: actions/checkout@v2
+    - name: Generate version metadata
+      run: |
+        source .ci/ubuntu_ci.sh
+        update_version_metadata
     - name: Make ${{ matrix.docker_images }} wheel
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -29,6 +29,10 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
+    - name: Generate version metadata
+      run: |
+        . .\.ci\windows_ci.ps1
+        Update-version-metadata
     - name: Install dependencies
       run: |
         . .\.ci\windows_ci.ps1

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -37,24 +37,8 @@ import pkgutil
 import re
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
-
-MAJOR = 2
-MINOR = 0
-MICRO = 0
-RELEASE = False
-
-__version__ = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
-
-if not RELEASE:
-    # if it's a rcx release, it's not proceeded by a period. If it is a
-    # devx release, it must start with a period
-    __version__ += 'rc3'
-
-try:
-    from kivy.version import __hash__, __date__
-    __hash__ = __hash__[:7]
-except ImportError:
-    __hash__ = __date__ = ''
+from kivy._version import __version__, RELEASE as _KIVY_RELEASE, \
+    _kivy_git_hash, _kivy_build_date
 
 # internals for post-configuration
 __kivy_post_configuration = []
@@ -492,10 +476,11 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 for msg in _logging_msgs:
     Logger.info(msg)
 
-if RELEASE:
+if _KIVY_RELEASE:
     Logger.info('Kivy: v%s' % __version__)
-elif not RELEASE and __hash__ and __date__:
-    Logger.info('Kivy: v%s, git-%s, %s' % (__version__, __hash__, __date__))
+elif not _KIVY_RELEASE and _kivy_git_hash and _kivy_build_date:
+    Logger.info('Kivy: v%s, git-%s, %s' % (
+        __version__, _kivy_git_hash[:7], _kivy_build_date))
 Logger.info('Kivy: Installed at "{}"'.format(__file__))
 Logger.info('Python: v{}'.format(sys.version))
 Logger.info('Python: Interpreter at "{}"'.format(sys.executable))

--- a/kivy/_version.py
+++ b/kivy/_version.py
@@ -1,0 +1,17 @@
+# This file is imported from __init__.py and exec'd from setup.py
+
+MAJOR = 2
+MINOR = 0
+MICRO = 0
+RELEASE = False
+
+__version__ = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+
+if not RELEASE:
+    # if it's a rcx release, it's not proceeded by a period. If it is a
+    # devx release, it must start with a period
+    __version__ += 'rc3'
+
+
+_kivy_git_hash = ''
+_kivy_build_date = ''

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,7 @@ from distutils.command.build_ext import build_ext
 from distutils.version import LooseVersion
 from distutils.sysconfig import get_python_inc
 from collections import OrderedDict
-from time import time, sleep
-from subprocess import check_output, CalledProcessError
-from datetime import datetime
+from time import sleep
 from sysconfig import get_paths
 from pathlib import Path
 import logging
@@ -45,37 +43,6 @@ LooseVersion.__eq__ = ver_equal
 def get_description():
     with open(join(dirname(__file__), 'README.md'), 'rb') as fileh:
         return fileh.read().decode("utf8").replace('\r\n', '\n')
-
-
-def get_version(filename='kivy/version.py'):
-    VERSION = kivy.__version__
-    epoch = int(environ.get('SOURCE_DATE_EPOCH', time()))
-    DATE = datetime.utcfromtimestamp(epoch).strftime('%Y%m%d')
-    try:
-        GIT_REVISION = check_output(
-            ['git', 'rev-parse', 'HEAD']
-        ).strip().decode('ascii')
-    except (CalledProcessError, OSError, IOError, FileNotFoundError) as e:
-        # CalledProcessError has no errno
-        errno = getattr(e, 'errno', None)
-        if errno != 2 and 'CalledProcessError' not in repr(e):
-            raise
-        GIT_REVISION = "Unknown"
-
-    cnt = (
-        "# THIS FILE IS GENERATED FROM KIVY SETUP.PY\n"
-        "__version__ = '%(version)s'\n"
-        "__hash__ = '%(hash)s'\n"
-        "__date__ = '%(date)s'\n"
-    )
-
-    with open(filename, 'w') as f:
-        f.write(cnt % {
-            'version': VERSION,
-            'hash': GIT_REVISION,
-            'date': DATE
-        })
-    return VERSION
 
 
 def getoutput(cmd, env=None):
@@ -231,6 +198,11 @@ if platform in ('ios', 'android'):
 src_path = build_path = dirname(__file__)
 print("Current directory is: {}".format(os.getcwd()))
 print("Source and initial build directory is: {}".format(src_path))
+
+# __version__ is imported by exec, but help linter not complain
+__version__ = None
+with open(join(src_path, 'kivy', '_version.py'), encoding="utf-8") as f:
+    exec(f.read())
 
 
 class KivyBuildExt(build_ext, object):
@@ -1089,7 +1061,7 @@ def glob_paths(*patterns, excludes=('.pyc', )):
 if not build_examples:
     setup(
         name='Kivy',
-        version=get_version(),
+        version=__version__,
         author='Kivy Team and other contributors',
         author_email='kivy-dev@googlegroups.com',
         url='http://kivy.org',
@@ -1151,7 +1123,7 @@ if not build_examples:
 else:
     setup(
         name='Kivy-examples',
-        version=get_version(),
+        version=__version__,
         author='Kivy Team and other contributors',
         author_email='kivy-dev@googlegroups.com',
         url='http://kivy.org',


### PR DESCRIPTION
This adds a `_version.py` file where the version is kept. This helps getting the version in situations where kivy is not yet installed so you can't properly import kivy.

Also, previously we generated git tag and date and stored it in `version.py`, instead, this is also stored in `_version.py` and was moved to be part of the CI built process, rather than in `setup.py`. So that it's less fragile and not run by default on user systems.