### PR TITLE
Add min basic dependencies to install requirements.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ install_requires =
     Kivy-Garden>=0.1.4
     docutils
     pygments
+    kivy_deps.angle~=0.2.0; sys_platform == "win32"
+    kivy_deps.sdl2~=0.2.0; sys_platform == "win32"
+    kivy_deps.glew~=0.2.0; sys_platform == "win32"
+    pypiwin32; sys_platform == "win32"
 dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
 
 [options.extras_require]


### PR DESCRIPTION
This moves some of the dependencies listed in `base` to `install_requires` as a stopgap until there's a way to make pip install `base` by default, but also disabled if it's not wanted. This will make installs work by default, and for advanced users who don't want these requirements, they'll just have to install with `--no-deps`.

We still recommend that users install kivy with `pip install kivy[base]` as these requirements maybe removed from `install_requires` in the future when [defaults extras](https://discuss.python.org/t/adding-a-default-extra-require-environment/4898) are available.