### PR TITLE
[wip] optimize GridLayout

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -944,7 +944,6 @@
         pos: root.pos
         cols: 1
         id: menu
-        orientation: 'vertical'
         padding: 5
 
         canvas.after:

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -5,6 +5,6 @@ import pytest
 def test_always_lr_tb(orientation):
     from kivy.uix.bubble import Bubble
     b = Bubble(orientation=orientation)
-    assert b.fills_row_first
-    assert b.fills_from_left_to_right
-    assert b.fills_from_top_to_bottom
+    assert b._fills_row_first
+    assert b._fills_from_left_to_right
+    assert b._fills_from_top_to_bottom

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.parametrize('orientation', ('vertical', 'horizontal'))
+def test_always_lr_tb(orientation):
+    from kivy.uix.bubble import Bubble
+    b = Bubble(orientation=orientation)
+    assert b.fills_row_first
+    assert b.fills_from_left_to_right
+    assert b.fills_from_top_to_bottom

--- a/kivy/tests/test_uix_gridlayout.py
+++ b/kivy/tests/test_uix_gridlayout.py
@@ -109,5 +109,26 @@ def test_children_pos(n_cols, n_rows, orientation, n_children, expectation):
     assert actual_layout == expectation
 
 
+@pytest.mark.parametrize(
+    "n_cols, n_rows, orientation", [
+        (None, 2, 'lr-tb', ),
+        (None, 2, 'lr-bt', ),
+        (None, 2, 'rl-tb', ),
+        (None, 2, 'rl-bt', ),
+        (2, None, 'tb-lr', ),
+        (2, None, 'tb-rl', ),
+        (2, None, 'bt-lr', ),
+        (2, None, 'bt-rl', ),
+    ]
+)
+def test_invalid_configuration(n_cols, n_rows, orientation):
+    from kivy.uix.widget import Widget
+    from kivy.uix.gridlayout import GridLayout, GridLayoutException
+    gl = GridLayout(cols=n_cols, rows=n_rows, orientation=orientation)
+    gl.add_widget(Widget())
+    with pytest.raises(GridLayoutException):
+        gl.do_layout()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/kivy/tests/test_uix_gridlayout.py
+++ b/kivy/tests/test_uix_gridlayout.py
@@ -65,10 +65,10 @@ class UixGridLayoutTest(GraphicUnitTest):
         (2, 3, 'bt-rl', [(1, 2), (1, 1), (1, 0), (0, 2), (0, 1), (0, 0)]),
     ]
 )
-def test_create_col_and_row_index_iter(
+def test_create_idx_iter(
         n_cols, n_rows, orientation, expectation):
-    from kivy.uix.gridlayout import _create_col_and_row_index_iter
-    index_iter = _create_col_and_row_index_iter(n_cols, n_rows, orientation)
+    from kivy.uix.gridlayout import _create_idx_iter
+    index_iter = _create_idx_iter(n_cols, n_rows, orientation)
     assert expectation == list(index_iter)
 
 
@@ -76,9 +76,9 @@ def test_create_col_and_row_index_iter(
     'lr-tb', 'lr-bt', 'rl-tb', 'rl-bt',
     'tb-lr', 'tb-rl', 'bt-lr', 'bt-rl',
 ])
-def test_create_col_and_row_index_iter2(orientation):
-    from kivy.uix.gridlayout import _create_col_and_row_index_iter
-    index_iter = _create_col_and_row_index_iter(1, 1, orientation)
+def test_create_idx_iter2(orientation):
+    from kivy.uix.gridlayout import _create_idx_iter
+    index_iter = _create_idx_iter(1, 1, orientation)
     assert [(0, 0)] == list(index_iter)
 
 

--- a/kivy/tests/test_uix_gridlayout.py
+++ b/kivy/tests/test_uix_gridlayout.py
@@ -109,26 +109,5 @@ def test_children_pos(n_cols, n_rows, orientation, n_children, expectation):
     assert actual_layout == expectation
 
 
-@pytest.mark.parametrize(
-    "n_cols, n_rows, orientation", [
-        (None, 2, 'lr-tb', ),
-        (None, 2, 'lr-bt', ),
-        (None, 2, 'rl-tb', ),
-        (None, 2, 'rl-bt', ),
-        (2, None, 'tb-lr', ),
-        (2, None, 'tb-rl', ),
-        (2, None, 'bt-lr', ),
-        (2, None, 'bt-rl', ),
-    ]
-)
-def test_invalid_configuration(n_cols, n_rows, orientation):
-    from kivy.uix.widget import Widget
-    from kivy.uix.gridlayout import GridLayout, GridLayoutException
-    gl = GridLayout(cols=n_cols, rows=n_rows, orientation=orientation)
-    gl.add_widget(Widget())
-    with pytest.raises(GridLayoutException):
-        gl.do_layout()
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/kivy/tests/test_uix_gridlayout.py
+++ b/kivy/tests/test_uix_gridlayout.py
@@ -67,8 +67,9 @@ class UixGridLayoutTest(GraphicUnitTest):
 )
 def test_create_idx_iter(
         n_cols, n_rows, orientation, expectation):
-    from kivy.uix.gridlayout import _create_idx_iter
-    index_iter = _create_idx_iter(n_cols, n_rows, orientation)
+    from kivy.uix.gridlayout import GridLayout
+    gl = GridLayout(orientation=orientation)
+    index_iter = gl._create_idx_iter(n_cols, n_rows)
     assert expectation == list(index_iter)
 
 
@@ -77,8 +78,9 @@ def test_create_idx_iter(
     'tb-lr', 'tb-rl', 'bt-lr', 'bt-rl',
 ])
 def test_create_idx_iter2(orientation):
-    from kivy.uix.gridlayout import _create_idx_iter
-    index_iter = _create_idx_iter(1, 1, orientation)
+    from kivy.uix.gridlayout import GridLayout
+    gl = GridLayout(orientation=orientation)
+    index_iter = gl._create_idx_iter(1, 1)
     assert [(0, 0)] == list(index_iter)
 
 

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -159,15 +159,6 @@ class Bubble(GridLayout):
     defaults to 'None'.
     '''
 
-    orientation = OptionProperty('horizontal',
-                                 options=('horizontal', 'vertical'))
-    '''This specifies the manner in which the children inside bubble
-    are arranged. Can be one of 'vertical' or 'horizontal'.
-
-    :attr:`orientation` is a :class:`~kivy.properties.OptionProperty` and
-    defaults to 'horizontal'.
-    '''
-
     limit_to = ObjectProperty(None, allownone=True)
     '''Specifies the widget to which the bubbles position is restricted.
 
@@ -209,6 +200,7 @@ class Bubble(GridLayout):
         content.parent = None
         self.add_widget(content)
         self.on_arrow_pos()
+        self.on_orientation()
 
     def add_widget(self, *l):
         content = self.content
@@ -276,7 +268,7 @@ class Bubble(GridLayout):
         content = self.content
         if not content:
             return
-        if self.orientation[0] == 'v':
+        if not self.fills_row_first:
             content.cols = 1
             content.rows = 99
         else:

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -394,3 +394,15 @@ class Bubble(GridLayout):
     def _update_arrow(self, *dt):
         if self.arrow_pos in ('left_mid', 'right_mid'):
             self._sctr.center_y = self._arrow_layout.center_y
+
+    @property
+    def _fills_row_first(self):
+        return True
+
+    @property
+    def _fills_from_left_to_right(self):
+        return True
+
+    @property
+    def _fills_from_top_to_bottom(self):
+        return True

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -163,6 +163,7 @@ class Bubble(GridLayout):
                                  options=('horizontal', 'vertical'))
     '''This specifies the manner in which the children inside bubble
     are arranged. Can be one of 'vertical' or 'horizontal'.
+
     :attr:`orientation` is a :class:`~kivy.properties.OptionProperty` and
     defaults to 'horizontal'.
     '''

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -159,6 +159,14 @@ class Bubble(GridLayout):
     defaults to 'None'.
     '''
 
+    orientation = OptionProperty('horizontal',
+                                 options=('horizontal', 'vertical'))
+    '''This specifies the manner in which the children inside bubble
+    are arranged. Can be one of 'vertical' or 'horizontal'.
+    :attr:`orientation` is a :class:`~kivy.properties.OptionProperty` and
+    defaults to 'horizontal'.
+    '''
+
     limit_to = ObjectProperty(None, allownone=True)
     '''Specifies the widget to which the bubbles position is restricted.
 
@@ -268,7 +276,7 @@ class Bubble(GridLayout):
         content = self.content
         if not content:
             return
-        if not self.fills_row_first:
+        if self.orientation[0] == 'v':
             content.cols = 1
             content.rows = 99
         else:

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -209,7 +209,6 @@ class Bubble(GridLayout):
         content.parent = None
         self.add_widget(content)
         self.on_arrow_pos()
-        self.on_orientation()
 
     def add_widget(self, *l):
         content = self.content

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -255,7 +255,7 @@ class GridLayout(Layout):
 
     orientation = OptionProperty('lr-tb', options=(
         'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt', 'bt-lr', 'rl-bt',
-        'bt-rl', ))
+        'bt-rl'))
     '''Orientation of the layout.
 
     :attr:`orientation` is an :class:`~kivy.properties.OptionProperty` and

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -309,15 +309,15 @@ class GridLayout(Layout):
 
     @property
     def _fills_row_first(self):
-        return self.orientation[0] not in 'tb'
+        return self.orientation[0] in 'lr'
 
     @property
     def _fills_from_left_to_right(self):
-        return 'rl' not in self.orientation
+        return 'lr' in self.orientation
 
     @property
     def _fills_from_top_to_bottom(self):
-        return 'bt' not in self.orientation
+        return 'tb' in self.orientation
 
     def _init_rows_cols_sizes(self, count):
         # the goal here is to calculate the minimum size of every cols/rows

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -352,7 +352,7 @@ class GridLayout(Layout):
         self._rows_sh = [None] * current_rows
         self._rows_sh_min = [None] * current_rows
         self._rows_sh_max = [None] * current_rows
-        self._col_and_row_indices = tuple(_create_col_and_row_index_iter(
+        self._col_and_row_indices = tuple(_create_idx_iter(
             current_cols, current_rows, self.orientation))
 
         # update minimum size from the dicts
@@ -618,7 +618,7 @@ class GridLayout(Layout):
                     c.size = (w, h)
 
 
-def _create_col_and_row_index_iter(n_cols, n_rows, orientation):
+def _create_idx_iter(n_cols, n_rows, orientation):
     col_indices = range(n_cols) if 'lr' in orientation \
         else range(n_cols - 1, -1, -1)
     row_indices = range(n_rows) if 'tb' in orientation \

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -255,14 +255,14 @@ class GridLayout(Layout):
 
     orientation = OptionProperty('lr-tb', options=(
         'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt', 'bt-lr', 'rl-bt',
-        'bt-rl', 'horizontal', 'vertical', ))
+        'bt-rl', ))
     '''Orientation of the layout.
 
     :attr:`orientation` is an :class:`~kivy.properties.OptionProperty` and
     defaults to 'lr-tb'.
 
     Valid orientations are 'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt',
-    'bt-lr', 'rl-bt', 'bt-rl', 'horizontal' and 'vertical'.
+    'bt-lr', 'rl-bt' and 'bt-rl'.
 
     .. versionadded:: 2.0.0
 
@@ -272,8 +272,6 @@ class GridLayout(Layout):
         'rl' means Right to Left.
         'tb' means Top to Bottom.
         'bt' means Bottom to Top.
-        'horizontal' is an alias of 'lr-tb'.
-        'vertical' is an alias of 'tb-lr'.
     '''
 
     def __init__(self, **kwargs):
@@ -311,7 +309,7 @@ class GridLayout(Layout):
 
     @property
     def fills_row_first(self):
-        return self.orientation[0] in 'lrh'
+        return self.orientation[0] not in 'tb'
 
     @property
     def fills_from_left_to_right(self):

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -336,15 +336,15 @@ class GridLayout(Layout):
 
         if current_cols is None:
             if self.fills_row_first:
-                Logger.warning(
+                raise GridLayoutException(
                     'Being asked to fill row-first, but a number of columns '
-                    'is not defined. You might get an unexpected result.')
+                    'is not defined.')
             current_cols = int(ceil(count / float(current_rows)))
         elif current_rows is None:
             if not self.fills_row_first:
-                Logger.warning(
+                raise GridLayoutException(
                     'Being asked to fill column-first, but a number of rows '
-                    'is not defined. You might get an unexpected result.')
+                    'is not defined.')
             current_rows = int(ceil(count / float(current_cols)))
 
         current_cols = max(1, current_cols)

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -333,16 +333,8 @@ class GridLayout(Layout):
             return
 
         if current_cols is None:
-            if self._fills_row_first:
-                Logger.warning(
-                    'Being asked to fill row-first, but a number of columns '
-                    'is not defined. You might get an unexpected result.')
             current_cols = int(ceil(count / float(current_rows)))
         elif current_rows is None:
-            if not self._fills_row_first:
-                Logger.warning(
-                    'Being asked to fill column-first, but a number of rows '
-                    'is not defined. You might get an unexpected result.')
             current_rows = int(ceil(count / float(current_cols)))
 
         current_cols = max(1, current_cols)

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -308,7 +308,7 @@ class GridLayout(Layout):
                 'Too many children in GridLayout. Increase rows/cols!')
 
     @property
-    def _fills_row_first(self):
+    def fills_row_first(self):
         return self.orientation[0] in 'lr'
 
     def _init_rows_cols_sizes(self, count):
@@ -325,13 +325,13 @@ class GridLayout(Layout):
             return
 
         if current_cols is None:
-            if self._fills_row_first:
+            if self.fills_row_first:
                 Logger.warning(
                     'Being asked to fill row-first, but a number of columns '
                     'is not defined. You might get an unexpected result.')
             current_cols = int(ceil(count / float(current_rows)))
         elif current_rows is None:
-            if not self._fills_row_first:
+            if not self.fills_row_first:
                 Logger.warning(
                     'Being asked to fill column-first, but a number of rows '
                     'is not defined. You might get an unexpected result.')
@@ -558,7 +558,7 @@ class GridLayout(Layout):
             ))
             rows = reversed(rows)
 
-        if self._fills_row_first:
+        if self.fills_row_first:
             for i, (y, x), (row_height, col_width) in zip(
                     reversed(range(count)),
                     product(y_iter, x_iter),

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -352,8 +352,6 @@ class GridLayout(Layout):
         self._rows_sh = [None] * current_rows
         self._rows_sh_min = [None] * current_rows
         self._rows_sh_max = [None] * current_rows
-        self._col_and_row_indices = tuple(_create_idx_iter(
-            current_cols, current_rows, self.orientation))
 
         # update minimum size from the dicts
         items = (i for i in self.cols_minimum.items() if i[0] < len(cols))
@@ -373,8 +371,8 @@ class GridLayout(Layout):
 
         # calculate minimum size for each columns and rows
         has_bound_y = has_bound_x = False
-        for child, (col, row) in zip(reversed(self.children),
-                                     self._col_and_row_indices):
+        idx_iter = _create_idx_iter(len(cols), len(rows), self.orientation)
+        for child, (col, row) in zip(reversed(self.children), idx_iter):
             (shw, shh), (w, h) = child.size_hint, child.size
             shw_min, shh_min = child.size_hint_min
             shw_max, shh_max = child.size_hint_max

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -334,15 +334,15 @@ class GridLayout(Layout):
 
         if current_cols is None:
             if self.fills_row_first:
-                raise GridLayoutException(
+                Logger.warning(
                     'Being asked to fill row-first, but a number of columns '
-                    'is not defined.')
+                    'is not defined. You might get an unexpected result.')
             current_cols = int(ceil(count / float(current_rows)))
         elif current_rows is None:
             if not self.fills_row_first:
-                raise GridLayoutException(
+                Logger.warning(
                     'Being asked to fill column-first, but a number of rows '
-                    'is not defined.')
+                    'is not defined. You might get an unexpected result.')
             current_rows = int(ceil(count / float(current_cols)))
 
         current_cols = max(1, current_cols)

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -308,15 +308,15 @@ class GridLayout(Layout):
                 'Too many children in GridLayout. Increase rows/cols!')
 
     @property
-    def fills_row_first(self):
+    def _fills_row_first(self):
         return self.orientation[0] not in 'tb'
 
     @property
-    def fills_from_left_to_right(self):
+    def _fills_from_left_to_right(self):
         return 'rl' not in self.orientation
 
     @property
-    def fills_from_top_to_bottom(self):
+    def _fills_from_top_to_bottom(self):
         return 'bt' not in self.orientation
 
     def _init_rows_cols_sizes(self, count):
@@ -333,13 +333,13 @@ class GridLayout(Layout):
             return
 
         if current_cols is None:
-            if self.fills_row_first:
+            if self._fills_row_first:
                 Logger.warning(
                     'Being asked to fill row-first, but a number of columns '
                     'is not defined. You might get an unexpected result.')
             current_cols = int(ceil(count / float(current_rows)))
         elif current_rows is None:
-            if not self.fills_row_first:
+            if not self._fills_row_first:
                 Logger.warning(
                     'Being asked to fill column-first, but a number of rows '
                     'is not defined. You might get an unexpected result.')
@@ -529,7 +529,7 @@ class GridLayout(Layout):
         spacing_x, spacing_y = self.spacing
 
         cols = self._cols
-        if self.fills_from_left_to_right:
+        if self._fills_from_left_to_right:
             x_iter = accumulate(chain(
                 (self.x + padding[0], ),
                 (
@@ -548,7 +548,7 @@ class GridLayout(Layout):
             cols = reversed(cols)
 
         rows = self._rows
-        if self.fills_from_top_to_bottom:
+        if self._fills_from_top_to_bottom:
             y_iter = accumulate(chain(
                 (self.top - padding[1] - rows[0], ),
                 (
@@ -566,7 +566,7 @@ class GridLayout(Layout):
             ))
             rows = reversed(rows)
 
-        if self.fills_row_first:
+        if self._fills_row_first:
             for i, (y, x), (row_height, col_width) in zip(
                     reversed(range(count)),
                     product(y_iter, x_iter),
@@ -624,12 +624,12 @@ class GridLayout(Layout):
                     c.size = (w, h)
 
     def _create_idx_iter(self, n_cols, n_rows):
-        col_indices = range(n_cols) if self.fills_from_left_to_right \
+        col_indices = range(n_cols) if self._fills_from_left_to_right \
             else range(n_cols - 1, -1, -1)
-        row_indices = range(n_rows) if self.fills_from_top_to_bottom \
+        row_indices = range(n_rows) if self._fills_from_top_to_bottom \
             else range(n_rows - 1, -1, -1)
 
-        if self.fills_row_first:
+        if self._fills_row_first:
             return (
                 (col_index, row_index)
                 for row_index, col_index in product(row_indices, col_indices))

--- a/kivy/uix/gridlayout.py
+++ b/kivy/uix/gridlayout.py
@@ -255,14 +255,14 @@ class GridLayout(Layout):
 
     orientation = OptionProperty('lr-tb', options=(
         'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt', 'bt-lr', 'rl-bt',
-        'bt-rl'))
+        'bt-rl', 'horizontal', 'vertical', ))
     '''Orientation of the layout.
 
     :attr:`orientation` is an :class:`~kivy.properties.OptionProperty` and
     defaults to 'lr-tb'.
 
     Valid orientations are 'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt',
-    'bt-lr', 'rl-bt' and 'bt-rl'.
+    'bt-lr', 'rl-bt', 'bt-rl', 'horizontal' and 'vertical'.
 
     .. versionadded:: 2.0.0
 
@@ -272,6 +272,8 @@ class GridLayout(Layout):
         'rl' means Right to Left.
         'tb' means Top to Bottom.
         'bt' means Bottom to Top.
+        'horizontal' is an alias of 'lr-tb'.
+        'vertical' is an alias of 'tb-lr'.
     '''
 
     def __init__(self, **kwargs):
@@ -309,15 +311,15 @@ class GridLayout(Layout):
 
     @property
     def fills_row_first(self):
-        return self.orientation[0] in 'lr'
+        return self.orientation[0] in 'lrh'
 
     @property
     def fills_from_left_to_right(self):
-        return 'lr' in self.orientation
+        return 'rl' not in self.orientation
 
     @property
     def fills_from_top_to_bottom(self):
-        return 'tb' in self.orientation
+        return 'bt' not in self.orientation
 
     def _init_rows_cols_sizes(self, count):
         # the goal here is to calculate the minimum size of every cols/rows

--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -212,7 +212,7 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
             ix = len(cols) - ix - 1
         if 'tb' in ori:
             iy = len(rows) - iy - 1
-        return (iy * len(cols) + ix) if self._fills_row_first else \
+        return (iy * len(cols) + ix) if self.fills_row_first else \
             (ix * len(rows) + iy)
 
     def compute_visible_views(self, data, viewport):
@@ -233,7 +233,7 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
 
         n = len(data)
         indices = []
-        stride = len(self._cols) if self._fills_row_first else len(self._rows)
+        stride = len(self._cols) if self.fills_row_first else len(self._rows)
         if stride:
             x_slice = br - bl + 1
             for s in range(tl, bl + 1, stride):

--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -40,7 +40,6 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
         cols_sh_min, rows_sh_min = self._cols_sh_min, self._rows_sh_min
         cols_sh_max, rows_sh_max = self._cols_sh_max, self._rows_sh_max
         self._cols_count = cols_count = [defaultdict(int) for _ in cols]
-        # !! bottom-to-top, the opposite of the other attributes.
         self._rows_count = rows_count = [defaultdict(int) for _ in rows]
 
         # calculate minimum size for each columns and rows
@@ -224,7 +223,7 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
         top = y + h
         at_idx = self.get_view_index_at
         # 'tl' is not actually 'top-left' unless 'orientation' is 'lr-tb'.
-        # But we can pretend it is. Same for 'bl' and 'br'.
+        # But we can pretend it always is. Same for 'bl' and 'br'.
         tl, __, bl, br = sorted((
             at_idx((x, y)),
             at_idx((right, y)),

--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -207,11 +207,11 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
                     break
                 iy += 1
 
-        if not self.fills_from_left_to_right:
+        if not self._fills_from_left_to_right:
             ix = len(cols) - ix - 1
-        if self.fills_from_top_to_bottom:
+        if self._fills_from_top_to_bottom:
             iy = len(rows) - iy - 1
-        return (iy * len(cols) + ix) if self.fills_row_first else \
+        return (iy * len(cols) + ix) if self._fills_row_first else \
             (ix * len(rows) + iy)
 
     def compute_visible_views(self, data, viewport):
@@ -232,7 +232,7 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
 
         n = len(data)
         indices = []
-        stride = len(self._cols) if self.fills_row_first else len(self._rows)
+        stride = len(self._cols) if self._fills_row_first else len(self._rows)
         if stride:
             x_slice = br - bl + 1
             for s in range(tl, bl + 1, stride):
@@ -241,12 +241,12 @@ class RecycleGridLayout(RecycleLayout, GridLayout):
 
     def _calculate_idx_from_a_view_idx(self, n_cols, n_rows, view_idx):
         '''returns a tuple of (column-index, row-index) from a view-index'''
-        if self.fills_row_first:
+        if self._fills_row_first:
             row_idx, col_idx = divmod(view_idx, n_cols)
         else:
             col_idx, row_idx = divmod(view_idx, n_rows)
-        if not self.fills_from_left_to_right:
+        if not self._fills_from_left_to_right:
             col_idx = n_cols - col_idx - 1
-        if not self.fills_from_top_to_bottom:
+        if not self._fills_from_top_to_bottom:
             row_idx = n_rows - row_idx - 1
         return (col_idx, row_idx, )

--- a/kivy/uix/recyclegridlayout.py
+++ b/kivy/uix/recyclegridlayout.py
@@ -15,8 +15,7 @@ The RecycleGridLayout is designed to provide a
 """
 
 from kivy.uix.recyclelayout import RecycleLayout
-from kivy.uix.gridlayout import \
-    GridLayout, GridLayoutException, nmax, nmin
+from kivy.uix.gridlayout import GridLayout, GridLayoutException, nmax, nmin
 from collections import defaultdict
 
 __all__ = ('RecycleGridLayout', )

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -629,8 +629,7 @@ class SettingsPanel(GridLayout):
     '''
 
     def __init__(self, **kwargs):
-        if 'cols' not in kwargs:
-            self.cols = 1
+        kwargs.setdefault('cols', 1)
         super(SettingsPanel, self).__init__(**kwargs)
 
     def on_config(self, instance, value):

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -472,11 +472,13 @@ class TabbedPanel(GridLayout):
         # these variables need to be initialized before the kv lang is
         # processed setup the base layout for the tabbed panel
         self._childrens = []
-        self._tab_layout = StripLayout(rows=1)
+        self._tab_layout = StripLayout(rows=1, orientation='tb-lr')
         self.rows = 1
+        self.orientation = 'tb-lr'
         self._tab_strip = TabbedPanelStrip(
             tabbed_panel=self,
             rows=1, size_hint=(None, None),
+            orientation='tb-lr',
             height=self.tab_height, width=self.tab_width)
 
         self._partial_update_scrollview = None

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -472,13 +472,11 @@ class TabbedPanel(GridLayout):
         # these variables need to be initialized before the kv lang is
         # processed setup the base layout for the tabbed panel
         self._childrens = []
-        self._tab_layout = StripLayout(rows=1, orientation='tb-lr')
+        self._tab_layout = StripLayout(rows=1)
         self.rows = 1
-        self.orientation = 'tb-lr'
         self._tab_strip = TabbedPanelStrip(
             tabbed_panel=self,
             rows=1, size_hint=(None, None),
-            orientation='tb-lr',
             height=self.tab_height, width=self.tab_width)
 
         self._partial_update_scrollview = None


### PR DESCRIPTION
#6741 (a recently merged PR I wrote) may be terrible in terms of efficiency, because it creates list/tuple in the situation where iterator is enough. This PR tries to fix it.

### TODO

- [x] replace temporal lists/tuples with iterators
- [x] avoid holding pre-calculated indices (`_col_and_row_indices`)
- [x] keep the compatibility with [Bubble](https://kivy.org/doc/master/api-kivy.uix.bubble.html#kivy.uix.bubble.Bubble.orientation)
- [x] keep the compatibility with [TabbedPanel](https://kivy.org/doc/master/api-kivy.uix.tabbedpanel.html)
- [ ] ~~raise an exception when the configuration is wrong (https://github.com/kivy/kivy/pull/6741#discussion_r498640070)~~ (not going to do this at least in this PR)
