### PR TITLE
Stop building wheels for RPi stretch

### DIFF
--- a/.ci/build-wheels-linux.sh
+++ b/.ci/build-wheels-linux.sh
@@ -43,7 +43,7 @@ make distclean;
 
 cd /io;
 for PYBIN in /opt/python/*3*/bin; do
-    if [[ $PYBIN != *"34"* ]]; then
+    if [[ $PYBIN != *"34"* && $PYBIN != *"35"* ]]; then
         "${PYBIN}/pip" install --upgrade setuptools pip;
         "${PYBIN}/pip" install --upgrade cython nose pygments docutils;
         KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" "${PYBIN}/pip" wheel --no-deps . -w dist/;

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        docker_images: ['balenalib/armv7hf-debian:stretch', 'balenalib/armv7hf-debian:buster']
+        docker_images: ['balenalib/armv7hf-debian:buster']
     steps:
     - uses: actions/checkout@v2
     - name: Generate version metadata


### PR DESCRIPTION
This stops building wheels for RPi stretch and python 3.5 manylinux. 

Previously we already didn't build 3.5 wheels for some platforms because master does not support 3.5. However, now pip has deprecated support for 3.5 and will completely stop supporting it in January. In addition now Kivy definitely doesn't build on 3.5 anymore because of the python version selector metadata so pip refuses to build kivy on 3.5.

Stretch comes with python 3.5, hence we cannot build wheels anymore on it. We can re-enable it if someone thinks it's worth it by installing python 3.6 on stretch. But that will probably not be useful because most people will expect 3.5 if they use stretch.