### PR TITLE
Expand dependency selection varaibles

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ base =
     pypiwin32; sys_platform == "win32"
 media =
     kivy_deps.gstreamer~=0.3.1; sys_platform == "win32"
-    ffpyplayer; sys_platform in ("linux", "darwin")
+    ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
 full =
     pillow
     docutils
@@ -66,7 +66,7 @@ full =
     kivy_deps.angle~=0.3.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.3.1; sys_platform == "win32"
     kivy_deps.glew~=0.3.0; sys_platform == "win32"
-    ffpyplayer; sys_platform in ("linux", "darwin")
+    ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
     pypiwin32; sys_platform == "win32"
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,9 @@ dev =
     sphinxcontrib-seqdiag
     sphinxcontrib-actdiag
     sphinxcontrib-nwdiag
+    kivy_deps.gstreamer_dev~=0.3.1; sys_platform == "win32"
+    kivy_deps.sdl2_dev~=0.3.1; sys_platform == "win32"
+    kivy_deps.glew_dev~=0.3.0; sys_platform == "win32"
     flake8
 base =
     pillow
@@ -52,6 +55,9 @@ base =
     kivy_deps.sdl2~=0.3.1; sys_platform == "win32"
     kivy_deps.glew~=0.3.0; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
+media =
+    kivy_deps.gstreamer~=0.3.1; sys_platform == "win32"
+    ffpyplayer; sys_platform in ("linux", "darwin")
 full =
     pillow
     docutils
@@ -60,6 +66,7 @@ full =
     kivy_deps.angle~=0.3.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.3.1; sys_platform == "win32"
     kivy_deps.glew~=0.3.0; sys_platform == "win32"
+    ffpyplayer; sys_platform in ("linux", "darwin")
     pypiwin32; sys_platform == "win32"
 
 [flake8]


### PR DESCRIPTION
* Adds a `media` option with gstreamer when it's available (windows) and ffpyplayer otherwise (linux, darwin).
* Similarly adds `media` to `full`.
* Adds `kivy_deps.xxx_dev` to `dev` install so that an editable install will include them. `pyproject.toml` only installs them in the temporary internal pip env used to build, this installs it in the host env as well for recompiling after the initial install. This is only required until PEP517 makes editable install work better.