### PR TITLE
Switch to staging docs on kivy-website-docs

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -141,21 +141,22 @@ upload_docs_to_server() {
     return
   fi
 
-  git clone https://github.com/kivy/kivy-website-docs.git
+  git clone --depth 1 --branch "$branch" https://github.com/kivy/kivy-website-docs.git
   cd kivy-website-docs
 
   git config user.email "kivy@kivy.org"
-  git config user.name "Kivy developers"
+  git config user.name "Kivy bot"
   git remote rm origin || true
   git remote add origin "https://x-access-token:${DOC_PUSH_TOKEN}@github.com/kivy/kivy-website-docs.git"
 
-  git checkout --orphan "$branch"
-  rm LICENSE README.md
-  cp -rp ../doc/build/html/* .
+  rsync --delete --force --exclude .git/ --exclude .gitignore -r ../doc/build/html/ .
 
   git add .
-  git commit -a -m "Docs for git-$commit"
-  git push origin "$branch" -f
+  git add -u
+  if ! git diff --cached --exit-code --quiet; then
+    git commit -m "Docs for git-$commit"
+    git push origin "$branch"
+  fi
 }
 
 generate_manylinux2010_wheels() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -133,24 +133,29 @@ generate_docs() {
 }
 
 upload_docs_to_server() {
-  versions=$1
-  branch=$2
-  ip=$3
+  branch="docs-$1"
+  commit="$2"
 
-  if [ ! -d ~/.ssh ]; then
-    mkdir ~/.ssh
+  # only upload docs if we have a branch for it
+  if [ -z "$(git ls-remote --heads https://github.com/kivy/kivy-website-docs.git "$branch")" ]; then
+    return
   fi
-  printf "%s" "$UBUNTU_UPLOAD_KEY" >~/.ssh/id_rsa
-  chmod 600 ~/.ssh/id_rsa
-  echo -e "Host $ip\n\tStrictHostKeyChecking no\n" >>~/.ssh/config
 
-  for version in $versions; do
-    if [ "$version" == "${branch}" ]; then
-      echo "[$(echo $versions | tr ' ' ', ' | sed -s 's/\([^,]\+\)/"\1"/g')]" >versions.json
-      rsync --force -e "ssh -p 2457" versions.json root@$ip:/web/doc/
-      rsync --delete --force -r -e "ssh -p 2457" ./doc/build/html/ root@$ip:/web/doc/$version
-    fi
-  done
+  git clone https://github.com/kivy/kivy-website-docs.git
+  cd kivy-website-docs
+
+  git config user.email "kivy@kivy.org"
+  git config user.name "Kivy developers"
+  git remote rm origin || true
+  git remote add origin "https://x-access-token:${DOC_PUSH_TOKEN}@github.com/kivy/kivy-website-docs.git"
+
+  git checkout --orphan "$branch"
+  rm LICENSE README.md
+  cp -rp ./doc/build/html/* .
+
+  git add .
+  git commit -a -m "Docs for git-$commit"
+  git push origin "$branch" -f
 }
 
 generate_manylinux2010_wheels() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -151,7 +151,7 @@ upload_docs_to_server() {
 
   git checkout --orphan "$branch"
   rm LICENSE README.md
-  cp -rp ./doc/build/html/* .
+  cp -rp ../doc/build/html/* .
 
   git add .
   git commit -a -m "Docs for git-$commit"

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -4,8 +4,6 @@ on: [push, pull_request]
 
 env:
   KIVY_SPLIT_EXAMPLES: 1
-  SERVER_IP: '159.203.106.198'
-  DOC_VERSIONS: 'stable master stable-1.10.1 stable-1.11.0'
 
 jobs:
   PEP8_test:
@@ -86,12 +84,12 @@ jobs:
       with:
         name: docs
         path: doc/build/html
-    - name: Upload docs to server
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/stable'))
+    - name: Upload docs to kivy-website-docs
+      if: github.event_name == 'push'
       env:
         REF_NAME: ${{ github.ref }}
-        UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
+        DOC_PUSH_TOKEN: ${{ secrets.DOC_PUSH_TOKEN }}
       run: |
         branch_name=$(python3 -c "print('$REF_NAME'.split('/')[-1])")
         source .ci/ubuntu_ci.sh
-        upload_docs_to_server "$DOC_VERSIONS" "$branch_name" "$SERVER_IP"
+        upload_docs_to_server "$branch_name" "$GITHUB_SHA"


### PR DESCRIPTION
Kivy uses sphinx to generate API and install/guide docs shown to the user. This means that to show any changes the docs need to be rebuilt. What happens if we need to update the docs of a older release and we cannot do that anymore because the CI isn't able to build that old version anymore?

In an effort to be able to edit docs long after the CI that generates the docs is dead, I created the https://github.com/kivy/kivy-website-docs repo that we use to stage our docs before it is fetched by the kivy server and served on kivy.org. Only the CI is meant to update the repo, and there are `docs-` prefixed branches for each kivy version. The CI updates and pushes there whenever the docs change.

Once the CI is dead for a version and we don't run the risk of the CI overwriting any changes to the branch, any further changes required can be done manually.

I coped over the docs from the server and made branches for each of the older and current kivy versions. The CI will only push docs to that repo, if that repo contains a similarly named branch. Please read that repo's readme for more details.

A proper solution of course would involve separating API from install docs so that install docs are independent and can always be updated. However, that is more complicated as we'd need to make a new docs repo and add it to the site, so this seemed more practical.

Corresponding PR: https://github.com/kivy/kivy-server/pull/19.