### PR TITLE
Inlcude doc in PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,9 @@ Below are items maintainers should consider when merging the PR. Feel free to su
 -->
 Maintainer merge checklist
 * [ ] Title is descriptive/clear for inclusion in release notes.
-* [ ] Applied a `unit@` label.
+* [ ] Applied a `Component: xxx` label.
 * [ ] Applied the `api-deprecation` or `api-break` label.
-* [ ] Applied the `release-highlight` to be highlighted in release notes.
+* [ ] Applied the `release-highlight` label to be highlighted in release notes.
 * [ ] Added to the milestone version it was merged into.
 * [ ] **Unittests** are included in PR.
 * [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@ Maintainer merge checklist
 * [ ] Applied the `release-highlight` to be highlighted in release notes.
 * [ ] Added to the milestone version it was merged into.
 * [ ] **Unittests** are included in PR.
+* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `unit@` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
