### PR TITLE
CI: Test all wheel versions, not just one per OS

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -75,6 +75,13 @@ install_platypus() {
 }
 
 generate_osx_wheels() {
+  # for some reason wheels sometimes fail to properly generate because both the parent and grandparent
+  # are named kivy so instead acquire a new grandparent name
+  root=$(pwd)
+  cd ~
+  mv "$root" kivy_project
+  cd kivy_project
+
   python3 -m pip install git+http://github.com/tito/osxrelocator
   python3 -m pip install --upgrade delocate
   python3 setup.py bdist_wheel
@@ -118,6 +125,9 @@ generate_osx_wheels() {
   popd
 
   delocate-addplat --rm-orig -x 10_9 -x 10_10 dist/*.whl
+
+  cd ..
+  mv kivy_project "$root"
 }
 
 generate_osx_app_bundle() {

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -95,7 +95,8 @@ function Install-kivy-wheel {
     python -m pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
 
     $version=python -c "import sys; print('{}{}'.format(sys.version_info.major, sys.version_info.minor))"
-    $kivy_fname=(ls $root/dist/Kivy-*$version*win_amd64*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
+    $bitness=python -c "import sys; print('win_amd64' if sys.maxsize > 2**32 else 'win32')"
+    $kivy_fname=(ls $root/dist/Kivy-*$version*$bitness*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
     $kivy_examples_fname=(ls $root/dist/Kivy_examples-*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
     echo "kivy_fname = $kivy_fname, kivy_examples_fname = $kivy_examples_fname"
     python -m pip install "$root/dist/$kivy_fname[full,dev]" "$root/dist/$kivy_examples_fname"

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -59,11 +59,10 @@ jobs:
         name: manylinux_wheels
         path: dist
 
-  manylinux_wheel_upload_test:
+  manylinux_wheel_upload:
     runs-on: ubuntu-18.04
     needs: [manylinux_wheel_create, kivy_examples_create]
-    env:
-      DISPLAY: ':99.0'
+    if: github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x
@@ -80,7 +79,6 @@ jobs:
         source .ci/ubuntu_ci.sh
         rename_wheels
     - name: Upload wheels to server
-      if: github.event_name != 'pull_request'
       env:
         UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
       run: |
@@ -102,6 +100,25 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         upload_artifacts_to_pypi
+
+  manylinux_wheel_test:
+    runs-on: ubuntu-18.04
+    needs: [manylinux_wheel_create, kivy_examples_create]
+    strategy:
+      matrix:
+        python: [ '3.6', '3.7', '3.8', '3.9' ]
+    env:
+      DISPLAY: ':99.0'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - uses: actions/download-artifact@v2
+      with:
+        name: manylinux_wheels
+        path: dist
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -89,9 +89,10 @@ jobs:
         name: osx_wheels
         path: dist
 
-  osx_wheel_upload_test:
+  osx_wheel_upload:
     runs-on: macos-10.15
-    needs: [osx_wheels_create, kivy_examples_create]
+    needs: osx_wheels_create
+    if: github.event_name != 'pull_request'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:
@@ -110,7 +111,6 @@ jobs:
         source .ci/ubuntu_ci.sh
         rename_wheels
     - name: Upload wheels to server
-      if: github.event_name != 'pull_request'
       env:
         UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
       run: |
@@ -132,26 +132,45 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         upload_artifacts_to_pypi
-    - name: Install test dependencies
-      run: |
-        source .ci/ubuntu_ci.sh
-        install_kivy_test_wheel_run_pip_deps
-    - name: Install Kivy wheel
-      run: |
-        source .ci/ubuntu_ci.sh
-        install_kivy_wheel
-    - uses: actions/download-artifact@v2
-      with:
-        name: osx_examples_wheel
-        path: dist
-    - name: Install kivy-examples wheel
-      run: |
-        source .ci/ubuntu_ci.sh
-        install_kivy_examples_wheel
-    - name: Test Kivy wheel
-      run: |
-        source .ci/ubuntu_ci.sh
-        test_kivy_install
+
+  osx_wheel_test:
+    runs-on: macos-10.15
+    needs: [ osx_wheels_create, kivy_examples_create ]
+    strategy:
+      matrix:
+        python: [ '3.6', '3.7', '3.8', '3.9' ]
+    env:
+      KIVY_GL_BACKEND: 'mock'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: osx_wheels
+          path: dist
+      - name: Install test dependencies
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_test_wheel_run_pip_deps
+      - name: Install Kivy wheel
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_wheel
+      - uses: actions/download-artifact@v2
+        with:
+          name: osx_examples_wheel
+          path: dist
+      - name: Install kivy-examples wheel
+        run: |
+          source .ci/ubuntu_ci.sh
+          install_kivy_examples_wheel
+      - name: Test Kivy wheel
+        run: |
+          source .ci/ubuntu_ci.sh
+          test_kivy_install
 
   osx_app_create:
     runs-on: macos-10.15

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -58,9 +58,10 @@ jobs:
         name: windows_wheels
         path: dist
 
-  windows_wheel_upload_test:
+  windows_wheel_upload:
     runs-on: windows-latest
     needs: windows_wheels_create
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -79,7 +80,6 @@ jobs:
       - name: Install MSYS2
         run: choco install msys2
       - name: Upload wheels to server
-        if: github.event_name != 'pull_request'
         env:
           UBUNTU_UPLOAD_KEY: ${{ secrets.UBUNTU_UPLOAD_KEY }}
           MSYSTEM: MINGW64
@@ -103,6 +103,25 @@ jobs:
         run: |
           . .\.ci\windows_ci.ps1
           Upload-artifacts-to-pypi
+
+  windows_wheel_test:
+    runs-on: windows-latest
+    needs: windows_wheels_create
+    strategy:
+      matrix:
+        python: [ '3.6', '3.7', '3.8', '3.9' ]
+        arch: [ 'x64', 'x86' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: ${{ matrix.arch }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows_wheels
+          path: dist
       - name: Install Kivy Wheel
         run: |
           . .\.ci\windows_ci.ps1


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Tests all the generated wheel combinations, not just one per OS like before. Because there may be issues with only one of the python versions, like the other issue fixed in the PR.

Also fixes, where for 3.9 on osx the wheel was incorrectly generated. Basically, because GH creates a folder named kivy, clones kivy into folder named kivy, which itself has a folder named kivy, this confuses `bdist_wheel` somehow. Fixed by moving the cloned project.