### PR TITLE
Tests: Ensure Bubble uses it's superclass's valid private API

### DIFF
--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -6,7 +6,7 @@ import pytest
     '_fills_from_left_to_right',
     '_fills_from_top_to_bottom',
 ))
-def test_a_certain_properties_are_actually_overwritten(prop_name):
+def test_a_certain_properties_from_the_super_class_are_overwritten(prop_name):
     from kivy.uix.bubble import Bubble
     from kivy.uix.gridlayout import GridLayout
     assert issubclass(Bubble, GridLayout)

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -1,6 +1,17 @@
 import pytest
 
 
+@pytest.mark.parametrize('prop_name', (
+    '_fills_row_first',
+    '_fills_from_left_to_right',
+    '_fills_from_top_to_bottom',
+))
+def test_a_certain_properties_exist_in_any_of_the_super_classes(prop_name):
+    from kivy.uix.bubble import Bubble
+    super_classes = Bubble.mro()[1:]  # exclude Bubble itself
+    assert any(hasattr(klass, prop_name) for klass in super_classes)
+
+
 @pytest.mark.parametrize('orientation', ('vertical', 'horizontal'))
 def test_always_lr_tb(orientation):
     from kivy.uix.bubble import Bubble

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -6,9 +6,11 @@ import pytest
     '_fills_from_left_to_right',
     '_fills_from_top_to_bottom',
 ))
-def test_a_certain_properties_exist_in_the_super_class(prop_name):
+def test_a_certain_properties_are_actually_overwritten(prop_name):
+    from kivy.uix.bubble import Bubble
     from kivy.uix.gridlayout import GridLayout
-    assert hasattr(GridLayout, prop_name)
+    assert issubclass(Bubble, GridLayout)
+    assert getattr(Bubble, prop_name) is not getattr(GridLayout, prop_name)
 
 
 @pytest.mark.parametrize('orientation', ('vertical', 'horizontal'))

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -6,10 +6,9 @@ import pytest
     '_fills_from_left_to_right',
     '_fills_from_top_to_bottom',
 ))
-def test_a_certain_properties_exist_in_any_of_the_super_classes(prop_name):
-    from kivy.uix.bubble import Bubble
-    super_classes = Bubble.mro()[1:]  # exclude Bubble itself
-    assert any(hasattr(klass, prop_name) for klass in super_classes)
+def test_a_certain_properties_exist_in_the_super_class(prop_name):
+    from kivy.uix.gridlayout import GridLayout
+    assert hasattr(GridLayout, prop_name)
 
 
 @pytest.mark.parametrize('orientation', ('vertical', 'horizontal'))


### PR DESCRIPTION
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

## Problem

Bubble currently overwrites some of GridLayout's internal properties: `_fills_row_first`, `_fills_from_left_to_right` and `_fills_from_top_to_bottom`. If any of them are renamed/removed, Bubble's should be renamed/removed as well. The problem is that the unittests don't say anything about this. So if someone only modifies GridLayout's, and forgot to modify Bubble's, Bubble might silently get broken.

 ## What this PR does

This PR lets the unittests check if those properties actually exist in Bubble's super classes.
(I feel like there is a better way to solve the problem, so I put "WIP" in the title.)