### PR TITLE
ScrollView: Match scroll effect stop condition to start condition.

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -973,14 +973,12 @@ class ScrollView(StencilView):
         self._touch = None
         uid = self._get_uid()
         ud = touch.ud[uid]
-        if self.do_scroll_x and self.effect_x:
-            if not touch.ud.get('in_bar_x', False) and\
-                    self.scroll_type != ['bars']:
-                self.effect_x.stop(touch.x)
-        if self.do_scroll_y and self.effect_y and\
-                self.scroll_type != ['bars']:
-            if not touch.ud.get('in_bar_y', False):
-                self.effect_y.stop(touch.y)
+        not_in_bar = not touch.ud.get('in_bar_x', False) and \
+            not touch.ud.get('in_bar_y', False)
+        if self.do_scroll_x and self.effect_x and not_in_bar:
+            self.effect_x.stop(touch.x)
+        if self.do_scroll_y and self.effect_y and not_in_bar:
+            self.effect_y.stop(touch.y)
         if ud['mode'] == 'unknown':
             # we must do the click at least..
             # only send the click if it was not a click to stop

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -895,6 +895,9 @@ class ScrollView(StencilView):
                 ud['mode'] = 'scroll'
 
         if ud['mode'] == 'scroll':
+            not_in_bar = not touch.ud.get('in_bar_x', False) and \
+                not touch.ud.get('in_bar_y', False)
+
             if not touch.ud['sv.handled']['x'] and self.do_scroll_x \
                     and self.effect_x:
                 width = self.width
@@ -903,9 +906,9 @@ class ScrollView(StencilView):
                         dx = touch.dx / float(width - width * self.hbar[1])
                         self.scroll_x = min(max(self.scroll_x + dx, 0.), 1.)
                         self._trigger_update_from_scroll()
-                else:
-                    if self.scroll_type != ['bars']:
-                        self.effect_x.update(touch.x)
+                elif not_in_bar:
+                    self.effect_x.update(touch.x)
+
                 if self.scroll_x < 0 or self.scroll_x > 1:
                     rv = False
                 else:
@@ -919,9 +922,9 @@ class ScrollView(StencilView):
                     dy = touch.dy / float(height - height * self.vbar[1])
                     self.scroll_y = min(max(self.scroll_y + dy, 0.), 1.)
                     self._trigger_update_from_scroll()
-                else:
-                    if self.scroll_type != ['bars']:
-                        self.effect_y.update(touch.y)
+                elif not_in_bar:
+                    self.effect_y.update(touch.y)
+
                 if self.scroll_y < 0 or self.scroll_y > 1:
                     rv = False
                 else:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Fixes #7207.

Currently the stop condition is such that the effect stop may be executed even if the effect start was not called. Because the start and stop were guarded under different conditions. This makes them equal.