### PR TITLE
Keyboard: Add keyboard suggestions and fix input type on android

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1912,7 +1912,9 @@ class WindowBase(EventDispatcher):
             if keyboard:
                 keyboard.release()
 
-    def request_keyboard(self, callback, target, input_type='text'):
+    def request_keyboard(
+            self, callback, target, input_type='text', keyboard_suggestions=True
+    ):
         '''.. versionadded:: 1.0.4
 
         Internal widget method to request the keyboard. This method is rarely
@@ -1945,6 +1947,11 @@ class WindowBase(EventDispatcher):
                     `input_type` is currently only honored on mobile devices.
 
                 .. versionadded:: 1.8.0
+
+            `keyboard_suggestions`: bool
+                If True provides auto suggestions on top of keyboard.
+                This will only work if input_type is set to `text`, `url`,
+                `mail` or `address`.
 
         :Return:
             An instance of :class:`Keyboard` containing the callback, target,

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1953,6 +1953,8 @@ class WindowBase(EventDispatcher):
                 This will only work if input_type is set to `text`, `url`,
                 `mail` or `address`.
 
+                .. versionadded:: 2.1.0
+
         :Return:
             An instance of :class:`Keyboard` containing the callback, target,
             and if the configuration allows it, a

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -468,7 +468,13 @@ cdef class _WindowSDL2Storage:
         SDL_DestroyWindow(self.win)
         SDL_Quit()
 
-    def show_keyboard(self, system_keyboard, softinput_mode):
+    def show_keyboard(
+        self,
+        system_keyboard,
+        softinput_mode,
+        input_type,
+        keyboard_suggestions=True,
+    ):
         if SDL_IsTextInputActive():
             return
         cdef SDL_Rect *rect = <SDL_Rect *>PyMem_Malloc(sizeof(SDL_Rect))
@@ -513,6 +519,51 @@ cdef class _WindowSDL2Storage:
                     rect.w = 10
                     rect.h = 1
                     SDL_SetTextInputRect(rect)
+
+                """
+                Android input type selection.
+                Based on input_type and keyboard_suggestions arguments, set the
+                keyboard type to be shown. Note that text suggestions will only
+                work when input_type is "text" or a text variation.
+                """
+
+                from android import mActivity
+
+                # InputType definitions, from Android documentation
+
+                TYPE_CLASS_DATETIME = 4
+                TYPE_CLASS_NUMBER = 2
+                TYPE_CLASS_PHONE = 3
+                TYPE_CLASS_TEXT = 1
+
+                TYPE_TEXT_VARIATION_EMAIL_ADDRESS = 32
+                TYPE_TEXT_VARIATION_URI = 16
+                TYPE_TEXT_VARIATION_POSTAL_ADDRESS = 112
+
+                TYPE_TEXT_FLAG_NO_SUGGESTIONS = 524288
+
+                input_type_value = {
+                                "text": TYPE_CLASS_TEXT,
+                                "number": TYPE_CLASS_NUMBER,
+                                "url":
+                                TYPE_CLASS_TEXT |
+                                TYPE_TEXT_VARIATION_URI,
+                                "mail":
+                                TYPE_CLASS_TEXT |
+                                TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
+                                "datetime": TYPE_CLASS_DATETIME,
+                                "tel": TYPE_CLASS_PHONE,
+                                "address":
+                                TYPE_CLASS_TEXT |
+                                TYPE_TEXT_VARIATION_POSTAL_ADDRESS
+                              }.get(input_type, TYPE_CLASS_TEXT)
+
+                text_keyboards = {"text", "url", "mail", "address"}
+
+                if not keyboard_suggestions and input_type in text_keyboards:
+                    input_type_value |= TYPE_TEXT_FLAG_NO_SUGGESTIONS
+
+                mActivity.changeKeyboard(input_type_value)
 
             SDL_StartTextInput()
         finally:

--- a/kivy/core/window/window_pygame.py
+++ b/kivy/core/window/window_pygame.py
@@ -432,9 +432,11 @@ class WindowPygame(WindowBase):
         if mods & (pygame.KMOD_META | pygame.KMOD_LMETA):
             self._modifiers.append('meta')
 
-    def request_keyboard(self, callback, target, input_type='text'):
+    def request_keyboard(
+            self, callback, target, input_type='text', keyboard_suggestions=True
+    ):
         keyboard = super(WindowPygame, self).request_keyboard(
-            callback, target, input_type)
+            callback, target, input_type, keyboard_suggestions)
         if android and not self.allow_vkeyboard:
             android.show_keyboard(target, input_type)
         return keyboard

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -772,10 +772,19 @@ class WindowSDL(WindowBase):
         self._modifiers = list(modifiers)
         return
 
-    def request_keyboard(self, callback, target, input_type='text'):
+    def request_keyboard(
+            self, callback, target, input_type='text', keyboard_suggestions=True
+    ):
         self._sdl_keyboard = super(WindowSDL, self).\
-            request_keyboard(callback, target, input_type)
-        self._win.show_keyboard(self._system_keyboard, self.softinput_mode)
+            request_keyboard(
+            callback, target, input_type, keyboard_suggestions
+        )
+        self._win.show_keyboard(
+            self._system_keyboard,
+            self.softinput_mode,
+            input_type,
+            keyboard_suggestions,
+        )
         Clock.schedule_interval(self._check_keyboard_shown, 1 / 5.)
         return self._sdl_keyboard
 

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -237,6 +237,15 @@ class FocusBehavior(object):
         2.0.0.
     '''
 
+    keyboard_suggestions = BooleanProperty(True)
+    '''If True provides auto suggestions on top of keyboard.
+    This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
+    `address`.
+    .. versionadded:: 2.0.0
+    :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
+    and defaults to True
+    '''
+
     def _set_on_focus_next(self, instance, value):
         ''' If changing code, ensure following code is not infinite loop:
         widget.focus_next = widget
@@ -388,9 +397,12 @@ class FocusBehavior(object):
     def _ensure_keyboard(self):
         if self._keyboard is None:
             self._requested_keyboard = True
-            keyboard = self._keyboard =\
-                EventLoop.window.request_keyboard(
-                    self._keyboard_released, self, input_type=self.input_type)
+            keyboard = self._keyboard = EventLoop.window.request_keyboard(
+                self._keyboard_released,
+                self,
+                input_type=self.input_type,
+                keyboard_suggestions=self.keyboard_suggestions,
+            )
             keyboards = FocusBehavior._keyboards
             if keyboard not in keyboards:
                 keyboards[keyboard] = None

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -241,9 +241,9 @@ class FocusBehavior(object):
     '''If True provides auto suggestions on top of keyboard.
     This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
     `address`.
-    
+
     .. versionadded:: 2.1.0
-    
+
     :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to True
     '''

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -241,7 +241,9 @@ class FocusBehavior(object):
     '''If True provides auto suggestions on top of keyboard.
     This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
     `address`.
+    
     .. versionadded:: 2.1.0
+    
     :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to True
     '''

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -241,7 +241,7 @@ class FocusBehavior(object):
     '''If True provides auto suggestions on top of keyboard.
     This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
     `address`.
-    .. versionadded:: 2.0.0
+    .. versionadded:: 2.1.0
     :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
     and defaults to True
     '''

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -455,6 +455,10 @@ class TextInput(FocusBehavior, Widget):
 
     .. versionchanged:: 1.7.0
         `on_double_tap`, `on_triple_tap` and `on_quad_touch` events added.
+
+    .. versionchanged:: 2.0.0
+        :attr:`~kivy.uix.behaviors.FocusBehavior.keyboard_suggestions`
+        is now inherited from :class:`~kivy.uix.behaviors.FocusBehavior`.
     '''
 
     __events__ = ('on_text_validate', 'on_double_tap', 'on_triple_tap',
@@ -2715,16 +2719,6 @@ class TextInput(FocusBehavior, Widget):
 
     :attr:`password_mask` is a :class:`~kivy.properties.StringProperty` and
     defaults to `'*'`.
-    '''
-
-    keyboard_suggestions = BooleanProperty(True)
-    '''If True provides auto suggestions on top of keyboard.
-    This will only work if :attr:`input_type` is set to `text`.
-
-    .. versionadded:: 1.8.0
-
-    :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`
-    and defaults to True.
     '''
 
     cursor_blink = BooleanProperty(True)

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -456,7 +456,7 @@ class TextInput(FocusBehavior, Widget):
     .. versionchanged:: 1.7.0
         `on_double_tap`, `on_triple_tap` and `on_quad_touch` events added.
 
-    .. versionchanged:: 2.0.0
+    .. versionchanged:: 2.1.0
         :attr:`~kivy.uix.behaviors.FocusBehavior.keyboard_suggestions`
         is now inherited from :class:`~kivy.uix.behaviors.FocusBehavior`.
     '''


### PR DESCRIPTION
This PR gives kivy the ability to set keyboard input type correctly on android. 

Emojis do not work as the default font doesn't support them. It also creates some oddities when using input filtering and emojis are entered.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
