### PR TITLE
fix setup.py w/ python3.9 (abs __file__)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -998,6 +998,7 @@ def get_extensions_from_sources(sources):
         print('Fake build_ext asked, will generate only .h/.c')
         return ext_modules
     for pyx, flags in sources.items():
+        module_name = get_modulename_from_file(join('kivy', pyx))
         is_graphics = pyx.startswith('graphics')
         pyx = expand(src_path, pyx)
         depends = [expand(src_path, x) for x in flags.pop('depends', [])]
@@ -1009,7 +1010,6 @@ def get_extensions_from_sources(sources):
             depends = resolve_dependencies(pyx, depends)
         f_depends = [x for x in depends if x.rsplit('.', 1)[-1] in (
             'c', 'cpp', 'm')]
-        module_name = get_modulename_from_file(pyx)
         flags_clean = {'depends': depends}
         for key, value in flags.items():
             if len(value):


### PR DESCRIPTION
From the [Python 3.9 changelog](https://docs.python.org/3/whatsnew/changelog.html):

> [bpo-20443](https://bugs.python.org/issue20443): Python now gets the absolute path of the script filename specified on the command line (ex: “python3 script.py”): the `__file__` attribute of the `__main__` module and `sys.path[0]` become an absolute path, rather than a relative path.

Example:

```bash
$ cat setup.py
print(__file__)
$ python3.8 setup.py 
setup.py
$ python3.9 setup.py 
/some/path/to/setup.py
```

As a result of the way file names are expanded and module names are derived from those file names in `setup.py`, extension module names accidentally become e.g. `kivy.arm64-v8a__ndk_target_21.kivy.kivy._event` (instead of `kivy._event`).

Build log snippet w/ 3.8 (`src_path` is an empty string):

```
2020-12-03T18:25:34.8350229Z Current directory is: /home/runner/work/kivy-android-hello-world/kivy-android-hello-world/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy/arm64-v8a__ndk_target_21/kivy
2020-12-03T18:25:34.8351606Z Source and initial build directory is:
```

Build log snippet w/ 3.9 (`src_path` is an absolute path):

```
2020-12-03T17:55:35.7131754Z Current directory is: /home/runner/work/kivy-android-hello-world/kivy-android-hello-world/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy/arm64-v8a__ndk_target_21/kivy
2020-12-03T17:55:35.7134333Z Source and initial build directory is: /home/runner/work/kivy-android-hello-world/kivy-android-hello-world/.buildozer/android/platform/build-arm64-v8a/build/other_builds/kivy/arm64-v8a__ndk_target_21/kivy
```

I've confirmed that this fixes a [simple "hello world" p4a kivy app](https://github.com/obfusk/kivy-android-hello-world) (using my `python3.9` p4a branch).

---

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.