### PR TITLE
Resources: Add a cache for resource_find

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -296,7 +296,9 @@ class BuilderBase(object):
 
             `encoding`: File charcter encoding. Defaults to utf-8,
         '''
-        filename = resource_find(filename) or filename
+
+        # Cache here can give problems since Clock sometimes does not exist.
+        filename = resource_find(filename, use_cache=False) or filename
         if __debug__:
             trace('Lang: load file %s, using %s encoding', filename, encoding)
 

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -297,8 +297,7 @@ class BuilderBase(object):
             `encoding`: File charcter encoding. Defaults to utf-8,
         '''
 
-        # Cache here can give problems since Clock sometimes does not exist.
-        filename = resource_find(filename, use_cache=False) or filename
+        filename = resource_find(filename) or filename
         if __debug__:
             trace('Lang: load file %s, using %s encoding', filename, encoding)
 

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -36,6 +36,7 @@ from kivy.cache import Cache
 from kivy.utils import platform
 from kivy.logger import Logger
 import sys
+import os
 import kivy
 
 resource_paths = ['.', dirname(sys.argv[0])]
@@ -46,7 +47,7 @@ resource_paths += [dirname(kivy.__file__), join(kivy_data_dir, '..')]
 Cache.register('kv.resourcefind', timeout=60)
 
 
-def resource_find(filename, use_cache=True):
+def resource_find(filename, use_cache=("KIVY_DOC_INCLUDE" not in os.environ)):
     '''Search for a resource in the list of paths.
     Use resource_add_path to add a custom path to the search.
     By default, results are cached for 60 seconds.

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -69,9 +69,9 @@ def resource_find(filename, use_cache=True):
             found_filename = abspath(filename)
         else:
             for path in reversed(resource_paths):
-                output = abspath(join(path, filename))
-                if exists(output):
-                    found_filename = output
+                abspath_filename = abspath(join(path, filename))
+                if exists(abspath_filename):
+                    found_filename = abspath_filename
                     break
         if not found_filename and filename.startswith("data:"):
             found_filename = filename

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -75,7 +75,7 @@ def resource_find(filename, use_cache=True):
                     break
         if not found_filename and filename.startswith("data:"):
             found_filename = filename
-    if use_cache:
+    if use_cache and found_filename:
         Cache.append('kv.resourcefind', filename, found_filename)
     return found_filename
 

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -51,6 +51,8 @@ def resource_find(filename, use_cache=True):
     Use resource_add_path to add a custom path to the search.
     By default, results are cached for 60 seconds.
     This can be disabled using use_cache=False.
+    .. versionchanged:: 2.0.0rc5
+        A default cache and the `use_cache` parameter were added.
     '''
     if not filename:
         return

--- a/kivy/tests/test_resources.py
+++ b/kivy/tests/test_resources.py
@@ -1,0 +1,60 @@
+"""
+Resource loading tests
+======================
+"""
+import pytest
+import tempfile
+import os
+from kivy.cache import Cache
+
+from kivy.resources import resource_find, resource_add_path
+
+
+@pytest.fixture
+def test_file():
+    return "uix/textinput.py"
+
+
+RESOURCE_CACHE = "kv.resourcefind"
+
+
+def test_load_resource_cached(test_file):
+    Cache.remove(RESOURCE_CACHE)
+    found_file = resource_find(test_file)
+    assert found_file is not None
+    cached_filename = Cache.get(RESOURCE_CACHE, test_file)
+    assert found_file == cached_filename
+
+
+def test_load_resource_not_cached(test_file):
+    Cache.remove(RESOURCE_CACHE)
+    found_file = resource_find(test_file, use_cache=False)
+    assert found_file is not None
+    cached_filename = Cache.get(RESOURCE_CACHE, test_file)
+    assert cached_filename is None
+
+
+def test_load_resource_not_found():
+    Cache.remove(RESOURCE_CACHE)
+    missing_file_name = "missing_test_file.foo"
+
+    find_missing_file = resource_find(missing_file_name)
+    assert find_missing_file is None
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        missing_file_path = os.path.join(temp_dir, missing_file_name)
+
+        with open(missing_file_path, "w"):
+            pass  # touch file
+
+        find_missing_file_again = resource_find(missing_file_name)
+        assert find_missing_file_again is None
+
+        cached_filename = Cache.get(RESOURCE_CACHE, missing_file_name)
+        assert cached_filename is None
+
+        resource_add_path(temp_dir)
+
+        found_file = resource_find(missing_file_name)
+        assert missing_file_path == found_file
+        assert missing_file_path == Cache.get(RESOURCE_CACHE, missing_file_name)


### PR DESCRIPTION
Before:
resource_find dominates render time, causing noticable lag in rendering. 

![image](https://user-images.githubusercontent.com/48946947/101400190-d605f600-38d0-11eb-86aa-7a15631d47de.png)

Caching in user code, always passing an absolute path, the large amount of abspath calls still take significant time, but don't dominate.

![image](https://user-images.githubusercontent.com/48946947/101399852-5aa44480-38d0-11eb-8d37-0a6674d9dced.png)

After this PR, no file calls to be found and rendering is smooth.
![image](https://user-images.githubusercontent.com/48946947/101398970-2714ea80-38cf-11eb-9ed4-8886d4d4b224.png)

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
