### PR TITLE
Setup: Fix buggy detection of cython module name

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -75,13 +75,6 @@ install_platypus() {
 }
 
 generate_osx_wheels() {
-  # for some reason wheels sometimes fail to properly generate because both the parent and grandparent
-  # are named kivy so instead acquire a new grandparent name
-  root=$(pwd)
-  cd ~
-  mv "$root" kivy_project
-  cd kivy_project
-
   python3 -m pip install git+http://github.com/tito/osxrelocator
   python3 -m pip install --upgrade delocate
   python3 setup.py bdist_wheel
@@ -125,9 +118,6 @@ generate_osx_wheels() {
   popd
 
   delocate-addplat --rm-orig -x 10_9 -x 10_10 dist/*.whl
-
-  cd ..
-  mv kivy_project "$root"
 }
 
 generate_osx_app_bundle() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -64,11 +64,7 @@ prepare_env_for_unittest() {
 }
 
 install_kivy() {
-  path="$(pwd)"
-  ln -s "$path" ~/base_kivy
-  cd ~/base_kivy
   python3 -m pip install -e "$(pwd)[dev,full]"
-  cd "$path"
 }
 
 

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -77,11 +77,7 @@ function Install-kivy-test-run-pip-deps {
 }
 
 function Install-kivy {
-    $old=(pwd).Path
-    cmd /c mklink /d "$HOME\kivy" "$old"
-    cd "$HOME\kivy"
     python -m pip install -e .[dev,full]
-    cd "$old"
 }
 
 function Install-kivy-wheel {

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ omit =
     */pyinstaller/*_widget/*
 plugins =
     kivy.tools.coverage
+concurrency = thread, multiprocessing
 
 [options]
 python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -534,18 +534,6 @@ if c_options['use_sdl2'] or (
 # -----------------------------------------------------------------------------
 # declare flags
 
-
-def get_modulename_from_file(filename):
-    filename = filename.replace(sep, '/')
-    pyx = '.'.join(filename.split('.')[:-1])
-    pyxl = pyx.split('/')
-    while pyxl[0] != 'kivy':
-        pyxl.pop(0)
-    if pyxl[1] == 'kivy':
-        pyxl.pop(0)
-    return '.'.join(pyxl)
-
-
 def expand(root, *args):
     return join(root, 'kivy', *args)
 
@@ -999,23 +987,23 @@ def get_extensions_from_sources(sources):
         return ext_modules
     for pyx, flags in sources.items():
         is_graphics = pyx.startswith('graphics')
-        pyx = expand(src_path, pyx)
+        pyx_path = expand(src_path, pyx)
         depends = [expand(src_path, x) for x in flags.pop('depends', [])]
         c_depends = [expand(src_path, x) for x in flags.pop('c_depends', [])]
         if not can_use_cython:
             # can't use cython, so use the .c files instead.
-            pyx = '%s.c' % pyx[:-4]
+            pyx_path = '%s.c' % pyx_path[:-4]
         if is_graphics:
-            depends = resolve_dependencies(pyx, depends)
+            depends = resolve_dependencies(pyx_path, depends)
         f_depends = [x for x in depends if x.rsplit('.', 1)[-1] in (
             'c', 'cpp', 'm')]
-        module_name = get_modulename_from_file(pyx)
+        module_name = '.'.join(['kivy'] + pyx[:-4].split('/'))
         flags_clean = {'depends': depends}
         for key, value in flags.items():
             if len(value):
                 flags_clean[key] = value
         ext_modules.append(CythonExtension(
-            module_name, [pyx] + f_depends + c_depends, **flags_clean))
+            module_name, [pyx_path] + f_depends + c_depends, **flags_clean))
     return ext_modules
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Previously, when if a folder named kivy contained the repo, the cython module names would be incorrectly determined. This has been a long standing issue that I had to work around on the CI because on the CI the repo is cloned into a parent folder named kivy and the install would fail. I thought this was something buggy with GH actions and so renamed the parent folders, but no, we incorrectly determined the module name.