### PR TITLE
Use NSString instead of AVCaptureSessionPreset in order to support MacOS < 10.13

### DIFF
--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -137,7 +137,7 @@ public:
     int startCaptureDevice();
     void stopCaptureDevice();
     bool attemptFrameRateSelection(int desiredFrameRate);
-    bool attemptCapturePreset(AVCaptureSessionPreset preset);
+    bool attemptCapturePreset(NSString *preset);
     bool attemptStartMetadataAnalysis();
     bool haveNewMetadata();
 
@@ -294,7 +294,7 @@ bool Camera::attemptFrameRateSelection(int desiredFrameRate){
     return isFPSSupported;
 }
 
-bool Camera::attemptCapturePreset(AVCaptureSessionPreset preset){
+bool Camera::attemptCapturePreset(NSString *preset){
     // See available presets: https://developer.apple.com/documentation/avfoundation/avcapturesessionpreset
     if([mCaptureSession canSetSessionPreset: preset]){
         [mCaptureSession setSessionPreset: preset];
@@ -393,7 +393,7 @@ int Camera::startCaptureDevice() {
         /* By default, We're using the AVCaptureSessionPresetHigh preset for capturing frames on both iOS and MacOS.
            The user can override these settings by calling the attemptCapturePreset() function
         */
-        attemptCapturePreset(AVCaptureSessionPresetHigh);
+        attemptCapturePreset(@"AVCaptureSessionPresetHigh");
 
         [mCaptureSession addInput:mCaptureDeviceInput];
         [mCaptureSession addOutput:mCaptureDecompressedVideoOutput];
@@ -702,7 +702,7 @@ bool avf_camera_attempt_framerate_selection(camera_t camera, int fps){
 }
 
 bool avf_camera_attempt_capture_preset(camera_t camera, char *preset){
-    AVCaptureSessionPreset capture_preset = (AVCaptureSessionPreset)[NSString stringWithUTF8String:preset];
+    NSString *capture_preset = [NSString stringWithUTF8String:preset];
     NSLog(@"Preset: %@", capture_preset);
     return ((Camera *)camera)->attemptCapturePreset(capture_preset);
 }


### PR DESCRIPTION
As discussed with @matham on discord, in order to support MacOS 10.12 (which is the current  `MACOSX_DEPLOYMENT_TARGET` for `conda`), We decided to use `NSString` instead of `AVCaptureSessionPreset`.

The `AVCaptureSessionPreset` constants were only introduced since MacOS SDK 10.13.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
