### PR TITLE
Camera: Added API to change avfoundation camera provider orientation

### DIFF
--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -20,6 +20,7 @@ cdef extern from "camera_avfoundation_implem.h":
     bint avf_camera_attempt_start_metadata_analysis(camera_t camera)
     void avf_camera_get_metadata(camera_t camera, char **metatype, char **data)
     bint avf_camera_have_new_metadata(camera_t camera);
+    bint avf_camera_set_video_orientation(camera_t camera, int orientation)
 
 
 from kivy.logger import Logger
@@ -109,6 +110,10 @@ class CameraAVFoundation(CameraBase):
     def set_preset(self, preset):
         cdef _AVStorage storage = <_AVStorage>self._storage
         avf_camera_attempt_capture_preset(storage.camera, preset)
+
+    def set_video_orientation(self, orientation):
+        cdef _AVStorage storage = <_AVStorage>self._storage
+        avf_camera_set_video_orientation(storage.camera, orientation)
 
     def start_metadata_analysis(self, callback=None):
         cdef _AVStorage storage = <_AVStorage>self._storage

--- a/kivy/core/camera/camera_avfoundation_implem.h
+++ b/kivy/core/camera/camera_avfoundation_implem.h
@@ -11,3 +11,4 @@ bool avf_camera_attempt_capture_preset(camera_t camera, char* preset);
 bool avf_camera_attempt_start_metadata_analysis(camera_t camera);
 void avf_camera_get_metadata(camera_t camera, char **metatype, char **data);
 bool avf_camera_have_new_metadata(camera_t camera);
+bool avf_camera_set_video_orientation(camera_t camera, int orientation);


### PR DESCRIPTION
This PR adds the ability to programmatically change the orientation of the video feed provided by the AvFoundation camera provider.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
