### PR TITLE
Graphics: Check whether user updated GL instructions from external thread.

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -102,7 +102,7 @@ install_kivy_sdist() {
 
 test_kivy() {
   rm -rf kivy/tests/build || true
-  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+  KIVY_NO_ARGS=1 python3 -m pytest --maxfail=10 --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
 }
 
 test_kivy_install() {
@@ -116,7 +116,7 @@ test_kivy_install() {
   plugins = kivy.tools.coverage
 
 EOF
-  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 .
+  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --maxfail=10 --timeout=300 .
 }
 
 upload_coveralls() {

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -369,7 +369,7 @@ from weakref import ref
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 22
+KIVY_CONFIG_VERSION = 23
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -889,6 +889,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 21:
             Config.setdefault('graphics', 'vsync', '')
+
+        elif version == 22:
+            Config.setdefault('graphics', 'verify_gl_main_thread', '1')
 
         else:
             # for future.

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -244,6 +244,9 @@ Available configuration tokens
         ``0`` -- disables vsync, ``1`` or larger -- sets vsync interval,
         ``-1`` sets adaptive vsync. It falls back to 1 if setting to ``2+``
         or ``-1`` failed. See ``SDL_GL_SetSwapInterval``.
+    `verify_gl_main_thread`: int, 1 or 0, defaults to 1
+        Whether to check if code that changes any gl instructions is
+        running outside the main thread and then raise an error.
 
 :input:
 
@@ -316,7 +319,8 @@ Available configuration tokens
     arguments.
 
 .. versionchanged:: 2.1.0
-    `vsync` has been added to the graphics section
+    `vsync` has been added to the graphics section.
+    `verify_gl_main_thread` has been added to the graphics section.
 
 .. versionchanged:: 1.10.0
     `min_state_time`  and `allow_screensaver` have been added

--- a/kivy/graphics/cgl.pxd
+++ b/kivy/graphics/cgl.pxd
@@ -641,7 +641,7 @@ ctypedef struct GLES2_Context:
 
 cdef GLES2_Context *cgl
 cdef int kivy_opengl_es2
-cdef long long initialized_tid
+cdef unsigned long initialized_tid
 cdef public int verify_gl_main_thread
 cpdef cgl_init(allowed=*, ignored=*)
 cdef GLES2_Context *cgl_get_context()

--- a/kivy/graphics/cgl.pxd
+++ b/kivy/graphics/cgl.pxd
@@ -641,7 +641,7 @@ ctypedef struct GLES2_Context:
 
 cdef GLES2_Context *cgl
 cdef int kivy_opengl_es2
-cdef int initialized_tid
+cdef long long initialized_tid
 cdef public int verify_gl_main_thread
 cpdef cgl_init(allowed=*, ignored=*)
 cdef GLES2_Context *cgl_get_context()

--- a/kivy/graphics/cgl.pxd
+++ b/kivy/graphics/cgl.pxd
@@ -641,6 +641,8 @@ ctypedef struct GLES2_Context:
 
 cdef GLES2_Context *cgl
 cdef int kivy_opengl_es2
+cdef int initialized_tid
+cdef public int verify_gl_main_thread
 cpdef cgl_init(allowed=*, ignored=*)
 cdef GLES2_Context *cgl_get_context()
 cdef void cgl_set_context(GLES2_Context* ctx)

--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -49,7 +49,7 @@ cdef GLES2_Context g_cgl
 cdef GLES2_Context *cgl = &g_cgl
 cdef object cgl_name = None
 cdef int kivy_opengl_es2 = USE_OPENGL_ES2 or environ.get('KIVY_GRAPHICS', '').lower() == 'gles'
-cdef long long initialized_tid = 0
+cdef unsigned long initialized_tid = 0
 cdef public int verify_gl_main_thread = 1
 """Whether we should check if the gl instructions occur in a thread outside the main thread.
 """

--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -49,7 +49,7 @@ cdef GLES2_Context g_cgl
 cdef GLES2_Context *cgl = &g_cgl
 cdef object cgl_name = None
 cdef int kivy_opengl_es2 = USE_OPENGL_ES2 or environ.get('KIVY_GRAPHICS', '').lower() == 'gles'
-cdef int initialized_tid = 0
+cdef long long initialized_tid = 0
 cdef public int verify_gl_main_thread = 1
 """Whether we should check if the gl instructions occur in a thread outside the main thread.
 """

--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -42,11 +42,26 @@ from os import environ
 from .cgl cimport GLES2_Context
 import importlib
 from kivy.logger import Logger
+from threading import get_ident
+from kivy.config import Config
 
 cdef GLES2_Context g_cgl
 cdef GLES2_Context *cgl = &g_cgl
 cdef object cgl_name = None
 cdef int kivy_opengl_es2 = USE_OPENGL_ES2 or environ.get('KIVY_GRAPHICS', '').lower() == 'gles'
+cdef int initialized_tid = 0
+cdef public int verify_gl_main_thread = 1
+"""Whether we should check if the gl instructions occur in a thread outside the main thread.
+"""
+
+
+def _update_verify_gl_main_thread(*args):
+    global verify_gl_main_thread
+    verify_gl_main_thread = Config.getboolean('graphics', 'verify_gl_main_thread')
+
+if not environ.get('KIVY_DOC_INCLUDE'):
+    Config.add_callback(_update_verify_gl_main_thread, 'graphics', 'verify_gl_main_thread')
+    _update_verify_gl_main_thread()
 
 
 cpdef cgl_get_initialized_backend_name():
@@ -84,8 +99,9 @@ cdef void cgl_set_context(GLES2_Context* ctx):
 cpdef cgl_init(allowed=[], ignored=[]):
     Logger.info('GL: Using the "{}" graphics system'.format(
         'OpenGL ES 2' if kivy_opengl_es2 else 'OpenGL'))
-    global cgl_name
+    global cgl_name, initialized_tid
     cgl_name = backend = cgl_get_backend_name(allowed, ignored)
+    initialized_tid = get_ident()
 
     # for ANGLE, currently we use sdl2, and only on windows.
     if backend == "angle_sdl2":

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -273,6 +273,7 @@ cdef class Color(ContextInstruction):
     @rgba.setter
     def rgba(self, rgba):
         self.set_state('color', [float(x) for x in rgba])
+        self.flag_data_update()
 
     @property
     def rgb(self):
@@ -402,7 +403,7 @@ cdef class BindTexture(ContextInstruction):
         if self._texture is texture:
             return
         self._texture = texture
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def index(self):
@@ -413,7 +414,7 @@ cdef class BindTexture(ContextInstruction):
         if self._index == index:
             return
         self._index = index
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def source(self):
@@ -593,7 +594,7 @@ cdef class MatrixInstruction(ContextInstruction):
     @matrix.setter
     def matrix(self, x):
         self._matrix = x
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def stack(self):

--- a/kivy/graphics/fbo.pyx
+++ b/kivy/graphics/fbo.pyx
@@ -448,7 +448,7 @@ cdef class Fbo(RenderContext):
         self._width, self._height = x
         self.delete_fbo()
         self.create_fbo()
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def clear_color(self):

--- a/kivy/graphics/gl_instructions.pyx
+++ b/kivy/graphics/gl_instructions.pyx
@@ -66,7 +66,7 @@ cdef class ClearColor(Instruction):
         self.g = clear_color[1]
         self.b = clear_color[2]
         self.a = clear_color[3]
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def rgb(self):
@@ -81,7 +81,7 @@ cdef class ClearColor(Instruction):
         self.g = clear_color[1]
         self.b = clear_color[2]
         self.a = 1
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def r(self):
@@ -92,7 +92,7 @@ cdef class ClearColor(Instruction):
     @r.setter
     def r(self, r):
         self.r = r
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def g(self):
@@ -103,7 +103,7 @@ cdef class ClearColor(Instruction):
     @g.setter
     def g(self, g):
         self.g = g
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def b(self):
@@ -114,7 +114,7 @@ cdef class ClearColor(Instruction):
     @b.setter
     def b(self, b):
         self.b = b
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def a(self):
@@ -125,7 +125,7 @@ cdef class ClearColor(Instruction):
     @a.setter
     def a(self, a):
         self.a = a
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class ClearBuffers(Instruction):

--- a/kivy/graphics/instructions.pxd
+++ b/kivy/graphics/instructions.pxd
@@ -31,6 +31,7 @@ cdef class Instruction(ObjectWithUid):
         cpdef flag_update(self, int do_parent=?, list _instrs=?)
     ELSE:
         cpdef flag_update(self, int do_parent=?)
+    cpdef flag_data_update(self)
     cdef void flag_update_done(self)
     cdef void set_parent(self, Instruction parent)
     cdef void reload(self) except *

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -20,6 +20,7 @@ from kivy.compat import PY2
 from kivy.logger import Logger
 from kivy.graphics.context cimport get_context, Context
 from weakref import proxy
+from threading import get_ident
 
 
 cdef int _need_reset_gl = 1
@@ -53,6 +54,11 @@ cdef class Instruction(ObjectWithUid):
         if kwargs.get('noadd'):
             self.flags |= GI_NO_REMOVE
             return
+
+        if verify_gl_main_thread and get_ident() != initialized_tid:
+            raise TypeError("Cannot create graphics instruction outside "
+                            "the main Kivy thread")
+
         self.parent = getActiveCanvas()
         if self.parent:
             self.parent.add(self)
@@ -74,6 +80,12 @@ cdef class Instruction(ObjectWithUid):
             if do_parent == 1 and self.parent is not None:
                 self.parent.flag_update()
             self.flags |= GI_NEEDS_UPDATE
+
+    cpdef flag_data_update(self):
+        if verify_gl_main_thread and get_ident() != initialized_tid:
+            raise TypeError("Cannot change graphics instruction outside "
+                            "the main Kivy thread")
+        self.flag_update()
 
     cdef void flag_update_done(self):
         self.flags &= ~GI_NEEDS_UPDATE
@@ -171,20 +183,20 @@ cdef class InstructionGroup(Instruction):
         '''Add a new :class:`Instruction` to our list.
         '''
         c.radd(self)
-        self.flag_update()
+        self.flag_data_update()
         return
 
     cpdef insert(self, int index, Instruction c):
         '''Insert a new :class:`Instruction` into our list at index.
         '''
         c.rinsert(self, index)
-        self.flag_update()
+        self.flag_data_update()
 
     cpdef remove(self, Instruction c):
         '''Remove an existing :class:`Instruction` from our list.
         '''
         c.rremove(self)
-        self.flag_update()
+        self.flag_data_update()
 
     def indexof(self, Instruction c):
         cdef int i
@@ -332,7 +344,7 @@ cdef class VertexInstruction(Instruction):
             self.tex_coords = tex.tex_coords
         else:
             self.tex_coords = [0.0,0.0, 1.0,0.0, 1.0,1.0, 0.0,1.0]
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def source(self):
@@ -404,7 +416,7 @@ cdef class VertexInstruction(Instruction):
         cdef int index
         for index in xrange(8):
             self._tex_coords[index] = tc[index]
-        self.flag_update()
+        self.flag_data_update()
 
     cdef void build(self):
         pass
@@ -474,7 +486,7 @@ cdef class Callback(Instruction):
 
         .. versionadded:: 1.0.4
         '''
-        self.flag_update()
+        self.flag_data_update()
 
     cdef int apply(self) except -1:
         cdef RenderContext rcx
@@ -542,7 +554,7 @@ cdef class Callback(Instruction):
         if self._reset_context == ivalue:
             return
         self._reset_context = ivalue
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def callback(self):
@@ -555,7 +567,7 @@ cdef class Callback(Instruction):
         if self.func == func:
             return
         self.func = func
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class CanvasBase(InstructionGroup):
@@ -645,18 +657,18 @@ cdef class Canvas(CanvasBase):
             c.radd(self)
         else:
             c.rinsert(self, -1)
-        self.flag_update()
+        self.flag_data_update()
 
     cpdef remove(self, Instruction c):
         c.rremove(self)
-        self.flag_update()
+        self.flag_data_update()
 
     def ask_update(self):
         '''Inform the canvas that we'd like it to update on the next frame.
         This is useful when you need to trigger a redraw due to some value
         having changed for example.
         '''
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def before(self):
@@ -719,7 +731,7 @@ cdef class Canvas(CanvasBase):
     @opacity.setter
     def opacity(self, value):
         self._opacity = value
-        self.flag_update()
+        self.flag_data_update()
 
 # Active Canvas and getActiveCanvas function is used
 # by instructions, so they know which canvas to add
@@ -938,7 +950,7 @@ cdef class RenderContext(Canvas):
         cdef cvalue = int(bool(value))
         if self._use_parent_projection != cvalue:
             self._use_parent_projection = cvalue
-            self.flag_update()
+            self.flag_data_update()
 
     @property
     def use_parent_modelview(self):
@@ -961,7 +973,7 @@ cdef class RenderContext(Canvas):
         cdef cvalue = int(bool(value))
         if self._use_parent_modelview != cvalue:
             self._use_parent_modelview = cvalue
-            self.flag_update()
+            self.flag_data_update()
 
     @property
     def use_parent_frag_modelview(self):
@@ -978,7 +990,7 @@ cdef class RenderContext(Canvas):
         cdef cvalue = int(bool(value))
         if self._use_parent_frag_modelview != cvalue:
             self._use_parent_frag_modelview = cvalue
-            self.flag_update()
+            self.flag_data_update()
 
 
 cdef RenderContext ACTIVE_CONTEXT = None

--- a/kivy/graphics/scissor_instructions.pyx
+++ b/kivy/graphics/scissor_instructions.pyx
@@ -118,7 +118,7 @@ cdef class ScissorPush(Instruction):
     def x(self, value):
         self._x = value
         self._rect = Rect(self._x, self._y, self._width, self._height)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def y(self):
@@ -128,7 +128,7 @@ cdef class ScissorPush(Instruction):
     def y(self, value):
         self._y = value
         self._rect = Rect(self._x, self._y, self._width, self._height)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def width(self):
@@ -138,7 +138,7 @@ cdef class ScissorPush(Instruction):
     def width(self, value):
         self._width = value
         self._rect = Rect(self._x, self._y, self._width, self._height)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def height(self):
@@ -148,7 +148,7 @@ cdef class ScissorPush(Instruction):
     def height(self, value):
         self._height = value
         self._rect = Rect(self._x, self._y, self._width, self._height)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def pos(self):
@@ -158,7 +158,7 @@ cdef class ScissorPush(Instruction):
     def pos(self, value):
         self._x, self._y = value
         self._rect = Rect(self._x, self._y, self._width, self._height)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def size(self):
@@ -168,7 +168,7 @@ cdef class ScissorPush(Instruction):
     def size(self, value):
         self._width, self._height = value
         self._rect = Rect(self._x, self._y, self._width, self._height)
-        self.flag_update()
+        self.flag_data_update()
 
     def __init__(self, **kwargs):
         self._x, self._y = kwargs.pop(

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -276,7 +276,7 @@ cdef class StencilUse(Instruction):
         cdef int op = _stencil_op_to_gl(x)
         if op != self._op:
             self._op = op
-            self.flag_update()
+            self.flag_data_update()
 
 
 cdef class StencilUnUse(Instruction):

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -225,7 +225,7 @@ cdef class Bezier(VertexInstruction):
         self._points = list(points)
         if self._loop:
             self._points.extend(points[:2])
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def segments(self):
@@ -238,7 +238,7 @@ cdef class Bezier(VertexInstruction):
         if value <= 1:
             raise GraphicException('Invalid segments value, must be >= 2')
         self._segments = value
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def dash_length(self):
@@ -252,7 +252,7 @@ cdef class Bezier(VertexInstruction):
         if value < 0:
             raise GraphicException('Invalid dash_length value, must be >= 0')
         self._dash_length = value
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def dash_offset(self):
@@ -267,7 +267,7 @@ cdef class Bezier(VertexInstruction):
         if value < 0:
             raise GraphicException('Invalid dash_offset value, must be >= 0')
         self._dash_offset = value
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class StripMesh(VertexInstruction):
@@ -473,7 +473,7 @@ cdef class Mesh(VertexInstruction):
         self._vertices, self._fvertices = _ensure_float_view(value,
             &self._pvertices)
         self.vcount = <long>len(self._vertices)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def indices(self):
@@ -491,7 +491,7 @@ cdef class Mesh(VertexInstruction):
         self._indices, self._lindices = _ensure_ushort_view(value,
             &self._pindices)
         self.icount = <long>len(self._indices)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def mode(self):
@@ -642,7 +642,7 @@ cdef class Point(VertexInstruction):
         self.batch.append_data(vertices, 4, indices, 6)
 
         if self.parent is not None:
-            self.parent.flag_update()
+            self.parent.flag_data_update()
 
     @property
     def points(self):
@@ -659,7 +659,7 @@ cdef class Point(VertexInstruction):
         if len(_points) > 2**15-2:
             raise GraphicException('Too many elements (limit is 2^15-2)')
         self._points = list(points)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def pointsize(self):
@@ -674,7 +674,7 @@ cdef class Point(VertexInstruction):
         if self._pointsize == pointsize:
             return
         self._pointsize = pointsize
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class Triangle(VertexInstruction):
@@ -725,7 +725,7 @@ cdef class Triangle(VertexInstruction):
     @points.setter
     def points(self, points):
         self._points = list(points)
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class Quad(VertexInstruction):
@@ -785,7 +785,7 @@ cdef class Quad(VertexInstruction):
             raise GraphicException(
                 'Quad: invalid number of points (%d instead of 8)' % len(
                 self._points))
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class Rectangle(VertexInstruction):
@@ -848,7 +848,7 @@ cdef class Rectangle(VertexInstruction):
             return
         self.x = x
         self.y = y
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def size(self):
@@ -864,7 +864,7 @@ cdef class Rectangle(VertexInstruction):
             return
         self.w = w
         self.h = h
-        self.flag_update()
+        self.flag_data_update()
 
 
 
@@ -1087,7 +1087,7 @@ cdef class BorderImage(Rectangle):
     @border.setter
     def border(self, b):
         self._border = list(b)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def auto_scale(self):
@@ -1100,7 +1100,7 @@ cdef class BorderImage(Rectangle):
     @auto_scale.setter
     def auto_scale(self, str value):
         self._auto_scale = value
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def display_border(self):
@@ -1111,7 +1111,7 @@ cdef class BorderImage(Rectangle):
     @display_border.setter
     def display_border(self, b):
         self._display_border = list(b)
-        self.flag_update()
+        self.flag_data_update()
 
 cdef class Ellipse(Rectangle):
     '''A 2D ellipse.
@@ -1237,7 +1237,7 @@ cdef class Ellipse(Rectangle):
     @segments.setter
     def segments(self, value):
         self._segments = value
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def angle_start(self):
@@ -1248,7 +1248,7 @@ cdef class Ellipse(Rectangle):
     @angle_start.setter
     def angle_start(self, value):
         self._angle_start = value
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def angle_end(self):
@@ -1259,7 +1259,7 @@ cdef class Ellipse(Rectangle):
     @angle_end.setter
     def angle_end(self, value):
         self._angle_end = value
-        self.flag_update()
+        self.flag_data_update()
 
 
 cdef class RoundedRectangle(Rectangle):
@@ -1561,7 +1561,7 @@ cdef class RoundedRectangle(Rectangle):
     @segments.setter
     def segments(self, value):
         self._segments = self._check_segments(value)
-        self.flag_update()
+        self.flag_data_update()
 
     @property
     def radius(self):
@@ -1572,4 +1572,4 @@ cdef class RoundedRectangle(Rectangle):
     @radius.setter
     def radius(self, value):
         self._radius = self._check_radius(value)
-        self.flag_update()
+        self.flag_data_update()

--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -724,7 +724,7 @@ cdef class Line(VertexInstruction):
                 self._points = list(points)
 
             self._mode = LINE_MODE_POINTS
-            self.flag_update()
+            self.flag_data_update()
 
     property dash_length:
         '''Property for getting/setting the length of the dashes in the curve
@@ -738,7 +738,7 @@ cdef class Line(VertexInstruction):
             if value < 0:
                 raise GraphicException('Invalid dash_length value, must be >= 0')
             self._dash_length = value
-            self.flag_update()
+            self.flag_data_update()
 
     property dash_offset:
         '''Property for getting/setting the offset between the dashes in the curve
@@ -752,7 +752,7 @@ cdef class Line(VertexInstruction):
             if value < 0:
                 raise GraphicException('Invalid dash_offset value, must be >= 0')
             self._dash_offset = value
-            self.flag_update()
+            self.flag_data_update()
 
     property dashes:
         '''Property for getting/setting ``dashes``.
@@ -768,7 +768,7 @@ cdef class Line(VertexInstruction):
 
         def __set__(self, value):
             self._dash_list = list(value)
-            self.flag_update()
+            self.flag_data_update()
 
     property width:
         '''Determine the width of the line, defaults to 1.0.
@@ -782,7 +782,7 @@ cdef class Line(VertexInstruction):
             if value <= 0:
                 raise GraphicException('Invalid width value, must be > 0')
             self._width = value
-            self.flag_update()
+            self.flag_data_update()
 
     property cap:
         '''Determine the cap of the line, defaults to 'round'. Can be one of
@@ -807,7 +807,7 @@ cdef class Line(VertexInstruction):
                 self._cap = LINE_CAP_ROUND
             else:
                 self._cap = LINE_CAP_NONE
-            self.flag_update()
+            self.flag_data_update()
 
     property joint:
         '''Determine the join of the line, defaults to 'round'. Can be one of
@@ -837,7 +837,7 @@ cdef class Line(VertexInstruction):
                 self._joint = LINE_JOINT_MITER
             else:
                 self._joint = LINE_JOINT_NONE
-            self.flag_update()
+            self.flag_data_update()
 
     property cap_precision:
         '''Number of iteration for drawing the "round" cap, defaults to 10.
@@ -853,7 +853,7 @@ cdef class Line(VertexInstruction):
             if value < 1:
                 raise GraphicException('Invalid cap_precision value, must be >= 1')
             self._cap_precision = int(value)
-            self.flag_update()
+            self.flag_data_update()
 
     property joint_precision:
         '''Number of iteration for drawing the "round" joint, defaults to 10.
@@ -869,7 +869,7 @@ cdef class Line(VertexInstruction):
             if value < 1:
                 raise GraphicException('Invalid joint_precision value, must be >= 1')
             self._joint_precision = int(value)
-            self.flag_update()
+            self.flag_data_update()
 
     property close:
         '''If True, the line will be closed.
@@ -882,7 +882,7 @@ cdef class Line(VertexInstruction):
 
         def __set__(self, value):
             self._close = int(bool(value))
-            self.flag_update()
+            self.flag_data_update()
 
     property ellipse:
         '''Use this property to build an ellipse, without calculating the
@@ -923,7 +923,7 @@ cdef class Line(VertexInstruction):
                         '{0} instead of 4, 6 or 7.'.format(len(args)))
             self._mode_args = tuple(args)
             self._mode = LINE_MODE_ELLIPSE
-            self.flag_update()
+            self.flag_data_update()
 
     cdef void prebuild_ellipse(self):
         cdef double x, y, w, h, angle_start = 0, angle_end = 360
@@ -1006,7 +1006,7 @@ cdef class Line(VertexInstruction):
                         '{0} instead of 3, 5 or 6.'.format(len(args)))
             self._mode_args = tuple(args)
             self._mode = LINE_MODE_CIRCLE
-            self.flag_update()
+            self.flag_data_update()
 
     cdef void prebuild_circle(self):
         cdef double x, y, r, angle_start = 0, angle_end = 360
@@ -1074,7 +1074,7 @@ cdef class Line(VertexInstruction):
                         '{0} instead of 4.'.format(len(args)))
             self._mode_args = tuple(args)
             self._mode = LINE_MODE_RECTANGLE
-            self.flag_update()
+            self.flag_data_update()
 
     cdef void prebuild_rectangle(self):
         cdef double x, y, width, height
@@ -1128,7 +1128,7 @@ cdef class Line(VertexInstruction):
                         '{0} not in (5, 6, 8, 9)'.format(len(args)))
             self._mode_args = tuple(args)
             self._mode = LINE_MODE_ROUNDED_RECTANGLE
-            self.flag_update()
+            self.flag_data_update()
 
     cdef void prebuild_rounded_rectangle(self):
         cdef float a, px, py, x, y, w, h, c1, c2, c3, c4
@@ -1211,7 +1211,7 @@ cdef class Line(VertexInstruction):
                         'Invalid bezier value: {0!r}'.format(args))
             self._mode_args = tuple(args)
             self._mode = LINE_MODE_BEZIER
-            self.flag_update()
+            self.flag_data_update()
 
     cdef void prebuild_bezier(self):
         cdef double x, y, l
@@ -1252,7 +1252,7 @@ cdef class Line(VertexInstruction):
             if value < 1:
                 raise GraphicException('Invalid bezier_precision value, must be >= 1')
             self._bezier_precision = int(value)
-            self.flag_update()
+            self.flag_data_update()
 
 
 cdef class SmoothLine(Line):
@@ -1557,5 +1557,5 @@ cdef class SmoothLine(Line):
             if value <= 0:
                 raise GraphicException('Invalid width value, must be > 0')
             self._owidth = value
-            self.flag_update()
+            self.flag_data_update()
 

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -131,7 +131,6 @@ class CallbackInstructionTest(GraphicUnitTest):
         self.assertTrue(root.callback_test == 'TEST')
 
 
-@requires_graphics
 @pytest.fixture
 def widget_verify_thread(request):
     from kivy.uix.widget import Widget
@@ -146,6 +145,7 @@ def widget_verify_thread(request):
     Config.set('graphics', 'verify_gl_main_thread', original)
 
 
+@requires_graphics
 @pytest.mark.parametrize('widget_verify_thread', ['0', '1'], indirect=True)
 def test_graphics_main_thread(widget_verify_thread):
     from kivy.graphics import Color
@@ -156,6 +156,7 @@ def test_graphics_main_thread(widget_verify_thread):
     color.rgb = .1, .2, .3
 
 
+@requires_graphics
 @pytest.mark.parametrize('widget_verify_thread', ['0', '1'], indirect=True)
 def test_create_graphics_second_thread(widget_verify_thread):
     from kivy.graphics import Color
@@ -182,6 +183,7 @@ def test_create_graphics_second_thread(widget_verify_thread):
         raise exception[0].with_traceback(exception[1])
 
 
+@requires_graphics
 @pytest.mark.parametrize('widget_verify_thread', ['0', '1'], indirect=True)
 def test_change_graphics_second_thread(widget_verify_thread):
     from kivy.graphics import Color

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -5,7 +5,10 @@ Graphics tests
 Testing the simple vertex instructions
 '''
 
-from kivy.tests.common import GraphicUnitTest
+import sys
+import pytest
+from threading import Thread
+from kivy.tests.common import GraphicUnitTest, requires_graphics
 
 
 class VertexInstructionTest(GraphicUnitTest):
@@ -126,3 +129,82 @@ class CallbackInstructionTest(GraphicUnitTest):
         r = self.render
         r(root)
         self.assertTrue(root.callback_test == 'TEST')
+
+
+@requires_graphics
+@pytest.fixture
+def widget_verify_thread(request):
+    from kivy.uix.widget import Widget
+    from kivy.config import Config
+
+    original = Config.get('graphics', 'verify_gl_main_thread')
+    Config.set('graphics', 'verify_gl_main_thread', request.param)
+
+    widget = Widget()
+    yield widget, request.param
+
+    Config.set('graphics', 'verify_gl_main_thread', original)
+
+
+@pytest.mark.parametrize('widget_verify_thread', ['0', '1'], indirect=True)
+def test_graphics_main_thread(widget_verify_thread):
+    from kivy.graphics import Color
+
+    widget, verify_thread = widget_verify_thread
+    with widget.canvas:
+        color = Color()
+    color.rgb = .1, .2, .3
+
+
+@pytest.mark.parametrize('widget_verify_thread', ['0', '1'], indirect=True)
+def test_create_graphics_second_thread(widget_verify_thread):
+    from kivy.graphics import Color
+    widget, verify_thread = widget_verify_thread
+    exception = None
+
+    def callback():
+        nonlocal exception
+        try:
+            with widget.canvas:
+                if verify_thread == '1':
+                    with pytest.raises(TypeError):
+                        Color()
+                else:
+                    Color()
+        except BaseException as e:
+            exception = e, sys.exc_info()[2]
+            raise
+
+    thread = Thread(target=callback)
+    thread.start()
+    thread.join()
+    if exception is not None:
+        raise exception[0].with_traceback(exception[1])
+
+
+@pytest.mark.parametrize('widget_verify_thread', ['0', '1'], indirect=True)
+def test_change_graphics_second_thread(widget_verify_thread):
+    from kivy.graphics import Color
+    widget, verify_thread = widget_verify_thread
+    with widget.canvas:
+        color = Color()
+
+    exception = None
+
+    def callback():
+        nonlocal exception
+        try:
+            if verify_thread == '1':
+                with pytest.raises(TypeError):
+                    color.rgb = .1, .2, .3
+            else:
+                color.rgb = .1, .2, .3
+        except BaseException as e:
+            exception = e, sys.exc_info()[2]
+            raise
+
+    thread = Thread(target=callback)
+    thread.start()
+    thread.join()
+    if exception is not None:
+        raise exception[0].with_traceback(exception[1])


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

New users often don't realize that you cannot set graphics or change properties that then set graphics properties outside the main Kivy thread. But they notice something is wrong, but don't know why.

This adds a option that will error out of graphics are created or updated outside the main kivy thread. By default the option is ON, but it can be turned off in config.

In terms of performance loss, if the option is turned OFF, there's basically no additional cost. But if it's turned ON, it's slower, but only in the tens of microseconds per property, which I think is negligible and worth making Kivy more bullet proof and friendlier to new users.

Here is the performance testing code:

```py
from timeit import timeit
from kivy.config import Config
from kivy.uix.widget import Widget
from kivy.graphics import Rectangle, Color, Line

widget = Widget()
with widget.canvas:
    color = Color()
    rect = Rectangle()
    line = Line()

number = 1_000_000
values = []
for val in ('0', '1'):
    Config.set('graphics', 'verify_gl_main_thread', val)
    values.append(sum(timeit(setup='from __main__ import color, rect, line', stmt='color.rgb = .1, .2, .3', number=number // 10) for _ in range(10)))
    values.append(sum(timeit(setup='from __main__ import color, rect, line', stmt='rect.pos = .1, .2', number=number // 10) for _ in range(10)))
    values.append(sum(timeit(setup='from __main__ import color, rect, line', stmt='line.points = [1, 2, 3, 4, 5, 6]', number=number // 10) for _ in range(10)))

for i in range(3):
    print(f'{values[i]:0.4f} -> {values[i + 3]:0.4f}: {(values[i + 3] - values[i]) / values[i] * 100:0.2f}%, {((values[i + 3] - values[i]) / number):0.2E} difference')
```

This prints:
```
0.2593 -> 0.3300: 27.24%, 7.07E-08 difference
0.0428 -> 0.0453: 5.75%, 2.46E-09 difference
0.1718 -> 0.2618: 52.41%, 9.00E-08 difference
```
The percent may seem large, but look at the actual increase, which is in microseconds.

I also ran it with master (where setting the config option does nothing), and it printed:
```
0.2397 -> 0.2262: -5.64%, -1.35E-08 difference
0.0447 -> 0.0471: 5.41%, 2.42E-09 difference
0.1762 -> 0.1735: -1.51%, -2.67E-09 difference
```
which shows that when the option is turned OFF (compare first number to the first number abover), it basically is the same.