### PR TITLE
Window: prevent "empty" mousewheel events from breaking scrollview

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -571,10 +571,16 @@ cdef class _WindowSDL2Storage:
         elif event.type == SDL_MOUSEWHEEL:
             x = event.wheel.x
             y = event.wheel.y
+            # TODO we should probably support events with both an x and y offset
             if x != 0:
                 suffix = 'left' if x > 0 else 'right'
-            else:
+            elif y != 0:
                 suffix = 'down' if y > 0 else 'up'
+            else:
+                # It's possible to get mouse wheel events with no offset in
+                # either x or y direction, we just ignore them
+                # https://wiki.libsdl.org/SDL_MouseWheelEvent
+                return None
             action = 'mousewheel' + suffix
             return (action, x, y, None)
         elif event.type == SDL_FINGERMOTION:


### PR DESCRIPTION
It seems on some machines, (and specificaly on windows) lenovo ones, but maybe others, scrolling with the touchpad can create a lot of "fake" scrolling events, without any associated offset (x or y), the way kivy works currently dispatches these events as "mousewheelup" (which indicates a scroll down). This makes it really hard to scroll up this way, as there is a constant stream of events pushing in the other direction, and the more we try to scroll, the more there are.

This change ignore these empty events.

fixes: #6646
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
