### PR TITLE
docs: fix simple typo, expressons -> expressions

### DIFF
--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -210,7 +210,7 @@ Note that the outermost widget applies the kv rules to all its inner widgets
 before any other rules are applied. This means if an inner widget contains ids,
 these ids may not be available during the inner widget's `__init__` function.
 
-Valid expressons
+Valid expressions
 ~~~~~~~~~~~~~~~~
 
 There are two places that accept python statements in a kv file:

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -211,7 +211,7 @@ before any other rules are applied. This means if an inner widget contains ids,
 these ids may not be available during the inner widget's `__init__` function.
 
 Valid expressions
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 There are two places that accept python statements in a kv file:
 after a property, which assigns to the property the result of the expression


### PR DESCRIPTION
There is a small typo in kivy/lang/__init__.py.

Should read `expressions` rather than `expressons`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md