### PR TITLE
Camera: improve avfoundation by using memoryview and re-scheduling the interval on framerate change

### DIFF
--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -11,7 +11,7 @@ cdef extern from "camera_avfoundation_implem.h":
     ctypedef void *camera_t
     camera_t avf_camera_init(int index, int width, int height)
     void avf_camera_deinit(camera_t camera)
-    void avf_camera_update(camera_t camera)
+    bint avf_camera_update(camera_t camera)
     void avf_camera_start(camera_t camera)
     void avf_camera_stop(camera_t camera)
     void avf_camera_get_image(camera_t camera, int *width, int *height, int *rowsize, char **data)
@@ -28,6 +28,7 @@ from kivy.clock import Clock
 from kivy.graphics.texture import Texture
 from kivy.core.camera import CameraBase
 from kivy.utils import platform
+from cython cimport view as cyview
 
 
 cdef class _AVStorage:
@@ -45,6 +46,7 @@ class CameraAVFoundation(CameraBase):
         self._storage = _AVStorage()
         self._update_ev = None
         self._metadata_callback = None
+        self._framerate = 30
         super(CameraAVFoundation, self).__init__(**kwargs)
 
     def init_camera(self):
@@ -52,22 +54,39 @@ class CameraAVFoundation(CameraBase):
         storage.camera = avf_camera_init(
             self._index, self.resolution[0], self.resolution[1])
 
+    @property
+    def _scheduled_rate(self):
+        # We're going 4 times faster the framerate to avoid frame skipping.
+        return 1 / (self._framerate * 4)
+
     def _update(self, dt):
         cdef _AVStorage storage = <_AVStorage>self._storage
         cdef int width, height, rowsize
         cdef char *data
         cdef char *metadata_type
         cdef char *metadata_data
+        cdef cyview.array cyarr
 
         if self.stopped:
             return
 
-        avf_camera_update(storage.camera)
+        if not avf_camera_update(storage.camera):
+            return
+
         avf_camera_get_image(storage.camera,
             &width, &height, &rowsize, &data)
 
         if data == NULL:
             return
+
+        cyarr = cyview.array(
+            shape=(rowsize * height,),
+            itemsize=sizeof(char),
+            format="B",
+            mode="c",
+            allocate_buffer=False,
+        )
+        cyarr.data = data
 
         self._resolution = (width, height)
         
@@ -79,20 +98,23 @@ class CameraAVFoundation(CameraBase):
             self._texture.flip_vertical()
             self.dispatch('on_load')
 
-        self._buffer = <bytes>data[:rowsize * height]
         self._format = 'bgra'
+        self._texture.blit_buffer(cyarr, colorfmt=self._format)
         self._copy_to_gpu()
         if self._metadata_callback:
             if avf_camera_have_new_metadata(storage.camera):
                 avf_camera_get_metadata(storage.camera, &metadata_type, &metadata_data)
                 self._metadata_callback(metadata_type, metadata_data)
+    
+    def _copy_to_gpu(self):
+        self.dispatch('on_texture')
 
     def start(self):
         cdef _AVStorage storage = <_AVStorage>self._storage
         super(CameraAVFoundation, self).start()
         if self._update_ev is not None:
             self._update_ev.cancel()
-        self._update_ev = Clock.schedule_interval(self._update, 1 / 30.)
+        self._update_ev = Clock.schedule_interval(self._update, self._scheduled_rate)
         avf_camera_start(storage.camera)
 
     def stop(self):
@@ -105,7 +127,11 @@ class CameraAVFoundation(CameraBase):
 
     def set_framerate(self, framerate):
         cdef _AVStorage storage = <_AVStorage>self._storage
-        avf_camera_attempt_framerate_selection(storage.camera, framerate)
+        if avf_camera_attempt_framerate_selection(storage.camera, framerate):
+            if self._update_ev is not None:
+                self._update_ev.cancel()
+            self._framerate = framerate
+            self._update_ev = Clock.schedule_interval(self._update, self._scheduled_rate)
 
     def set_preset(self, preset):
         cdef _AVStorage storage = <_AVStorage>self._storage

--- a/kivy/core/camera/camera_avfoundation_implem.h
+++ b/kivy/core/camera/camera_avfoundation_implem.h
@@ -2,7 +2,7 @@ typedef void *camera_t;
 
 camera_t avf_camera_init(int index, int width, int height);
 void avf_camera_deinit(camera_t camera);
-void avf_camera_update(camera_t camera);
+bool avf_camera_update(camera_t camera);
 void avf_camera_start(camera_t camera);
 void avf_camera_stop(camera_t camera);
 void avf_camera_get_image(camera_t camera, int *width, int *height, int *rowsize, char **data);

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -218,20 +218,23 @@ Camera::~Camera() {
 }
 
 bool Camera::grabFrame(double timeOut) {
-
+    
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
+    bool haveFrame = false;
     double sleepTime = 0.005;
     double total = 0;
     NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:sleepTime];
-    [capture updateImage];
-    while (![capture updateImage] && (total += sleepTime)<=timeOut &&
+    haveFrame = [capture updateImage];
+    while (!haveFrame && (total += sleepTime)<=timeOut &&
             [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
-            beforeDate:loopUntil])
+            beforeDate:loopUntil]){
+        haveFrame = [capture updateImage];
         loopUntil = [NSDate dateWithTimeIntervalSinceNow:sleepTime];
+    }
 
     [localpool drain];
 
-    return total <= timeOut;
+    return haveFrame;
 }
 
 CameraFrame* Camera::retrieveFrame() {
@@ -689,8 +692,8 @@ void avf_camera_deinit(camera_t camera) {
     delete (Camera *)(camera);
 }
 
-void avf_camera_update(camera_t camera) {
-    ((Camera *)camera)->grabFrame(0);
+bool avf_camera_update(camera_t camera) {
+    return ((Camera *)camera)->grabFrame(0);
 }
 
 void avf_camera_get_image(camera_t camera, int *width, int *height, int *rowsize, char **data) {


### PR DESCRIPTION
The purpose of this PR is to enhance the avfoundation camera provider on both iOS and macOS.

By using Cython memoryview I'm avoiding to call `PyBytes_FromStringAndSize` when assigning the buffer via `self._buffer = <bytes>data[:rowsize * height]`.

Now, the overall performance it's slightly better and I'm not incurring anymore random `BADACCESS` errors that were leading the App into a crash.

I've also added an update rescheduling procedure, to have a consistent update timing with the selected framerate.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
