### PR TITLE
Benchmarks: Add benchmarks option measurements to pytest

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -98,7 +98,13 @@ install_kivy_sdist() {
 
 test_kivy() {
   rm -rf kivy/tests/build || true
-  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+  KIVY_NO_ARGS=1 python3 -m pytest --benchmark-skip --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+}
+
+test_kivy_benchmark() {
+  KIVY_NO_ARGS=1 python3 -m pytest "$(pwd)/kivy/tests/test_benchmark.py" --benchmark-warmup=on --benchmark-warmup-iterations=5 \
+  --benchmark-disable-gc --benchmark-name=short --benchmark-sort=fullname --benchmark-group-by=fullfunc \
+  --benchmark-storage=benchmarks --benchmark-save=kivy
 }
 
 test_kivy_install() {
@@ -112,7 +118,7 @@ test_kivy_install() {
   plugins = kivy.tools.coverage
 
 EOF
-  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 .
+  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --benchmark-skip --timeout=300 .
 }
 
 upload_coveralls() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -98,13 +98,11 @@ install_kivy_sdist() {
 
 test_kivy() {
   rm -rf kivy/tests/build || true
-  KIVY_NO_ARGS=1 python3 -m pytest --benchmark-skip --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+  KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
 }
 
 test_kivy_benchmark() {
-  KIVY_NO_ARGS=1 python3 -m pytest "$(pwd)/kivy/tests/test_benchmark.py" --benchmark-warmup=on --benchmark-warmup-iterations=5 \
-  --benchmark-disable-gc --benchmark-name=short --benchmark-sort=fullname --benchmark-group-by=fullfunc \
-  --benchmark-storage=benchmarks --benchmark-save=kivy
+  KIVY_NO_ARGS=1 python3 -m pytest "$(pwd)/kivy/tests" --benchmark-only
 }
 
 test_kivy_install() {
@@ -118,7 +116,7 @@ test_kivy_install() {
   plugins = kivy.tools.coverage
 
 EOF
-  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --benchmark-skip --timeout=300 .
+  KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --timeout=300 .
 }
 
 upload_coveralls() {

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -111,7 +111,13 @@ function Install-kivy-sdist {
 }
 
 function Test-kivy {
-    python -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+    python -m pytest  --benchmark-skip --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+}
+
+function Test-kivy-benchmark {
+    python -m pytest "$(pwd)/kivy/tests/test_benchmark.py" --benchmark-warmup=on --benchmark-warmup-iterations=5 `
+--benchmark-disable-gc --benchmark-name=short --benchmark-sort=fullname --benchmark-group-by=fullfunc `
+--benchmark-storage=benchmarks --benchmark-save=kivy
 }
 
 function Test-kivy-installed {
@@ -121,7 +127,7 @@ function Test-kivy-installed {
     cd "$test_path"
 
     echo "[run]`nplugins = kivy.tools.coverage`n" > .coveragerc
-    raise-only-error -Func {python -m pytest --timeout=300 .}
+    raise-only-error -Func {python -m pytest --benchmark-skip --timeout=300 .}
 }
 
 function Upload-artifacts-to-pypi {

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -111,13 +111,11 @@ function Install-kivy-sdist {
 }
 
 function Test-kivy {
-    python -m pytest  --benchmark-skip --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+    python -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
 }
 
 function Test-kivy-benchmark {
-    python -m pytest "$(pwd)/kivy/tests/test_benchmark.py" --benchmark-warmup=on --benchmark-warmup-iterations=5 `
---benchmark-disable-gc --benchmark-name=short --benchmark-sort=fullname --benchmark-group-by=fullfunc `
---benchmark-storage=benchmarks --benchmark-save=kivy
+    python -m pytest "$(pwd)/kivy/tests" --benchmark-only
 }
 
 function Test-kivy-installed {
@@ -127,7 +125,7 @@ function Test-kivy-installed {
     cd "$test_path"
 
     echo "[run]`nplugins = kivy.tools.coverage`n" > .coveragerc
-    raise-only-error -Func {python -m pytest --benchmark-skip --timeout=300 .}
+    raise-only-error -Func {python -m pytest --timeout=300 .}
 }
 
 function Upload-artifacts-to-pypi {

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -144,6 +144,16 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         test_kivy_install
+    - name: Test Kivy benchmarks
+      if: matrix.python == '3.9' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
+      run: |
+        source .ci/ubuntu_ci.sh
+        test_kivy_benchmark
+    - name: Upload benchamrks as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: benchmarks
+        path: .benchmarks-kivy
 
   sdist_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -42,10 +42,6 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         install_kivy
-    - name: Test Kivy benchmarks
-      run: |
-        source .ci/ubuntu_ci.sh
-        test_kivy_benchmark
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh
@@ -57,6 +53,15 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         upload_coveralls
+    - name: Test Kivy benchmarks
+      run: |
+        source .ci/ubuntu_ci.sh
+        test_kivy_benchmark
+    - name: Upload benchamrks as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: benchmarks
+        path: .benchmarks-kivy
 
   gen_docs:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -42,6 +42,10 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         install_kivy
+    - name: Test Kivy benchmarks
+      run: |
+        source .ci/ubuntu_ci.sh
+        test_kivy_benchmark
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -31,6 +31,11 @@ jobs:
       run: |
         . .\.ci\windows_ci.ps1
         Install-kivy
+    - name: Test Kivy benchmarks
+      if: matrix.python == '3.9' && matrix.arch == 'x64'
+      run: |
+        . .\.ci\windows_ci.ps1
+        Test-kivy-benchmark
     - name: Test Kivy
       run: |
         . .\.ci\windows_ci.ps1

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -31,12 +31,17 @@ jobs:
       run: |
         . .\.ci\windows_ci.ps1
         Install-kivy
+    - name: Test Kivy
+      run: |
+        . .\.ci\windows_ci.ps1
+        Test-kivy
     - name: Test Kivy benchmarks
       if: matrix.python == '3.9' && matrix.arch == 'x64'
       run: |
         . .\.ci\windows_ci.ps1
         Test-kivy-benchmark
-    - name: Test Kivy
-      run: |
-        . .\.ci\windows_ci.ps1
-        Test-kivy
+    - name: Upload benchamrks as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: benchmarks
+        path: .benchmarks-kivy

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -130,6 +130,16 @@ jobs:
         run: |
           . .\.ci\windows_ci.ps1
           Test-kivy-installed
+      - name: Test Kivy benchmarks
+        if: matrix.python == '3.9' && matrix.arch == 'x64' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
+        run: |
+          . .\.ci\windows_ci.ps1
+          Test-kivy-benchmark
+      - name: Upload benchamrks as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmarks
+          path: .benchmarks-kivy
 
   windows_sdist_test:
     runs-on: windows-latest

--- a/kivy/tests/test_benchmark.py
+++ b/kivy/tests/test_benchmark.py
@@ -1,0 +1,104 @@
+import pytest
+from string import ascii_letters
+from random import randint
+import gc
+
+import sys
+
+
+@pytest.fixture
+def kivy_benchmark(benchmark, kivy_clock):
+    from kivy.core.window import Window
+    from kivy.cache import Cache
+    from kivy.utils import platform
+    import kivy
+    from kivy.core.gl import glGetString, GL_VENDOR, GL_RENDERER, GL_VERSION
+
+    for category in list(Cache._objects.keys()):
+        if category not in Cache._categories:
+            continue
+
+        for key in list(Cache._objects[category].keys()):
+            Cache.remove(category, key)
+
+    gc.collect()
+
+    benchmark.extra_info['platform'] = str(sys.platform)
+    benchmark.extra_info['python_version'] = str(sys.version)
+    benchmark.extra_info['python_api'] = str(sys.api_version)
+    benchmark.extra_info['kivy_platform'] = platform
+    benchmark.extra_info['kivy_version'] = kivy.__version__
+    benchmark.extra_info['gl_vendor'] = str(glGetString(GL_VENDOR))
+    benchmark.extra_info['gl_renderer'] = str(glGetString(GL_RENDERER))
+    benchmark.extra_info['gl_version'] = str(glGetString(GL_VERSION))
+
+    yield benchmark
+
+
+def test_widget_creation(kivy_benchmark):
+    from kivy.uix.widget import Widget
+    # create one just so we don't incur loading cost
+    w = Widget()
+    kivy_benchmark(Widget)
+
+
+@pytest.mark.parametrize('n', [1, 5, 10, 50, 100, 1_000, 10_000])
+def test_widget_empty_draw(kivy_benchmark, n):
+    from kivy.graphics import RenderContext
+    from kivy.uix.widget import Widget
+    ctx = RenderContext()
+    root = Widget()
+    for x in range(n):
+        root.add_widget(Widget())
+    ctx.add(root.canvas)
+
+    kivy_benchmark(ctx.draw)
+
+
+@pytest.mark.parametrize('n', [1, 5, 10, 50, 100, 1_000])
+def test_widget_dispatch_touch(kivy_benchmark, n):
+    from kivy.tests.common import UnitTestTouch
+    from kivy.uix.widget import Widget
+
+    root = Widget()
+    for x in range(10):
+        parent = Widget()
+        for y in range(n):
+            parent.add_widget(Widget())
+        root.add_widget(parent)
+
+    touch = UnitTestTouch(10, 10)
+
+    def dispatch():
+        root.dispatch('on_touch_down', touch)
+        root.dispatch('on_touch_move', touch)
+        root.dispatch('on_touch_up', touch)
+
+    kivy_benchmark(dispatch)
+
+
+@pytest.mark.parametrize('n', [1, 5, 10, 50, 100, 1_000])
+@pytest.mark.parametrize('name', ['label', 'button'])
+@pytest.mark.parametrize('tick', ['tick', 'no_tick'])
+def test_random_label_create(kivy_benchmark, n, name, tick):
+    from kivy.clock import Clock
+    from kivy.uix.label import Label
+    from kivy.uix.button import Button
+    label = Label(text='*&^%')
+    button = Button(text='*&^%')
+    cls = Label if name == 'label' else Button
+
+    labels = []
+    k = len(ascii_letters)
+    for x in range(n):
+        label = [ascii_letters[randint(0, k - 1)] for _ in range(10)]
+        labels.append(''.join(label))
+
+    def make_labels():
+        o = []
+        for text in labels:
+            o.append(cls(text=text))
+
+        if tick == 'tick':
+            Clock.tick()
+    kivy_benchmark(make_labels)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,4 @@ requires = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchamrks-kivy --benchmark-save=kivy"
+addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchmarks-kivy --benchmark-save=kivy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ requires = [
     'kivy_deps.sdl2~=0.3.1; sys_platform == "win32"',
     'kivy_deps.glew~=0.3.0; sys_platform == "win32"',
 ]
+
+[tool.pytest.ini_options]
+addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchamrks-kivy --benchmark-save=kivy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ dev =
     pytest-cov
     pytest_asyncio!=0.11.0
     pytest-timeout
+    pytest-benchmark
     pyinstaller
     sphinx
     sphinxcontrib-blockdiag


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

This adds benchmark testing to pytest. It is disabled by default. To run it, pass the `--benchmark-only` arg to pytest.

It also runs every night on schedule when the wheels are built as well as for every pr/push test suite as a extra step. Running it on the CI may not be super helpful, as I'm not sure how meaningful it is to run on some random cranky server sharing other workloads, but it could be useful. It would be nice if we had a dedicated computer to run it on. It does make the unit test take longer so maybe we can remove it from the unit tests and just run it nightly.

It also uploads the benchmark results as a artifact. In the long term it would be nice if we could upload the results to the server and display it, like https://speed.python.org. And to run it on older kivy releases. But maybe such results would only be meaningful if run on a single computer.