### PR TITLE
Properties: Add dynamic screen density/dpi support

### DIFF
--- a/kivy/_event.pxd
+++ b/kivy/_event.pxd
@@ -50,9 +50,11 @@ cdef class EventObservers:
 
     cdef inline void bind(self, object observer, object src_observer, int is_ref) except *
     cdef inline object fbind(self, object observer, tuple largs, dict kwargs, int is_ref)
+    cdef inline BoundCallback fbind_callback(self, object observer, tuple largs, dict kwargs, int is_ref)
     cdef inline void unbind(self, object observer, int stop_on_first) except *
     cdef inline void funbind(self, object observer, tuple largs, dict kwargs) except *
     cdef inline object unbind_uid(self, object uid)
+    cdef inline object unbind_callback(self, BoundCallback callback)
     cdef inline void remove_callback(self, BoundCallback callback, int force=*) except *
     cdef inline object _dispatch(
         self, object f, tuple slargs, dict skwargs, object obj, object value, tuple largs, dict kwargs)

--- a/kivy/_event.pxd
+++ b/kivy/_event.pxd
@@ -34,6 +34,9 @@ cdef class BoundCallback:
     cdef BoundCallback next  # next callback in chain
     cdef BoundCallback prev  # previous callback in chain
     cdef object uid  # the uid given for this callback, None if not given
+    cdef EventObservers observers
+
+    cdef void set_largs(self, tuple largs)
 
 
 cdef class EventObservers:
@@ -48,9 +51,11 @@ cdef class EventObservers:
     # The uid to assign to the next bound callback.
     cdef object uid
 
+    cdef inline BoundCallback make_callback(self, object observer, tuple largs, dict kwargs, int is_ref, uid=*)
     cdef inline void bind(self, object observer, object src_observer, int is_ref) except *
     cdef inline object fbind(self, object observer, tuple largs, dict kwargs, int is_ref)
     cdef inline BoundCallback fbind_callback(self, object observer, tuple largs, dict kwargs, int is_ref)
+    cdef inline void fbind_existing_callback(self, BoundCallback callback)
     cdef inline void unbind(self, object observer, int stop_on_first) except *
     cdef inline void funbind(self, object observer, tuple largs, dict kwargs) except *
     cdef inline object unbind_uid(self, object uid)

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -1025,12 +1025,7 @@ cdef class EventObservers:
             callback = callback.next
 
         new_callback = self.make_callback(observer, None, None, is_ref)
-        if self.first_callback is None:
-            self.last_callback = self.first_callback = new_callback
-        else:
-            self.last_callback.next = new_callback
-            new_callback.prev = self.last_callback
-            self.last_callback = new_callback
+        self.fbind_existing_callback(new_callback)
 
     cdef inline object fbind(self, object observer, tuple largs, dict kwargs,
                                int is_ref):
@@ -1042,13 +1037,7 @@ cdef class EventObservers:
         self.uid += 1
         cdef BoundCallback new_callback = self.make_callback(
             observer, largs, kwargs, is_ref, uid)
-
-        if self.first_callback is None:
-            self.last_callback = self.first_callback = new_callback
-        else:
-            self.last_callback.next = new_callback
-            new_callback.prev = self.last_callback
-            self.last_callback = new_callback
+        self.fbind_existing_callback(new_callback)
         return uid
 
     cdef inline BoundCallback fbind_callback(
@@ -1059,13 +1048,7 @@ cdef class EventObservers:
         '''
         cdef BoundCallback new_callback = self.make_callback(
             observer, largs, kwargs, is_ref)
-
-        if self.first_callback is None:
-            self.last_callback = self.first_callback = new_callback
-        else:
-            self.last_callback.next = new_callback
-            new_callback.prev = self.last_callback
-            self.last_callback = new_callback
+        self.fbind_existing_callback(new_callback)
         return new_callback
 
     cdef inline void fbind_existing_callback(self, BoundCallback callback):

--- a/kivy/_metrics.pxd
+++ b/kivy/_metrics.pxd
@@ -1,0 +1,5 @@
+from kivy._event cimport EventObservers
+
+cdef EventObservers pixel_scale_observers
+
+cpdef float dpi2px(value, str ext) except *

--- a/kivy/_metrics.pyx
+++ b/kivy/_metrics.pyx
@@ -1,0 +1,61 @@
+"""Low level Metrics
+====================
+
+Module for low level metrics operations.
+
+"""
+__all__ = ('dpi2px', 'NUMERIC_FORMATS', 'dispatch_pixel_scale')
+
+
+cdef float g_dpi = -1
+cdef float g_density = -1
+cdef float g_fontscale = -1
+cdef EventObservers pixel_scale_observers = EventObservers.__new__(
+    EventObservers)
+"""These observers are dispatched when the dpi/density/font scale changes.
+All NumericProperties bind to it, and dispatch their prop in response (if it
+causes changes to them).
+"""
+NUMERIC_FORMATS = ('in', 'px', 'dp', 'sp', 'pt', 'cm', 'mm')
+"""The tuple of supported suffixes in Kivy properties that support e.g.
+``"10dp"`` type syntax.
+"""
+
+
+def dispatch_pixel_scale(*args):
+    """Dispatches all properties that and watch pixel_scale_observers.
+
+    This should be called by Metrics when it changes any of the scaling
+    properties.
+    """
+    from kivy.metrics import Metrics
+    global g_dpi, g_density, g_fontscale
+
+    g_dpi = Metrics.dpi
+    g_density = Metrics.density
+    g_fontscale = Metrics.fontscale
+    pixel_scale_observers.dispatch(None, None, None, None, 0)
+
+
+cpdef float dpi2px(value, str ext) except *:
+    """Converts the value according to the ext."""
+    # 1in = 2.54cm = 25.4mm = 72pt = 12pc
+    if g_dpi == -1:
+        dispatch_pixel_scale()
+
+
+    cdef float rv = <float>float(value)
+    if ext == 'in':
+        return rv * g_dpi
+    elif ext == 'px':
+        return rv
+    elif ext == 'dp':
+        return rv * g_density
+    elif ext == 'sp':
+        return rv * g_density * g_fontscale
+    elif ext == 'pt':
+        return rv * g_dpi / <float>72.
+    elif ext == 'cm':
+        return rv * g_dpi / <float>2.54
+    elif ext == 'mm':
+        return rv * g_dpi / <float>25.4

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -261,9 +261,7 @@ class EventLoopBase(EventDispatcher):
             root_window = wid.get_root_window()
             if wid != root_window and root_window is not None:
                 me.push()
-                w, h = root_window.system_size
-                if platform == 'ios' or root_window._density != 1:
-                    w, h = root_window.size
+                w, h = root_window._get_effective_size()
                 kheight = root_window.keyboard_height
                 smode = root_window.softinput_mode
                 me.scale_for_screen(w, h, rotation=root_window.rotation,

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -892,8 +892,6 @@ class WindowBase(EventDispatcher):
         return cls.__instance
 
     def __init__(self, **kwargs):
-        from kivy.metrics import Metrics
-
         force = kwargs.pop('force', False)
 
         # don't init window 2 times,
@@ -908,7 +906,7 @@ class WindowBase(EventDispatcher):
         # property changes
         self.trigger_create_window = Clock.create_trigger(
             self.create_window, -1)
-        self.fbind('dpi', Metrics.reset_dpi)
+        self.fbind('dpi', self._reset_metrics_dpi)
 
         # Create a trigger for updating the keyboard height
         self.trigger_keyboard_height = Clock.create_trigger(
@@ -995,6 +993,10 @@ class WindowBase(EventDispatcher):
 
         # mark as initialized
         self.initialized = True
+
+    def _reset_metrics_dpi(self, *args):
+        from kivy.metrics import Metrics
+        Metrics.reset_dpi()
 
     def _bind_create_window(self):
         for prop in (

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -289,7 +289,7 @@ class MetricsBase(EventDispatcher):
         return True
 
     fontscale: float = AliasProperty(get_fontscale, set_fontscale, cache=True)
-    '''The fontscale user preference. 
+    '''The fontscale user preference.
 
     This value is 1 by default but can vary between 0.8 and 1.2.
 

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -223,7 +223,7 @@ class MetricsBase(EventDispatcher):
     Depending on the platform, the DPI can be taken from the Window provider
     (Desktop mainly) or from a platform-specific module (like android/ios).
 
-    :attr:`dpi` is a :class:`~kivy.properties.AliasProperty` and can be 
+    :attr:`dpi` is a :class:`~kivy.properties.AliasProperty` and can be
     set to change the value. But, the :attr:`density` is reloaded and reset if
     we got it from the Window and the Window ``dpi`` changed.
     '''
@@ -279,7 +279,7 @@ class MetricsBase(EventDispatcher):
     This value is 1 by default on desktops but varies on android depending on
     the screen.
 
-    :attr:`density` is a :class:`~kivy.properties.AliasProperty` and can be 
+    :attr:`density` is a :class:`~kivy.properties.AliasProperty` and can be
     set to change the value. But, the :attr:`density` is reloaded and reset if
     we got it from the Window and the Window ``density`` changed.
     '''

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -272,6 +272,11 @@ class MetricsBase(EventDispatcher):
     can vary between 0.8 and 1.2.
 '''
 
+    def reload_metrics(self, *args):
+        self.dpi = self.get_dpi(force_recompute=True)
+        self.density = self.get_density(force_recompute=True)
+        self.fontscale = self.get_fontscale(force_recompute=True)
+
 
 #: Default instance of :class:`MetricsBase`, used everywhere in the code
 #: .. versionadded:: 1.7.0

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -199,9 +199,14 @@ class MetricsBase(EventDispatcher):
         return True
 
     dpi = AliasProperty(get_dpi, set_dpi, cache=True)
-    '''Return the DPI of the screen. Depending on the platform, the DPI can
-    be taken from the Window provider (Desktop mainly) or from a
-    platform-specific module (like android/ios).
+    '''The DPI of the screen.
+
+    Depending on the platform, the DPI can be taken from the Window provider
+    (Desktop mainly) or from a platform-specific module (like android/ios).
+
+    The :attr:`dpi` can be set and that value will be used instead. But, the
+    :attr:`dpi` is reloaded and reset if we get it from the Window provider and
+    the Window changes dpi.
     '''
 
     def get_dpi_rounded(self):
@@ -216,8 +221,8 @@ class MetricsBase(EventDispatcher):
 
     dpi_rounded = AliasProperty(
         get_dpi_rounded, None, bind=('dpi', ), cache=True)
-    '''Return the DPI of the screen, rounded to the nearest of 120, 160,
-    240 or 320.
+    '''Return the :attr:`dpi` of the screen, rounded to the nearest of 120,
+    160, 240 or 320.
     '''
 
     def get_density(self, force_recompute=False):
@@ -244,8 +249,13 @@ class MetricsBase(EventDispatcher):
 
     density = AliasProperty(
         get_density, set_density, bind=('dpi', ), cache=True)
-    '''Return the density of the screen. This value is 1 by default
-    on desktops but varies on android depending on the screen.
+    '''The density of the screen.
+
+    This value is 1 by default on desktops but varies on android depending on
+    the screen.
+
+    The :attr:`density` can be set and that value will be used instead. But,
+    the :attr:`density` is reloaded and reset if we get it from the Window.
     '''
 
     def get_fontscale(self, force_recompute=False):
@@ -268,14 +278,26 @@ class MetricsBase(EventDispatcher):
         return True
 
     fontscale = AliasProperty(get_fontscale, set_fontscale, cache=True)
-    '''Return the fontscale user preference. This value is 1 by default but
-    can vary between 0.8 and 1.2.
-'''
+    '''The fontscale user preference. 
 
-    def reload_metrics(self, *args):
+    This value is 1 by default but can vary between 0.8 and 1.2.
+
+    The :attr:`fontscale` can be set and that value will be used instead.
+    '''
+
+    def reset_metrics(self):
+        """Resets the dpi/density/fontscale to the platform values, overwriting
+        any manually set values.
+        """
         self.dpi = self.get_dpi(force_recompute=True)
         self.density = self.get_density(force_recompute=True)
         self.fontscale = self.get_fontscale(force_recompute=True)
+
+    def reset_dpi(self, *args):
+        """Resets the dpi (and possibly density) to the platform values,
+        overwriting any manually set values.
+        """
+        self.dpi = self.get_dpi(force_recompute=True)
 
 
 #: Default instance of :class:`MetricsBase`, used everywhere in the code

--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -1,4 +1,4 @@
-from kivy._event cimport EventDispatcher, EventObservers
+from kivy._event cimport EventDispatcher, EventObservers, BoundCallback
 
 cdef class PropertyStorage:
     cdef object value

--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -3,19 +3,7 @@ from kivy._event cimport EventDispatcher, EventObservers, BoundCallback
 cdef class PropertyStorage:
     cdef object value
     cdef EventObservers observers
-    cdef object numeric_fmt
-    cdef long bnum_min
-    cdef long bnum_max
-    cdef float bnum_f_min
-    cdef float bnum_f_max
-    cdef int bnum_use_min
-    cdef int bnum_use_max
-    cdef list options
-    cdef tuple properties
-    cdef int stop_event
-    cdef object getter
-    cdef object setter
-    cdef int alias_initial
+
 
 cdef class Property:
     cdef str _name
@@ -28,6 +16,7 @@ cdef class Property:
     cdef public object defaultvalue
     cdef int deprecated
     cdef init_storage(self, EventDispatcher obj, PropertyStorage storage)
+    cdef PropertyStorage create_property_storage(self)
     cpdef link(self, EventDispatcher obj, str name)
     cpdef link_deps(self, EventDispatcher obj, str name)
     cpdef bind(self, EventDispatcher obj, observer)
@@ -41,6 +30,12 @@ cdef class Property:
     cdef check(self, EventDispatcher obj, x)
     cdef convert(self, EventDispatcher obj, x)
     cpdef dispatch(self, EventDispatcher obj)
+
+
+cdef class NumericPropertyStorage(PropertyStorage):
+    cdef object numeric_fmt
+    cdef object original_num
+
 
 cdef class NumericProperty(Property):
     cdef float parse_str(self, EventDispatcher obj, value) except *
@@ -62,6 +57,16 @@ cdef class ObjectProperty(Property):
 cdef class BooleanProperty(Property):
     pass
 
+
+cdef class BoundedNumericPropertyStorage(PropertyStorage):
+    cdef long bnum_min
+    cdef long bnum_max
+    cdef float bnum_f_min
+    cdef float bnum_f_max
+    cdef int bnum_use_min
+    cdef int bnum_use_max
+
+
 cdef class BoundedNumericProperty(Property):
     cdef int use_min
     cdef int use_max
@@ -70,13 +75,31 @@ cdef class BoundedNumericProperty(Property):
     cdef float f_min
     cdef float f_max
 
+
+cdef class OptionPropertyStorage(PropertyStorage):
+    cdef list options
+
+
 cdef class OptionProperty(Property):
     cdef list options
+
+
+cdef class ReferenceListPropertyStorage(PropertyStorage):
+    cdef tuple properties
+    cdef int stop_event
+
 
 cdef class ReferenceListProperty(Property):
     cdef list properties
     cpdef trigger_change(self, EventDispatcher obj, value)
     cpdef setitem(self, EventDispatcher obj, key, value)
+
+
+cdef class AliasPropertyStorage(PropertyStorage):
+    cdef object getter
+    cdef object setter
+    cdef int alias_initial
+
 
 cdef class AliasProperty(Property):
     cdef object getter

--- a/kivy/properties.pxd
+++ b/kivy/properties.pxd
@@ -1,8 +1,10 @@
 from kivy._event cimport EventDispatcher, EventObservers, BoundCallback
+from kivy._metrics cimport dpi2px, pixel_scale_observers
 
 cdef class PropertyStorage:
     cdef object value
     cdef EventObservers observers
+    cdef Property property_obj
 
 
 cdef class Property:
@@ -109,11 +111,18 @@ cdef class AliasProperty(Property):
     cdef public int rebind
     cpdef trigger_change(self, EventDispatcher obj, value)
 
+
+cdef class VariableListPropertyStorage(PropertyStorage):
+    cdef object original_num
+    cdef int uses_scaling
+
+
 cdef class VariableListProperty(Property):
     cdef public int length
     cdef _convert_numeric(self, EventDispatcher obj, x)
     cdef float parse_str(self, EventDispatcher obj, value) except *
     cdef float parse_list(self, EventDispatcher obj, value, ext) except *
+
 
 cdef class ConfigParserProperty(Property):
     cdef object config

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -287,10 +287,15 @@ cdef float g_density = -1
 cdef float g_fontscale = -1
 cdef EventObservers pixel_scale_observers = EventObservers.__new__(
     EventObservers)
+"""These observers are dispatched when the dpi/density/font scale changes.
+All NumericProperties bind to it, and dispatch their prop in response (if it
+causes changes to them).
+"""
 NUMERIC_FORMATS = ('in', 'px', 'dp', 'sp', 'pt', 'cm', 'mm')
 
 
 def _dispatch_pixel_scale(*args):
+    """This is bound to Metrics.dpi/density/fontscale."""
     from kivy.metrics import Metrics
     global g_dpi, g_density, g_fontscale
 
@@ -300,7 +305,8 @@ def _dispatch_pixel_scale(*args):
     pixel_scale_observers.dispatch(None, None, None, None, 0)
 
 
-cpdef float dpi2px(value, ext) except *:
+cpdef float dpi2px(value, str ext) except *:
+    """Converts the value acording to the ext."""
     # 1in = 2.54cm = 25.4mm = 72pt = 12pc
     if g_dpi == -1:
         from kivy.metrics import Metrics
@@ -435,6 +441,7 @@ cdef class Property:
         storage.observers = EventObservers.__new__(EventObservers)
 
     cdef PropertyStorage create_property_storage(self):
+        """Returns a new property storage used by this property."""
         return PropertyStorage()
 
     cpdef link(self, EventDispatcher obj, str name):

--- a/kivy/tests/conftest.py
+++ b/kivy/tests/conftest.py
@@ -4,7 +4,8 @@ import os
 kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
 
 try:
-    from .fixtures import kivy_app, kivy_clock, kivy_exception_manager
+    from .fixtures import kivy_app, kivy_clock, kivy_metrics, \
+        kivy_exception_manager
 except SyntaxError:
     # async app tests would be skipped due to async_run forcing it to skip so
     # it's ok to fail here as it won't be used anyway

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -4,7 +4,7 @@ import weakref
 import time
 import os.path
 
-__all__ = ('kivy_clock', 'kivy_exception_manager', 'kivy_app', )
+__all__ = ('kivy_clock', 'kivy_metrics', 'kivy_exception_manager', 'kivy_app')
 
 
 @pytest.fixture()
@@ -25,6 +25,22 @@ def kivy_clock():
         Clock.stop_clock()
     finally:
         context.pop()
+
+
+@pytest.fixture()
+def kivy_metrics():
+    from kivy.context import Context
+    from kivy.metrics import MetricsBase, Metrics
+
+    context = Context(init=False)
+    context['Metrics'] = MetricsBase()
+    context.push()
+
+    try:
+        yield Metrics
+    finally:
+        context.pop()
+        Metrics._set_cached_scaling()
 
 
 @pytest.fixture()

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -31,10 +31,13 @@ def kivy_clock():
 def kivy_metrics():
     from kivy.context import Context
     from kivy.metrics import MetricsBase, Metrics
+    from kivy._metrics import dispatch_pixel_scale
 
     context = Context(init=False)
     context['Metrics'] = MetricsBase()
     context.push()
+    # need to do it to reset the global value
+    dispatch_pixel_scale()
 
     try:
         yield Metrics

--- a/kivy/tests/test_metrics.py
+++ b/kivy/tests/test_metrics.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+@pytest.mark.parametrize('unit', ['inch', 'dp', 'sp', 'pt', 'cm', 'mm'])
+def test_metrics_scale_factors(kivy_metrics, unit):
+    from kivy.metrics import dpi2px
+    import kivy.metrics as m
+    kivy_metrics.density = 2
+    kivy_metrics.dpi = 101
+    kivy_metrics.fontscale = 3
+
+    factor = getattr(kivy_metrics, unit)
+    print(kivy_metrics.fontscale)
+    assert pytest.approx(7 * factor) == dpi2px(7, unit[:2])  # inch -> in
+    assert pytest.approx(7 * factor) == getattr(m, unit)(7)
+
+    kivy_metrics.density = 5
+    kivy_metrics.dpi = 103
+    kivy_metrics.fontscale = 11
+
+    new_factor = getattr(kivy_metrics, unit)
+    assert new_factor != pytest.approx(factor)
+    assert pytest.approx(7 * new_factor) == dpi2px(7, unit[:2])
+    assert pytest.approx(7 * new_factor) == getattr(m, unit)(7)
+    assert pytest.approx(7 * factor) != dpi2px(7, unit[:2])
+    assert pytest.approx(7 * factor) != getattr(m, unit)(7)
+
+    # assert pytest.approx(10 * new_factor) == dpi2px(10, unit)
+    assert pytest.approx(100 * new_factor) == dpi2px(100, unit[:2])
+    assert pytest.approx(1000 * new_factor) == dpi2px(1000, unit[:2])

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -948,3 +948,70 @@ def test_variable_list_property_dp(kivy_metrics):
 
     assert counter == 3
     assert list(number.a) == [10, 20, 3, 4]
+
+
+def test_property_duplicate_name():
+    from kivy.event import EventDispatcher
+    from kivy.properties import ObjectProperty
+
+    class Event(EventDispatcher):
+
+        a = ObjectProperty(5)
+
+    event = Event()
+    counter = 0
+    counter2 = 0
+
+    def callback(*args):
+        nonlocal counter
+        counter += 1
+
+    def callback2(*args):
+        nonlocal counter2
+        counter2 += 1
+
+    event.fbind('a', callback)
+
+    event.create_property('a', None)
+    event.fbind('a', callback2)
+
+    event.a = 12
+    assert not counter
+    assert counter2 == 1
+
+
+def test_property_rename_duplicate():
+    from kivy.event import EventDispatcher
+    from kivy.properties import ObjectProperty
+
+    class Event(EventDispatcher):
+
+        b = ObjectProperty(5)
+        a = b
+
+    event = Event()
+    counter = 0
+    counter2 = 0
+
+    def callback(*args):
+        nonlocal counter
+        counter += 1
+
+    def callback2(*args):
+        nonlocal counter2
+        counter2 += 1
+
+    event.fbind('a', callback)
+    event.fbind('b', callback2)
+
+    event.a = 12
+    assert counter == 1
+    assert counter2 == 1
+    assert event.a == 12
+    assert event.b == 12
+
+    event.b = 14
+    assert counter == 2
+    assert counter2 == 2
+    assert event.a == 14
+    assert event.b == 14

--- a/setup.py
+++ b/setup.py
@@ -815,7 +815,9 @@ sources = {
     '_event.pyx': merge(base_flags, {'depends': ['properties.pxd']}),
     '_clock.pyx': {},
     'weakproxy.pyx': {},
-    'properties.pyx': merge(base_flags, {'depends': ['_event.pxd']}),
+    'properties.pyx': merge(
+        base_flags, {'depends': ['_event.pxd', '_metrics.pxd']}),
+    '_metrics.pyx': merge(base_flags, {'depends': ['_event.pxd']}),
     'graphics/buffer.pyx': merge(base_flags, gl_flags_base),
     'graphics/context.pyx': merge(base_flags, gl_flags_base),
     'graphics/compiler.pyx': merge(base_flags, gl_flags_base),


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

This PR adds support for dynamically updating and rescaling all `dpi` and `density` dependent NumericProperty instances. This allows automatically rescaling the UI as the `dpi` changes as in the following demo:

![dpi](https://user-images.githubusercontent.com/1644286/103183299-6d7eb900-487f-11eb-9dbb-d320c03328f2.gif)

To make this demo, all I had to do was add the following code to the kivycatalog:
```py
from functools import partial
def set_density(density, *args):
    from kivy.metrics import Metrics
    Metrics.density = density
Clock.schedule_once(partial(set_density, 1.5), 15)
Clock.schedule_once(partial(set_density, 1), 20)
```

Reasons for this change
---------------------------
1. Accessibility, so users could more easily change visual sizing by faking the `density`/`dpi`.
2. To be able to simulate different device configuration more easily.
3. The primary reason I worked on this: to support late importing of Window as the first step to reduce aggressive importing. Previously, as soon as you used `10dp` or directly called `dp(x)`, the Window got created because you needed the window to compute the density/dpi. You couldn't lazily have a default density/dpi value and then later update it to the real value as it became available, because all the properties would already have been initialized to the default value and stuck with it. 

   With this change, we can now initialize to a default value without creating a `Window`, and then when the Window is created, all the properties that used the default `dp` will be updated automatically. Note, this PR does not change the creation of Window when `dp` is computed, this will happen in the future.

The new feature
------------------

Any `NumericProperty` or `VariableListProperty` that is set or initialized to a string using any of the format suffixes, e.g.
```py
widget = Widget()
widget.width = '10dp'
# or
class MyWidget(Widget):
    value = NumericProperty('25dp')
    value = VariableListProperty(['25dp'])
```
when `Metrics.density`, `Metrics.dpi`, or `Metrics.fontscale` is changed, all these properties will have their value re-computed and anything bound to these properties will be dispatched.

If the property is set or initialized to `'10px'`, or just a number (`5`), these properties will NOT dispatch or be re-computed (as there's nothing to recompute). 

However, to help users who can't want to use the string version, I added a property for each scaling format to `Metrics`. I.e. given that all the conversions essentially multiply the input by a constant value, these new properties can be used directly to multiply the input. You can just do `width: self.texture_size[0] + 10 * Metrics.dp` instead of `width: self.texture_size[0] + dp(10)` and the former will update when `dp` changes since it's a kivy property. So in KV you can do either of the following and the result will be the same:

```
Label:
    size_hint_x: None
    offset: '10dp'
    width: self.texture_size[0] + self.offset

Label:
    size_hint_x: None
    width: self.texture_size[0] + 10 * Metrics.dp
```

Implementation strategy
---------------------------

We create a global `EventObservers` in `_metrics.pyx`, like those used by `EventDispatcher` and `Property` for binding, and every time a new `NumericProperty` of a `EventDispatcher` object is created and "`linked`", we bind to the global `EventObservers`. Such that if that is dispatched, these properties will be called and their value re-evaluated and dispatched (if it changed).

To make sure we don't prevent garbage collection, we only store a weakref. Furthermore, if the widget dies, the binding is undone. 

When `Metrics` density/dpi/fontscale changes, then we cause a dispatch to the `EventObservers`. And similarly, when Window's `dpi` changes, it causes a change in `Metrics.dpi`, which causes the dispatch.

I considered instead, when `Window.dpi` changes, to simply dispatch all widgets in the tree and all properties in the widget that use `dp` as this would be much faster for the widget creation phase, but this would leave widgets that are not currently in the tree out (e.g. a pop up that is hidden).

Performance 
--------------

The primary concern is to slow down creation of `NumericProperty` bearing widgets as little as possible, and similarly to slow down garbage collection when these widgets die as little as possible.  This is traded off against making any `dpi` updates as fast as possible, because I consider that to happen infrequently, but widget creation happens a lot.

To accomplish this I added `_metrics.pyx/pxd`, and moved the metrics related code from `properties.pyx` over there. I couldn't convert `metrics.py` to `metrics.pyx` because that leads to circular imports (metrics needs _event/properties, properties needs metrics), so the new stuff was added to `_metrics.pyx` instead.

So, the binding and unbinding happens within cython which makes it super fast. Additionally, I added a cython only way to fbind (`fbind_existing_callback`), this allows a more direct binding from cython and is the fastest way to bind. Next, unbinding was also sped up. Currently, the fastest unbinding happens with `funbind_uid`, however, this is `O(n)` still. So I added a new way to unbind if you have the callback (API is only internal, although perhaps we should change `fbind` so it can be used) that is a very speedy `O(1)`.

Using the benchmark method from https://github.com/kivy/kivy/pull/7292, I compared `EventDispatcher` instantiation with master, if the class a `NumericProperty` vs a `StringProperty`:

```
Name (time in ns)                          Min                     Max                  Mean                StdDev                Median      

NumericProperty:
(master)                               940.0000 (2.60)      12,030.0000 (2.48)     1,258.1731 (2.47)       646.0043 (2.06)     1,040.0000 (2.55)
(dpi)                                1,370.0000 (3.79)      71,840.0000 (14.80)    1,877.1397 (3.69)       919.9020 (2.94)     1,540.0000 (3.78)

StringProperty:
(dpi)                                  880.0000 (2.43)      10,360.0000 (2.13)     1,156.8685 (2.28)       572.0594 (1.83)       980.0000 (2.40)
(master)                               920.0000 (2.54)      10,650.0000 (2.19)     1,195.3162 (2.35)       576.8812 (1.84)     1,020.0000 (2.50)
```
The results show that adding a `NumericProperty` is slower `1.9` vs `1.3` or about 0.6 us and my manual tests show this similarly. I similarly compared how long it takes to create a `Widget`
```
Name (time in us)         Min         Max     Mean   StdDev   Median
--------------------------------------------------------------------
dpi                    32.2000  496.2000    54.6560  26.5227  46.4000
master                 29.4000  2,095.9000  49.4672  29.9499  40.5000
```

and it's about 5 or 6 us slower. I don't think this is a big deal in the scheme of things, but it is slower.

Additional changes
---------------------

To be able to add this feature, I had to do some refactoring as follows:

* Changed instantiation of cython classes used in binding to use `__new__`, this allows cython to skip having to call `__init__`, which makes it faster. I changed this for all the bindings and creating `PropertyStorage`. This is ok, because these classes don't do anything in `__init__`.
* Previously, we had one `PropertyStorage` class, so variables used by every property type was added there, making the class huge. Instead, I made a per property type `PropertyStorage`, e.g. `NumericPropertyStorage` that inherit from `PropertyStorage`. And split up the property specific variables to them making `PropertyStorage` small.
* Changed the global `Metrics` variable to be a proxy, like `Clock`.
* Fixed a bug. We allow a property to be renamed and it's `PropertyStorage` to be reused. E.g.
   ```py
   class A(EventDispatcher):
       name = ObjectProperty()
       other_name = prop
   ```
   But this resulted in 
   ```py
   class A(EventDispatcher):
       name = ObjectProperty()
       name = NumericProperty()
   ```
   also reusing the internal `PropertyStorage`. So I fixed it to test to make sure it's only reused if the property object is the same object.