### PR TITLE
Disable the use of root logger

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -359,9 +359,6 @@ Logger = logging.getLogger('kivy')
 Logger.logfile_activated = None
 Logger.trace = partial(Logger.log, logging.TRACE)
 
-# set the Kivy logger as the default
-logging.root = Logger
-
 # add default kivy logger
 Logger.addHandler(LoggerHistory())
 file_log_handler = None


### PR DESCRIPTION
Configure kivy's logger not to use the root logger as it may collide with other modules or user loggers.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
