### PR TITLE
Doc: Add Kivy config example for inverted mtdev events

### DIFF
--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -34,6 +34,12 @@ To fix that, you can add these options to the argument line:
 * min_touch_minor : width shape minimum
 * max_touch_minor : height shape maximum
 * rotation : 0,90,180 or 270 to rotate
+
+An inverted display configuration will look like this::
+
+    [input]
+    # example for inverting touch events
+    display = mtdev,/dev/input/event0,invert_x=1,invert_y=1
 '''
 
 __all__ = ('MTDMotionEventProvider', 'MTDMotionEvent')


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

This commit resolves #7028

Example config added to doc to invert touch events including on_touch_up