### PR TITLE
Camera: Fix AVFoundation provider to release the camera, start it async, and check if started before stopping it

### DIFF
--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -59,7 +59,9 @@ class CameraAVFoundation(CameraBase):
 
     def _release_camera(self):
         cdef _AVStorage storage = <_AVStorage>self._storage
-        avf_camera_deinit(storage.camera)
+        if storage.camera != NULL:
+            avf_camera_deinit(storage.camera)
+            storage.camera = NULL
 
     @property
     def _scheduled_rate(self):

--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -49,10 +49,17 @@ class CameraAVFoundation(CameraBase):
         self._framerate = 30
         super(CameraAVFoundation, self).__init__(**kwargs)
 
+    def __del__(self):
+        self._release_camera()
+
     def init_camera(self):
         cdef _AVStorage storage = <_AVStorage>self._storage
         storage.camera = avf_camera_init(
             self._index, self.resolution[0], self.resolution[1])
+
+    def _release_camera(self):
+        cdef _AVStorage storage = <_AVStorage>self._storage
+        avf_camera_deinit(storage.camera)
 
     @property
     def _scheduled_rate(self):

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -214,7 +214,9 @@ Camera::Camera(int _cameraNum, int _width, int _height) {
 }
 
 Camera::~Camera() {
-    stopCaptureDevice();
+    if(started){
+        stopCaptureDevice();
+    }
 }
 
 bool Camera::grabFrame(double timeOut) {
@@ -411,7 +413,9 @@ int Camera::startCaptureDevice() {
 #endif
         [conn setVideoOrientation:default_orientation];
 
-        [mCaptureSession startRunning];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [mCaptureSession startRunning];
+        });
         [localpool drain];
 
         started = 1;


### PR DESCRIPTION
This PR fixes the following issues on AVFoundation Camera provider:

- Camera not released.
- `Camera` destructor crashes the App if the Camera is already stopped.
- UI blocked for ~ 1.5s during  `[mCaptureSession startRunning]` (See https://developer.apple.com/documentation/avfoundation/avcapturesession/1388185-startrunning?language=occ "Important" section for reference)


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
