### PR TITLE
Widget: fix export_to_png not passing arguments through

### DIFF
--- a/kivy/tests/test_widget.py
+++ b/kivy/tests/test_widget.py
@@ -82,9 +82,9 @@ class WidgetTestCase(unittest.TestCase):
         wid.export_to_png(join(tmp, 'b.png'), scale=.5)
         wid.export_to_png(join(tmp, 'c.png'), scale=2)
 
-        CoreImage(join(tmp, 'a.png')).size == (200, 100)
-        CoreImage(join(tmp, 'b.png')).size == (100, 50)
-        CoreImage(join(tmp, 'c.png')).size == (400, 200)
+        self.assertEqual(CoreImage(join(tmp, 'a.png')).size, (200, 100))
+        self.assertEqual(CoreImage(join(tmp, 'b.png')).size, (100, 50))
+        self.assertEqual(CoreImage(join(tmp, 'c.png')).size, (400, 200))
         rmtree(tmp)
 
         self.root.remove_widget(wid)

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -720,7 +720,7 @@ class Widget(WidgetBase):
 
                 .. versionadded:: 1.11.0
         '''
-        self.export_as_image().save(filename, flipped=False)
+        self.export_as_image(*args, **kwargs).save(filename, flipped=False)
 
     def export_as_image(self, *args, **kwargs):
         '''Return an core :class:`~kivy.core.image.Image` of the actual


### PR DESCRIPTION
This notably broke the scale parameter.

The test was passing because it didn't use `assert` or `assertEqual` but
simply `==.`

fixes #7314

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
