### PR TITLE
Fix/disable kivy no args

### DIFF
--- a/doc/sources/guide/environment.rst
+++ b/doc/sources/guide/environment.rst
@@ -72,9 +72,9 @@ KIVY_NO_CONSOLELOG
     If set, logs will be not print to the console
 
 KIVY_NO_ARGS
-    If set, the argument passed in command line will not be parsed and used by Kivy.
-    Ie, you can safely make a script or an app with your own arguments without
-    requiring the `--` delimiter::
+    If set to one of ('true', '1', 'yes'), the argument passed in command line
+    will not be parsed and used by Kivy. Ie, you can safely make a script or an
+    app with your own arguments without requiring the `--` delimiter::
 
         import os
         os.environ["KIVY_NO_ARGS"] = "1"

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -351,10 +351,10 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     level = LOG_LEVELS.get(Config.get('kivy', 'log_level'))
     Logger.setLevel(level=level)
 
-    # Can be overrided in command line
+    # Can be overriden in command line
     if ('KIVY_UNITTEST' not in environ and
             'KIVY_PACKAGING' not in environ and
-            'KIVY_NO_ARGS' not in environ):
+            environ.get('KIVY_NO_ARGS', "false") not in ('true', '1', 'yes')):
         # save sys argv, otherwise, gstreamer use it and display help..
         sys_argv = sys.argv
         sys.argv = sys.argv[:1]

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -25,11 +25,12 @@ def _patch_env(*filtered_keys, **kw):
 
 
 def _kivy_subproces_import(env):
-    return subprocess.check_output(
+    return subprocess.run(
         shlex.split(f"{sys.executable} -c 'import kivy' --help"),
+        stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
-    ).decode("utf8")
+    ).stdout.decode("utf8")
 
 
 @pytest.mark.parametrize("value", SAMPLE_VALUES)

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -9,7 +9,7 @@ import sys
 
 import pytest
 
-ENV_NAME="KIVY_NO_ARGS"
+ENV_NAME = "KIVY_NO_ARGS"
 KIVY_ENVS_TO_EXCLUDE = ('KIVY_UNITTEST', 'KIVY_PACKAGING')
 
 EXPECTED_STR = "Kivy Usage"
@@ -40,7 +40,7 @@ def _kivy_subproces_import(env):
 
 @pytest.mark.parametrize("value", SAMPLE_VALUES)
 def test_env_exist(value):
-    env = _patch_env(*KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME:value})
+    env = _patch_env(*KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME : value})
     stdout = _kivy_subproces_import(env)
 
     if value in TRUTHY:

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -34,7 +34,7 @@ def _kivy_subproces_import(env):
 
 @pytest.mark.parametrize("value", SAMPLE_VALUES)
 def test_env_exist(value):
-    env = _patch_env(*KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME : value})
+    env = _patch_env(*KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME: value})
     stdout = _kivy_subproces_import(env)
 
     if value in TRUTHY:

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -26,7 +26,7 @@ def _patch_env(*filtered_keys, **kw):
 
 def _kivy_subproces_import(env):
     return subprocess.run(
-        [sys.executable, "-c", "'import kivy'", "--help"],
+        [sys.executable, "-c", "import kivy", "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -1,7 +1,5 @@
 # coding=utf-8
 
-import itertools
-from functools import partial
 from os import environ
 import shlex
 import subprocess
@@ -10,31 +8,27 @@ import sys
 import pytest
 
 ENV_NAME = "KIVY_NO_ARGS"
-KIVY_ENVS_TO_EXCLUDE = ('KIVY_UNITTEST', 'KIVY_PACKAGING')
+KIVY_ENVS_TO_EXCLUDE = ("KIVY_UNITTEST", "KIVY_PACKAGING")
 
 EXPECTED_STR = "Kivy Usage"
 
-TRUTHY = {'true', '1', 'yes'}
-FALSY = {'false', '0', 'no', "anything-else"}
+TRUTHY = {"true", "1", "yes"}
+FALSY = {"false", "0", "no", "anything-else"}
 
-SAMPLE_VALUES = {
-    *TRUTHY, *FALSY
-}
+SAMPLE_VALUES = {*TRUTHY, *FALSY}
+
 
 def _patch_env(*filtered_keys, **kw):
-    env = {
-        k: v
-        for k, v in environ.items()
-        if k not in filtered_keys
-    }
+    env = {k: v for k, v in environ.items() if k not in filtered_keys}
     env.update(kw)
     return env
+
 
 def _kivy_subproces_import(env):
     return subprocess.check_output(
         shlex.split(f"{sys.executable} -c 'import kivy' --help"),
         stderr=subprocess.PIPE,
-        env=env
+        env=env,
     ).decode("utf8")
 
 
@@ -47,6 +41,7 @@ def test_env_exist(value):
         assert EXPECTED_STR not in stdout
     else:
         assert EXPECTED_STR in stdout
+
 
 def test_env_not_exist():
     env = _patch_env(ENV_NAME, *KIVY_ENVS_TO_EXCLUDE)

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -26,7 +26,7 @@ def _patch_env(*filtered_keys, **kw):
 
 def _kivy_subproces_import(env):
     return subprocess.run(
-        shlex.split(f"{sys.executable} -c 'import kivy' --help"),
+        [sys.executable, "-c", "'import kivy'", "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+
+import itertools
+from functools import partial
+from os import environ
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+ENV_NAME="KIVY_NO_ARGS"
+EXPECTED_STR = "Kivy Usage"
+
+
+TRUTHY = {'true', '1', 'yes'}
+FALSY = {'false', '0', 'no', "anything-else"}
+
+SAMPLE_VALUES = {
+    *TRUTHY, *FALSY
+}
+
+def _patch_env(**kw):
+    env = {
+        k: v
+        for k, v in environ.items()
+        if "kivy" not in k.lower()
+    }
+
+    env.update(**kw)
+    return env
+
+def _kivy_subproces_import(env):
+    return subprocess.check_output(
+        shlex.split(f"{sys.executable} -c 'import kivy' --help"),
+        stderr=subprocess.PIPE,
+        env=env
+    ).decode("utf8")
+
+
+@pytest.mark.parametrize("value", SAMPLE_VALUES)
+def test_env_exist(value):
+    env = _patch_env(**{ENV_NAME:value})
+    stdout = _kivy_subproces_import(env)
+
+    if value.lower() in TRUTHY:
+        assert EXPECTED_STR not in stdout
+    else:
+        assert EXPECTED_STR in stdout
+
+def test_env_not_exist():
+    env = _patch_env()
+    stdout = _kivy_subproces_import(env)
+    assert EXPECTED_STR in stdout

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -27,6 +27,8 @@ def _patch_env(*filtered_keys, **kw):
         for k, v in environ.items()
         if k not in filtered_keys
     }
+    env.update(kw)
+    return env
 
 def _kivy_subproces_import(env):
     return subprocess.check_output(
@@ -38,7 +40,7 @@ def _kivy_subproces_import(env):
 
 @pytest.mark.parametrize("value", SAMPLE_VALUES)
 def test_env_exist(value):
-    env = _patch_env(ENV_NAME, *KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME:value})
+    env = _patch_env(*KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME:value})
     stdout = _kivy_subproces_import(env)
 
     if value in TRUTHY:
@@ -47,6 +49,6 @@ def test_env_exist(value):
         assert EXPECTED_STR in stdout
 
 def test_env_not_exist():
-    env = _patch_env(ENV_NAME *KIVY_ENVS_TO_EXCLUDE)
+    env = _patch_env(ENV_NAME, *KIVY_ENVS_TO_EXCLUDE)
     stdout = _kivy_subproces_import(env)
     assert EXPECTED_STR in stdout

--- a/kivy/tests/test_environ_cli.py
+++ b/kivy/tests/test_environ_cli.py
@@ -10,8 +10,9 @@ import sys
 import pytest
 
 ENV_NAME="KIVY_NO_ARGS"
-EXPECTED_STR = "Kivy Usage"
+KIVY_ENVS_TO_EXCLUDE = ('KIVY_UNITTEST', 'KIVY_PACKAGING')
 
+EXPECTED_STR = "Kivy Usage"
 
 TRUTHY = {'true', '1', 'yes'}
 FALSY = {'false', '0', 'no', "anything-else"}
@@ -20,15 +21,12 @@ SAMPLE_VALUES = {
     *TRUTHY, *FALSY
 }
 
-def _patch_env(**kw):
+def _patch_env(*filtered_keys, **kw):
     env = {
         k: v
         for k, v in environ.items()
-        if "kivy" not in k.lower()
+        if k not in filtered_keys
     }
-
-    env.update(**kw)
-    return env
 
 def _kivy_subproces_import(env):
     return subprocess.check_output(
@@ -40,15 +38,15 @@ def _kivy_subproces_import(env):
 
 @pytest.mark.parametrize("value", SAMPLE_VALUES)
 def test_env_exist(value):
-    env = _patch_env(**{ENV_NAME:value})
+    env = _patch_env(ENV_NAME, *KIVY_ENVS_TO_EXCLUDE, **{ENV_NAME:value})
     stdout = _kivy_subproces_import(env)
 
-    if value.lower() in TRUTHY:
+    if value in TRUTHY:
         assert EXPECTED_STR not in stdout
     else:
         assert EXPECTED_STR in stdout
 
 def test_env_not_exist():
-    env = _patch_env()
+    env = _patch_env(ENV_NAME *KIVY_ENVS_TO_EXCLUDE)
     stdout = _kivy_subproces_import(env)
     assert EXPECTED_STR in stdout


### PR DESCRIPTION
Enable the environment value `KIVY_NO_ARGS` to contain a "falsy" value without
disabling kivy cli parsing.

Kivy only checks for `KIVY_NO_ARGS` environment variable to be existent, without
checking its value. Setting it to a "falsy" value (eg 0, "false", etc) would still disable
cli arg parsing, which is could be misleading.

With this fix, only setting it to one of ('true', '1', 'yes') actually disables it.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
