### PR TITLE
Camera: Android camera focus mode fix

### DIFF
--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -50,7 +50,10 @@ class CameraAndroid(CameraBase):
         params = self._android_camera.getParameters()
         width, height = self._resolution
         params.setPreviewSize(width, height)
-        params.setFocusMode('continuous-picture')
+        supported_focus_modes = self._android_camera.getParameters() \
+        	.getSupportedFocusModes()
+        if supported_focus_modes.contains('continuous-picture'):
+            params.setFocusMode('continuous-picture')
         self._android_camera.setParameters(params)
         # self._android_camera.setDisplayOrientation()
         self.fps = 30.

--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -51,7 +51,7 @@ class CameraAndroid(CameraBase):
         width, height = self._resolution
         params.setPreviewSize(width, height)
         supported_focus_modes = self._android_camera.getParameters() \
-        	.getSupportedFocusModes()
+            .getSupportedFocusModes()
         if supported_focus_modes.contains('continuous-picture'):
             params.setFocusMode('continuous-picture')
         self._android_camera.setParameters(params)


### PR DESCRIPTION
An Android camera is initialized with the focus mode set to 'continuous-picture' which leads to a crash if a particular camera does not support this mode (that's true for some front-facing cameras). 
The way I see it, the correct way to avoid the crash is checking the focus capabilities of a camera and setting the focus mode to 'continuous-picture' only if it is supported.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
