### PR TITLE
Window: Delay binding dpi until window is ready.

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -906,7 +906,6 @@ class WindowBase(EventDispatcher):
         # property changes
         self.trigger_create_window = Clock.create_trigger(
             self.create_window, -1)
-        self.fbind('dpi', self._reset_metrics_dpi)
 
         # Create a trigger for updating the keyboard height
         self.trigger_keyboard_height = Clock.create_trigger(


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Fixes issue mentioned in https://github.com/kivy/kivy/pull/7299. I overlooked removing this when fixing a previous merge conflict.