### PR TITLE
Fix first doc line being ignored

### DIFF
--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -133,8 +133,9 @@ cdef class Instruction(ObjectWithUid):
 
 
 cdef class InstructionGroup(Instruction):
-    '''Group of :class:`Instruction`. Allows for the adding and
-    removing of graphics instructions. It can be used directly as follows::
+    """
+    Group of :class:`Instruction`. Allows for the adding and removing
+    of graphics instructions. It can be used directly as follows::
 
         blue = InstructionGroup()
         blue.add(Color(0, 0, 1, 0.2))
@@ -146,8 +147,7 @@ cdef class InstructionGroup(Instruction):
 
         # Here, self should be a Widget or subclass
         [self.canvas.add(group) for group in [blue, green]]
-
-    '''
+    """
     def __init__(self, **kwargs):
         Instruction.__init__(self, **kwargs)
         self.children = list()


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Somehow the first line is still being ignored: https://kivy.org/doc/master/api-kivy.graphics.html#kivy.graphics.InstructionGroup