### PR TITLE
Build: No oneliners in [options.extras_require]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,10 +71,14 @@ full =
     kivy_deps.glew~=0.3.0; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
     pypiwin32; sys_platform == "win32"
-gstreamer = kivy_deps.gstreamer~=0.3.1; sys_platform == "win32"
-angle = kivy_deps.angle~=0.3.0; sys_platform == "win32"
-sdl2 = kivy_deps.sdl2~=0.3.1; sys_platform == "win32"
-glew = kivy_deps.glew~=0.3.0; sys_platform == "win32"
+gstreamer =
+    kivy_deps.gstreamer~=0.3.1; sys_platform == "win32"
+angle =
+    kivy_deps.angle~=0.3.0; sys_platform == "win32"
+sdl2 =
+    kivy_deps.sdl2~=0.3.1; sys_platform == "win32"
+glew =
+    kivy_deps.glew~=0.3.0; sys_platform == "win32"
 
 [flake8]
 ignore = E125,E126,E127,E128,E402,E741,E731,W503,F401,W504,F841,E722


### PR DESCRIPTION
Fix `setup.cfg` so that the resulting `METADATA` when generating
wheels contains correctly (not split) `Requires-Dist` entries.

Before:

Provides-Extra: angle
Requires-Dist: kivy-deps.angle (~=0.3.0) ; extra == 'angle'
Requires-Dist: sys-platform (=="win32") ; extra == 'angle'

After:

Provides-Extra: angle
Requires-Dist: kivy-deps.angle (~=0.3.0) ; (sys_platform == "win32") and extra == 'angle'

The same goes for gstreamer, angle, sdl2, and glew.

Complete metadata diff comparing before vs after the patch:

   ```diff
      diff --git a/./m1 b/./m2
   index dc7f1ef..fd89685 100644
   --- a/./m1
   +++ b/./m2
   @@ -47,8 +47,7 @@ Requires-Dist: kivy-deps.sdl2 (~=0.3.1) ; sys_platform == "win32"
    Requires-Dist: kivy-deps.glew (~=0.3.0) ; sys_platform == "win32"
    Requires-Dist: pypiwin32 ; sys_platform == "win32"
    Provides-Extra: angle
   -Requires-Dist: kivy-deps.angle (~=0.3.0) ; extra == 'angle'
   -Requires-Dist: sys-platform (=="win32") ; extra == 'angle'
   +Requires-Dist: kivy-deps.angle (~=0.3.0) ; (sys_platform == "win32") and extra == 'angle'
    Provides-Extra: base
    Requires-Dist: pillow ; extra == 'base'
    Requires-Dist: docutils ; extra == 'base'
   @@ -83,17 +82,14 @@ Requires-Dist: kivy-deps.sdl2 (~=0.3.1) ; (sys_platform == "win32") and extra ==
    Requires-Dist: kivy-deps.glew (~=0.3.0) ; (sys_platform == "win32") and extra == 'full'
    Requires-Dist: pypiwin32 ; (sys_platform == "win32") and extra == 'full'
    Provides-Extra: glew
   -Requires-Dist: kivy-deps.glew (~=0.3.0) ; extra == 'glew'
   -Requires-Dist: sys-platform (=="win32") ; extra == 'glew'
   +Requires-Dist: kivy-deps.glew (~=0.3.0) ; (sys_platform == "win32") and extra == 'glew'
    Provides-Extra: gstreamer
   -Requires-Dist: kivy-deps.gstreamer (~=0.3.1) ; extra == 'gstreamer'
   -Requires-Dist: sys-platform (=="win32") ; extra == 'gstreamer'
   +Requires-Dist: kivy-deps.gstreamer (~=0.3.1) ; (sys_platform == "win32") and extra == 'gstreamer'
    Provides-Extra: media
    Requires-Dist: ffpyplayer ; (sys_platform == "linux" or sys_platform == "darwin") and extra == 'media'
    Requires-Dist: kivy-deps.gstreamer (~=0.3.1) ; (sys_platform == "win32") and extra == 'media'
    Provides-Extra: sdl2
   -Requires-Dist: kivy-deps.sdl2 (~=0.3.1) ; extra == 'sdl2'
   -Requires-Dist: sys-platform (=="win32") ; extra == 'sdl2'
   +Requires-Dist: kivy-deps.sdl2 (~=0.3.1) ; (sys_platform == "win32") and extra == 'sdl2'
    Provides-Extra: tuio
    Requires-Dist: oscpy ; extra == 'tuio'
 
   ```


related: https://github.com/python-poetry/poetry/issues/3629

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
