### PR TITLE
python 3: use print() in docs, comment and generated code

### DIFF
--- a/doc/sources/guide/events.rst
+++ b/doc/sources/guide/events.rst
@@ -64,7 +64,7 @@ You can call a function or a method every X times per second using
 function named my_callback 30 times per second::
 
     def my_callback(dt):
-        print 'My callback is called', dt
+        print('My callback is called', dt)
     event = Clock.schedule_interval(my_callback, 1 / 30.)
 
 You have multiple ways of unscheduling a previously scheduled event. One, is
@@ -84,9 +84,9 @@ unscheduled::
         global count
         count += 1
         if count == 10:
-            print 'Last call of my callback, bye bye !'
+            print('Last call of my callback, bye bye !')
             return False
-        print 'My callback is called'
+        print('My callback is called')
     Clock.schedule_interval(my_callback, 1 / 30.)
 
 
@@ -97,7 +97,7 @@ Using :meth:`~kivy.clock.Clock.schedule_once`, you can call a function "later",
 like in the next frame, or in X seconds::
 
     def my_callback(dt):
-        print 'My callback is called !'
+        print('My callback is called !')
     Clock.schedule_once(my_callback, 1)
 
 This will call ``my_callback`` in one second. The second argument is the amount
@@ -117,7 +117,7 @@ inside the callback itself::
 
 
     def my_callback(dt):
-        print 'My callback is called !'
+        print('My callback is called !')
         Clock.schedule_once(my_callback, 1)
     Clock.schedule_once(my_callback, 1)
 
@@ -188,7 +188,7 @@ See the following example::
             self.dispatch('on_test', value)
 
         def on_test(self, *args):
-            print "I am dispatched", args
+            print("I am dispatched", args)
 
 
 Attaching callbacks
@@ -205,7 +205,7 @@ the arguments that the event emits. For this, it's usually safest to accept the
 Example::
 
     def my_callback(value, *args):
-        print "Hello, I got an event!", args
+        print("Hello, I got an event!", args)
 
 
     ev = MyEventDispatcher()
@@ -283,7 +283,7 @@ For example, consider the following code:
             return super(CustomBtn, self).on_touch_down(touch)
 
         def on_pressed(self, instance, pos):
-            print ('pressed at {pos}'.format(pos=pos))
+            print('pressed at {pos}'.format(pos=pos))
 
 In the code above at line 3::
 
@@ -315,7 +315,7 @@ to continue as it would normally have occurred.
 Finally on line 11::
 
     def on_pressed(self, instance, pos):
-        print ('pressed at {pos}'.format(pos=pos))
+        print('pressed at {pos}'.format(pos=pos))
 
 We define an `on_pressed` function that will be called by the property whenever the
 property value is changed.
@@ -349,7 +349,7 @@ For example, consider the following code:
             self.add_widget(Button(text='btn 2'))
 
         def btn_pressed(self, instance, pos):
-            print ('pos: printed from root widget: {pos}'.format(pos=.pos))
+            print('pos: printed from root widget: {pos}'.format(pos=.pos))
 
 If you run the code as is, you will notice two print statements in the console.
 One from the `on_pressed` event that is called inside the `CustomBtn` class and
@@ -375,7 +375,7 @@ function is defined. You can use an in-line function as follows:
     cb = CustomBtn()
 
     def _local_func(instance, pos):
-        print ('pos: printed from root widget: {pos}'.format(pos=pos))
+        print('pos: printed from root widget: {pos}'.format(pos=pos))
 
     cb.bind(pressed=_local_func)
     self.add_widget(cb)
@@ -408,7 +408,7 @@ use to copy and paste into an editor to experiment.
             self.add_widget(Button(text='btn 2'))
 
         def btn_pressed(self, instance, pos):
-            print ('pos: printed from root widget: {pos}'.format(pos=pos))
+            print('pos: printed from root widget: {pos}'.format(pos=pos))
 
     class CustomBtn(Widget):
 
@@ -423,7 +423,7 @@ use to copy and paste into an editor to experiment.
             return super(CustomBtn, self).on_touch_down(touch)
 
         def on_pressed(self, instance, pos):
-            print ('pressed at {pos}'.format(pos=pos))
+            print('pressed at {pos}'.format(pos=pos))
 
     class TestApp(App):
 

--- a/kivy/graphics/tesselator.pyx
+++ b/kivy/graphics/tesselator.pyx
@@ -36,7 +36,7 @@ is possible that the tesselator won't work. In that case, it can return
 False::
 
     if not tess.tesselate():
-        print "Tesselator didn't work :("
+        print("Tesselator didn't work :(")
         return
 
 After the tessellation, you have multiple ways to iterate over the result. The
@@ -54,7 +54,7 @@ Or, you can get the "raw" result, with just polygons and x/y coordinates with
 :meth:`Tesselator.vertices`::
 
     for vertices in tess.vertices:
-        print "got polygon", vertices
+        print("got polygon", vertices)
 
 """
 

--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -1386,7 +1386,7 @@ cdef class SmoothLine(Line):
             osin1 = sin(a1) * owidth
             ocos2 = cos(a2) * owidth
             osin2 = sin(a2) * owidth
-            print 'angle diff', ad_angle
+            print('angle diff', ad_angle)
             '''
             #l = width
             #ol = owidth
@@ -1411,7 +1411,7 @@ cdef class SmoothLine(Line):
                     bx + cos(la2) * width,
                     by + sin(la2) * width,
                     &rx, &ry) == 0:
-                    #print 'ERROR LINE INTERSECTION 1'
+                    # print('ERROR LINE INTERSECTION 1')
                     pass
 
                 l = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
@@ -1426,7 +1426,7 @@ cdef class SmoothLine(Line):
                     bx + cos(ra2) * owidth,
                     by + sin(ra2) * owidth,
                     &rx, &ry) == 0:
-                    #print 'ERROR LINE INTERSECTION 2'
+                    # print('ERROR LINE INTERSECTION 2')
                     pass
 
                 ol = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
@@ -1538,7 +1538,7 @@ cdef class SmoothLine(Line):
             tindices[17] = i7
             tindices = tindices + 18
 
-        #print 'tindices', <long>tindices, <long>indices, (<long>tindices - <long>indices) / sizeof(unsigned short)
+        # print('tindices', <long>tindices, <long>indices, (<long>tindices - <long>indices) / sizeof(unsigned short))
 
 
         self.batch.set_data(vertices, <int>vcount, indices, <int>icount)

--- a/kivy/input/providers/leapfinger.py
+++ b/kivy/input/providers/leapfinger.py
@@ -85,7 +85,7 @@ class LeapFingerEventProvider(MotionEventProvider):
         available_uid = []
         for hand in frame.hands:
             for finger in hand.fingers:
-                # print hand.id(), finger.id(), finger.tip()
+                # print(hand.id(), finger.id(), finger.tip())
                 uid = '{0}:{1}'.format(hand.id, finger.id)
                 available_uid.append(uid)
                 position = finger.tip_position

--- a/kivy/tests/test_utils.py
+++ b/kivy/tests/test_utils.py
@@ -178,7 +178,7 @@ class UtilsTest(unittest.TestCase):
     def fib_100(self):
         """ return 100th Fibonacci number
         This uses modern view of F sub 1 = 0, F sub 2 = 1. """
-        # print "calculating..."
+        # print("calculating...")
         a, b = 0, 1
         for n in range(2, 101):
             a, b = b, a + b

--- a/kivy/tools/pep8checker/pep8.py
+++ b/kivy/tools/pep8checker/pep8.py
@@ -313,9 +313,9 @@ def extraneous_whitespace(logical_line):
     E202: spam(ham[1 ], {eggs: 2})
     E202: spam(ham[1], {eggs: 2 })
 
-    E203: if x == 4: print x, y; x, y = y , x
-    E203: if x == 4: print x, y ; x, y = y, x
-    E203: if x == 4 : print x, y; x, y = y, x
+    E203: if x == 4: print(x, y); x, y = y , x
+    E203: if x == 4: print(x, y); x, y = y, x
+    E203: if x == 4 : print(x, y); x, y = y, x
     """
     line = logical_line
     for match in EXTRANEOUS_WHITESPACE_REGEX.finditer(line):
@@ -1234,7 +1234,7 @@ def ambiguous_identifier(logical_line, tokens):
 def python_3000_has_key(logical_line, noqa):
     r"""The {}.has_key() method is removed in Python 3: use the 'in' operator.
 
-    Okay: if "alph" in d:\n    print d["alph"]
+    Okay: if "alph" in d:\n    print(d["alph"])
     W601: assert d.has_key('alph')
     """
     pos = logical_line.find('.has_key(')

--- a/kivy/tools/stub-gl-debug.py
+++ b/kivy/tools/stub-gl-debug.py
@@ -181,7 +181,7 @@ for x in lines:
 
     print('%s with gil:' % x)
     s = x.split()
-    print('    print "GL %s(' % s[2], end=' ')
+    print('    print("GL %s(' % s[2], end=' ')
     pointer = 0
     for arg in s[3:]:
         arg = arg.strip()
@@ -195,7 +195,7 @@ for x in lines:
         else:
             print('%s = ", %s, ",' % (arg, arg), end=' ')
         pointer = 0
-    print(')"')
+    print(')")')
     print('    %s' % y)
     print('    ret = glGetError()')
     print('    if ret: print("ERR {} / {}".format(ret, ret))')

--- a/kivy/uix/colorpicker.py
+++ b/kivy/uix/colorpicker.py
@@ -24,9 +24,9 @@ Usage::
 
     # To monitor changes, we can bind to color property changes
     def on_color(instance, value):
-        print "RGBA = ", str(value)  #  or instance.color
-        print "HSV = ", str(instance.hsv)
-        print "HEX = ", str(instance.hex_color)
+        print("RGBA = ", str(value))  #  or instance.color
+        print("HSV = ", str(instance.hsv))
+        print("HEX = ", str(instance.hex_color))
 
     clr_picker.bind(color=on_color)
 


### PR DESCRIPTION
Since kivy has moved on to Python 3, let's use the print() function
instead of statement in docs etc.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
