### PR TITLE
Mouse: Update MouseMotionEventProvider to dispatch hover events

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -157,14 +157,13 @@ class MotionEvent(MotionEventBase):
          'is_triple_tap', 'triple_tap_time',
          'ud')
 
-    def __init__(self, device, id, args):
+    def __init__(self, device, id, args, is_touch=False):
         if self.__class__ == MotionEvent:
             raise NotImplementedError('class MotionEvent is abstract')
         MotionEvent.__uniq_id += 1
 
-        #: True if the Motion Event is a Touch. Can be also verified is
-        #: `pos` is :attr:`profile`.
-        self.is_touch = False
+        #: True if the Motion Event is a Touch.
+        self.is_touch = is_touch
 
         #: Attributes to push by default, when we use :meth:`push` : x, y, z,
         #: dx, dy, dz, ox, oy, oz, px, py, pz.
@@ -187,6 +186,9 @@ class MotionEvent(MotionEventBase):
         #: Used to determine which widget the touch is being dispatched to.
         #: Check the :meth:`grab` function for more information.
         self.grab_current = None
+
+        #: Currently pressed button
+        self.button = None
 
         #: Profiles currently used in the touch
         self.profile = []
@@ -322,9 +324,10 @@ class MotionEvent(MotionEventBase):
                 else:
                     # it's a normal touch
                     pass
+
+        .. versionchanged:: 2.1.0
+            Allowed grab for non-touch events.
         '''
-        if not self.is_touch:
-            raise Exception('Grab works only for Touch MotionEvents.')
         if self.grab_exclusive_class is not None:
             raise Exception('Cannot grab the touch, touch is exclusive')
         class_instance = weakref.ref(class_instance.__self__)

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -80,23 +80,31 @@ Color = Ellipse = None
 
 class MouseMotionEvent(MotionEvent):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.multitouch_sim = None
+
     def depack(self, args):
-        profile = self.profile
-        # don't overwrite previous profile
-        if not profile:
-            profile.extend(('pos', 'button'))
-        self.is_touch = True
         self.sx, self.sy = args[:2]
-        if len(args) >= 3:
-            self.button = args[2]
-        if len(args) == 4:
-            self.multitouch_sim = args[3]
-            profile.append('multitouch_sim')
-        super(MouseMotionEvent, self).depack(args)
+        profile = self.profile
+        if self.is_touch:
+            # don't overwrite previous profile
+            if not profile:
+                profile.extend(('pos', 'button'))
+            if len(args) >= 3:
+                self.button = args[2]
+            if len(args) == 4:
+                self.multitouch_sim = args[3]
+                profile.append('multitouch_sim')
+        else:
+            if not profile:
+                profile.append('pos')
+        super().depack(args)
 
     #
     # Create automatically touch on the surface.
     #
+
     def update_graphics(self, win, create=False):
         global Color, Ellipse
         de = self.ud.get('_drawelement', None)
@@ -140,7 +148,7 @@ class MouseMotionEventProvider(MotionEventProvider):
         self.disable_on_activity = False
         self.disable_multitouch = False
         self.multitouch_on_demand = False
-
+        self.hover_event = None
         # split arguments
         args = args.split(',')
         for arg in args:
@@ -160,19 +168,31 @@ class MouseMotionEventProvider(MotionEventProvider):
         '''Start the mouse provider'''
         if not EventLoop.window:
             return
-        EventLoop.window.bind(
-            on_mouse_move=self.on_mouse_motion,
-            on_mouse_down=self.on_mouse_press,
-            on_mouse_up=self.on_mouse_release)
+        fbind = EventLoop.window.fbind
+        fbind('on_mouse_down', self.on_mouse_press)
+        fbind('on_mouse_move', self.on_mouse_motion)
+        fbind('on_mouse_up', self.on_mouse_release)
+        fbind('mouse_pos', self.begin_or_update_hover_event)
+        fbind('system_size', self.update_hover_event)
+        fbind('on_cursor_enter', self.begin_hover_event)
+        fbind('on_cursor_leave', self.end_hover_event)
+        fbind('on_close', self.end_hover_event)
+        fbind('on_rotate', self.update_hover_event)
 
     def stop(self):
         '''Stop the mouse provider'''
         if not EventLoop.window:
             return
-        EventLoop.window.unbind(
-            on_mouse_move=self.on_mouse_motion,
-            on_mouse_down=self.on_mouse_press,
-            on_mouse_up=self.on_mouse_release)
+        funbind = EventLoop.window.funbind
+        funbind('on_mouse_down', self.on_mouse_press)
+        funbind('on_mouse_move', self.on_mouse_motion)
+        funbind('on_mouse_up', self.on_mouse_release)
+        funbind('mouse_pos', self.begin_or_update_hover_event)
+        funbind('system_size', self.update_hover_event)
+        funbind('on_cursor_enter', self.begin_hover_event)
+        funbind('on_cursor_leave', self.end_hover_event)
+        funbind('on_close', self.end_hover_event)
+        funbind('on_rotate', self.update_hover_event)
 
     def test_activity(self):
         if not self.disable_on_activity:
@@ -196,16 +216,21 @@ class MouseMotionEventProvider(MotionEventProvider):
                 return t
         return False
 
-    def create_touch(self, rx, ry, is_double_tap, do_graphics, button):
+    def create_event_id(self):
         self.counter += 1
-        id = 'mouse' + str(self.counter)
+        return self.device + str(self.counter)
+
+    def create_touch(self, rx, ry, is_double_tap, do_graphics, button):
+        event_id = self.create_event_id()
         args = [rx, ry, button]
         if do_graphics:
             args += [not self.multitouch_on_demand]
-        self.current_drag = cur = MouseMotionEvent(self.device, id=id,
-                                                   args=args)
+        self.current_drag = cur = MouseMotionEvent(
+            self.device, event_id, args,
+            is_touch=True
+        )
         cur.is_double_tap = is_double_tap
-        self.touches[id] = cur
+        self.touches[event_id] = cur
         if do_graphics:
             # only draw red circle if multitouch is not disabled, and
             # if the multitouch_on_demand feature is not enable
@@ -226,6 +251,23 @@ class MouseMotionEventProvider(MotionEventProvider):
         cur.update_time_end()
         self.waiting_event.append(('end', cur))
         cur.clear_graphics(EventLoop.window)
+
+    def create_hover(self, etype, win):
+        width, height = win.system_size
+        args = (win.mouse_pos[0] / width, win.mouse_pos[1] / height)
+        hover = self.hover_event
+        if hover:
+            hover.move(args)
+        else:
+            self.hover_event = hover = MouseMotionEvent(
+                self.device,
+                self.create_event_id(),
+                args
+            )
+        if etype == 'end':
+            hover.update_time_end()
+            self.hover_event = None
+        self.waiting_event.append((etype, hover))
 
     def on_mouse_motion(self, win, x, y, modifiers):
         width, height = EventLoop.window.system_size
@@ -292,6 +334,22 @@ class MouseMotionEventProvider(MotionEventProvider):
             self.remove_touch(self.alt_touch)
             self.alt_touch = None
         return True
+
+    def begin_or_update_hover_event(self, win, *args):
+        etype = 'update' if self.hover_event else 'begin'
+        self.create_hover(etype, win)
+
+    def begin_hover_event(self, win, *args):
+        if not self.hover_event:
+            self.create_hover('begin', win)
+
+    def update_hover_event(self, win, *args):
+        if self.hover_event:
+            self.create_hover('update', win)
+
+    def end_hover_event(self, win, *args):
+        if self.hover_event:
+            self.create_hover('end', win)
 
     def update(self, dispatch_fn):
         '''Update the mouse provider (pop event from the queue)'''

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -253,8 +253,9 @@ class MouseMotionEventProvider(MotionEventProvider):
         cur.clear_graphics(EventLoop.window)
 
     def create_hover(self, etype, win):
-        width, height = win.system_size
-        args = (win.mouse_pos[0] / width, win.mouse_pos[1] / height)
+        x_max, y_max = win.system_size[0] - 1, win.system_size[1] - 1
+        args = (win.mouse_pos[0] / x_max if x_max > 0 else 0.0,
+                win.mouse_pos[1] / y_max if y_max > 0 else 0.0)
         hover = self.hover_event
         if hover:
             hover.move(args)

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -81,8 +81,8 @@ Color = Ellipse = None
 class MouseMotionEvent(MotionEvent):
 
     def __init__(self, *args, **kwargs):
+        self.multitouch_sim = False
         super().__init__(*args, **kwargs)
-        self.multitouch_sim = None
 
     def depack(self, args):
         self.sx, self.sy = args[:2]

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -254,8 +254,10 @@ class MouseMotionEventProvider(MotionEventProvider):
 
     def create_hover(self, etype, win):
         x_max, y_max = win.system_size[0] - 1, win.system_size[1] - 1
-        args = (win.mouse_pos[0] / x_max if x_max > 0 else 0.0,
-                win.mouse_pos[1] / y_max if y_max > 0 else 0.0)
+        args = (
+            win.mouse_pos[0] / win._density / x_max if x_max > 0 else 0.0,
+            win.mouse_pos[1] / win._density / y_max if y_max > 0 else 0.0
+        )
         hover = self.hover_event
         if hover:
             hover.move(args)

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -52,13 +52,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         self.etype = etype
         self.motion_event = event
 
-    def on_touch_down(self, _, touch):
-        self.touch_event = touch
-
-    def on_touch_move(self, _, touch):
-        self.touch_event = touch
-
-    def on_touch_up(self, _, touch):
+    def on_any_touch_event(self, _, touch):
         self.touch_event = touch
 
     def to_relative_pos(self, win, x, y):
@@ -79,9 +73,9 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win = EventLoop.window
         if with_window_children:
             from kivy.uix.button import Button
-            button = Button(on_touch_down=self.on_touch_down,
-                            on_touch_move=self.on_touch_move,
-                            on_touch_up=self.on_touch_up)
+            button = Button(on_touch_down=self.on_any_touch_event,
+                            on_touch_move=self.on_any_touch_event,
+                            on_touch_up=self.on_any_touch_event)
             self.button_widget = button
             win.add_widget(button)
         return win, self.mouse

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -6,11 +6,15 @@ class MouseHoverEventTestCase(GraphicUnitTest):
     '''Tests hover event from `MouseMotionEventProvider`.
     '''
 
+    framecount = 3
+    '''Must be equal of max number of `self.advance_frame` in test method.'''
+
     def setUp(self):
         super().setUp()
         self.etype = None
-        self.hover_event = None
+        self.motion_event = None
         self.touch_event = None
+        self.button_widget = None
         self.mouse = mouse = MouseMotionEventProvider('mouse', '')
         from kivy.base import EventLoop
         win = EventLoop.window
@@ -19,24 +23,34 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.system_size = (320, 240)
         mouse.start()
         EventLoop.add_input_provider(mouse)
+        win.fbind('on_motion', self.on_motion)
+        # Patch `win.on_close` method to prevent EventLoop from removing
+        # window from event listeners list.
+        self.old_on_close = win.on_close
+        win.on_close = lambda *args: None
 
     def tearDown(self, fake=False):
         super().tearDown(fake)
         self.etype = None
-        self.hover_event = None
+        self.motion_event = None
         self.touch_event = None
         from kivy.base import EventLoop
         win = EventLoop.window
-        for widget in win.children[:]:
-            win.remove_widget(widget)
+        if self.button_widget:
+            win.remove_widget(self.button_widget)
+            self.button_widget = None
         mouse = self.mouse
         mouse.stop()
-        EventLoop.remove_event_listener(mouse)
+        EventLoop.remove_input_provider(mouse)
         self.mouse = None
+        win.funbind('on_motion', self.on_motion)
+        # Restore method `on_close` to window
+        win.on_close = self.old_on_close
+        self.old_on_close = None
 
-    def dispatch_fn(self, etype, event):
+    def on_motion(self, _, etype, event):
         self.etype = etype
-        self.hover_event = event
+        self.motion_event = event
 
     def on_touch_down(self, _, touch):
         self.touch_event = touch
@@ -52,82 +66,83 @@ class MouseHoverEventTestCase(GraphicUnitTest):
 
     def assert_event(self, etype, spos):
         assert self.etype == etype
-        assert 'pos' in self.hover_event.profile
-        assert self.hover_event.is_touch is False
-        assert self.hover_event.spos == spos
+        assert 'pos' in self.motion_event.profile
+        assert self.motion_event.is_touch is False
+        assert self.motion_event.spos == spos
 
     def assert_no_event(self):
         assert self.etype is None
-        assert self.hover_event is None
+        assert self.motion_event is None
 
     def get_providers(self, with_window_children=False):
         from kivy.base import EventLoop
-        from kivy.uix.button import Button
         win = EventLoop.window
         if with_window_children:
+            from kivy.uix.button import Button
             button = Button(on_touch_down=self.on_touch_down,
                             on_touch_move=self.on_touch_move,
                             on_touch_up=self.on_touch_up)
+            self.button_widget = button
             win.add_widget(button)
         return win, self.mouse
 
     def test_no_event_on_cursor_leave(self):
         win, mouse = self.get_providers()
         win.dispatch('on_cursor_leave')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_no_event()
 
     def test_no_event_on_system_size(self):
         win, mouse = self.get_providers()
         w, h = win.system_size
         win.system_size = (w + 10, h + 10)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_no_event()
 
     def test_no_event_on_rotate(self):
         win, mouse = self.get_providers()
         win.rotation = 90
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_no_event()
 
     def test_no_event_on_close(self):
         win, mouse = self.get_providers()
         win.dispatch('on_close')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_no_event()
 
     def test_begin_event_on_cursor_enter(self):
         win, mouse = self.get_providers()
         x, y = win.mouse_pos
         win.dispatch('on_cursor_enter')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('begin', self.to_relative_pos(win, x, y))
 
     def test_begin_event_on_mouse_pos(self):
         win, mouse = self.get_providers()
         x, y = win.mouse_pos = (10.0, 10.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('begin', self.to_relative_pos(win, x, y))
 
     def test_update_event_with_enter_and_mouse_pos(self):
         win, mouse = self.get_providers()
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos = (50.0, 50.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
 
     def test_update_event_with_mouse_pos(self):
         win, mouse = self.get_providers()
         win.mouse_pos = (10.0, 10.0)
         x, y = win.mouse_pos = (50.0, 50.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
 
     def test_update_event_on_rotate(self):
         win, mouse = self.get_providers()
         x, y = win.mouse_pos = (10.0, 10.0)
         win.rotation = 90
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
 
     def test_update_event_on_system_size(self):
@@ -135,21 +150,21 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         x, y = win.mouse_pos = (10.0, 10.0)
         w, h = win.system_size
         win.system_size = (w + 10, h + 10)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
 
     def test_end_event_on_cursor_leave(self):
         win, mouse = self.get_providers()
         x, y = win.mouse_pos = (10.0, 10.0)
         win.dispatch('on_cursor_leave')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('end', self.to_relative_pos(win, x, y))
 
     def test_end_event_on_window_close(self):
         win, mouse = self.get_providers()
         x, y = win.mouse_pos = (10.0, 10.0)
         win.dispatch('on_close')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('end', self.to_relative_pos(win, x, y))
 
     def test_with_full_cycle_with_cursor_events(self):
@@ -157,37 +172,37 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         # Test begin event
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('begin', self.to_relative_pos(win, x, y))
         # Test update event
         x, y = win.mouse_pos = (10.0, 10.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
         # Test end event
         win.dispatch('on_cursor_leave')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('end', self.to_relative_pos(win, x, y))
 
     def test_with_full_cycle_with_mouse_pos_and_on_close_event(self):
         win, mouse = self.get_providers()
         # Test begin event
         x, y = win.mouse_pos = (5.0, 5.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('begin', self.to_relative_pos(win, x, y))
         # Test update event
         x, y = win.mouse_pos = (10.0, 10.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
         # Test end event
         win.dispatch('on_close')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('end', self.to_relative_pos(win, x, y))
 
     def test_begin_event_no_dispatch_through_on_touch_events(self):
         win, mouse = self.get_providers(with_window_children=True)
         x, y = win.mouse_pos
         win.dispatch('on_cursor_enter')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('begin', self.to_relative_pos(win, x, y))
         assert self.touch_event is None
 
@@ -195,7 +210,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win, mouse = self.get_providers(with_window_children=True)
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos = (10.0, 10.0)
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('update', self.to_relative_pos(win, x, y))
         assert self.touch_event is None
 
@@ -204,6 +219,6 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos = (10.0, 10.0)
         win.dispatch('on_cursor_leave')
-        mouse.update(self.dispatch_fn)
+        self.advance_frames(1)
         self.assert_event('end', self.to_relative_pos(win, x, y))
         assert self.touch_event is None

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -1,4 +1,3 @@
-from kivy.input.providers.mouse import MouseMotionEventProvider
 from kivy.tests.common import GraphicUnitTest
 
 
@@ -15,6 +14,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         self.motion_event = None
         self.touch_event = None
         self.button_widget = None
+        from kivy.input.providers.mouse import MouseMotionEventProvider
         self.mouse = mouse = MouseMotionEventProvider('mouse', '')
         from kivy.base import EventLoop
         win = EventLoop.window

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -1,0 +1,209 @@
+from kivy.input.providers.mouse import MouseMotionEventProvider
+from kivy.tests.common import GraphicUnitTest
+
+
+class MouseHoverEventTestCase(GraphicUnitTest):
+    '''Tests hover event from `MouseMotionEventProvider`.
+    '''
+
+    def setUp(self):
+        super().setUp()
+        self.etype = None
+        self.hover_event = None
+        self.touch_event = None
+        self.mouse = mouse = MouseMotionEventProvider('mouse', '')
+        from kivy.base import EventLoop
+        win = EventLoop.window
+        win.mouse_pos = (0.0, 0.0)
+        win.rotation = 0
+        win.system_size = (320, 240)
+        mouse.start()
+        EventLoop.add_input_provider(mouse)
+
+    def tearDown(self, fake=False):
+        super().tearDown(fake)
+        self.etype = None
+        self.hover_event = None
+        self.touch_event = None
+        from kivy.base import EventLoop
+        win = EventLoop.window
+        for widget in win.children[:]:
+            win.remove_widget(widget)
+        mouse = self.mouse
+        mouse.stop()
+        EventLoop.remove_event_listener(mouse)
+        self.mouse = None
+
+    def dispatch_fn(self, etype, event):
+        self.etype = etype
+        self.hover_event = event
+
+    def on_touch_down(self, _, touch):
+        self.touch_event = touch
+
+    def on_touch_move(self, _, touch):
+        self.touch_event = touch
+
+    def on_touch_up(self, _, touch):
+        self.touch_event = touch
+
+    def to_relative_pos(self, win, x, y):
+        return x / (win.system_size[0] - 1), y / (win.system_size[1] - 1)
+
+    def assert_event(self, etype, spos):
+        assert self.etype == etype
+        assert 'pos' in self.hover_event.profile
+        assert self.hover_event.is_touch is False
+        assert self.hover_event.spos == spos
+
+    def assert_no_event(self):
+        assert self.etype is None
+        assert self.hover_event is None
+
+    def get_providers(self, with_window_children=False):
+        from kivy.base import EventLoop
+        from kivy.uix.button import Button
+        win = EventLoop.window
+        if with_window_children:
+            button = Button(on_touch_down=self.on_touch_down,
+                            on_touch_move=self.on_touch_move,
+                            on_touch_up=self.on_touch_up)
+            win.add_widget(button)
+        return win, self.mouse
+
+    def test_no_event_on_cursor_leave(self):
+        win, mouse = self.get_providers()
+        win.dispatch('on_cursor_leave')
+        mouse.update(self.dispatch_fn)
+        self.assert_no_event()
+
+    def test_no_event_on_system_size(self):
+        win, mouse = self.get_providers()
+        w, h = win.system_size
+        win.system_size = (w + 10, h + 10)
+        mouse.update(self.dispatch_fn)
+        self.assert_no_event()
+
+    def test_no_event_on_rotate(self):
+        win, mouse = self.get_providers()
+        win.rotation = 90
+        mouse.update(self.dispatch_fn)
+        self.assert_no_event()
+
+    def test_no_event_on_close(self):
+        win, mouse = self.get_providers()
+        win.dispatch('on_close')
+        mouse.update(self.dispatch_fn)
+        self.assert_no_event()
+
+    def test_begin_event_on_cursor_enter(self):
+        win, mouse = self.get_providers()
+        x, y = win.mouse_pos
+        win.dispatch('on_cursor_enter')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('begin', self.to_relative_pos(win, x, y))
+
+    def test_begin_event_on_mouse_pos(self):
+        win, mouse = self.get_providers()
+        x, y = win.mouse_pos = (10.0, 10.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('begin', self.to_relative_pos(win, x, y))
+
+    def test_update_event_with_enter_and_mouse_pos(self):
+        win, mouse = self.get_providers()
+        win.dispatch('on_cursor_enter')
+        x, y = win.mouse_pos = (50.0, 50.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+
+    def test_update_event_with_mouse_pos(self):
+        win, mouse = self.get_providers()
+        win.mouse_pos = (10.0, 10.0)
+        x, y = win.mouse_pos = (50.0, 50.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+
+    def test_update_event_on_rotate(self):
+        win, mouse = self.get_providers()
+        x, y = win.mouse_pos = (10.0, 10.0)
+        win.rotation = 90
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+
+    def test_update_event_on_system_size(self):
+        win, mouse = self.get_providers()
+        x, y = win.mouse_pos = (10.0, 10.0)
+        w, h = win.system_size
+        win.system_size = (w + 10, h + 10)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+
+    def test_end_event_on_cursor_leave(self):
+        win, mouse = self.get_providers()
+        x, y = win.mouse_pos = (10.0, 10.0)
+        win.dispatch('on_cursor_leave')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('end', self.to_relative_pos(win, x, y))
+
+    def test_end_event_on_window_close(self):
+        win, mouse = self.get_providers()
+        x, y = win.mouse_pos = (10.0, 10.0)
+        win.dispatch('on_close')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('end', self.to_relative_pos(win, x, y))
+
+    def test_with_full_cycle_with_cursor_events(self):
+        win, mouse = self.get_providers()
+        # Test begin event
+        win.dispatch('on_cursor_enter')
+        x, y = win.mouse_pos
+        mouse.update(self.dispatch_fn)
+        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        # Test update event
+        x, y = win.mouse_pos = (10.0, 10.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+        # Test end event
+        win.dispatch('on_cursor_leave')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('end', self.to_relative_pos(win, x, y))
+
+    def test_with_full_cycle_with_mouse_pos_and_on_close_event(self):
+        win, mouse = self.get_providers()
+        # Test begin event
+        x, y = win.mouse_pos = (5.0, 5.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        # Test update event
+        x, y = win.mouse_pos = (10.0, 10.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+        # Test end event
+        win.dispatch('on_close')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('end', self.to_relative_pos(win, x, y))
+
+    def test_begin_event_no_dispatch_through_on_touch_events(self):
+        win, mouse = self.get_providers(with_window_children=True)
+        x, y = win.mouse_pos
+        win.dispatch('on_cursor_enter')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        assert self.touch_event is None
+
+    def test_update_event_no_dispatch_through_on_touch_events(self):
+        win, mouse = self.get_providers(with_window_children=True)
+        win.dispatch('on_cursor_enter')
+        x, y = win.mouse_pos = (10.0, 10.0)
+        mouse.update(self.dispatch_fn)
+        self.assert_event('update', self.to_relative_pos(win, x, y))
+        assert self.touch_event is None
+
+    def test_end_event_no_dispatch_through_on_touch_events(self):
+        win, mouse = self.get_providers(with_window_children=True)
+        win.dispatch('on_cursor_enter')
+        x, y = win.mouse_pos = (10.0, 10.0)
+        win.dispatch('on_cursor_leave')
+        mouse.update(self.dispatch_fn)
+        self.assert_event('end', self.to_relative_pos(win, x, y))
+        assert self.touch_event is None

--- a/kivy/tests/test_mouse_multitouchsim.py
+++ b/kivy/tests/test_mouse_multitouchsim.py
@@ -63,6 +63,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             10, self.correct_y(win, 10),
             'right', {}
         )
+        event_id = next(iter(mouse.touches))
         self.assertEqual(mouse.counter, 1)
 
         if 'on_demand' in kwargs and 'scatter' not in kwargs:
@@ -78,7 +79,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         elif 'on_demand' in kwargs and 'scatter' in kwargs:
             self.assertIn(
                 'multitouch_sim',
-                mouse.touches['mouse1'].profile
+                mouse.touches[event_id].profile
             )
             self.assertTrue(mouse.multitouch_on_demand)
 
@@ -90,18 +91,18 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             # without ME dispatch, on_touch_down was not
             # called == multitouch_sim is False
             self.advance_frames(1)  # initialize stuff
-            wid.on_touch_down(mouse.touches['mouse1'])
-            wid.on_touch_up(mouse.touches['mouse1'])
-            self.assertTrue(mouse.touches['mouse1'].multitouch_sim)
+            wid.on_touch_down(mouse.touches[event_id])
+            wid.on_touch_up(mouse.touches[event_id])
+            self.assertTrue(mouse.touches[event_id].multitouch_sim)
 
         elif 'disabled' in kwargs:
             self.assertIsNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot isn't present
 
         else:
             self.assertIsNotNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot is present
 
         # XXX right button up
@@ -120,9 +121,9 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
 
         # because the red dot is removed by the left button
         if 'disabled' not in kwargs:
-            self.assertIn('mouse1', mouse.touches)
+            self.assertIn(event_id, mouse.touches)
             self.assertIsNotNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot is present
 
         # button is down on the previous dot's position
@@ -140,7 +141,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         if 'disabled' in kwargs:
             # the right click is ignored, test ends here
             self.assertNotIn(
-                'mouse1', mouse.touches
+                event_id, mouse.touches
             )
             # cleanup!
             # remove mouse provider
@@ -149,12 +150,12 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             return
         else:
             self.assertIsNotNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot is present
 
         # ellipse proxy (<3 #1318 Instruction.proxy_ref)
         dot_proxy = mouse.touches[
-            'mouse1'
+            event_id
         ].ud.get('_drawelement')[1].proxy_ref
 
         # the dot is removed after the touch is released
@@ -178,14 +179,14 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
                 print(dot_proxy)
 
             self.assertEqual(mouse.counter, 1)
-            self.assertNotIn('mouse1', mouse.touches)
+            self.assertNotIn(event_id, mouse.touches)
             self.assertEqual(mouse.touches, {})
 
         elif button == 'right':
             self.assertEqual(mouse.counter, 1)
-            self.assertIn('mouse1', mouse.touches)
+            self.assertIn(event_id, mouse.touches)
             self.assertIsNotNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot is present
 
         self.render(wid)
@@ -215,6 +216,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             10, self.correct_y(win, 10),
             'right', {}
         )
+        event_id = next(iter(mouse.touches))
         self.assertEqual(mouse.counter, 1)
 
         if 'on_demand' in kwargs and 'scatter' not in kwargs:
@@ -237,7 +239,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             # on_demand works after the touch is up
             self.assertIn(
                 'multitouch_sim',
-                mouse.touches['mouse1'].profile
+                mouse.touches[event_id].profile
             )
             self.assertTrue(mouse.multitouch_on_demand)
 
@@ -249,9 +251,9 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             # without ME dispatch, on_touch_down was not
             # called == multitouch_sim is False
             self.advance_frames(1)  # initialize stuff
-            wid.on_touch_down(mouse.touches['mouse1'])
-            wid.on_touch_up(mouse.touches['mouse1'])
-            self.assertTrue(mouse.touches['mouse1'].multitouch_sim)
+            wid.on_touch_down(mouse.touches[event_id])
+            wid.on_touch_up(mouse.touches[event_id])
+            self.assertTrue(mouse.touches[event_id].multitouch_sim)
 
             win.dispatch(
                 'on_mouse_up',
@@ -259,10 +261,10 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
                 'right', {}
             )
             color = mouse.touches[
-                'mouse1'
+                event_id
             ].ud.get('_drawelement')[0].proxy_ref
             ellipse = mouse.touches[
-                'mouse1'
+                event_id
             ].ud.get('_drawelement')[1].proxy_ref
             win.dispatch(
                 'on_mouse_down',
@@ -272,12 +274,12 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
 
         elif 'disabled' in kwargs:
             self.assertIsNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot isn't present
 
         else:
             self.assertIsNotNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot is present
 
         # do NOT make any hard refs to '_drawelement'
@@ -285,7 +287,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             # the right click doesn't draw the red dot
             # the instructions aren't present, test ends
             self.assertIsNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot isn't present
             # cleanup!
             # remove mouse provider
@@ -295,10 +297,10 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
 
         else:
             color = mouse.touches[
-                'mouse1'
+                event_id
             ].ud.get('_drawelement')[0].proxy_ref
             ellipse = mouse.touches[
-                'mouse1'
+                event_id
             ].ud.get('_drawelement')[1].proxy_ref
 
         # the red dot moves when the touch is moving
@@ -321,9 +323,9 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         self.assertEqual(mouse.counter, 1)
 
         # because the red dot is removed by the left button
-        self.assertIn('mouse1', mouse.touches)
+        self.assertIn(event_id, mouse.touches)
         self.assertIsNotNone(
-            mouse.touches['mouse1'].ud.get('_drawelement')
+            mouse.touches[event_id].ud.get('_drawelement')
         )  # the red dot is present
 
         # the dot is at (11, 11), but the touch is in
@@ -338,7 +340,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         # no new one was created
         self.assertEqual(mouse.counter, 1)
         self.assertIsNotNone(
-            mouse.touches['mouse1'].ud.get('_drawelement')
+            mouse.touches[event_id].ud.get('_drawelement')
         )  # the red dot is present
 
         # the red dot moves when the touch is moving
@@ -363,11 +365,11 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         self.assertEqual(mouse.counter, 1)
 
         if button == 'left':
-            self.assertNotIn('mouse1', mouse.touches)
+            self.assertNotIn(event_id, mouse.touches)
         elif button == 'right':
-            self.assertIn('mouse1', mouse.touches)
+            self.assertIn(event_id, mouse.touches)
             self.assertIsNotNone(
-                mouse.touches['mouse1'].ud.get('_drawelement')
+                mouse.touches[event_id].ud.get('_drawelement')
             )  # the red dot is present
 
         self.render(wid)
@@ -395,6 +397,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             10, self.correct_y(win, 10),
             'left', {}
         )
+        event_id = next(iter(mouse.touches))
         win.dispatch(
             'on_mouse_move',
             11, self.correct_y(win, 11),
@@ -402,7 +405,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         )
         self.assertEqual(mouse.counter, 1)
         self.assertIsNone(
-            mouse.touches['mouse1'].ud.get('_drawelement')
+            mouse.touches[event_id].ud.get('_drawelement')
         )  # the red dot isn't present
 
         # left button up
@@ -414,7 +417,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         # after the releasing the touch disappears,
         # but the counter remains
         self.assertEqual(mouse.counter, 1)
-        self.assertNotIn('mouse1', mouse.touches)
+        self.assertNotIn(event_id, mouse.touches)
 
         self.advance_frames(1)
         self.render(wid)
@@ -441,17 +444,18 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             10, self.correct_y(win, 10),
             'right', {}
         )
+        event_id = next(iter(mouse.touches))
         self.assertEqual(mouse.counter, 1)
         self.assertIsNotNone(
-            mouse.touches['mouse1'].ud.get('_drawelement')
+            mouse.touches[event_id].ud.get('_drawelement')
         )  # the red dot is present
 
         # do NOT make any hard refs to '_drawelement'
         color = mouse.touches[
-            'mouse1'
+            event_id
         ].ud.get('_drawelement')[0].proxy_ref
         ellipse = mouse.touches[
-            'mouse1'
+            event_id
         ].ud.get('_drawelement')[1].proxy_ref
 
         # check ellipse's position
@@ -488,9 +492,9 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         )  # bounding box from Rectangle, R=10 -> 20 width
         self.assertEqual(mouse.counter, 1)
         # because the red dot is removed by the left button
-        self.assertIn('mouse1', mouse.touches)
+        self.assertIn(event_id, mouse.touches)
         self.assertIsNotNone(
-            mouse.touches['mouse1'].ud.get('_drawelement')
+            mouse.touches[event_id].ud.get('_drawelement')
         )  # the red dot is present
 
         self.render(wid)

--- a/kivy/tests/test_mouse_multitouchsim.py
+++ b/kivy/tests/test_mouse_multitouchsim.py
@@ -1,7 +1,4 @@
 from kivy.tests.common import GraphicUnitTest
-from kivy.input.providers.mouse import (
-    MouseMotionEventProvider as Mouse
-)
 
 
 class MultitouchSimulatorTestCase(GraphicUnitTest):
@@ -32,7 +29,8 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
             mode = 'disable_multitouch'
         else:
             mode = ''
-        mouse = Mouse('unittest', mode)
+        from kivy.input.providers.mouse import MouseMotionEventProvider
+        mouse = MouseMotionEventProvider('unittest', mode)
         mouse.is_touch = True
 
         # defaults from ME, it's missing because we use


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Proposed changes will make `MouseMotionEventProvider` dispatch hover `MouseMotionEvent` event by reacting on properties/events:
- `mouse_pos`
- `system_size`
- `on_cursor_enter`
- `on_cursor_leave`
- `on_close`
- `on_rotate`

Changes:
- `MotionEvent.__init__` method now accept `is_touch` as argument and that change was needed to make `depack` work with touch and hover (non-touch) events
- Method `grab` in `MotionEvent` is changed to enable grab of non-touch events.
- Attribute `button` is added to `MotionEvent` because it was missing from `__init__` and is used by `is_mouse_scrolling` property.
- If window provider dispatches `on_cursor_xxx` events, then `on_cursor_enter` will create `begin` hover event and `on_cursor_leave` will create `end` hover event. Otherwise, the first change of `mouse_pos` will create `begin` event and `end` will be dispatched on `on_close` event. In both cases change to `mouse_pos` will dispatch `update` events.
- Updated `MouseMotionEventProvider` to use `fbind/funbind` methods.


Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
