### PR TITLE
Fix SoundAndroidPlayer state persisting after playback completion

### DIFF
--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -36,6 +36,7 @@ class SoundAndroidPlayer(Sound):
 
     def __init__(self, **kwargs):
         self._mediaplayer = None
+        self._completion_listener = None
         super(SoundAndroidPlayer, self).__init__(**kwargs)
 
     def load(self):
@@ -49,6 +50,8 @@ class SoundAndroidPlayer(Sound):
         else:
             self._mediaplayer.setAudioStreamType(AudioManager.STREAM_MUSIC)
         self._mediaplayer.setDataSource(self.source)
+        self._completion_listener = OnCompletionListener(self._completion_callback)
+        self._mediaplayer.setOnCompletionListener(self._completion_listener)
         self._mediaplayer.prepare()
 
     def unload(self):
@@ -82,6 +85,9 @@ class SoundAndroidPlayer(Sound):
         if self._mediaplayer:
             volume = float(volume)
             self._mediaplayer.setVolume(volume, volume)
+
+    def _completion_callback(self):
+        super(SoundAndroidPlayer, self).stop()
 
     def _get_length(self):
         if self._mediaplayer:

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -4,7 +4,7 @@ AudioAndroid: Kivy audio implementation for Android using native API
 
 __all__ = ("SoundAndroidPlayer", )
 
-from jnius import autoclass
+from jnius import autoclass, java_method, PythonJavaClass
 from android import api_version
 from kivy.core.audio import Sound, SoundLoader
 
@@ -13,6 +13,19 @@ MediaPlayer = autoclass("android.media.MediaPlayer")
 AudioManager = autoclass("android.media.AudioManager")
 if api_version >= 21:
     AudioAttributesBuilder = autoclass("android.media.AudioAttributes$Builder")
+
+
+class OnCompletionListener(PythonJavaClass):
+    __javainterfaces__ = ["android/media/MediaPlayer$OnCompletionListener"]
+    __javacontext__ = "app"
+
+    def __init__(self, callback, **kwargs):
+        super(OnCompletionListener, self).__init__(**kwargs)
+        self.callback = callback
+
+    @java_method("(Landroid/media/MediaPlayer;)V")
+    def onCompletion(self, mp):
+        self.callback()
 
 
 class SoundAndroidPlayer(Sound):

--- a/kivy/core/audio/audio_android.py
+++ b/kivy/core/audio/audio_android.py
@@ -50,7 +50,9 @@ class SoundAndroidPlayer(Sound):
         else:
             self._mediaplayer.setAudioStreamType(AudioManager.STREAM_MUSIC)
         self._mediaplayer.setDataSource(self.source)
-        self._completion_listener = OnCompletionListener(self._completion_callback)
+        self._completion_listener = OnCompletionListener(
+            self._completion_callback
+        )
         self._mediaplayer.setOnCompletionListener(self._completion_listener)
         self._mediaplayer.prepare()
 


### PR DESCRIPTION
This PR adds an `OnCompletionListener` that will call its callback once the playback is finished. Before this, once the playback had finished, the `state` would still stay on `play` and `on_stop` wouldn't be dispatched since there was no call to `Sound.stop`. This takes care of that.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
