### PR TITLE
Docs: Fix packaging-osx docs (homebrew)

### DIFF
--- a/doc/sources/guide/packaging-osx.rst
+++ b/doc/sources/guide/packaging-osx.rst
@@ -56,14 +56,14 @@ Complete guide
      To use Python 3, ``brew install python3`` and replace ``pip`` with
      ``pip3`` in the guide below.
 
-#. (Re)install your dependencies with ``--build-bottle`` to make sure they can
+#. (Re)install your dependencies with ``--build-from-source`` to make sure they can
    be used on other machines::
 
-    $ brew reinstall --build-bottle sdl2 sdl2_image sdl2_ttf sdl2_mixer
+    $ brew reinstall --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
 
    .. note::
        If your project depends on GStreamer or other additional libraries
-       (re)install them with ``--build-bottle`` as described
+       (re)install them with ``--build-from-source`` as described
        `below <additional libraries_>`_.
 
 #. Install Cython and Kivy:
@@ -137,7 +137,7 @@ GStreamer
 ^^^^^^^^^
 If your project depends on GStreamer::
 
-    $ brew reinstall --build-bottle gstreamer gst-plugins-{base,good,bad,ugly}
+    $ brew reinstall --build-from-source gstreamer gst-plugins-{base,good,bad,ugly}
 
 .. note::
     If your Project needs Ogg Vorbis support be sure to add the
@@ -147,7 +147,7 @@ If you are using Python from Homebrew you will also need the following step
 until `this pull request <https://github.com/Homebrew/homebrew/pull/46097>`_
 gets merged::
 
-    $ brew reinstall --with-python --build-bottle https://github.com/cbenhagen/homebrew/raw/patch-3/Library/Formula/gst-python.rb
+    $ brew reinstall --with-python --build-from-source https://github.com/cbenhagen/homebrew/raw/patch-3/Library/Formula/gst-python.rb
 
 
 Using PyInstaller without Homebrew


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

On this page https://kivy.org/doc/stable/guide/packaging-osx.html there are a lot of commads such as `brew reinstall --build-bottle ...` and they all are not working. Because homebrew reinstall doesn't have such option as `--build-bottle` https://docs.brew.sh/Manpage#reinstall-options-formulacask- 

In this request, I've replaced  `--build-bottle` with `--build-from-source`. It works fine for me.