### PR TITLE
Window: Fix logging message

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -245,7 +245,7 @@ cdef class _WindowSDL2Storage:
                 status = ''
                 if vsync not in (0, 1):
                     res = SDL_GL_SetSwapInterval(1)
-                    status = ', trying fallback to 1: ' + 'failed' if res == -1 else 'succeeded'
+                    status = ', trying fallback to 1: ' + ('failed' if res == -1 else 'succeeded')
 
                 Logger.debug('WindowSDL: requested vsync failed' + status)
 


### PR DESCRIPTION
This caused the string `requested vsync failedsucceeded` to be logged instead of the intended `requested vsync failed, trying fallback to 1: succeeded`

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
