### PR TITLE
Mouse: Fix computation of relative touch position in MouseMotionEventProvider

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -355,27 +355,32 @@ class MotionEvent(MotionEventBase):
 
     def scale_for_screen(self, w, h, p=None, rotation=0,
                          smode='None', kheight=0):
-        '''Scale position for the screen
+        '''Scale position for the screen.
+
+        .. versionchanged:: 2.1.0
+            Max value for `x`, `y` and `z` is changed respectively to `w` - 1,
+            `h` - 1 and `p` - 1.
         '''
+        x_max, y_max = w - 1.0, h - 1.0
         sx, sy = self.sx, self.sy
         if rotation == 0:
-            self.x = sx * float(w)
-            self.y = sy * float(h)
+            self.x = sx * x_max
+            self.y = sy * y_max
         elif rotation == 90:
             sx, sy = sy, 1 - sx
-            self.x = sx * float(h)
-            self.y = sy * float(w)
+            self.x = sx * y_max
+            self.y = sy * x_max
         elif rotation == 180:
             sx, sy = 1 - sx, 1 - sy
-            self.x = sx * float(w)
-            self.y = sy * float(h)
+            self.x = sx * x_max
+            self.y = sy * y_max
         elif rotation == 270:
             sx, sy = 1 - sy, sx
-            self.x = sx * float(h)
-            self.y = sy * float(w)
+            self.x = sx * y_max
+            self.y = sy * x_max
 
-        if p:
-            self.z = self.sz * float(p)
+        if p is not None:
+            self.z = self.sz * (p - 1.0)
 
         if smode:
             if smode == 'pan':

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -361,7 +361,7 @@ class MotionEvent(MotionEventBase):
             Max value for `x`, `y` and `z` is changed respectively to `w` - 1,
             `h` - 1 and `p` - 1.
         '''
-        x_max, y_max = w - 1.0, h - 1.0
+        x_max, y_max = max(0.0, w - 1.0), max(0.0, h - 1.0)
         sx, sy = self.sx, self.sy
         if rotation == 0:
             self.x = sx * x_max
@@ -380,7 +380,7 @@ class MotionEvent(MotionEventBase):
             self.y = sy * x_max
 
         if p is not None:
-            self.z = self.sz * (p - 1.0)
+            self.z = self.sz * max(0.0, p - 1.0)
 
         if smode:
             if smode == 'pan':

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -228,9 +228,9 @@ class MouseMotionEventProvider(MotionEventProvider):
         cur.clear_graphics(EventLoop.window)
 
     def on_mouse_motion(self, win, x, y, modifiers):
-        width, height = EventLoop.window.system_size
-        rx = x / float(width)
-        ry = 1. - y / float(height)
+        width, height = win.system_size
+        rx = x / (width - 1.0)
+        ry = 1.0 - y / (height - 1.0)
         if self.current_drag:
             cur = self.current_drag
             cur.move([rx, ry])
@@ -245,9 +245,9 @@ class MouseMotionEventProvider(MotionEventProvider):
     def on_mouse_press(self, win, x, y, button, modifiers):
         if self.test_activity():
             return
-        width, height = EventLoop.window.system_size
-        rx = x / float(width)
-        ry = 1. - y / float(height)
+        width, height = win.system_size
+        rx = x / (width - 1.0)
+        ry = 1.0 - y / (height - 1.0)
         new_me = self.find_touch(rx, ry)
         if new_me:
             self.current_drag = new_me

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -228,9 +228,9 @@ class MouseMotionEventProvider(MotionEventProvider):
         cur.clear_graphics(EventLoop.window)
 
     def on_mouse_motion(self, win, x, y, modifiers):
-        width, height = win.system_size
-        rx = x / (width - 1.0)
-        ry = 1.0 - y / (height - 1.0)
+        x_max, y_max = win.system_size[0] - 1.0, win.system_size[1] - 1.0
+        rx = x / x_max if x_max > 0 else 0.0
+        ry = 1.0 - (y / y_max if y_max > 0 else 0.0)
         if self.current_drag:
             cur = self.current_drag
             cur.move([rx, ry])
@@ -245,9 +245,9 @@ class MouseMotionEventProvider(MotionEventProvider):
     def on_mouse_press(self, win, x, y, button, modifiers):
         if self.test_activity():
             return
-        width, height = win.system_size
-        rx = x / (width - 1.0)
-        ry = 1.0 - y / (height - 1.0)
+        x_max, y_max = win.system_size[0] - 1.0, win.system_size[1] - 1.0
+        rx = x / x_max if x_max > 0 else 0.0
+        ry = 1.0 - (y / y_max if y_max > 0 else 0.0)
         new_me = self.find_touch(rx, ry)
         if new_me:
             self.current_drag = new_me

--- a/kivy/tests/async_common.py
+++ b/kivy/tests/async_common.py
@@ -29,8 +29,8 @@ class AsyncUnitTestTouch(UnitTestTouch):
     def touch_move(self, x, y):
         win = self.eventloop.window
         self.move({
-            "x": x / float(win.width),
-            "y": y / float(win.height)
+            "x": x / (win.width - 1.0),
+            "y": y / (win.height - 1.0)
         })
         self.eventloop._dispatch_input("update", self)
 

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -420,8 +420,8 @@ class UnitTestTouch(MotionEvent):
         super(UnitTestTouch, self).__init__(
             # device, (tuio) id, args
             self.__class__.__name__, 99, {
-                "x": x / float(win.width),
-                "y": y / float(win.height),
+                "x": x / (win.width - 1.0),
+                "y": y / (win.height - 1.0),
             }
         )
 
@@ -431,8 +431,8 @@ class UnitTestTouch(MotionEvent):
     def touch_move(self, x, y):
         win = self.eventloop.window
         self.move({
-            "x": x / float(win.width),
-            "y": y / float(win.height)
+            "x": x / (win.width - 1.0),
+            "y": y / (win.height - 1.0)
         })
         self.eventloop.post_dispatch_input("update", self)
 

--- a/kivy/tests/test_app.py
+++ b/kivy/tests/test_app.py
@@ -1,4 +1,5 @@
 import os.path
+from math import isclose
 from textwrap import dedent
 
 from kivy.app import App
@@ -93,7 +94,8 @@ async def test_drag_app(kivy_app):
             pos=(100, 100), target_pos=(200, 200)):
         pass
 
-    assert tuple(scatter.pos) == (100, 100)
+    assert isclose(scatter.x, 100)
+    assert isclose(scatter.y, 100)
 
 
 def text_app():

--- a/kivy/tests/test_mouse_multitouchsim.py
+++ b/kivy/tests/test_mouse_multitouchsim.py
@@ -12,7 +12,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         # flip, because the mouse provider uses system's
         # raw one and it's changed to bottom-left origin
         # with Window's system_size[1] for 'mouse_pos'
-        return win.height - y
+        return win.height - 1.0 - y
 
     def mouse_init(self, on_demand=False, disabled=False, scatter=False):
         # prepare MouseMotionEventProvider
@@ -309,7 +309,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         )
         self.assertEqual(
             ellipse.pos,
-            (1, self.correct_y(win, win.height - 1))
+            (1, 1)
         )  # bounding box from Rectangle, R=10 -> 20 width
 
         # right button up
@@ -349,7 +349,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         )
         self.assertEqual(
             ellipse.pos,
-            (40, self.correct_y(win, win.height - 40))
+            (40, 40)
         )  # bounding box from Rectangle, R=10 -> 20 width
 
         # the dot is removed after the touch is released
@@ -455,16 +455,11 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         ].ud.get('_drawelement')[1].proxy_ref
 
         # check ellipse's position
-        self.assertEqual(
-            ellipse.pos[0], 0
-        )  # bounding box from Rectangle, R=10 -> 20 width
+        self.assertAlmostEqual(ellipse.pos[0], 0, delta=0.0001)
+        # bounding box from Rectangle, R=10 -> 20 width
         # almost equal because the correct_y uses the same
         # float - float, which returns decimal garbage
-        self.assertAlmostEqual(
-            ellipse.pos[1],
-            self.correct_y(win, win.height),
-            delta=0.0001
-        )
+        self.assertAlmostEqual(ellipse.pos[1], 0, delta=0.0001)
 
         win.dispatch(
             'on_mouse_move',
@@ -474,7 +469,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
         # the red dot moves when the touch is moving
         self.assertEqual(
             ellipse.pos,
-            (1, self.correct_y(win, win.height - 1))
+            (1, 1)
         )  # bounding box from Rectangle, R=10 -> 20 width
         win.dispatch(
             'on_mouse_up',
@@ -484,7 +479,7 @@ class MultitouchSimulatorTestCase(GraphicUnitTest):
 
         self.assertEqual(
             ellipse.pos,
-            (1, self.correct_y(win, win.height - 1))
+            (1, 1)
         )  # bounding box from Rectangle, R=10 -> 20 width
         self.assertEqual(mouse.counter, 1)
         # because the red dot is removed by the left button


### PR DESCRIPTION
This changes fix computation of relative touch position in `MouseMotionEventProvider` and scaling of events in `MotionEvent.scale_for_screen` method which gives correct positions when events are dispatched through `on_touch_xxx` methods.

The fix changes the position range from `[0, Window.system_size[0]]` and `[0, Window.system_size[1]]` to `[0, Window.system_size[0] - 1]` and `[0, Window.system_size[1] - 1]`.

We most likely need the same fix for other providers which compute relative touch position when creating motion events.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
