### PR TITLE
Clock: Print remaining events before next frame upon too much iteration error

### DIFF
--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -114,6 +114,7 @@ cdef class CyClockBase(object):
     cpdef _process_events_before_frame(self)
     cpdef get_min_timeout(self)
     cpdef get_events(self)
+    cpdef get_before_frame_events(self)
     cpdef _process_clock_ended_del_safe_events(self)
     cpdef _process_clock_ended_callbacks(self)
 

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -664,10 +664,13 @@ cdef class CyClockBase(object):
         while found:
             count -= 1
             if count == -1:
+                remaining_events = '\n'.join(
+                    map(str, self.get_before_frame_events()))
                 Logger.critical(
-                    'Clock: Warning, too much iteration done before'
-                    ' the next frame. Check your code, or increase'
-                    ' the Clock.max_iteration attribute')
+                    f'Clock: Warning, too much iteration done before'
+                    f' the next frame. Check your code, or increase'
+                    f' the Clock.max_iteration attribute. Remaining events:\n'
+                    f'{remaining_events}')
                 break
 
             # search event that have timeout = -1
@@ -732,6 +735,22 @@ cdef class CyClockBase(object):
         ev = self._root_event
         while ev is not None:
             events.append(ev)
+            ev = ev.next
+        self._lock_release()
+        return events
+
+    cpdef get_before_frame_events(self):
+        '''Returns the list of :class:`ClockEvent` instances that are scheduled
+        to be called before the next frame (``-1`` timeout).
+        '''
+        cdef list events = []
+        cdef ClockEvent ev
+
+        self._lock_acquire()
+        ev = self._root_event
+        while ev is not None:
+            if ev.timeout == -1:
+                events.append(ev)
             ev = ev.next
         self._lock_release()
         return events

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -742,6 +742,8 @@ cdef class CyClockBase(object):
     cpdef get_before_frame_events(self):
         '''Returns the list of :class:`ClockEvent` instances that are scheduled
         to be called before the next frame (``-1`` timeout).
+
+        .. versionadded:: 2.1.0
         '''
         cdef list events = []
         cdef ClockEvent ev


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

Previously you'd get the warning: `[CRITICAL] [Clock       ] Warning, too much iteration done before the next frame. Check your code, or increase the Clock.max_iteration attribute`. However, it would be a guessing game to figure out who is responsible.

With this change, it actually prints the remaining events that are being scheduled before the next frame as follows:
```
[CRITICAL] [Clock       ] Warning, too much iteration done before the next frame. Check your code, or increase the Clock.max_iteration attribute. Remaining events:
<ClockEvent (-1.0) callback=<bound method AnchorLayout.do_layout of <kivymd.uix.button.MDFlatButton object at 0x00000196C5365E48>>>
<ClockEvent (-1.0) callback=<bound method BoxLayout.do_layout of <kivymd.uix.boxlayout.MDBoxLayout object at 0x00000196C544A198>>>
```

This e.g. helped me troubleshoot https://github.com/kivy/kivy/issues/7398.