### PR TITLE
ModalView: code cleanup regarding detection of main-Window:

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -498,7 +498,7 @@
         Color:
             rgba: root.overlay_color[:3] + [root.overlay_color[-1] * self._anim_alpha]
         Rectangle:
-            size: root.get_root_window().size if root.get_root_window() else (0, 0)
+            size: self._window.size if self._window else (0, 0)
 
         Color:
             rgba: root.background_color

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -498,7 +498,7 @@
         Color:
             rgba: root.overlay_color[:3] + [root.overlay_color[-1] * self._anim_alpha]
         Rectangle:
-            size: self._window.size if self._window else (0, 0)
+            size: root.get_root_window().size if root.get_root_window() else (0, 0)
 
         Color:
             rgba: root.background_color

--- a/kivy/tests/test_uix_modal.py
+++ b/kivy/tests/test_uix_modal.py
@@ -3,12 +3,13 @@ from math import isclose
 
 
 def modal_app():
+    """ test app factory function. """
     from kivy.app import App
     from kivy.uix.button import Button
     from kivy.uix.modalview import ModalView
 
     class ModalButton(Button):
-
+        """ button used as root widget to test touch. """
         modal = None
 
         def on_touch_down(self, touch):
@@ -26,8 +27,7 @@ def modal_app():
     class TestApp(UnitKivyApp, App):
         def build(self):
             root = ModalButton()
-            root.modal = self.modal_view = ModalView(
-                size_hint=(.2, .5), auto_dismiss=True)
+            root.modal = ModalView(size_hint=(.2, .5))
             return root
 
     return TestApp()
@@ -36,16 +36,16 @@ def modal_app():
 @async_run(app_cls_func=modal_app)
 async def test_modal_app(kivy_app):
     await kivy_app.wait_clock_frames(2)
-    modal = kivy_app.modal_view
     button = kivy_app.root
+    modal = button.modal
     modal._anim_duration = 0
     assert modal._window is None
 
     # just press button
     async for _ in kivy_app.do_touch_down_up(widget=button):
-        pass
+        assert modal._window is None
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
-        pass
+        assert modal._window is None
 
     # open modal
     modal.open()

--- a/kivy/tests/test_uix_modal.py
+++ b/kivy/tests/test_uix_modal.py
@@ -1,3 +1,4 @@
+""" modal view unit tests. """
 from kivy.tests import async_run, UnitKivyApp
 from math import isclose
 
@@ -8,24 +9,30 @@ def modal_app():
     from kivy.uix.button import Button
     from kivy.uix.modalview import ModalView
 
+    # noinspection PyProtectedMember
     class ModalButton(Button):
         """ button used as root widget to test touch. """
         modal = None
 
         def on_touch_down(self, touch):
-            assert self.modal._window is None
+            """ touch down event handler. """
+            assert not self.modal._is_open
             return super(ModalButton, self).on_touch_down(touch)
 
         def on_touch_move(self, touch):
-            assert self.modal._window is None
+            """ touch move event handler. """
+            assert not self.modal._is_open
             return super(ModalButton, self).on_touch_move(touch)
 
         def on_touch_up(self, touch):
-            assert self.modal._window is None
+            """ touch up event handler. """
+            assert not self.modal._is_open
             return super(ModalButton, self).on_touch_up(touch)
 
     class TestApp(UnitKivyApp, App):
+        """ test app class. """
         def build(self):
+            """ build root layout. """
             root = ModalButton()
             root.modal = ModalView(size_hint=(.2, .5))
             return root
@@ -39,44 +46,44 @@ async def test_modal_app(kivy_app):
     button = kivy_app.root
     modal = button.modal
     modal._anim_duration = 0
-    assert modal._window is None
+    assert not modal._is_open
 
     # just press button
     async for _ in kivy_app.do_touch_down_up(widget=button):
-        assert modal._window is None
+        assert not modal._is_open
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
-        assert modal._window is None
+        assert not modal._is_open
 
     # open modal
     modal.open()
     await kivy_app.wait_clock_frames(2)
-    assert modal._window is not None
+    assert modal._is_open
     assert isclose(modal.center_x, button.center_x, abs_tol=.1)
     assert isclose(modal.center_y, button.center_y, abs_tol=.1)
 
     # press within modal area - should stay open
     async for _ in kivy_app.do_touch_down_up(widget=button):
         pass
-    assert modal._window is not None
+    assert modal._is_open
     # start in modal but release outside - should stay open
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
         pass
-    assert modal._window is not None
+    assert modal._is_open
 
     # start outside but release in modal - should close
     async for _ in kivy_app.do_touch_drag(
             pos=(button.center_x + button.width / 4, button.center_y),
             target_widget=button):
         pass
-    assert modal._window is None
+    assert not modal._is_open
 
     # open modal again
     modal.open()
     await kivy_app.wait_clock_frames(2)
-    assert modal._window is not None
+    assert modal._is_open
 
     # press outside modal area - should close
     async for _ in kivy_app.do_touch_down_up(
             pos=(button.center_x + button.width / 4, button.center_y)):
         pass
-    assert modal._window is None
+    assert not modal._is_open

--- a/kivy/tests/test_uix_modal.py
+++ b/kivy/tests/test_uix_modal.py
@@ -16,16 +16,19 @@ def modal_app():
 
         def on_touch_down(self, touch):
             """ touch down event handler. """
+            assert self.modal._window is None
             assert not self.modal._is_open
             return super(ModalButton, self).on_touch_down(touch)
 
         def on_touch_move(self, touch):
             """ touch move event handler. """
+            assert self.modal._window is None
             assert not self.modal._is_open
             return super(ModalButton, self).on_touch_move(touch)
 
         def on_touch_up(self, touch):
             """ touch up event handler. """
+            assert self.modal._window is None
             assert not self.modal._is_open
             return super(ModalButton, self).on_touch_up(touch)
 
@@ -46,17 +49,21 @@ async def test_modal_app(kivy_app):
     button = kivy_app.root
     modal = button.modal
     modal._anim_duration = 0
+    assert modal._window is None
     assert not modal._is_open
 
     # just press button
     async for _ in kivy_app.do_touch_down_up(widget=button):
+        assert modal._window is None
         assert not modal._is_open
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
+        assert modal._window is None
         assert not modal._is_open
 
     # open modal
     modal.open()
     await kivy_app.wait_clock_frames(2)
+    assert modal._window is not None
     assert modal._is_open
     assert isclose(modal.center_x, button.center_x, abs_tol=.1)
     assert isclose(modal.center_y, button.center_y, abs_tol=.1)
@@ -64,10 +71,12 @@ async def test_modal_app(kivy_app):
     # press within modal area - should stay open
     async for _ in kivy_app.do_touch_down_up(widget=button):
         pass
+    assert modal._window is not None
     assert modal._is_open
     # start in modal but release outside - should stay open
     async for _ in kivy_app.do_touch_drag(widget=button, dx=button.width / 4):
         pass
+    assert modal._window is not None
     assert modal._is_open
 
     # start outside but release in modal - should close
@@ -75,15 +84,18 @@ async def test_modal_app(kivy_app):
             pos=(button.center_x + button.width / 4, button.center_y),
             target_widget=button):
         pass
+    assert modal._window is None
     assert not modal._is_open
 
     # open modal again
     modal.open()
     await kivy_app.wait_clock_frames(2)
+    assert modal._window is not None
     assert modal._is_open
 
     # press outside modal area - should close
     async for _ in kivy_app.do_touch_down_up(
             pos=(button.center_x + button.width / 4, button.center_y)):
         pass
+    assert modal._window is None
     assert not modal._is_open

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -77,7 +77,6 @@ returning `True` from your callback::
 __all__ = ('ModalView', )
 
 from kivy.animation import Animation
-from kivy.core.window import Window
 from kivy.properties import (
     StringProperty, BooleanProperty, ObjectProperty, NumericProperty,
     ListProperty, ColorProperty)
@@ -119,7 +118,6 @@ class ModalView(AnchorLayout):
     defaults to True.
     '''
 
-    # noinspection PyArgumentEqualDefault
     attach_to = ObjectProperty(None, deprecated=True)
     '''If a widget is set on attach_to, the view will attach to the nearest
     parent window of the widget. If none is found, it will attach to the
@@ -180,7 +178,6 @@ class ModalView(AnchorLayout):
 
     # Internals properties used for graphical representation.
 
-    # noinspection PyArgumentEqualDefault
     _anim_alpha = NumericProperty(0)
 
     _anim_duration = NumericProperty(.1)
@@ -206,6 +203,7 @@ class ModalView(AnchorLayout):
             view.open(animation=False)
 
         """
+        from kivy.core.window import Window
         if self._is_open:
             return
         self._window = Window
@@ -255,7 +253,7 @@ class ModalView(AnchorLayout):
 
     def _align_center(self, *_args):
         if self._is_open:
-            self.center = Window.center
+            self.center = self._window.center
 
     def on_touch_down(self, touch):
         """ touch down event handler. """
@@ -316,6 +314,7 @@ class ModalView(AnchorLayout):
 if __name__ == '__main__':
     from kivy.base import runTouchApp
     from kivy.uix.button import Button
+    from kivy.core.window import Window
     from kivy.uix.label import Label
     from kivy.uix.gridlayout import GridLayout
 

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -1,11 +1,11 @@
-'''
+"""
 ModalView
 =========
 
 .. versionadded:: 1.4.0
 
 The :class:`ModalView` widget is used to create modal views. By default, the
-view will cover the whole "parent" window.
+view will cover the whole "main" window.
 
 Remember that the default size of a Widget is size_hint=(1, 1). If you don't
 want your view to be fullscreen, either use size hints with values lower than
@@ -32,7 +32,7 @@ the ModalView instance::
 
     view.dismiss()
 
-Both :meth:`ModalView.open` and :meth:`ModalView.dismiss` are bindable. That
+Both :meth:`ModalView.open` and :meth:`ModalView.dismiss` are bind-able. That
 means you can directly bind the function to an action, e.g. to a button's
 on_press ::
 
@@ -51,10 +51,12 @@ on_press ::
 ModalView Events
 ----------------
 
-There are two events available: `on_open` which is raised when the view is
-opening, and `on_dismiss` which is raised when the view is closed.
-For `on_dismiss`, you can prevent the view from closing by explicitly returning
-True from your callback. ::
+There are four events available: `on_pre_open` and `on_open` which are raised
+when the view is opening; `on_pre_dismiss` and `on_dismiss` which are raised
+when the view is closed.
+
+For `on_dismiss`, you can prevent the view from closing by explicitly
+returning `True` from your callback::
 
     def my_callback(instance):
         print('ModalView', instance, 'is being dismissed, but is prevented!')
@@ -70,19 +72,20 @@ True from your callback. ::
     keyboard if the :attr:`ModalView.auto_dismiss` property is True (the
     default).
 
-'''
+"""
 
 __all__ = ('ModalView', )
 
-from kivy.logger import Logger
 from kivy.animation import Animation
+from kivy.core.window import Window
+from kivy.properties import (
+    StringProperty, BooleanProperty, ObjectProperty, NumericProperty,
+    ListProperty, ColorProperty)
 from kivy.uix.anchorlayout import AnchorLayout
-from kivy.properties import StringProperty, BooleanProperty, ObjectProperty, \
-    NumericProperty, ListProperty, ColorProperty
 
 
 class ModalView(AnchorLayout):
-    '''ModalView class. See module documentation for more information.
+    """ModalView class. See module documentation for more information.
 
     :Events:
         `on_pre_open`:
@@ -102,23 +105,14 @@ class ModalView(AnchorLayout):
     .. versionchanged:: 2.0.0
         Added property 'overlay_color'.
 
-    '''
+    """
 
-    auto_dismiss = BooleanProperty(True)
+    auto_dismiss = BooleanProperty()
     '''This property determines if the view is automatically
     dismissed when the user clicks outside it.
 
     :attr:`auto_dismiss` is a :class:`~kivy.properties.BooleanProperty` and
     defaults to True.
-    '''
-
-    attach_to = ObjectProperty(None)
-    '''If a widget is set on attach_to, the view will attach to the nearest
-    parent window of the widget. If none is found, it will attach to the
-    main/global Window.
-
-    :attr:`attach_to` is an :class:`~kivy.properties.ObjectProperty` and
-    defaults to None.
     '''
 
     background_color = ColorProperty([1, 1, 1, 1])
@@ -172,11 +166,11 @@ class ModalView(AnchorLayout):
 
     # Internals properties used for graphical representation.
 
-    _anim_alpha = NumericProperty(0)
+    _anim_alpha = NumericProperty()
 
     _anim_duration = NumericProperty(.1)
 
-    _window = ObjectProperty(None, allownone=True, rebind=True)
+    _window = ObjectProperty(allownone=True, rebind=True)
 
     _touch_started_inside = None
 
@@ -186,38 +180,16 @@ class ModalView(AnchorLayout):
         self._parent = None
         super(ModalView, self).__init__(**kwargs)
 
-    def _search_window(self):
-        # get window to attach to
-        window = None
-        if self.attach_to is not None:
-            window = self.attach_to.get_parent_window()
-            if not window:
-                window = self.attach_to.get_root_window()
-        if not window:
-            from kivy.core.window import Window
-            window = Window
-        return window
-
-    def open(self, *largs, **kwargs):
-        '''Show the view window from the :attr:`attach_to` widget. If set, it
-        will attach to the nearest window. If the widget is not attached to any
-        window, the view will attach to the global
-        :class:`~kivy.core.window.Window`.
+    def open(self, *_args, **kwargs):
+        """ attach this view to the main window.
 
         When the view is opened, it will be faded in with an animation. If you
         don't want the animation, use::
 
             view.open(animation=False)
 
-        '''
-        if self._window is not None:
-            Logger.warning('ModalView: you can only open once.')
-            return
-        # search window
-        self._window = self._search_window()
-        if not self._window:
-            Logger.warning('ModalView: cannot open view, no window found.')
-            return
+        """
+        self._window = Window
         self.dispatch('on_pre_open')
         self._window.add_widget(self)
         self._window.bind(
@@ -228,27 +200,27 @@ class ModalView(AnchorLayout):
         self.fbind('size', self._align_center)
         if kwargs.get('animation', True):
             a = Animation(_anim_alpha=1., d=self._anim_duration)
-            a.bind(on_complete=lambda *x: self.dispatch('on_open'))
+            a.bind(on_complete=lambda *_args: self.dispatch('on_open'))
             a.start(self)
         else:
             self._anim_alpha = 1.
             self.dispatch('on_open')
 
-    def dismiss(self, *largs, **kwargs):
-        '''Close the view if it is open. If you really want to close the
-        view, whatever the on_dismiss event returns, you can use the *force*
-        argument:
-        ::
+    def dismiss(self, *_args, **kwargs):
+        """ Close the view if it is open.
+
+        If you really want to close the view, whatever the on_dismiss
+        event returns, you can use the *force* keyword argument::
 
             view = ModalView()
             view.dismiss(force=True)
 
         When the view is dismissed, it will be faded out before being
-        removed from the parent. If you don't want animation, use::
+        removed from the parent. If you don't want this animation, use::
 
             view.dismiss(animation=False)
 
-        '''
+        """
         if self._window is None:
             return
         self.dispatch('on_pre_dismiss')
@@ -261,22 +233,25 @@ class ModalView(AnchorLayout):
             self._anim_alpha = 0
             self._real_remove_widget()
 
-    def _align_center(self, *l):
+    def _align_center(self, *_args):
         if self._window:
             self.center = self._window.center
 
     def on_touch_down(self, touch):
+        """ touch down event handler. """
         self._touch_started_inside = self.collide_point(*touch.pos)
         if not self.auto_dismiss or self._touch_started_inside:
             super(ModalView, self).on_touch_down(touch)
         return True
 
     def on_touch_move(self, touch):
+        """ touch moved event handler. """
         if not self.auto_dismiss or self._touch_started_inside:
             super(ModalView, self).on_touch_move(touch)
         return True
 
     def on_touch_up(self, touch):
+        """ touch up event handler. """
         # Explicitly test for False as None occurs when shown by on_touch_down
         if self.auto_dismiss and self._touch_started_inside is False:
             self.dismiss()
@@ -285,7 +260,8 @@ class ModalView(AnchorLayout):
         self._touch_started_inside = None
         return True
 
-    def on__anim_alpha(self, instance, value):
+    def on__anim_alpha(self, _instance, value):
+        """ animation progress callback. """
         if value == 0 and self._window is not None:
             self._real_remove_widget()
 
@@ -299,18 +275,22 @@ class ModalView(AnchorLayout):
         self._window = None
 
     def on_pre_open(self):
+        """ default pre-open event handler. """
         pass
 
     def on_open(self):
+        """ default open event handler. """
         pass
 
     def on_pre_dismiss(self):
+        """ default pre-dismiss event handler. """
         pass
 
     def on_dismiss(self):
+        """ default dismiss event handler. """
         pass
 
-    def _handle_keyboard(self, window, key, *largs):
+    def _handle_keyboard(self, _window, key, *_args):
         if key == 27 and self.auto_dismiss:
             self.dismiss()
             return True
@@ -321,25 +301,19 @@ if __name__ == '__main__':
     from kivy.uix.button import Button
     from kivy.uix.label import Label
     from kivy.uix.gridlayout import GridLayout
-    from kivy.core.window import Window
 
     # add view
     content = GridLayout(cols=1)
     content.add_widget(Label(text='This is a hello world'))
-    view = ModalView(size_hint=(None, None), size=(256, 256),
-                     auto_dismiss=True)
+    view = ModalView(size_hint=(None, None), size=(256, 256))
     view.add_widget(content)
-
-    def open_view(btn):
-        view.open()
 
     layout = GridLayout(cols=3)
     for x in range(9):
-        btn = Button(text='click me %s' % x)
+        btn = Button(text=f"click me {x}")
         btn.bind(on_release=view.open)
         layout.add_widget(btn)
     Window.add_widget(layout)
 
     view.open()
-
     runTouchApp()

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -79,8 +79,8 @@ __all__ = ('ModalView', )
 from kivy.animation import Animation
 from kivy.core.window import Window
 from kivy.properties import (
-    StringProperty, BooleanProperty, NumericProperty, ListProperty,
-    ColorProperty)
+    StringProperty, BooleanProperty, ObjectProperty, NumericProperty,
+    ListProperty, ColorProperty)
 from kivy.uix.anchorlayout import AnchorLayout
 
 
@@ -170,6 +170,8 @@ class ModalView(AnchorLayout):
 
     _anim_duration = NumericProperty(.1)
 
+    _window = ObjectProperty(allownone=True, rebind=True)
+
     _is_open = BooleanProperty(False)
 
     _touch_started_inside = None
@@ -189,14 +191,14 @@ class ModalView(AnchorLayout):
             view.open(animation=False)
 
         """
+        self._window = Window
         self._is_open = True
         self.dispatch('on_pre_open')
-        main_win = Window
-        main_win.add_widget(self)
-        main_win.bind(
+        Window.add_widget(self)
+        Window.bind(
             on_resize=self._align_center,
             on_keyboard=self._handle_keyboard)
-        self.center = main_win.center
+        self.center = Window.center
         self.fbind('center', self._align_center)
         self.fbind('size', self._align_center)
         if kwargs.get('animation', True):
@@ -269,12 +271,12 @@ class ModalView(AnchorLayout):
     def _real_remove_widget(self):
         if not self._is_open:
             return
-        main_win = Window
-        main_win.remove_widget(self)
-        main_win.unbind(
+        Window.remove_widget(self)
+        Window.unbind(
             on_resize=self._align_center,
             on_keyboard=self._handle_keyboard)
         self._is_open = False
+        self._window = None
 
     def on_pre_open(self):
         """ default pre-open event handler. """

--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -72,6 +72,13 @@ returning `True` from your callback::
     keyboard if the :attr:`ModalView.auto_dismiss` property is True (the
     default).
 
+.. versionchanged:: 2.1.0
+    Removed `attach_to` property. In contrary to :attr:`DropDown.attach_to`
+    it had no influence on the positioning of a `ModalView` instance; it got
+    only used to determine the main window, which results in any case as
+    :data:`kivy.core.window.Window`. Simply remove it from your project code
+    if you update an old project to the Kivy version 2.1.0 or higher.
+
 """
 
 __all__ = ('ModalView', )


### PR DESCRIPTION
#7412 -discussion-follow-up from 14-Mar-2021 with @matham (pinging @tshirtman).

- removed unneeded _search_window() method and attach_to property.
- added undocumented events on_pre_open and on_pre_dismiss to module docstring.
- allow stacking of multiple ModalView instances.
- simplified demo code.
- simplified unit test (test_uix_modal.py).

This is a WIP commit (1 of 2) - if you agree with the changes done in this first step, I'd like to go even further and replace the current `_window` property of ModalView with the main window `kivy.core.window.Window`, because `_window` is currently only used as a flag if the modal view is opened/visible (holding `None` if not opened or the main window instance if opened).

The only place where the window instance is accessed is in the declaration of ModalView (in style.kv), which could also be replaced with `Window`.

The opening state of the modal view could then be represented by an added `is_open` property (will be added in commit 2 of 2).

These changes would make the modal view faster, more readable/understandable, and easier to maintain/test.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
