### PR TITLE
Docs: Fix creating of docs of compoundselection.py

### DIFF
--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -129,11 +129,11 @@ __all__ = ('CompoundSelectionBehavior', )
 from time import time
 from os import environ
 
-from kivy.config import Config
 from kivy.properties import NumericProperty, BooleanProperty, ListProperty
 
 
 if 'KIVY_DOC' not in environ:
+    from kivy.config import Config
     _is_desktop = Config.getboolean('kivy', 'desktop')
 else:
     _is_desktop = False


### PR DESCRIPTION
It's a possible fix for readthedocs error while creating docs.

Traceback from readthedocs:
```
Configuration error:
There is a programable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/sphinx/config.py", line 161, in __init__
    execfile_(filename, config)
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "conf.py", line 73, in <module>
    import autobuild
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/checkouts/7387/doc/autobuild.py", line 35, in <module>
    import kivy.core.gl
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/kivy/core/gl/__init__.py", line 83, in <module>
    import kivy.core.window  # NOQA
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/kivy/core/window/__init__.py", line 28, in <module>
    from kivy.uix.behaviors import FocusBehavior
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/kivy/uix/behaviors/__init__.py", line 90, in <module>
    from kivy.uix.behaviors.compoundselection import CompoundSelectionBehavior
  File "/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/kivy/uix/behaviors/compoundselection.py", line 137, in <module>
    _is_desktop = Config.getboolean('kivy', 'desktop')
AttributeError: 'NoneType' object has no attribute 'getboolean'

/home/docs/checkouts/readthedocs.org/user_builds/kivy/envs/7387/lib/python3.7/site-packages/kivy/__init__.py

```

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
