### PR TITLE
EventDispatcher: Rename method unregister_event_types to unregister_event_type

### DIFF
--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -13,6 +13,7 @@ handlers.
 
 __all__ = ('EventDispatcher', 'ObjectWithUid', 'Observable')
 
+cimport cython
 from libc.stdlib cimport malloc, free
 from libc.string cimport memset
 
@@ -24,6 +25,7 @@ from kivy.compat import string_types
 from kivy.properties cimport (Property, PropertyStorage, ObjectProperty,
     NumericProperty, StringProperty, ListProperty, DictProperty,
     BooleanProperty)
+from kivy.utils import deprecated
 
 cdef int widget_uid = 0
 cdef dict cache_properties = {}
@@ -286,6 +288,12 @@ cdef class EventDispatcher(ObjectWithUid):
         if event_type not in self.__event_stack:
             self.__event_stack[event_type] = EventObservers.__new__(
                 EventObservers, 1, 0)
+
+    @deprecated(msg='Deprecated in 2.1.0, use unregister_event_type instead. '
+                    'Will be removed after two releases')
+    @cython.binding(True)
+    def unregister_event_types(self, event_type):
+        self.unregister_event_type(event_type)
 
     def unregister_event_type(self, event_type):
         '''Unregister an event type in the dispatcher.

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -287,11 +287,14 @@ cdef class EventDispatcher(ObjectWithUid):
             self.__event_stack[event_type] = EventObservers.__new__(
                 EventObservers, 1, 0)
 
-    def unregister_event_types(self, event_type):
+    def unregister_event_type(self, event_type):
         '''Unregister an event type in the dispatcher.
+
+        .. versionchanged:: 2.1.0
+            Method renamed from `unregister_event_types` to
+            `unregister_event_type`.
         '''
-        if event_type in self.__event_stack:
-            del self.__event_stack[event_type]
+        self.__event_stack.pop(event_type, None)
 
     def is_event_type(self, event_type):
         '''Return True if the event_type is already registered.


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
