### PR TITLE
Docs: Fix Type Error when creating bytes from array in Python 3

### DIFF
--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -59,7 +59,7 @@ For example, to blit immutable bytes data::
     buf = [int(x * 255 / size) for x in range(size)]
 
     # then, convert the array to a ubyte string
-    buf = b''.join(map(chr, buf))
+    buf = bytes(buf)
 
     # then blit the buffer
     texture.blit_buffer(buf, colorfmt='rgb', bufferfmt='ubyte')


### PR DESCRIPTION
The original line `buf = b''.join(map(chr, buf))` raises the following error in 3.8.6:
    `TypeError: sequence item 0: expected a bytes-like object, str found`
