### PR TITLE
Graphics: Only check for threading issues once graphics is initialized

### DIFF
--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -55,7 +55,8 @@ cdef class Instruction(ObjectWithUid):
             self.flags |= GI_NO_REMOVE
             return
 
-        if verify_gl_main_thread and get_ident() != initialized_tid:
+        if verify_gl_main_thread and initialized_tid \
+                and get_ident() != initialized_tid:
             raise TypeError("Cannot create graphics instruction outside "
                             "the main Kivy thread")
 
@@ -82,7 +83,8 @@ cdef class Instruction(ObjectWithUid):
             self.flags |= GI_NEEDS_UPDATE
 
     cpdef flag_data_update(self):
-        if verify_gl_main_thread and get_ident() != initialized_tid:
+        if verify_gl_main_thread and initialized_tid \
+                and get_ident() != initialized_tid:
             raise TypeError("Cannot change graphics instruction outside "
                             "the main Kivy thread")
         self.flag_update()


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


This fixes an issue, where if you created graphics instructions before kivy gl thread was initialized (which seems to happen with ScrollView), it would the error that you're accessing the graphics from the wrong thread. This fixes so it only does it once the thread has been initialized.

While technically this would allow people to create graphics from another thread before the kivy thread was initialized and it wouldn't warn about it. But it shouldn't happen often and this would still warn for the most common situation, while not warning on false positive.