### PR TITLE
Properties: Accept str-subclass where we accept strings

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -737,7 +737,7 @@ cdef class NumericProperty(Property):
             ps.numeric_fmt = 'px'
             ps.original_num = x
             return x
-        if tp is str:
+        if isinstance(x, str):
             return self.parse_str(obj, x, ps)
 
         if tp is tuple or tp is list:
@@ -793,7 +793,7 @@ cdef class StringProperty(Property):
     cdef check(self, EventDispatcher obj, value, PropertyStorage property_storage):
         if Property.check(self, obj, value, property_storage):
             return True
-        if type(value) is not str:
+        if not isinstance(value, str):
             raise ValueError('%s.%s accept only str' % (
                 obj.__class__.__name__,
                 self.name))
@@ -1765,7 +1765,8 @@ cdef class VariableListProperty(Property):
     cdef check(self, EventDispatcher obj, value, PropertyStorage property_storage):
         if Property.check(self, obj, value, property_storage):
             return True
-        if type(value) not in (int, float, list, tuple, str):
+        if type(value) not in (int, float, list, tuple, str) \
+                and not isinstance(value, str):
             err = '%s.%s accepts only int/float/list/tuple/str (got %r)'
             raise ValueError(err % (obj.__class__.__name__, self.name, value))
 
@@ -1786,7 +1787,7 @@ cdef class VariableListProperty(Property):
         # reset here, it'll be changed in parse is we use anything that is not px
         ps.uses_scaling = 0
         try:
-            if tp is int or tp is float or tp is str:
+            if tp is int or tp is float or isinstance(x, str):
                 y = self._convert_numeric(obj, x, ps)
                 if self.length == 4:
                     return [y, y, y, y]
@@ -1849,7 +1850,7 @@ cdef class VariableListProperty(Property):
         tp = type(x)
         if tp is int or tp is float:
             return x
-        if tp is str:
+        if isinstance(x, str):
             return self.parse_str(obj, x, ps)
 
         try:
@@ -2224,7 +2225,7 @@ cdef class ColorProperty(Property):
             return x
         cdef object color = x
         try:
-            if type(x) is str:
+            if isinstance(x, str):
                 color = self.parse_str(obj, x)
             color = self.parse_list(obj, color)
         except (ValueError, TypeError) as e:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

This revert back to previous behavior to consistently check if something is a instance of str or its subclasses, rather than if it's exactly a str. See https://github.com/kivy/kivy/pull/6984#issuecomment-811364105 for the reason.