### PR TITLE
AsyncImageTestCase: Fix for test_reload_asyncimage method and cleanup

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -12,7 +12,7 @@ The screenshots live in the 'kivy/tests/results' folder and are in PNG format,
 
 __all__ = (
     'GraphicUnitTest', 'UnitTestTouch', 'UTMotionEvent', 'async_run',
-    'requires_graphics')
+    'requires_graphics', 'ensure_web_server')
 
 import unittest
 import logging

--- a/kivy/tests/test_uix_asyncimage.py
+++ b/kivy/tests/test_uix_asyncimage.py
@@ -1,25 +1,26 @@
-from kivy.tests.common import GraphicUnitTest, ensure_web_server
-
-from kivy.uix.image import AsyncImage
-from kivy.config import Config
-from kivy import kivy_examples_dir
-
-from zipfile import ZipFile
-from os.path import join, dirname, abspath
 from os import remove
-
+from os.path import join
+from shutil import copyfile, rmtree
+from tempfile import mkdtemp
+from threading import Event
+from zipfile import ZipFile
 try:
     from urllib import urlretrieve
 except ImportError:
     from urllib.request import urlretrieve
 
+from kivy.tests.common import GraphicUnitTest, ensure_web_server
+
 
 class AsyncImageTestCase(GraphicUnitTest):
+
     @classmethod
     def setUpClass(cls):
+        from kivy import kivy_examples_dir
         ensure_web_server(kivy_examples_dir)
 
     def setUp(self):
+        from kivy.config import Config
         self.maxfps = Config.getint('graphics', 'maxfps')
         assert(self.maxfps > 0)
         super(AsyncImageTestCase, self).setUp()
@@ -28,30 +29,24 @@ class AsyncImageTestCase(GraphicUnitTest):
         with ZipFile(path) as zipf:
             return len(zipf.namelist())
 
-    def load_zipimage(self, source, frames):
-        # keep running the test until loaded (or timeout)
-        maxfps = self.maxfps
-        timeout = 30 * maxfps
-
-        # load ZIP with images named: 000.png, 001.png, ...
-        image = AsyncImage(
-            source=source,
-            anim_delay=0.0333333333333333
-        )
-        image.test_loaded = False
-        self.render(image)
-
-        # bind to 'on_load' because there are various
-        # steps where the image is (re)loaded, but
-        # the event is triggered only at the end
-        image.bind(on_load=lambda *_, **__: setattr(
-            image, 'test_loaded', True
-        ))
-
-        while timeout and not image.test_loaded:
+    def wait_for_event_or_timeout(self, event):
+        timeout = 30 * self.maxfps
+        while timeout and not event.is_set():
             self.advance_frames(1)
             timeout -= 1
 
+    def load_zipimage(self, source, frames):
+        # load ZIP with images named: 000.png, 001.png, ...
+        from kivy.uix.image import AsyncImage
+        event = Event()
+        image = AsyncImage(anim_delay=0.0333333333333333)
+        # bind to 'on_load' because there are various
+        # steps where the image is (re)loaded, but
+        # the event is triggered only at the end
+        image.bind(on_load=lambda *_args, **kwargs: event.set())
+        image.source = source
+        self.wait_for_event_or_timeout(event)
+        self.render(image)
         proxyimg = image._coreimage
         self.assertTrue(proxyimg.anim_available)
         self.assertEqual(len(proxyimg.image.textures), frames)
@@ -59,17 +54,15 @@ class AsyncImageTestCase(GraphicUnitTest):
 
     def test_remote_zipsequence(self):
         # cube ZIP has 63 PNGs used for animation
-        ZIP = (
+        zip_cube = (
             'http://localhost:8000/widgets/'
             'sequenced_images/data/images/cube.zip'
         )
-
         # ref Loader._load_urllib
-        tempf, headers = urlretrieve(ZIP)
-        ZIP_pngs = self.zip_frames(tempf)
+        tempf, headers = urlretrieve(zip_cube)
+        zip_pngs = self.zip_frames(tempf)
         remove(tempf)
-
-        image = self.load_zipimage(ZIP, ZIP_pngs)
+        image = self.load_zipimage(zip_cube, zip_pngs)
         # pure delay * fps isn't enough and
         # just +1 isn't either (index collisions)
         self.assertTrue(self.check_sequence_frames(
@@ -79,13 +72,13 @@ class AsyncImageTestCase(GraphicUnitTest):
 
     def test_local_zipsequence(self):
         # cube ZIP has 63 PNGs used for animation
-        ZIP = join(
+        from kivy import kivy_examples_dir
+        zip_cube = join(
             kivy_examples_dir, 'widgets', 'sequenced_images',
             'data', 'images', 'cube.zip'
         )
-        ZIP_pngs = self.zip_frames(ZIP)
-
-        image = self.load_zipimage(ZIP, ZIP_pngs)
+        zip_pngs = self.zip_frames(zip_cube)
+        image = self.load_zipimage(zip_cube, zip_pngs)
         # pure delay * fps isn't enough and
         # just +1 isn't either (index collisions)
         self.assertTrue(self.check_sequence_frames(
@@ -97,41 +90,42 @@ class AsyncImageTestCase(GraphicUnitTest):
         # check whether it really changes the images
         # in the anim_delay interval
         old = None
-
         while slides:
             # different frames, sequence is changing
             self.assertNotEqual(img.anim_index, old)
-
             old = img.anim_index
-            self.advance_frames(
-                frames
-            )
+            self.advance_frames(frames)
             slides -= 1
-
         return True
 
     def test_reload_asyncimage(self):
         from kivy.resources import resource_find
-        from tempfile import mkdtemp
-        from os import remove
-        from shutil import copyfile, rmtree
+        from kivy.uix.image import AsyncImage
+
+        temp_dir = mkdtemp()
+        event = Event()
+        image = AsyncImage()
+        image.bind(on_load=lambda *args, **kwargs: event.set())
 
         fn = resource_find('data/logo/kivy-icon-16.png')
-        t = mkdtemp()
-        source = join(t, 'source.png')
+        source = join(temp_dir, 'source.png')
         copyfile(fn, source)
-        image = AsyncImage(source=source)
+        event.clear()
+        image.source = source
+        self.wait_for_event_or_timeout(event)
         self.render(image, framecount=2)
         self.assertEqual(image.texture_size, [16, 16])
         remove(source)
 
         fn = resource_find('data/logo/kivy-icon-32.png')
         copyfile(fn, source)
+        event.clear()
         image.reload()
+        self.wait_for_event_or_timeout(event)
         self.render(image, framecount=2)
         self.assertEqual(image.texture_size, [32, 32])
         remove(source)
-        rmtree(t)
+        rmtree(temp_dir)
 
 
 if __name__ == '__main__':

--- a/kivy/tests/test_uix_asyncimage.py
+++ b/kivy/tests/test_uix_asyncimage.py
@@ -43,7 +43,7 @@ class AsyncImageTestCase(GraphicUnitTest):
         # bind to 'on_load' because there are various
         # steps where the image is (re)loaded, but
         # the event is triggered only at the end
-        image.bind(on_load=lambda *_args, **kwargs: event.set())
+        image.bind(on_load=lambda *args, **kwargs: event.set())
         image.source = source
         self.wait_for_event_or_timeout(event)
         self.render(image)


### PR DESCRIPTION
Fixes sync bug in `test_reload_asyncimage` which can cause this test to fail.

```
__________________ AsyncImageTestCase.test_reload_asyncimage __________________

self = <kivy.tests.test_uix_asyncimage.AsyncImageTestCase testMethod=test_reload_asyncimage>

    def test_reload_asyncimage(self):
        from kivy.resources import resource_find
        from tempfile import mkdtemp
        from os import remove
        from shutil import copyfile, rmtree
    
        fn = resource_find('data/logo/kivy-icon-16.png')
        t = mkdtemp()
        source = join(t, 'source.png')
        copyfile(fn, source)
        image = AsyncImage(source=source)
        self.render(image, framecount=2)
>       self.assertEqual(image.texture_size, [16, 16])
E       AssertionError: [32, 32] != [16, 16]

kivy\tests\test_uix_asyncimage.py:125: AssertionError
```
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
