### PR TITLE
Text: Raise when registering a font_regular with None

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -305,6 +305,9 @@ class LabelBase(object):
         fn_regular will be used instead.
         '''
 
+        if font_regular is None:
+            raise valueError("font_regular cannot be None")
+
         fonts = []
 
         for font_type in fn_regular, fn_italic, fn_bold, fn_bolditalic:

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -306,7 +306,7 @@ class LabelBase(object):
         '''
 
         if font_regular is None:
-            raise valueError("font_regular cannot be None")
+            raise ValueError("font_regular cannot be None")
 
         fonts = []
 

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -305,7 +305,7 @@ class LabelBase(object):
         fn_regular will be used instead.
         '''
 
-        if font_regular is None:
+        if fn_regular is None:
             raise ValueError("font_regular cannot be None")
 
         fonts = []


### PR DESCRIPTION
Currently, if the user tries to pass None for font_regular, then using it as fallback for other types won't work, raising an IndexError, of which the cause might not be clear to users.
Preemptively raising in this case seems better.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
