### PR TITLE
MouseHoverEventTestCase: Fix failing unit test on CI

### DIFF
--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -27,10 +27,9 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         # Patch `win.on_close` method to prevent EventLoop from removing
         # window from event listeners list.
         self.old_on_close = win.on_close
-        win.on_close = lambda *args: None
+        win.on_close = lambda *args, **kwargs: None
 
     def tearDown(self, fake=False):
-        super().tearDown(fake)
         self.etype = None
         self.motion_event = None
         self.touch_event = None
@@ -47,6 +46,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         # Restore method `on_close` to window
         win.on_close = self.old_on_close
         self.old_on_close = None
+        super().tearDown(fake)
 
     def on_motion(self, _, etype, event):
         self.etype = etype

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -5,9 +5,6 @@ class MouseHoverEventTestCase(GraphicUnitTest):
     '''Tests hover event from `MouseMotionEventProvider`.
     '''
 
-    framecount = 3
-    '''Must be equal of max number of `self.advance_frame` in test method.'''
-
     def setUp(self):
         super().setUp()
         self.etype = None
@@ -163,6 +160,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
 
     def test_with_full_cycle_with_cursor_events(self):
         win, mouse = self.get_providers()
+        self.framecount = 2
         # Test begin event
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos
@@ -179,6 +177,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
 
     def test_with_full_cycle_with_mouse_pos_and_on_close_event(self):
         win, mouse = self.get_providers()
+        self.framecount = 2
         # Test begin event
         x, y = win.mouse_pos = (5.0, 5.0)
         self.advance_frames(1)

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -160,7 +160,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
 
     def test_with_full_cycle_with_cursor_events(self):
         win, mouse = self.get_providers()
-        self.framecount = 2
+        self.framecount = 3
         # Test begin event
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos
@@ -177,7 +177,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
 
     def test_with_full_cycle_with_mouse_pos_and_on_close_event(self):
         win, mouse = self.get_providers()
-        self.framecount = 2
+        self.framecount = 3
         # Test begin event
         x, y = win.mouse_pos = (5.0, 5.0)
         self.advance_frames(1)

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -43,6 +43,8 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         # Restore method `on_close` to window
         win.on_close = self.old_on_close
         self.old_on_close = None
+        # Clear all motion events from EventLoop.touches
+        del EventLoop.touches[:]
         super().tearDown(fake)
 
     def on_motion(self, _, etype, event):

--- a/kivy/tests/test_mouse_multitouchsim.py
+++ b/kivy/tests/test_mouse_multitouchsim.py
@@ -4,6 +4,11 @@ from kivy.tests.common import GraphicUnitTest
 class MultitouchSimulatorTestCase(GraphicUnitTest):
     framecount = 0
 
+    def tearDown(self, fake=False):
+        from kivy.base import EventLoop
+        del EventLoop.touches[:]
+        super().tearDown(fake)
+
     # helper methods
     def correct_y(self, win, y):
         # flip, because the mouse provider uses system's


### PR DESCRIPTION
Possible fix for failing `MultitouchSimulatorTestCase` which fails on CI, but not on a local machine. See https://github.com/kivy/kivy/pull/7387#issuecomment-812091417.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
