### PR TITLE
Add support for preview image to Video

### DIFF
--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -251,12 +251,15 @@ class Image(Widget):
         super().__init__(**kwargs)
 
     def texture_update(self, *largs):
-        if not self.source:
+        self.set_texture_from_resource(self.source)
+
+    def set_texture_from_resource(self, resource):
+        if not resource:
             self._clear_core_image()
             return
-        source = resource_find(self.source)
+        source = resource_find(resource)
         if not source:
-            Logger.error('Image: Not found <%s>' % self.source)
+            Logger.error('Image: Not found <%s>' % resource)
             self._clear_core_image()
             return
         if self._coreimage:
@@ -270,7 +273,7 @@ class Image(Widget):
                 nocache=self.nocache
             )
         except Exception:
-            Logger.error('Image: Error loading <%s>' % self.source)
+            Logger.error('Image: Error loading <%s>' % resource)
             self._clear_core_image()
             image = self._coreimage
         if image:

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -56,9 +56,9 @@ class Video(Image):
     defaults to None.
 
     .. versionchanged:: 2.1.0
-        While the use of ``source`` is the historical way for defining
+        While the use of :attr:`source` is the historical way for defining
         video source and stays supported for backward compatibility, it is
-        recommended to use ``video_source`` instead.
+        recommended to use :attr:`video_source` instead.
     '''
 
     video_source = StringProperty(None, allownone=True)
@@ -74,7 +74,7 @@ class Video(Image):
     '''Filename / source of a preview image displayed before video starts.
 
     :attr:`preview_source` is a :class:`~kivy.properties.StringProperty` and
-    defaults to None. If None/empty string and :attr:`source ` is a
+    defaults to None. If None/empty string and :attr:`source` is a
     filename, that will be used for the preview filename.
     Otherwise, :attr:`source` will be set to :attr:`preview_source`.
 
@@ -180,7 +180,7 @@ class Video(Image):
         self._video = None
         super(Video, self).__init__(**kwargs)
         self.fbind('video_source', self._trigger_video_load)
-        self.fbind('preview_source', self._bc_video_load)
+        self.fbind('preview_source', self._update_source_from_preview)
         if self.preview_source:
             self.source = self.preview_source
 
@@ -213,7 +213,7 @@ class Video(Image):
             raise Exception('Video not loaded.')
         self._video.seek(percent, precise=precise)
 
-    def _bc_video_load(self, inst, val):
+    def _update_source_from_preview(self, inst, val):
         self.source = self.preview_source
 
     def _trigger_video_load(self, *largs):

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -214,7 +214,7 @@ class Video(Image):
         self._video.seek(percent, precise=precise)
 
     def _bc_video_load(self, inst, val):
-        self.video_source = val
+        self.source = self.preview_source
 
     def _trigger_video_load(self, *largs):
         ev = self._video_load_event

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -42,7 +42,7 @@ from kivy.uix.image import Image
 from kivy.core.video import Video as CoreVideo
 from kivy.resources import resource_find
 from kivy.properties import (BooleanProperty, NumericProperty, ObjectProperty,
-                             OptionProperty)
+                             OptionProperty, StringProperty)
 from kivy.logger import Logger
 
 

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -173,11 +173,8 @@ class Video(Image):
     _video_load_event = None
 
     def __init__(self, **kwargs):
-        # B/C case source is given. use it as video source
-        if 'source' in kwargs:
-            kwargs['video_source'] = kwargs['source']
         # Case preview is given
-        if 'preview_source' in kwargs:
+        if kwargs.get('preview_source'):
             kwargs['source'] = kwargs['preview_source']
 
         self._video = None

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -43,7 +43,6 @@ from kivy.core.video import Video as CoreVideo
 from kivy.resources import resource_find
 from kivy.properties import (BooleanProperty, NumericProperty, ObjectProperty,
                              OptionProperty, StringProperty)
-from kivy.logger import Logger
 
 
 class Video(Image):
@@ -57,8 +56,9 @@ class Video(Image):
     defaults to None.
 
     .. versionchanged:: 2.1.0
-        The use of ``source`` property is deprecated. Use ``video_source``
-        instead.
+        While the use of ``source`` is the historical way for defining
+        video source and stays supported for backward compatibility, it is
+        recommended to use ``video_source`` instead.
     '''
 
     video_source = StringProperty(None)
@@ -173,10 +173,6 @@ class Video(Image):
     def __init__(self, **kwargs):
         # B/C case source is given. use it as video source
         if 'source' in kwargs:
-            Logger.warning(
-                'The use of ``source`` property is deprecated. '
-                'Please use ``video_source`` instead.'
-            )
             kwargs['video_source'] = kwargs['source']
         # Case preview is given
         if 'preview_source' in kwargs:
@@ -217,10 +213,6 @@ class Video(Image):
         self._video.seek(percent, precise=precise)
 
     def _bc_video_load(self, inst, val):
-        Logger.warning(
-            'The use of ``source`` property is deprecated. '
-            'Please use ``video_source`` instead.'
-        )
         self.video_source = val
 
     def _trigger_video_load(self, *largs):

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -16,18 +16,22 @@ the video is loaded (when the texture is created)::
 
     def on_position_change(instance, value):
         print('The position in the video is', value)
+
     def on_duration_change(instance, value):
         print('The duration of the video is', value)
+
     video = Video(video_source='PandaSneezes.avi')
-    video.bind(position=on_position_change,
-               duration=on_duration_change)
+    video.bind(
+        position=on_position_change,
+        duration=on_duration_change
+    )
 
 One can define a preview image which gets displayed until the video is
 started/loaded by passing ``preview_image`` to the constructor::
 
     video = Video(
         video_source='PandaSneezes.avi',
-        preview_source='PandaSneezes_priview.png'
+        preview_source='PandaSneezes_preview.png'
     )
 '''
 

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -180,7 +180,9 @@ class Video(Image):
         self._video = None
         super(Video, self).__init__(**kwargs)
         self.fbind('video_source', self._trigger_video_load)
-        self.fbind('source', self._bc_video_load)
+        self.fbind('preview_source', self._bc_video_load)
+        if self.preview_source:
+            self.source = self.preview_source
 
         if "eos" in kwargs:
             self.options["eos"] = kwargs["eos"]

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -18,10 +18,17 @@ the video is loaded (when the texture is created)::
         print('The position in the video is', value)
     def on_duration_change(instance, value):
         print('The duration of the video is', value)
-    video = Video(source='PandaSneezes.avi')
+    video = Video(video_source='PandaSneezes.avi')
     video.bind(position=on_position_change,
                duration=on_duration_change)
 
+One can define a preview image which gets displayed until the video is
+started/loaded by passing ``preview_image`` to the constructor::
+
+    video = Video(
+        video_source='PandaSneezes.avi',
+        preview_source='PandaSneezes_priview.png'
+    )
 '''
 
 __all__ = ('Video', )
@@ -53,7 +60,7 @@ class Video(Image):
     video_source = StringProperty(None)
     '''Filename / source of your video.
 
-    :attr:`source` is a :class:`~kivy.properties.StringProperty` and
+    :attr:`video_source` is a :class:`~kivy.properties.StringProperty` and
     defaults to None.
 
     .. versionadded:: 2.1.0
@@ -62,7 +69,7 @@ class Video(Image):
     preview_source = StringProperty(None)
     '''Filename / source of a preview image displayed before video starts.
 
-    :attr:`source` is a :class:`~kivy.properties.StringProperty` and
+    :attr:`preview_source` is a :class:`~kivy.properties.StringProperty` and
     defaults to None.
 
     .. versionadded:: 2.1.0
@@ -72,10 +79,10 @@ class Video(Image):
     '''String, indicates whether to play, pause, or stop the video::
 
         # start playing the video at creation
-        video = Video(source='movie.mkv', state='play')
+        video = Video(video_source='movie.mkv', state='play')
 
         # create the video, and start later
-        video = Video(source='movie.mkv')
+        video = Video(video_source='movie.mkv')
         # and later
         video.state = 'play'
 
@@ -92,10 +99,10 @@ class Video(Image):
     You can start/stop the video by setting this property::
 
         # start playing the video at creation
-        video = Video(source='movie.mkv', play=True)
+        video = Video(video_source='movie.mkv', play=True)
 
         # create the video, and start later
-        video = Video(source='movie.mkv')
+        video = Video(video_source='movie.mkv')
         # and later
         video.play = True
 

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -196,10 +196,10 @@ class Video(Image):
         super(Video, self).__init__(**kwargs)
 
         # Unbind texture_update on superclass to prevent updating texture
-        # automatically once source gets set.
+        # automatically once source gets set on instance of this class.
         self.funbind('source', self.texture_update)
 
-        # Bind video loading if video_source or source property gets set
+        # Bind video loading if video_source or source property gets set.
         self.fbind('video_source', self._trigger_video_load)
         self.fbind('source', self._bc_video_load)
 
@@ -234,6 +234,12 @@ class Video(Image):
 
     def _bc_video_load(self, inst, val):
         # B/C video loading behavior if source gets set on instance
+
+        # Since we unbound the ``update_texture`` function from ``Image``
+        # on ``source`` change, we need to update the texture manually to
+        # ensure corrent B/C behavior when setting ``source`` property on
+        # instance.
+        self.set_texture_from_resource(val)
         self.video_source = val
 
     def _trigger_video_load(self, *largs):

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -74,7 +74,9 @@ class Video(Image):
     '''Filename / source of a preview image displayed before video starts.
 
     :attr:`preview_source` is a :class:`~kivy.properties.StringProperty` and
-    defaults to None.
+    defaults to None. If None/empty string and :attr:`source ` is a
+    filename, that will be used for the preview filename.
+    Otherwise, :attr:`source` will be set to :attr:`preview_source`.
 
     .. versionadded:: 2.1.0
     '''

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -186,7 +186,7 @@ class Video(Image):
 
         if "eos" in kwargs:
             self.options["eos"] = kwargs["eos"]
-        if self.video_source:
+        if self.source or self.video_source:
             self._trigger_video_load()
 
     def seek(self, percent, precise=True):

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -231,7 +231,7 @@ class Video(Image):
             self._video = None
             self.texture = None
         else:
-            filename = self.video_source
+            filename = self.video_source or self.source
             # Check if filename is not url
             if '://' not in filename:
                 filename = resource_find(filename)

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -227,7 +227,7 @@ class Video(Image):
         if CoreVideo is None:
             return
         self.unload()
-        if not self.video_source:
+        if not self.source and not self.video_source:
             self._video = None
             self.texture = None
         else:

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -49,7 +49,7 @@ class Video(Image):
     '''Video class. See module documentation for more information.
     '''
 
-    source = StringProperty(None)
+    source = StringProperty(None, allownone=True)
     '''Filename / source of your video.
 
     :attr:`source` is a :class:`~kivy.properties.StringProperty` and
@@ -61,7 +61,7 @@ class Video(Image):
         recommended to use ``video_source`` instead.
     '''
 
-    video_source = StringProperty(None)
+    video_source = StringProperty(None, allownone=True)
     '''Filename / source of your video.
 
     :attr:`video_source` is a :class:`~kivy.properties.StringProperty` and
@@ -70,7 +70,7 @@ class Video(Image):
     .. versionadded:: 2.1.0
     '''
 
-    preview_source = StringProperty(None)
+    preview_source = StringProperty(None, allownone=True)
     '''Filename / source of a preview image displayed before video starts.
 
     :attr:`preview_source` is a :class:`~kivy.properties.StringProperty` and


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

Here's the PR to https://github.com/kivy/kivy/issues/7470

The behavior is as follows:

- If ``Video`` gets created with ``source`` argument, a deprecation warning is logged that this usage is deprecated, and passed ``source`` value is set as ``video_source``. Same applies if setting ``source`` property on instance.
- If ``Video`` gets created with ``video_source`` argument only, the underlying ``Image.source`` keeps untouched, thus stays ``None``. This way we avoid the annoying Image not found log message.
- If ``Video`` gets created with ``video_source``  and ``preview_source`` arguments, latter is passed as ``source`` to superclass and gets displayed as texture until video is loaded/started.
