### PR TITLE
MouseHoverEventTestCase: Skip testing on Windows platform

### DIFF
--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -1,6 +1,14 @@
+import os
+import pytest
+
+from kivy import platform
 from kivy.tests.common import GraphicUnitTest
 
 
+@pytest.mark.skipif(
+    platform == 'win' and 'CI' in os.environ,
+    reason='Causes test_mouse_multitouchsim.py to fail on CI.'
+)
 class MouseHoverEventTestCase(GraphicUnitTest):
     '''Tests hover event from `MouseMotionEventProvider`.
     '''
@@ -30,7 +38,6 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.on_close = lambda *args: None
 
     def tearDown(self, fake=False):
-        super().tearDown(fake)
         self.etype = None
         self.motion_event = None
         self.touch_event = None
@@ -47,6 +54,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         # Restore method `on_close` to window
         win.on_close = self.old_on_close
         self.old_on_close = None
+        super().tearDown(fake)
 
     def on_motion(self, _, etype, event):
         self.etype = etype


### PR DESCRIPTION
Class `MouseHoverEventTestCase`, added in https://github.com/kivy/kivy/pull/7387, is causing `MultitouchSimulatorTestCase` to fail on CI on Windows platform. This pull request adds code to skip `MouseHoverEventTestCase`.

For more info see https://github.com/kivy/kivy/pull/7387#issuecomment-812091417.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
