### PR TITLE
Doc: Properties spelling fix

### DIFF
--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1692,7 +1692,7 @@ cdef class VariableListProperty(Property):
             Not currently used.
 
     Keeping in mind that the `default` list is expanded to a list of length 4,
-    here are some examples of how VariableListProperties are handled.
+    here are some examples of how VariableListProperty is handled.
 
     - VariableListProperty([1]) represents [1, 1, 1, 1].
     - VariableListProperty([1, 2]) represents [1, 2, 1, 2].

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -1692,7 +1692,7 @@ cdef class VariableListProperty(Property):
             Not currently used.
 
     Keeping in mind that the `default` list is expanded to a list of length 4,
-    here are some examples of how VariabelListProperty's are handled.
+    here are some examples of how VariableListProperties are handled.
 
     - VariableListProperty([1]) represents [1, 1, 1, 1].
     - VariableListProperty([1, 2]) represents [1, 2, 1, 2].


### PR DESCRIPTION
I hope this is the right way to contribute a tiny fix, please let me know if not!

Wanted to fix Variabel -> Variable, but also wasn't sure how to pluralize a class name, so I went by what was done elsewhere in the code ("NumericProperties" in kivy/_metrics.pyx line 17).

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
