### PR TITLE
WindowBase: Add to_normalized_pos method

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1389,8 +1389,8 @@ class WindowBase(EventDispatcher):
         return (x, y)
 
     def to_normalized_pos(self, x, y):
-        '''Transforms absolute to normalized coordinate using
-        :attr:`system_size`.
+        '''Transforms absolute coordinates to normalized (0-1) coordinates
+        using :attr:`system_size`.
 
         .. versionadded:: 2.1.0
         '''

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1388,6 +1388,19 @@ class WindowBase(EventDispatcher):
     def to_window(self, x, y, initial=True, relative=False):
         return (x, y)
 
+    def to_relative_pos(self, x, y):
+        '''Transforms absolute to relative coordinate using
+        :attr:`system_size`.
+
+        .. versionadded:: 2.1.0
+        '''
+        x_max = self.system_size[0] - 1.0
+        y_max = self.system_size[1] - 1.0
+        return (
+            x / x_max if x_max > 0 else 0.0,
+            y / y_max if y_max > 0 else 0.0
+        )
+
     def _apply_transform(self, m):
         return m
 

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1388,8 +1388,8 @@ class WindowBase(EventDispatcher):
     def to_window(self, x, y, initial=True, relative=False):
         return (x, y)
 
-    def to_relative_pos(self, x, y):
-        '''Transforms absolute to relative coordinate using
+    def to_normalized_pos(self, x, y):
+        '''Transforms absolute to normalized coordinate using
         :attr:`system_size`.
 
         .. versionadded:: 2.1.0

--- a/kivy/tests/test_window_base.py
+++ b/kivy/tests/test_window_base.py
@@ -1,0 +1,16 @@
+from itertools import product
+
+from kivy.tests import GraphicUnitTest
+
+
+class WindowBaseTest(GraphicUnitTest):
+
+    def test_to_relative_pos(self):
+        for x, y in product([0, 319, 50, 51], [0, 239, 50, 51]):
+            self.Window.system_size = (320, 240)
+            w, h = self.Window.system_size
+            expected_sx = x / (w - 1.0)
+            expected_sy = y / (h - 1.0)
+            result_sx, result_sy = self.Window.to_relative_pos(x, y)
+            assert result_sx == expected_sx
+            assert result_sy == expected_sy

--- a/kivy/tests/test_window_base.py
+++ b/kivy/tests/test_window_base.py
@@ -5,12 +5,12 @@ from kivy.tests import GraphicUnitTest
 
 class WindowBaseTest(GraphicUnitTest):
 
-    def test_to_relative_pos(self):
+    def test_to_normalized_pos(self):
         for x, y in product([0, 319, 50, 51], [0, 239, 50, 51]):
             self.Window.system_size = (320, 240)
             w, h = self.Window.system_size
             expected_sx = x / (w - 1.0)
             expected_sy = y / (h - 1.0)
-            result_sx, result_sy = self.Window.to_relative_pos(x, y)
+            result_sx, result_sy = self.Window.to_normalized_pos(x, y)
             assert result_sx == expected_sx
             assert result_sy == expected_sy

--- a/kivy/tests/test_window_base.py
+++ b/kivy/tests/test_window_base.py
@@ -6,14 +6,15 @@ from kivy.tests import GraphicUnitTest
 class WindowBaseTest(GraphicUnitTest):
 
     def test_to_normalized_pos(self):
-        old_system_size = self.Window.system_size[:]
-        self.Window.system_size = w, h = (320, 240)
+        win = self.Window
+        old_system_size = win.system_size[:]
+        win.system_size = w, h = type(old_system_size)((320, 240))
         try:
             for x, y in product([0, 319, 50, 51], [0, 239, 50, 51]):
                 expected_sx = x / (w - 1.0)
                 expected_sy = y / (h - 1.0)
-                result_sx, result_sy = self.Window.to_normalized_pos(x, y)
+                result_sx, result_sy = win.to_normalized_pos(x, y)
                 assert result_sx == expected_sx
                 assert result_sy == expected_sy
         finally:
-            self.Window.system_size = old_system_size
+            win.system_size = old_system_size

--- a/kivy/tests/test_window_base.py
+++ b/kivy/tests/test_window_base.py
@@ -6,11 +6,14 @@ from kivy.tests import GraphicUnitTest
 class WindowBaseTest(GraphicUnitTest):
 
     def test_to_normalized_pos(self):
-        for x, y in product([0, 319, 50, 51], [0, 239, 50, 51]):
-            self.Window.system_size = (320, 240)
-            w, h = self.Window.system_size
-            expected_sx = x / (w - 1.0)
-            expected_sy = y / (h - 1.0)
-            result_sx, result_sy = self.Window.to_normalized_pos(x, y)
-            assert result_sx == expected_sx
-            assert result_sy == expected_sy
+        old_system_size = self.Window.system_size[:]
+        self.Window.system_size = w, h = (320, 240)
+        try:
+            for x, y in product([0, 319, 50, 51], [0, 239, 50, 51]):
+                expected_sx = x / (w - 1.0)
+                expected_sy = y / (h - 1.0)
+                result_sx, result_sy = self.Window.to_normalized_pos(x, y)
+                assert result_sx == expected_sx
+                assert result_sy == expected_sy
+        finally:
+            self.Window.system_size = old_system_size


### PR DESCRIPTION
Method `to_relative_pos` to be used in motion event providers to transform absolute to relative coordinates. 

I didn't use name `normalize_pos` as suggested at https://github.com/kivy/kivy/pull/4238#discussion_r613552441 because it's close to vector normalize which has a different meaning (https://github.com/kivy/kivy/blob/master/kivy/vector.py#L265).

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
