### PR TITLE
FocusBehavior: Fix assumption that modifiers is always a set.

### DIFF
--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -531,6 +531,7 @@ class FocusBehavior(object):
         key was consumed.
         '''
         if keycode[1] == 'tab':  # deal with cycle
+            modifiers = set(modifiers)
             if {'ctrl', 'alt', 'meta', 'super', 'compose'} & modifiers:
                 return False
             if 'shift' in modifiers:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


I got the following error on a linux computer. Not sure what exactly I did, but it happened periodically:

```
ERROR  ] [Traceback (most recent call last)]
  File "/home/cpl/venv_ceed/lib/python3.8/site-packages/kivy/base.py", line 347, in mainloop
    self.window.mainloop()
  File "/home/cpl/venv_ceed/lib/python3.8/site-packages/kivy/core/window/window_sdl2.py", line 701, in mainloop
    if self.dispatch('on_key_down', key,
  File "kivy/_event.pyx", line 715, in kivy._event.EventDispatcher.dispatch
  File "kivy/_event.pyx", line 1295, in kivy._event.EventObservers.dispatch
  File "kivy/_event.pyx", line 1219, in kivy._event.EventObservers._dispatch
  File "/home/cpl/venv_ceed/lib/python3.8/site-packages/kivy/core/window/__init__.py", line 162, in _on_window_key_down
    return self.dispatch('on_key_down', keycode, text, modifiers)
  File "kivy/_event.pyx", line 715, in kivy._event.EventDispatcher.dispatch
  File "kivy/_event.pyx", line 1295, in kivy._event.EventObservers.dispatch
  File "kivy/_event.pyx", line 1219, in kivy._event.EventObservers._dispatch
  File "/home/cpl/venv_ceed/ceed/ceed/graphics/__init__.py", line 50, in keyboard_on_key_down
    return super(ShowMoreSelection, self).keyboard_on_key_down(
  File "/home/cpl/venv_ceed/ceed/ceed/graphics/__init__.py", line 145, in keyboard_on_key_down
    if super(WidgetList, self).keyboard_on_key_down(
  File "/home/cpl/venv_ceed/lib/python3.8/site-packages/kivy/uix/behaviors/focus.py", line 534, in keyboard_on_key_down
    if {'ctrl', 'alt', 'meta', 'super', 'compose'} & modifiers:
TypeError: unsupported operand type(s) for &: 'set' and 'ObservableList'
```

This should fix it.