### PR TITLE
MouseMotionEventProvider: Refactor of provider and tests

### DIFF
--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -209,55 +209,55 @@ class MouseMotionEventProvider(MotionEventProvider):
                 return True
         return False
 
-    def find_touch(self, x, y):
-        factor = 10. / EventLoop.window.system_size[0]
-        for t in self.touches.values():
-            if abs(x - t.sx) < factor and abs(y - t.sy) < factor:
-                return t
-        return False
+    def find_touch(self, win, x, y):
+        factor = 10. / win.system_size[0]
+        for touch in self.touches.values():
+            if abs(x - touch.sx) < factor and abs(y - touch.sy) < factor:
+                return touch
+        return None
 
     def create_event_id(self):
         self.counter += 1
         return self.device + str(self.counter)
 
-    def create_touch(self, rx, ry, is_double_tap, do_graphics, button):
+    def create_touch(self, win, nx, ny, is_double_tap, do_graphics, button):
         event_id = self.create_event_id()
-        args = [rx, ry, button]
+        args = [nx, ny, button]
         if do_graphics:
             args += [not self.multitouch_on_demand]
-        self.current_drag = cur = MouseMotionEvent(
+        self.current_drag = touch = MouseMotionEvent(
             self.device, event_id, args,
             is_touch=True
         )
-        cur.is_double_tap = is_double_tap
-        self.touches[event_id] = cur
+        touch.is_double_tap = is_double_tap
+        self.touches[event_id] = touch
         if do_graphics:
             # only draw red circle if multitouch is not disabled, and
             # if the multitouch_on_demand feature is not enable
             # (because in that case, we wait to see if multitouch_sim
             # is True or not before doing the multitouch)
             create_flag = (
-                (not self.disable_multitouch) and
-                (not self.multitouch_on_demand)
+                not self.disable_multitouch
+                and not self.multitouch_on_demand
             )
-            cur.update_graphics(EventLoop.window, create_flag)
-        self.waiting_event.append(('begin', cur))
-        return cur
+            touch.update_graphics(win, create_flag)
+        self.waiting_event.append(('begin', touch))
+        return touch
 
-    def remove_touch(self, cur):
-        if cur.id not in self.touches:
+    def remove_touch(self, win, touch):
+        if touch.id not in self.touches:
             return
-        del self.touches[cur.id]
-        cur.update_time_end()
-        self.waiting_event.append(('end', cur))
-        cur.clear_graphics(EventLoop.window)
+        del self.touches[touch.id]
+        touch.update_time_end()
+        self.waiting_event.append(('end', touch))
+        touch.clear_graphics(win)
 
     def create_hover(self, etype, win):
-        x_max, y_max = win.system_size[0] - 1, win.system_size[1] - 1
-        args = (
-            win.mouse_pos[0] / win._density / x_max if x_max > 0 else 0.0,
-            win.mouse_pos[1] / win._density / y_max if y_max > 0 else 0.0
-        )
+        nx, ny = win.to_normalized_pos(*win.mouse_pos)
+        # Divide by density because it's used by mouse_pos
+        nx /= win._density
+        ny /= win._density
+        args = (nx, ny)
         hover = self.hover_event
         if hover:
             hover.move(args)
@@ -273,68 +273,68 @@ class MouseMotionEventProvider(MotionEventProvider):
         self.waiting_event.append((etype, hover))
 
     def on_mouse_motion(self, win, x, y, modifiers):
-        x_max, y_max = win.system_size[0] - 1.0, win.system_size[1] - 1.0
-        rx = x / x_max if x_max > 0 else 0.0
-        ry = 1.0 - (y / y_max if y_max > 0 else 0.0)
+        nx, ny = win.to_normalized_pos(x, y)
+        ny = 1.0 - ny
         if self.current_drag:
-            cur = self.current_drag
-            cur.move([rx, ry])
-            cur.update_graphics(win)
-            self.waiting_event.append(('update', cur))
+            touch = self.current_drag
+            touch.move([nx, ny])
+            touch.update_graphics(win)
+            self.waiting_event.append(('update', touch))
         elif self.alt_touch is not None and 'alt' not in modifiers:
             # alt just released ?
             is_double_tap = 'shift' in modifiers
-            cur = self.create_touch(rx, ry, is_double_tap, True, [])
+            self.create_touch(win, nx, ny, is_double_tap, True, [])
         return True
 
     def on_mouse_press(self, win, x, y, button, modifiers):
         if self.test_activity():
             return
-        x_max, y_max = win.system_size[0] - 1.0, win.system_size[1] - 1.0
-        rx = x / x_max if x_max > 0 else 0.0
-        ry = 1.0 - (y / y_max if y_max > 0 else 0.0)
-        new_me = self.find_touch(rx, ry)
-        if new_me:
-            self.current_drag = new_me
+        nx, ny = win.to_normalized_pos(x, y)
+        ny = 1.0 - ny
+        found_touch = self.find_touch(win, nx, ny)
+        if found_touch:
+            self.current_drag = found_touch
         else:
             is_double_tap = 'shift' in modifiers
-            do_graphics = (not self.disable_multitouch) and (
-                button != 'left' or 'ctrl' in modifiers)
-            cur = self.create_touch(rx, ry, is_double_tap, do_graphics, button)
+            do_graphics = (
+                not self.disable_multitouch
+                and (button != 'left' or 'ctrl' in modifiers)
+            )
+            touch = self.create_touch(
+                win, nx, ny, is_double_tap, do_graphics, button
+            )
             if 'alt' in modifiers:
-                self.alt_touch = cur
+                self.alt_touch = touch
                 self.current_drag = None
         return True
 
     def on_mouse_release(self, win, x, y, button, modifiers):
-        # special case, if button is all, then remove all the current mouses.
         if button == 'all':
-            for cur in list(self.touches.values())[:]:
-                self.remove_touch(cur)
+            # Special case, if button is all,
+            # then remove all the current touches.
+            for touch in list(self.touches.values()):
+                self.remove_touch(win, touch)
             self.current_drag = None
-
-        cur = self.current_drag
-        if cur:
+        touch = self.current_drag
+        if touch:
             not_right = button in (
                 'left',
                 'scrollup', 'scrolldown',
                 'scrollleft', 'scrollright'
             )
-            not_ctrl = not ('ctrl' in modifiers)
+            not_ctrl = 'ctrl' not in modifiers
             not_multi = (
-                self.disable_multitouch or
-                'multitouch_sim' not in cur.profile or
-                not cur.multitouch_sim
+                self.disable_multitouch
+                or 'multitouch_sim' not in touch.profile
+                or not touch.multitouch_sim
             )
-
-            if (not_right and not_ctrl or not_multi):
-                self.remove_touch(cur)
+            if not_right and not_ctrl or not_multi:
+                self.remove_touch(win, touch)
                 self.current_drag = None
             else:
-                cur.update_graphics(EventLoop.window, True)
-
+                touch.update_graphics(win, True)
         if self.alt_touch:
-            self.remove_touch(self.alt_touch)
+            self.remove_touch(win, self.alt_touch)
             self.alt_touch = None
         return True
 

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -284,7 +284,6 @@ class MouseMotionEventProvider(MotionEventProvider):
             # alt just released ?
             is_double_tap = 'shift' in modifiers
             self.create_touch(win, nx, ny, is_double_tap, True, [])
-        return True
 
     def on_mouse_press(self, win, x, y, button, modifiers):
         if self.test_activity():
@@ -306,7 +305,6 @@ class MouseMotionEventProvider(MotionEventProvider):
             if 'alt' in modifiers:
                 self.alt_touch = touch
                 self.current_drag = None
-        return True
 
     def on_mouse_release(self, win, x, y, button, modifiers):
         if button == 'all':
@@ -336,7 +334,6 @@ class MouseMotionEventProvider(MotionEventProvider):
         if self.alt_touch:
             self.remove_touch(win, self.alt_touch)
             self.alt_touch = None
-        return True
 
     def begin_or_update_hover_event(self, win, *args):
         etype = 'update' if self.hover_event else 'begin'

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -199,8 +199,7 @@ class MouseMotionEventProvider(MotionEventProvider):
             return False
         # trying to get if we currently have other touch than us
         # discard touches generated from kinetic
-        touches = EventLoop.touches
-        for touch in touches:
+        for touch in EventLoop.touches:
             # discard all kinetic touch
             if touch.__class__.__name__ == 'KineticMotionEvent':
                 continue
@@ -245,12 +244,11 @@ class MouseMotionEventProvider(MotionEventProvider):
         return touch
 
     def remove_touch(self, win, touch):
-        if touch.id not in self.touches:
-            return
-        del self.touches[touch.id]
-        touch.update_time_end()
-        self.waiting_event.append(('end', touch))
-        touch.clear_graphics(win)
+        if touch.id in self.touches:
+            del self.touches[touch.id]
+            touch.update_time_end()
+            self.waiting_event.append(('end', touch))
+            touch.clear_graphics(win)
 
     def create_hover(self, win, etype):
         nx, ny = win.to_normalized_pos(*win.mouse_pos)
@@ -263,9 +261,7 @@ class MouseMotionEventProvider(MotionEventProvider):
             hover.move(args)
         else:
             self.hover_event = hover = MouseMotionEvent(
-                self.device,
-                self.create_event_id(),
-                args
+                self.device, self.create_event_id(), args
             )
         if etype == 'end':
             hover.update_time_end()

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -252,7 +252,7 @@ class MouseMotionEventProvider(MotionEventProvider):
         self.waiting_event.append(('end', touch))
         touch.clear_graphics(win)
 
-    def create_hover(self, etype, win):
+    def create_hover(self, win, etype):
         nx, ny = win.to_normalized_pos(*win.mouse_pos)
         # Divide by density because it's used by mouse_pos
         nx /= win._density
@@ -340,19 +340,19 @@ class MouseMotionEventProvider(MotionEventProvider):
 
     def begin_or_update_hover_event(self, win, *args):
         etype = 'update' if self.hover_event else 'begin'
-        self.create_hover(etype, win)
+        self.create_hover(win, etype)
 
     def begin_hover_event(self, win, *args):
         if not self.hover_event:
-            self.create_hover('begin', win)
+            self.create_hover(win, 'begin')
 
     def update_hover_event(self, win, *args):
         if self.hover_event:
-            self.create_hover('update', win)
+            self.create_hover(win, 'update')
 
     def end_hover_event(self, win, *args):
         if self.hover_event:
-            self.create_hover('end', win)
+            self.create_hover(win, 'end')
 
     def update(self, dispatch_fn):
         '''Update the mouse provider (pop event from the queue)'''

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -71,9 +71,6 @@ class MouseHoverEventTestCase(GraphicUnitTest):
     def on_any_touch_event(self, _, touch):
         self.touch_event = touch
 
-    def to_relative_pos(self, win, x, y):
-        return x / (win.system_size[0] - 1), y / (win.system_size[1] - 1)
-
     def assert_event(self, etype, spos):
         assert self.etype == etype
         assert 'pos' in self.motion_event.profile
@@ -130,7 +127,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         x, y = win.mouse_pos
         win.dispatch('on_cursor_enter')
         self.advance_frames(1)
-        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        self.assert_event('begin', win.to_normalized_pos(x, y))
         # Cleanup
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
@@ -139,7 +136,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win, mouse = self.get_providers()
         x, y = win.mouse_pos = (10.0, 10.0)
         self.advance_frames(1)
-        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        self.assert_event('begin', win.to_normalized_pos(x, y))
         # Cleanup
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
@@ -149,7 +146,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos = (50.0, 50.0)
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         # Cleanup
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
@@ -159,7 +156,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.mouse_pos = (10.0, 10.0)
         x, y = win.mouse_pos = (50.0, 50.0)
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         # Cleanup
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
@@ -169,7 +166,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         x, y = win.mouse_pos = (10.0, 10.0)
         win.rotation = 90
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         # Cleanup
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
@@ -180,7 +177,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         w, h = win.system_size
         win.system_size = (w + 10, h + 10)
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         # Cleanup
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
@@ -190,7 +187,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         x, y = win.mouse_pos = (10.0, 10.0)
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
-        self.assert_event('end', self.to_relative_pos(win, x, y))
+        self.assert_event('end', win.to_normalized_pos(x, y))
 
     @pytest.mark.skipif(
         platform == 'win' and 'CI' in os.environ,
@@ -201,7 +198,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         x, y = win.mouse_pos = (10.0, 10.0)
         win.dispatch('on_close')
         self.advance_frames(1)
-        self.assert_event('end', self.to_relative_pos(win, x, y))
+        self.assert_event('end', win.to_normalized_pos(x, y))
 
     def test_with_full_cycle_with_cursor_events(self):
         win, mouse = self.get_providers()
@@ -209,15 +206,15 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos
         self.advance_frames(1)
-        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        self.assert_event('begin', win.to_normalized_pos(x, y))
         # Test update event
         x, y = win.mouse_pos = (10.0, 10.0)
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         # Test end event
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
-        self.assert_event('end', self.to_relative_pos(win, x, y))
+        self.assert_event('end', win.to_normalized_pos(x, y))
 
     @pytest.mark.skipif(
         platform == 'win' and 'CI' in os.environ,
@@ -228,22 +225,22 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         # Test begin event
         x, y = win.mouse_pos = (5.0, 5.0)
         self.advance_frames(1)
-        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        self.assert_event('begin', win.to_normalized_pos(x, y))
         # Test update event
         x, y = win.mouse_pos = (10.0, 10.0)
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         # Test end event
         win.dispatch('on_close')
         self.advance_frames(1)
-        self.assert_event('end', self.to_relative_pos(win, x, y))
+        self.assert_event('end', win.to_normalized_pos(x, y))
 
     def test_begin_event_no_dispatch_through_on_touch_events(self):
         win, mouse = self.get_providers(with_window_children=True)
         x, y = win.mouse_pos
         win.dispatch('on_cursor_enter')
         self.advance_frames(1)
-        self.assert_event('begin', self.to_relative_pos(win, x, y))
+        self.assert_event('begin', win.to_normalized_pos(x, y))
         assert self.touch_event is None
         # Cleanup
         win.dispatch('on_cursor_leave')
@@ -254,7 +251,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         win.dispatch('on_cursor_enter')
         x, y = win.mouse_pos = (10.0, 10.0)
         self.advance_frames(1)
-        self.assert_event('update', self.to_relative_pos(win, x, y))
+        self.assert_event('update', win.to_normalized_pos(x, y))
         assert self.touch_event is None
         # Cleanup
         win.dispatch('on_cursor_leave')
@@ -266,5 +263,5 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         x, y = win.mouse_pos = (10.0, 10.0)
         win.dispatch('on_cursor_leave')
         self.advance_frames(1)
-        self.assert_event('end', self.to_relative_pos(win, x, y))
+        self.assert_event('end', win.to_normalized_pos(x, y))
         assert self.touch_event is None


### PR DESCRIPTION
Changes:
- Uses Window.to_normalize_pos method
- Uses `win` argument in methods instead of `Window` 
- Does not accept `on_mouse_xxx` events so that user can handle them which fixes issue https://github.com/kivy/kivy/issues/4387

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
