### PR TITLE
GraphicUnitTest: Add clear_window_and_event_loop method 

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -162,8 +162,23 @@ class GraphicUnitTest(_base):
         Window.create_window()
         Window.register()
         Window.initialized = True
-        Window.canvas.clear()
-        Window.close = lambda *s: True
+        Window.close = lambda *s: None
+        self.clear_window_and_event_loop()
+
+    def clear_window_and_event_loop(self):
+        from kivy.base import EventLoop
+        window = self.Window
+        for child in window.children[:]:
+            window.remove_widget(child)
+        window.canvas.before.clear()
+        window.canvas.clear()
+        window.canvas.after.clear()
+        EventLoop.touches.clear()
+        for post_proc in EventLoop.postproc_modules:
+            if hasattr(post_proc, 'touches'):
+                post_proc.touches.clear()
+            elif hasattr(post_proc, 'last_touches'):
+                post_proc.last_touches.clear()
 
     def on_window_flip(self, window):
         '''Internal method to be called when the window have just displayed an
@@ -299,10 +314,10 @@ class GraphicUnitTest(_base):
         '''
         from kivy.base import stopTouchApp
         from kivy.core.window import Window
-        from kivy.clock import Clock
         Window.unbind(on_flip=self.on_window_flip)
+        self.clear_window_and_event_loop()
+        self.Window = None
         stopTouchApp()
-
         if not fake and self.test_failed:
             self.assertTrue(False)
         super(GraphicUnitTest, self).tearDown()


### PR DESCRIPTION
Adds `clear_window_and_event_loop` method to `GraphicUnitTest` which clears `Window.children`, `EventLoop.touches` and event references from post processing.

This is an another possible fix to CI "random" failing tests, like the one reported here https://github.com/kivy/kivy/pull/7476#issuecomment-821491727.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
