### PR TITLE
Update events.rst

### DIFF
--- a/doc/sources/gettingstarted/events.rst
+++ b/doc/sources/gettingstarted/events.rst
@@ -55,7 +55,7 @@ for implementing all its behaviour previously handled by the base class. The
 easiest way to do this is to call `super()`::
 
     def on_touch_down(self, touch):
-        if super(OurClassName, self).on_touch_down(touch):
+        if super().on_touch_down(touch):
             return True
         if not self.collide_point(touch.x, touch.y):
             return False


### PR DESCRIPTION
Remove the Python 2 compatible use of `super()`, it still works in Python 3, but is no longer idiomatic for  a framework supporting Python 3.5-3.9.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
