### PR TITLE
MultitouchSimulatorTestCase: Don't render widgets in tests

### DIFF
--- a/kivy/tests/test_mouse_multitouchsim.py
+++ b/kivy/tests/test_mouse_multitouchsim.py
@@ -2,7 +2,11 @@ from kivy.tests.common import GraphicUnitTest
 
 
 class MultitouchSimulatorTestCase(GraphicUnitTest):
-    framecount = 0
+
+    framecount = 3
+
+    def render(self, root, framecount=1):
+        pass
 
     # helper methods
     def correct_y(self, win, y):


### PR DESCRIPTION
Overrides method `render` to skip rendering of widget which causes `EventLoop` to start already started input providers which causes failures on CI. Attribute `framecount` is now set to 3 to avoid `EventLoop.stop` call in `on_window_filp` method which in some tests can stop the event loop before the test ends.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
