### PR TITLE
kivy.cache.Cache : added a callback to be called when we're about to remove a key

### DIFF
--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -52,9 +52,9 @@ class Cache(object):
                 Time after which to delete the object if it has not been used.
                 If None, no timeout is applied.
             `remove_callback`: function (optional)
-                add a callback that's called when an object of this category is removed
-                callback signature : f(category, objet)
-                filled with the category and the object about to be removed
+                add a callback that's called when a key of this category is about to be removed
+                callback signature : f(category, key)
+                filled with the category and the key about to be removed
         '''
         Cache._categories[category] = {
             'limit': limit,

--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -52,7 +52,8 @@ class Cache(object):
                 Time after which to delete the object if it has not been used.
                 If None, no timeout is applied.
             `remove_callback`: function (optional)
-                add a callback that's called when a key of this category is about to be removed
+                add a callback that's called when a key of this category
+                is about to be removed
                 callback signature : f(category, key)
                 filled with the category and the key about to be removed
         '''

--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -190,7 +190,8 @@ class Cache(object):
                 Logger.trace('Cache: Removed %s:%s from cache' %
                              (category, key))
             else:
-                # when purging the category, call the callback function for every key
+                # when purging the category, call the callback function
+                # for every key
                 callback = Cache._categories[category]['remove_callback']
                 if callback is not None:
                     for key in Cache._objects[category].keys():


### PR DESCRIPTION
Added a per category callback function that is called when a key is about to be removed.

use case:
this may be useful if the cache is used for files. 
We create the file and add it the cache. When the key is about to be removed, we call the function (and delete the file).

Added code and docs.

Personally, I plan to use it with the mapview widget to offer a limited caching system for tiles.

Hope you'll find it useful

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
