### PR TITLE
EventLoopBase: Remove provider from auto-remove list

### DIFF
--- a/kivy/base.py
+++ b/kivy/base.py
@@ -153,9 +153,14 @@ class EventLoopBase(EventDispatcher):
 
     def remove_input_provider(self, provider):
         '''Remove an input provider.
+
+        .. versionchanged:: 2.1.0
+            Provider will be also removed if it exist in auto-remove list.
         '''
         if provider in self.input_providers:
             self.input_providers.remove(provider)
+            if provider in self.input_providers_autoremove:
+                self.input_providers_autoremove.remove(provider)
 
     def add_event_listener(self, listener):
         '''Add a new event listener for getting touch events.
@@ -209,9 +214,7 @@ class EventLoopBase(EventDispatcher):
         # problem happens, crashing badly without error
         for provider in reversed(self.input_providers[:]):
             provider.stop()
-            if provider in self.input_providers_autoremove:
-                self.input_providers_autoremove.remove(provider)
-                self.input_providers.remove(provider)
+            self.remove_input_provider(provider)
 
         # ensure any restart will not break anything later.
         self.input_events = []


### PR DESCRIPTION
This fixes `remove_input_provider` method in `EventLoopBase` which was not removing provider from auto-remove list when called. Method is also used in `stop` method to remove previously added providers.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
