### PR TITLE
App: Process app quit event while paused

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -514,9 +514,9 @@ class WindowSDL(WindowBase):
             if action == 'dropfile':
                 dropfile = args
                 self.dispatch('on_dropfile', dropfile[0])
-            # A quit event might be received while the app is paused
-            elif action == 'quit':
-                EventLoop.quit = True
+            # app_terminating event might be received while the app is paused
+            # in this case EventLoop.quit will be set at _event_filter
+            elif EventLoop.quit:
                 return
 
         while True:

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -514,6 +514,10 @@ class WindowSDL(WindowBase):
             if action == 'dropfile':
                 dropfile = args
                 self.dispatch('on_dropfile', dropfile[0])
+            # A quit event might be received while the app is paused
+            elif action == 'quit':
+                EventLoop.quit = True
+                return
 
         while True:
             event = self._win.poll()


### PR DESCRIPTION
Hi,

While I was testing foreground services on Android, I found an issue when the kivy-based app hangs.

This issue happened to me in two cases (ref. [minimal demo app](https://github.com/syrykh/kivy-pause-issue) with apks available).
1. When foreground service is started and the app is swiped-out

https://user-images.githubusercontent.com/7023634/116788963-2581d400-aab5-11eb-8396-0b1e3ebeba08.mp4

2. When the app is paused

https://user-images.githubusercontent.com/7023634/116788985-3f231b80-aab5-11eb-8ded-d2c5ff222084.mp4

In both of these cases the app was still shown in process list (`ps -A`) and the last log line in logcat was:
```
05-01 17:24:32.843 12822 12822 V SDL     : onDestroy()
```

The hang is not actually visible to end user, but when there's an attempt to start the app again, only a blank screen is shown.

The issue was reproduced on Android 10@Pixel 1, Android 11@Pixel 2 and Android 11@AVD emulator, however it was not reproduced on Pocophone F1 with MIUI (probably because of the MIUI).

SDK: 30, NDK: r19c, kivy: master@fe1ab549e and [the app itself](https://github.com/syrykh/kivy-pause-issue)

While debugging this issue I came to mainloop of `core/window/window_sdl2.py` and added some logs there with [window_sdl2.py-log.patch.txt](https://github.com/kivy/kivy/files/6409976/window_sdl2.py-log.patch.txt). When the issue happens the logs are:
```
05-01 19:03:56.569 12902 12930 I python  : [INFO   ] [window_sdl2.py] mainloop: _pause_loop: wait_event done
05-01 19:03:56.569 12902 12930 I python  : [INFO   ] [window_sdl2.py] mainloop: _pause_loop: invoking self._win.poll()
05-01 19:03:56.569 12902 12930 I python  : [INFO   ] [window_sdl2.py] mainloop: _pause_loop: self._win.poll() done, event = ('quit',)
05-01 19:03:56.569 12902 12930 I python  : [INFO   ] [window_sdl2.py] mainloop: _pause_loop: invoking wait_event
```

That means that the pause loop receives a 'quit' event, ignores it, and waits for the next event, which will never come.
My PR fixes this issue by breaking the mainloop in this case.

Logs after the fix became:
```
05-01 19:34:23.435 13556 13556 V SDL     : onDestroy()
05-01 19:34:23.441 13556 13584 I python  : [INFO   ] [Base        ] Leaving application in progress...
05-01 19:34:23.442 13556 13584 I python  : Python for android ended.
```

**Demos with the fix**
1. When foreground service is started and the app is swiped-out

https://user-images.githubusercontent.com/7023634/116789638-7f37cd80-aab8-11eb-8417-737f61b5f377.mp4

2. When the app is paused

https://user-images.githubusercontent.com/7023634/116789648-8b238f80-aab8-11eb-9130-32582d076cdd.mp4


Not sure how to add unittests for this issue. The fix was verified on Android 10@Pixel 1, Android 11@Pixel 2 and Android 11@AVD emulator.

Please accept this PR. Thanks in advance!

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
