### PR TITLE
CI: Switch rsa ssh key to ed25519 for server upload

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -217,8 +217,8 @@ upload_file_to_server() {
     mkdir ~/.ssh
   fi
 
-  printf "%s" "$UBUNTU_UPLOAD_KEY" >~/.ssh/id_rsa
-  chmod 600 ~/.ssh/id_rsa
+  printf "%s" "$UBUNTU_UPLOAD_KEY" >~/.ssh/id_ed25519
+  chmod 600 ~/.ssh/id_ed25519
 
   echo -e "Host $ip\n\tStrictHostKeyChecking no\n" >>~/.ssh/config
   rsync -avh -e "ssh -p 2458" --include="*/" --include="$file_pat" --exclude="*" "$file_path/" "root@$ip:/web/downloads/ci/$server_path"

--- a/.ci/windows-server-upload.sh
+++ b/.ci/windows-server-upload.sh
@@ -4,8 +4,8 @@ pacman -S --noconfirm git rsync openssl
 if [ ! -d ~/.ssh ]; then
   mkdir ~/.ssh
 fi
-printf "%s" "$UBUNTU_UPLOAD_KEY" > ~/.ssh/id_rsa
-chmod 600 ~/.ssh/id_rsa
+printf "%s" "$UBUNTU_UPLOAD_KEY" > ~/.ssh/id_ed25519
+chmod 600 ~/.ssh/id_ed25519
 
 echo -e "Host $1\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 echo "copying $3 from $2 to root@$1:/web/downloads/$4"


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


This fixes an issue with the key for uploading wheels to the server. We switched from rsa to ed25519 but forgot to update the filename.