### PR TITLE
GraphicUnitTest: Fix signature of tearDown method to use (*args, **kwargs)

### DIFF
--- a/kivy/tests/test_module_inspector.py
+++ b/kivy/tests/test_module_inspector.py
@@ -60,12 +60,12 @@ class InspectorTestCase(GraphicUnitTest):
         builder.trace = lambda *_, **__: None
         super(InspectorTestCase, self).setUp()
 
-    def tearDown(self):
+    def tearDown(self, *args, **kwargs):
         # add the logging back
         import kivy.lang.builder as builder
         builder.Builder.unload_file("InspectorTestCase.KV")
         builder.trace = self._trace
-        super(InspectorTestCase, self).tearDown()
+        super(InspectorTestCase, self).tearDown(*args, **kwargs)
 
     def clean_garbage(self, *args):
         for child in self._win.children[:]:

--- a/kivy/tests/test_mouse_hover_event.py
+++ b/kivy/tests/test_mouse_hover_event.py
@@ -34,7 +34,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
             self.old_on_close = win.on_close
             win.on_close = lambda *args: None
 
-    def tearDown(self, fake=False):
+    def tearDown(self, *args, **kwargs):
         self.etype = None
         self.motion_event = None
         self.touch_event = None
@@ -58,7 +58,7 @@ class MouseHoverEventTestCase(GraphicUnitTest):
         if not (platform == 'win' and 'CI' in os.environ):
             win.on_close = self.old_on_close
             self.old_on_close = None
-        super().tearDown(fake)
+        super().tearDown(*args, **kwargs)
 
     def on_window_flip(self, window):
         # Not rendering widgets in tests so don't do screenshots

--- a/kivy/tests/test_uix_actionbar.py
+++ b/kivy/tests/test_uix_actionbar.py
@@ -96,11 +96,11 @@ class ActionBarTestCase(GraphicUnitTest):
         builder.trace = lambda *_, **__: None
         super(ActionBarTestCase, self).setUp()
 
-    def tearDown(self):
+    def tearDown(self, *args, **kwargs):
         # add the logging back
         import kivy.lang.builder as builder
         builder.trace = self._trace
-        super(ActionBarTestCase, self).tearDown()
+        super(ActionBarTestCase, self).tearDown(*args, **kwargs)
 
     def move_frames(self, t):
         for i in range(t):

--- a/kivy/tests/test_uix_slider.py
+++ b/kivy/tests/test_uix_slider.py
@@ -41,11 +41,11 @@ class SliderMoveTestCase(GraphicUnitTest):
         builder.trace = lambda *_, **__: None
         super(SliderMoveTestCase, self).setUp()
 
-    def tearDown(self):
+    def tearDown(self, *args, **kwargs):
         # add the logging back
         import kivy.lang.builder as builder
         builder.trace = self._trace
-        super(SliderMoveTestCase, self).tearDown()
+        super(SliderMoveTestCase, self).tearDown(*args, **kwargs)
 
     def test_slider_move(self):
         EventLoop.ensure_window()


### PR DESCRIPTION
Fixes missing argument(s) from `tearDown` method in classes which inherit from `GraphicUnitTest` and those are:
- `InspectorTestCase`
- `MouseHoverEventTestCase`
- `ActionBarTestCase`
- `SliderMoveTestCase`

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
