### PR TITLE
Core: Use importlib's __import__ for compatibility with patching

### DIFF
--- a/kivy/core/__init__.py
+++ b/kivy/core/__init__.py
@@ -25,6 +25,7 @@ import sys
 import traceback
 import tempfile
 import subprocess
+import importlib
 import kivy
 from kivy.logger import Logger
 
@@ -55,7 +56,7 @@ def core_select_lib(category, llist, create_instance=False,
                 pass
 
             # import module
-            mod = __import__(name='{2}.{0}.{1}'.format(
+            mod = importlib.__import__(name='{2}.{0}.{1}'.format(
                 basemodule, modulename, base),
                 globals=globals(),
                 locals=locals(),
@@ -127,7 +128,7 @@ def core_register_libs(category, libs, base='kivy.core'):
                 lib = libs_loadable[item]
             except KeyError:
                 continue
-            __import__(name='{2}.{0}.{1}'.format(category, lib, base),
+            importlib.__import__(name='{2}.{0}.{1}'.format(category, lib, base),
                        globals=globals(),
                        locals=locals(),
                        fromlist=[lib],

--- a/kivy/factory.py
+++ b/kivy/factory.py
@@ -41,6 +41,7 @@ classname before you re-assign it::
 __all__ = ('Factory', 'FactoryBase', 'FactoryException')
 
 import copy
+import importlib
 from kivy.logger import Logger
 from kivy.context import register_context
 
@@ -151,7 +152,7 @@ class FactoryBase(object):
         # No class to return, import the module
         if cls is None:
             if item['module']:
-                module = __import__(
+                module = importlib.__import__(
                     name=item['module'],
                     fromlist='*',
                     level=0  # force absolute

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -10,6 +10,7 @@ import re
 import sys
 import traceback
 import ast
+import importlib
 from re import sub, findall
 from types import CodeType
 from functools import partial
@@ -550,9 +551,9 @@ class Parser(object):
                 try:
                     if package not in sys.modules:
                         try:
-                            mod = __import__(package)
+                            mod = importlib.__import__(package)
                         except ImportError:
-                            mod = __import__('.'.join(package.split('.')[:-1]))
+                            mod = importlib.__import__('.'.join(package.split('.')[:-1]))
                         # resolve the whole thing
                         for part in package.split('.')[1:]:
                             mod = getattr(mod, part)

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -553,7 +553,8 @@ class Parser(object):
                         try:
                             mod = importlib.__import__(package)
                         except ImportError:
-                            mod = importlib.__import__('.'.join(package.split('.')[:-1]))
+                            module_name = '.'.join(package.split('.')[:-1])
+                            mod = importlib.__import__(module_name)
                         # resolve the whole thing
                         for part in package.split('.')[1:]:
                             mod = getattr(mod, part)

--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -97,6 +97,7 @@ __all__ = ('Modules', )
 from kivy.config import Config
 from kivy.logger import Logger
 import kivy
+import importlib
 import os
 import sys
 
@@ -146,11 +147,11 @@ class ModuleBase:
     def import_module(self, name):
         try:
             modname = 'kivy.modules.{0}'.format(name)
-            module = __import__(name=modname)
+            module = importlib.__import__(name=modname)
             module = sys.modules[modname]
         except ImportError:
             try:
-                module = __import__(name=name)
+                module = importlib.__import__(name=name)
                 module = sys.modules[name]
             except ImportError:
                 Logger.exception('Modules: unable to import <%s>' % name)


### PR DESCRIPTION
This uses importlib.__import__ instead of plain __import__

The package 'pythonnet' breaks kivy by patching python's global __import__.
Of course it's not kivy to blame here, but using importlib doesn't hurt and as a side effect is better documented.

https://github.com/pythonnet/pythonnet/issues/1245
https://github.com/pythonnet/pythonnet/issues/547
