### PR TITLE
Label: Fix label not displaying as disabled if it is disabled when created

### DIFF
--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -341,8 +341,12 @@ class Label(Widget):
         if (markup and cls is not CoreMarkupLabel) or \
            (not markup and cls is not CoreLabel):
             # markup have change, we need to change our rendering method.
-            d = Label._font_properties
-            dkw = dict(list(zip(d, [getattr(self, x) for x in d])))
+            dkw = {x: getattr(self, x) for x in self._font_properties}
+            dkw['usersize'] = self.text_size
+            if self.disabled:
+                dkw['color'] = self.disabled_color
+                dkw['outline_color'] = self.disabled_outline_color
+
             if markup:
                 self._label = CoreMarkupLabel(**dkw)
             else:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Fixes https://github.com/kivy/kivy/issues/7526.