### PR TITLE
Prevent multiple dropdown open

### DIFF
--- a/kivy/uix/dropdown.py
+++ b/kivy/uix/dropdown.py
@@ -235,7 +235,14 @@ class DropDown(ScrollView):
         the height of the dropdown, the dropdown might be above or below
         that widget.
         '''
+        # prevent multiple dropdown open
+        if self.parent:
+            return
+
         # ensure we are not already attached
+        # XXX: not sure this ever worked as expected, dismiss gets delayed
+        #      to another tick and self._win.add_widget(self) throws an error
+        #      if widget gets added again because parent is already set.
         if self.attach_to is not None:
             self.dismiss()
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

If Dropdown.open gets called multiple times (e.g. open is bound to a button on_release and user double taps) self._win.add_widget throws an error because parent is already set.

@tito did ``if self.attach_to is not None: self.dismiss()`` ever worked as expected?

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
