### PR TITLE
Fix missing word in doc/guide/events.rst

### DIFF
--- a/doc/sources/guide/events.rst
+++ b/doc/sources/guide/events.rst
@@ -166,7 +166,7 @@ A widget has 2 default types of events:
 - Widget-defined event: e.g. an event will be fired for a Button when it's pressed or
   released.
 
-For a discussion on how widget touch events managed and propagated, please refer
+For a discussion on how widget touch events are managed and propagated, please refer
 to the :ref:`Widget touch event bubbling <widget-event-bubbling>` section.
 
 Creating custom events


### PR DESCRIPTION
Small fix to the docs.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
