### PR TITLE
Typo on refreshing process.

### DIFF
--- a/kivy/tools/kviewer.py
+++ b/kivy/tools/kviewer.py
@@ -60,7 +60,7 @@ class KvViewerApp(App):
         o = Observer()
         o.schedule(KvHandler(self.update, TARGET), PATH)
         o.start()
-        Clock.schedule_once(self.update, 1)
+        Clock.schedule_interval(self.update, 1)
         return super(KvViewerApp, self).build()
 
     @mainthread


### PR DESCRIPTION
Guys! On line 63, I've noticed that _Clock is schedule_once, which blocks the kv file refreshing._
Probably a typo, since there's an interval set on args.
Sorry If I misunderstood anything!
Keep up the excellent work!
Best regards.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
