### PR TITLE
PyInstaller hook: Replace modname_tkinter with 'tkinter'

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -82,7 +82,6 @@ from PyInstaller.depend import bindepend
 
 from os import environ
 if 'KIVY_DOC' not in environ:
-    from PyInstaller.compat import modname_tkinter
     from PyInstaller.utils.hooks import collect_submodules
 
     curdir = dirname(__file__)
@@ -97,7 +96,7 @@ if 'KIVY_DOC' not in environ:
     pyinstaller.
     '''
 
-    excludedimports = [modname_tkinter, '_tkinter', 'twisted']
+    excludedimports = ['tkinter', '_tkinter', 'twisted']
     '''List of excludedimports that should always be excluded from
     pyinstaller.
     '''


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

https://github.com/pyinstaller/pyinstaller/commit/12ed9031f3cd4f62236fc9d28efbc646ea2ae2ad#diff-dc411fbd309c58fc4cdab26fe35e0bf9774c72531776696fefec960b9e72d5c1L180-L183

The `modname_tkinter` has been removed in this commit (develop branch) https://github.com/pyinstaller/pyinstaller/commit/12ed9031f3cd4f62236fc9d28efbc646ea2ae2ad.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
