### PR TITLE
Fixed unexpected overscrolling bug when using mouse wheel

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1504,7 +1504,8 @@ class TextInput(FocusBehavior, Widget):
                         self._trigger_update_graphics()
                 else:
                     if self.scroll_x > 0:
-                        self.scroll_x -= self.line_height
+                        self.scroll_x = max(0, self.scroll_x -
+                                            self.line_height)
                         self._trigger_update_graphics()
             if scroll_type == 'up':
                 if self.multiline:
@@ -1516,9 +1517,12 @@ class TextInput(FocusBehavior, Widget):
                         self.scroll_y += self.line_height
                         self._trigger_update_graphics()
                 else:
-                    if (self.scroll_x + self.width <
-                            self._lines_rects[-1].texture.size[0]):
-                        self.scroll_x += self.line_height
+                    minimum_width = (self._lines_rects[-1].texture.size[0] +
+                                     self.padding[0] + self.padding[2])
+                    max_scroll_x = max(0, minimum_width - self.width)
+                    if self.scroll_x < max_scroll_x:
+                        self.scroll_x = min(max_scroll_x, self.scroll_x +
+                                            self.line_height)
                         self._trigger_update_graphics()
             return True
 


### PR DESCRIPTION
I think this bug is a little hard to notice, but it does occur when using the mouse wheel to scroll text. What determines whether the bug will be noticed depends on the size of the text and the width of the text input.

If the text starts with a few letters (e.g. 'A'), in addition to the unexpected overscroll, there is still a trace of text rendering.

Below is a code for example. If you don't notice it immediately after running the file, please resize the window width and scroll the text to the beginning again.

I tested it on kivy 2.0.0 and the recent version of text input on kivy master

```python
from textwrap import dedent
from kivy.app import App
from kivy.uix.boxlayout import BoxLayout
from kivy.lang import Builder
from kivy.core.window import Window
Window.size = (310, 50)

KV = dedent(r'''
TextInput:
    pos_hint: {'center_x': 0.5,'top': 0.9}
    size_hint: (1, None)
    height: '40dp'
    font_size: '20dp'
    multiline: False
    valign: 'center'
    background_active:''
    background_normal:''

    background_color: "#454545"
    foreground_color: "#dedede"
    text: 'A Kivy runs on Linux, Windows, OS X, Android, iOS, and Raspberry Pi. You can run the same code'
    
''')

class TextInputApp(App):
    def build(self):
        return Builder.load_string(KV)
TextInputApp().run()
```


https://user-images.githubusercontent.com/73297572/132112840-b4fd6b85-983f-4188-b8c3-579a96a8faa2.mp4



Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
