### PR TITLE
Fix install command for zsh

### DIFF
--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -130,7 +130,7 @@ With the dependencies installed, you can now install Kivy into the virtual envir
 
 To install the stable version of Kivy, from the terminal do::
 
-    python -m pip install kivy[base] kivy_examples --no-binary kivy
+    python -m pip install "kivy[base]" kivy_examples --no-binary kivy
 
 To install the latest cutting-edge Kivy from **master**, instead do::
 


### PR DESCRIPTION
`python -m pip install kivy[base] kivy_examples --no-binary kivy` throws the error `zsh: no matches found: kivy[base]`, you need to use `python -m pip install "kivy[base]" kivy_examples --no-binary kivy` instead

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
