### PR TITLE
Fixed unexpected overscrolling bug when using mouse wheel, complement to #7612 

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1516,8 +1516,8 @@ class TextInput(FocusBehavior, Widget):
                                             self.line_height)
                         self._trigger_update_graphics()
                 else:
-                    minimum_width = (self._get_row_width(self.cursor_row) +
-                                     self.padding[0] + self.padding[2])
+                    minimum_width = (self._get_row_width(0) + self.padding[0] +
+                                     self.padding[2])
                     max_scroll_x = max(0, minimum_width - self.width)
                     if self.scroll_x < max_scroll_x:
                         self.scroll_x = min(max_scroll_x, self.scroll_x +

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1500,7 +1500,8 @@ class TextInput(FocusBehavior, Widget):
             if scroll_type == 'down':
                 if self.multiline:
                     if self.scroll_y > 0:
-                        self.scroll_y -= self.line_height
+                        self.scroll_y = max(0, self.scroll_y -
+                                            self.line_height)
                         self._trigger_update_graphics()
                 else:
                     if self.scroll_x > 0:
@@ -1509,12 +1510,10 @@ class TextInput(FocusBehavior, Widget):
                         self._trigger_update_graphics()
             if scroll_type == 'up':
                 if self.multiline:
-                    viewport_height = self.height\
-                                      - self.padding[1] - self.padding[3]
-                    text_height = len(self._lines) * (self.line_height
-                                                      + self.line_spacing)
-                    if viewport_height < text_height - self.scroll_y:
-                        self.scroll_y += self.line_height
+                    max_scroll_y = max(0, self.minimum_height - self.height)
+                    if self.scroll_y < max_scroll_y:
+                        self.scroll_y = min(max_scroll_y, self.scroll_y +
+                                            self.line_height)
                         self._trigger_update_graphics()
                 else:
                     minimum_width = (self._lines_rects[-1].texture.size[0] +

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1516,7 +1516,7 @@ class TextInput(FocusBehavior, Widget):
                                             self.line_height)
                         self._trigger_update_graphics()
                 else:
-                    minimum_width = (self._lines_rects[-1].texture.size[0] +
+                    minimum_width = (self._get_row_width(self.cursor_row) +
                                      self.padding[0] + self.padding[2])
                     max_scroll_x = max(0, minimum_width - self.width)
                     if self.scroll_x < max_scroll_x:


### PR DESCRIPTION
This PR is complementary to #7612, follow the same logic, and fixes the overscroll bug in y axis.

This PR and #7612 fixes the scrolling issue related in #7566 and maybe #6209 (not tested)

Runnable example that reproduces the bug:
```python
from textwrap import dedent
from kivy.app import App
from kivy.uix.boxlayout import BoxLayout
from kivy.lang import Builder
from kivy.core.window import Window
Window.size = (300, 200)

KV = dedent(r'''
TextInput:
    font_size: '20dp'
    text: 'A Kivy runs on Linux, Windows, OS X, Android, iOS, and Raspberry Pi' * 10
    
''')

class TextInputApp(App):
    def build(self):
        return Builder.load_string(KV)
TextInputApp().run()
```

https://user-images.githubusercontent.com/73297572/132146872-6420a867-ec90-4fec-9bcd-97c1fdb4c058.mp4

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
