### PR TITLE
Fixed TextInput visual selection bugs while scrolling

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2334,9 +2334,9 @@ class TextInput(FocusBehavior, Widget):
             islice(
                 rects,
                 max(selection_start_row, first_visible_line),
-                min(selection_end_row + 1, last_visible_line),
+                min(selection_end_row + 1, last_visible_line - 1),
             ),
-            start=selection_start_row
+            start=max(selection_start_row, first_visible_line)
         ):
             draw_selection(
                 rect.pos,
@@ -2355,7 +2355,6 @@ class TextInput(FocusBehavior, Widget):
                 canvas_add,
                 selection_color
             )
-            y -= dy
         self._position_handles('both')
 
     def _draw_selection(


### PR DESCRIPTION
Fixed TextInput visual selection bugs in multiline mode while scrolling vertically.
Removed unecessary operation.

The current master version has a bug that after selecting the text and scrolling vertically, some unexpected line overlaps appear, furthermore, the upper and lower limits of the selection don't seem to update as expected.

This PR solved the problems on my side.

Below, an example demonstrating the master's bug

https://user-images.githubusercontent.com/73297572/132766001-92bf76f2-7634-45f6-875f-7daea37fab93.mp4

</br>

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
