### PR TITLE
Core: Window: Fix for a broken on Windows Platform get_window_info() call

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -413,6 +413,7 @@ cdef class _WindowSDL2Storage:
                 windows_info = WindowInfoWindows()
                 windows_info.window = wm_info.info.win.window
                 windows_info.hdc = wm_info.info.win.hdc
+                return windows_info
 
     # Transparent Window background
     def is_window_shaped(self):


### PR DESCRIPTION
An initial commits set with the `get_window_info()` implementation states: "The implementation
only returns information for Linux (X11/Wayland) and **Windows**". At the same time an implementation of get_window_info() initially had a bug: forgotten `return` for a Windows platform. As result this functionality is not working on Windows.

This fix turnes on initially planned functionality for Windows platform (tested). This is necessary for a platform depend manipulations with main kivy window by getting it's HWND from `Window.get_window_info().window` property.