### PR TITLE
Fixed inconsistent behavior of TextInput bubble and handles

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -241,6 +241,7 @@ class Selector(ButtonBehavior, Image):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.always_release = True
         self.matrix = self.target.get_window_matrix()
 
         with self.canvas.before:
@@ -1618,12 +1619,16 @@ class TextInput(FocusBehavior, Widget):
             return
 
         self._update_selection()
+        
+        instance_x = self.to_window(instance.x, 0, False, True)[0]
+        instance_right = self.to_window(instance.right, 0, False, True)[0]
+        instance_top = self.to_window(0, instance.top, False, True)[1]
         self._show_cut_copy_paste(
             (
-                instance.right
+                instance_right
                 if instance is self._handle_left
-                else instance.x,
-                instance.top + self.line_height
+                else instance_x,
+                instance_top + self.line_height
             ),
             EventLoop.window
         )
@@ -1647,6 +1652,7 @@ class TextInput(FocusBehavior, Widget):
             x,
             y + instance._touch_diff + (self.line_height / 2)
         )
+        self.cursor = cursor
 
         if instance != touch.grab_current:
             return
@@ -1662,6 +1668,7 @@ class TextInput(FocusBehavior, Widget):
             self._selection_from = cindex
         elif instance == handle_right:
             self._selection_to = cindex
+        self._update_selection()
         self._trigger_update_graphics()
         self._trigger_position_handles()
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1658,11 +1658,10 @@ class TextInput(FocusBehavior, Widget):
             return
 
         if instance == handle_middle:
-            self.cursor = cursor
             self._position_handles(mode='middle')
             return
 
-        cindex = self.cursor_index(cursor=cursor)
+        cindex = self.cursor_index()
 
         if instance == handle_left:
             self._selection_from = cindex

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1619,16 +1619,12 @@ class TextInput(FocusBehavior, Widget):
             return
 
         self._update_selection()
-        
-        instance_x = self.to_window(instance.x, 0, False, True)[0]
-        instance_right = self.to_window(instance.right, 0, False, True)[0]
-        instance_top = self.to_window(0, instance.top, False, True)[1]
         self._show_cut_copy_paste(
             (
-                instance_right
+                self.x + instance.right
                 if instance is self._handle_left
-                else instance_x,
-                instance_top + self.line_height
+                else self.x + instance.x,
+                self.y + instance.top + self.line_height
             ),
             EventLoop.window
         )


### PR DESCRIPTION
The entirety of the bugs resolution is conditioned to the approval of #7618

This PR resolves several bugs that appear when using handles and bubble to select/copy/paste/cut text. Fixes: #7247, #7396

Fixed bugs:
- Selection is not updated even after moving handles
- In multiline mode, if you move the handles beyond the top and bottom edges, texts beyond those lines cannot be selected, which results in the selection limited to the viewport.
- The cut/copy/paste bubble is not shown after the handles' on_release event
- Bubbles are not displayed relative to textinput/handles position, after correcting the above error
- Bug that did not limit selection to the current line, while using handles and in multiline mode

Now the cursor follows the last handle dragged

</br>

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
