### PR TITLE
Sphinx: Use class instead of instance in add_lexer + Fixes search on sphinx>1.7.9

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,6 +1,5 @@
 Cython>=0.24
 # Frozen Sphinx requirements for easier pip installation
-sphinx==1.7.9
 sphinxcontrib-actdiag
 sphinxcontrib-blockdiag
 sphinxcontrib-nwdiag

--- a/doc/sources/.templates/layout.html
+++ b/doc/sources/.templates/layout.html
@@ -106,12 +106,14 @@
 
       };
     </script>
+{%- block scripts %}
     {%- for scriptfile in script_files %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}
     <script type="text/javascript" src="{{ pathto('_static/jquery-effects-core-and-slide.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/jquery.cookie.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/kivy.js', 1) }}"></script>
+{%- endblock %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"

--- a/doc/sources/sphinxext/preprocess.py
+++ b/doc/sources/sphinxext/preprocess.py
@@ -109,7 +109,7 @@ def setup(app):
     sys.path += [join(dirname(kivy.__file__), 'extras')]
     from highlight import KivyLexer
 
-    app.add_lexer('kv', KivyLexer())
+    app.add_lexer('kv', KivyLexer)
     app.add_autodocumenter(CythonMethodDocumenter)
     app.connect('autodoc-process-docstring', callback_docstring)
     app.connect('autodoc-process-signature', callback_signature)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Since Sphinx-2.1.0 (released Jun 02, 2019) ``Sphinx.add_lexer()`` takes a Lexer class instead of instance.
An instance of lexers was still supported until Sphinx-3.x.

