### PR TITLE
Sphinx: Fixes missing documentation_options

### DIFF
--- a/doc/sources/.templates/layout.html
+++ b/doc/sources/.templates/layout.html
@@ -96,24 +96,32 @@
     <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     {%- if not embedded %}
-    <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT:    '{{ url_root }}',
-        VERSION:     '{{ release|e }}',
-        COLLAPSE_MODINDEX: false,
-        FILE_SUFFIX: '{{ file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
-
-      };
-    </script>
-{%- block scripts %}
-    {%- for scriptfile in script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
-    {%- endfor %}
-    <script type="text/javascript" src="{{ pathto('_static/jquery-effects-core-and-slide.js', 1) }}"></script>
-    <script type="text/javascript" src="{{ pathto('_static/jquery.cookie.js', 1) }}"></script>
-    <script type="text/javascript" src="{{ pathto('_static/kivy.js', 1) }}"></script>
-{%- endblock %}
+    {%- block scripts %}
+        {% if sphinx_version >= "1.8.0" %} 
+          <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script> 
+          {%- for scriptfile in script_files %} 
+            {{ js_tag(scriptfile) }} 
+          {%- endfor %} 
+        {% else %} 
+          <script type="text/javascript"> 
+              var DOCUMENTATION_OPTIONS = { 
+                  URL_ROOT:'{{ url_root }}', 
+                  VERSION:'{{ release|e }}', 
+                  LANGUAGE:'{{ language }}', 
+                  COLLAPSE_INDEX:false, 
+                  FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}', 
+                  HAS_SOURCE:  {{ has_source|lower }}, 
+                  SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}' 
+              }; 
+          </script> 
+          {%- for scriptfile in script_files %} 
+            <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script> 
+          {%- endfor %} 
+        {% endif %}
+        <script type="text/javascript" src="{{ pathto('_static/jquery-effects-core-and-slide.js', 1) }}"></script>
+        <script type="text/javascript" src="{{ pathto('_static/jquery.cookie.js', 1) }}"></script>
+        <script type="text/javascript" src="{{ pathto('_static/kivy.js', 1) }}"></script>
+    {%- endblock %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

After the latest fixes, now docs were reporting 404 when clicking on search results.
This is due to a change on how scripts are needed to be included in new sphinx versions.
