### PR TITLE
Update line number references in documentation

### DIFF
--- a/doc/sources/guide/basic.rst
+++ b/doc/sources/guide/basic.rst
@@ -65,7 +65,7 @@ First off, let's get familiar with the Kivy app life cycle.
 
 As you can see above, for all intents and purposes, our entry point into our App
 is the run() method, and in our case that is "MyApp().run()". We will get back
-to this, but let's start from the third line::
+to this, but let's start from the line::
 
     from kivy.app import App
 
@@ -108,7 +108,7 @@ This Label will be the Root Widget of this App.
 
 .. Note::
     Python uses indentation to denote code blocks, therefore take note that in
-    the code provided above, at line 12 the class and function definition ends.
+    the code provided above, at line 11 the class and function definition ends.
 
 Now on to the portion that will make our app run at line 14 and 15::
 


### PR DESCRIPTION




<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.
-->
I've updated a bit of the documentation here to reference the actual line numbers, vs. probably those from a previous revision.

**Proposal** - enable line numbers on code snippets where the text references specific lines by number? (Or, enable line numbers generally?)

I believe the below checklist doesn't apply here, as this is documentation only.

Maintainer merge checklist
* [X] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
