### PR TITLE
fix wrong options in documentation fixes #7531

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -206,7 +206,7 @@ class WindowBase(EventDispatcher):
             Set the window border state. Check the
             :mod:`~kivy.config` documentation for a
             more detailed explanation on the values.
-        `fullscreen`: str, one of ('0', '1', 'auto', 'fake')
+        `fullscreen`: must be one of (True, False, 'auto', 'fake')
             Make the window fullscreen. Check the
             :mod:`~kivy.config` documentation for a
             more detailed explanation on the values.


### PR DESCRIPTION
fullscreen uses option property  with options `True, False, 'auto', 'fake'` made the docs say the same

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
