### PR TITLE
Fixed CodeNavigationBehavior _move_cursor_word_right doesnt't work for wrapped words

### DIFF
--- a/kivy/uix/behaviors/codenavigation.py
+++ b/kivy/uix/behaviors/codenavigation.py
@@ -26,14 +26,17 @@ class CodeNavigationBehavior(EventDispatcher):
     .. versionadded:: 1.9.1
     '''
 
-    def _move_cursor_word_left(self, index=None):
-        pos = index or self.cursor_index()
-        pos -= 1
+    def _move_cursor_word_left(self, cursor=None):
+        col, row = cursor or self.cursor
+        if col == 0:
+            if row > 0:
+                row -= 1
+                col = len(self._lines[row])
+        else:
+            col, row = col - 1, row
+        if col == 0 and row == 0:
+            return col, row
 
-        if pos == 0:
-            return 0, 0
-
-        col, row = self.get_cursor_from_index(pos)
         lines = self._lines
 
         ucase = string.ascii_uppercase
@@ -102,9 +105,8 @@ class CodeNavigationBehavior(EventDispatcher):
 
         return col, row
 
-    def _move_cursor_word_right(self, index=None):
-        pos = index or self.cursor_index()
-        col, row = self.get_cursor_from_index(pos)
+    def _move_cursor_word_right(self, cursor=None):
+        col, row = cursor or self.cursor
         lines = self._lines
         mrow = len(lines) - 1
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -948,12 +948,12 @@ class TextInput(FocusBehavior, Widget):
 
     _re_whitespace = re.compile(r'\s+')
 
-    def _move_cursor_word_left(self, index=None):
-        pos = index or self.cursor_index()
-        if pos == 0:
-            return self.cursor
+    def _move_cursor_word_left(self, cursor=None):
+        col, row = cursor or self.cursor
+        if col == 0 and row == 0:
+            return col, row
         lines = self._lines
-        col, row = self.get_cursor_from_index(pos)
+
         if col == 0:
             row -= 1
             col = len(lines[row])
@@ -986,9 +986,9 @@ class TextInput(FocusBehavior, Widget):
             col = mpos
             return col, row
 
-    def _move_cursor_word_right(self, index=None):
-        pos = index or self.cursor_index()
-        col, row = self.get_cursor_from_index(pos)
+    def _move_cursor_word_right(self, cursor=None):
+        col, row = cursor or self.cursor
+
         lines = self._lines
         mrow = len(lines) - 1
         if row == mrow and col == len(lines[row]):


### PR DESCRIPTION
![CodeInput move word right bug](https://user-images.githubusercontent.com/73047043/134629658-898e3c44-a5fd-4356-8ae4-01be95661ee2.png)
In CodeInput above __move_cursor_word_right_ (i.e. Ctrl + Right shortcut) here doesn't do anything.

Fixed by relying on cursor itself instead of cursor index, cause for wrapped words cursor index is the same for the end of line and for the beginning of the new line.
For consistency also implemented the same approach in TextInput._move_cursor_word_right, TextInput._move_cursor_word_left and in CodeNavigationBehavior._move_cursor_word_left methods.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
