### PR TITLE
Allows to limit the shape of the touch rippe to rounded shapes

### DIFF
--- a/kivy/uix/behaviors/touchripple.py
+++ b/kivy/uix/behaviors/touchripple.py
@@ -79,7 +79,7 @@ class TouchRippleBehavior(object):
     the given radius. It is recommended to set the radius when using touch
     ripple on a rounded target shape with a circle, ellipse, or rounded
     rectangle shape.
-    
+
     .. Note::
         In order for you to get the expected result, the radius given needs to
         be the same as the target shape to which the ripple will be applied.

--- a/kivy/uix/behaviors/touchripple.py
+++ b/kivy/uix/behaviors/touchripple.py
@@ -74,12 +74,17 @@ class TouchRippleBehavior(object):
     '''
 
     ripple_clipping_radius = ListProperty([0, 0, 0, 0])
-    '''Radius of the target shape that the touch ripple will be aplied. This
-    will clip the ripple to the target shape according to the radius given.
-    It is recommended to set the radius when using the touch ripple in a
-    rounded target shape as a circle, ellipse or rounded rectangle.
-    It's not necessary to set this property when using a rectangle as a target
-    shape.
+    '''Radius of the target shape to which the touch ripple is applied. This
+    will clip the ripple and adjust it to the shape of the target according to
+    the given radius. It is recommended to set the radius when using touch
+    ripple on a rounded target shape with a circle, ellipse, or rounded
+    rectangle shape.
+    
+    .. Note::
+        In order for you to get the expected result, the radius given needs to
+        be the same as the target shape to which the ripple will be applied.
+        It is not necessary to set this property when the target shape is
+        rectangular in shape.
 
     .. versionadded:: 2.1.0
 

--- a/kivy/uix/behaviors/touchripple.py
+++ b/kivy/uix/behaviors/touchripple.py
@@ -73,7 +73,7 @@ class TouchRippleBehavior(object):
                 return False
     '''
 
-    radius = ListProperty([0, 0, 0, 0])
+    ripple_clipping_radius = ListProperty([0, 0, 0, 0])
     '''Radius of the target shape that the touch ripple will be aplied. This
     will clip the ripple to the target shape according to the radius given.
     It is recommended to set the radius when using the touch ripple in a
@@ -83,7 +83,7 @@ class TouchRippleBehavior(object):
 
     .. versionadded:: 2.1.0
 
-    :attr:`radius` is a :class:`~kivy.properties.ListProperty`
+    :attr:`ripple_clipping_radius` is a :class:`~kivy.properties.ListProperty`
     and defaults to [0, 0, 0, 0].
     '''
 
@@ -181,7 +181,7 @@ class TouchRippleBehavior(object):
             RoundedRectangle(
                 size=self.size,
                 pos=self.pos,
-                radius=self.radius
+                radius=self.ripple_clipping_radius
             )
             StencilUse()
             self.ripple_col_instruction = Color(rgba=self.ripple_color)
@@ -196,7 +196,7 @@ class TouchRippleBehavior(object):
             RoundedRectangle(
                 size=self.size,
                 pos=self.pos,
-                radius=self.radius
+                radius=self.ripple_clipping_radius
             )
             StencilPop()
         anim = Animation(


### PR DESCRIPTION
Allows you to limit the touch ripple shape to rounded shapes using the *Stencil Instruction* instead of the *Scissor Instruction*. Previously, it was only possible to limit to rectangular shapes


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
