### PR TITLE
MotionEvent: Fix scale_for_screen method

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -411,8 +411,8 @@ class MotionEvent(MotionEventBase):
             return (1 - nx) * x_max, (1 - ny) * y_max
         elif rotation == 270:
             return (1 - ny) * x_max, nx * y_max
-        raise ValueError('Invalid rotation {}, valid values are {}'
-                         .format(rotation, (0, 90, 180, 270)))
+        raise ValueError('Invalid rotation %s, '
+                         'valid values are 0, 90, 180 or 270' % rotation)
 
     def push(self, attrs=None):
         '''Push attribute values in `attrs` onto the stack

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -410,7 +410,7 @@ class MotionEvent(MotionEventBase):
         elif rotation == 180:
             return (1 - nx) * x_max, (1 - ny) * y_max
         elif rotation == 270:
-            return (1 - ny) * x_max, nx * y_max
+            return (1 - ny) * y_max, nx * x_max
         raise ValueError('Invalid rotation %s, '
                          'valid values are 0, 90, 180 or 270' % rotation)
 

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -393,7 +393,7 @@ class MotionEvent(MotionEventBase):
         # Cache position
         self.pos = self.x, self.y
 
-    def to_absolute_pos(self, sx, sy, x_max, y_max, rotation=0):
+    def to_absolute_pos(self, nx, ny, x_max, y_max, rotation=0):
         '''Transforms normalized (0-1) coordinates `sx` and `sy` to absolute
         coordinates using `x_max`, `y_max` and `rotation`.
 
@@ -403,13 +403,13 @@ class MotionEvent(MotionEventBase):
         .. versionadded:: 2.1.0
         '''
         if rotation == 0:
-            return sx * x_max, sy * y_max
+            return nx * x_max, ny * y_max
         elif rotation == 90:
-            return sy * y_max, (1 - sx) * x_max
+            return ny * y_max, (1 - nx) * x_max
         elif rotation == 180:
-            return (1 - sx) * x_max, (1 - sy) * y_max
+            return (1 - nx) * x_max, (1 - ny) * y_max
         elif rotation == 270:
-            return (1 - sy) * x_max, sx * y_max
+            return (1 - ny) * x_max, nx * y_max
         raise ValueError('Invalid rotation {}, valid values are {}'
                          .format(rotation, (0, 90, 180, 270)))
 

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -383,8 +383,7 @@ class MotionEvent(MotionEventBase):
                 self.oy -= kheight
                 self.py -= kheight
             elif smode == 'scale':
-                offset = \
-                    (kheight * ((self.y - kheight) / (h - kheight))) - kheight
+                offset = kheight * (self.y - h) / (h - kheight)
                 self.y += offset
                 self.oy += offset
                 self.py += offset

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -371,9 +371,10 @@ class MotionEvent(MotionEventBase):
         self.px, self.py = absolute(self.psx, self.psy, x_max, y_max, rotation)
         # Update z values
         if p is not None:
-            self.z = self.sz * max(0, p - 1)
-            self.oz = self.osz * max(0, p - 1)
-            self.pz = self.psz * max(0, p - 1)
+            z_max = max(0, p - 1)
+            self.z = self.sz * z_max
+            self.oz = self.osz * z_max
+            self.pz = self.psz * z_max
             self.dz = self.z - self.pz
         if smode:
             # Adjust y for keyboard height
@@ -394,7 +395,7 @@ class MotionEvent(MotionEventBase):
         self.pos = self.x, self.y
 
     def to_absolute_pos(self, nx, ny, x_max, y_max, rotation):
-        '''Transforms normalized (0-1) coordinates `sx` and `sy` to absolute
+        '''Transforms normalized (0-1) coordinates `nx` and `ny` to absolute
         coordinates using `x_max`, `y_max` and `rotation`.
 
         :raises:

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -393,7 +393,7 @@ class MotionEvent(MotionEventBase):
         # Cache position
         self.pos = self.x, self.y
 
-    def to_absolute_pos(self, nx, ny, x_max, y_max, rotation=0):
+    def to_absolute_pos(self, nx, ny, x_max, y_max, rotation):
         '''Transforms normalized (0-1) coordinates `sx` and `sy` to absolute
         coordinates using `x_max`, `y_max` and `rotation`.
 

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -369,13 +369,14 @@ class MotionEvent(MotionEventBase):
         self.x, self.y = absolute(self.sx, self.sy, x_max, y_max, rotation)
         self.ox, self.oy = absolute(self.osx, self.osy, x_max, y_max, rotation)
         self.px, self.py = absolute(self.psx, self.psy, x_max, y_max, rotation)
-
+        # Update z values
         if p is not None:
             self.z = self.sz * max(0, p - 1)
             self.oz = self.osz * max(0, p - 1)
             self.pz = self.psz * max(0, p - 1)
-
+            self.dz = self.z - self.pz
         if smode:
+            # Adjust y for keyboard height
             if smode == 'pan':
                 self.y -= kheight
                 self.oy -= kheight
@@ -386,11 +387,9 @@ class MotionEvent(MotionEventBase):
                 self.y += offset
                 self.oy += offset
                 self.py += offset
-
+        # Update delta for x and y
         self.dx = self.x - self.px
         self.dy = self.y - self.py
-        self.dz = self.z - self.pz
-
         # Cache position
         self.pos = self.x, self.y
 

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -395,7 +395,7 @@ class MotionEvent(MotionEventBase):
 
     def to_absolute_pos(self, sx, sy, x_max, y_max, rotation=0):
         '''Transforms normalized (0-1) coordinates `sx` and `sy` to absolute
-        coordinates using `x_max` and `y_max`.
+        coordinates using `x_max`, `y_max` and `rotation`.
 
         :raises:
             `ValueError`: If `rotation` is not one of: 0, 90, 180 or 270

--- a/kivy/tests/test_motion_event.py
+++ b/kivy/tests/test_motion_event.py
@@ -10,6 +10,9 @@ class DummyMotionEvent(MotionEvent):
 
 class TestMotionEvent:
 
+    def create_dummy_motion_event(self):
+        return DummyMotionEvent('dummy', 'dummy1', (0, 0))
+
     def build_to_absolute_pos_data(self, x_max, y_max, x_step, y_step):
         for x, y in zip(range(0, x_max, x_step), range(0, y_max, y_step)):
             result = (x, y)
@@ -25,7 +28,7 @@ class TestMotionEvent:
             yield x / x_max, y / y_max, x_max, y_max, 270, result
 
     def test_to_absolute_pos(self):
-        event = DummyMotionEvent('dummy', 'dummy1', (0, 0))
+        event = self.create_dummy_motion_event()
         for item in self.build_to_absolute_pos_data(320, 240, 20, 21):
             args = item[:-1]
             expected_x, expected_y = item[-1]
@@ -36,6 +39,6 @@ class TestMotionEvent:
             assert correct, message
 
     def test_to_absolute_pos_error(self):
-        event = DummyMotionEvent('dummy', 'dummy1', (0, 0))
+        event = self.create_dummy_motion_event()
         with pytest.raises(ValueError):
             event.to_absolute_pos(0, 0, 100, 100, 10)

--- a/kivy/tests/test_motion_event.py
+++ b/kivy/tests/test_motion_event.py
@@ -1,0 +1,41 @@
+import pytest
+
+from kivy.compat import isclose
+from kivy.input import MotionEvent
+
+
+class DummyMotionEvent(MotionEvent):
+    pass
+
+
+class TestMotionEvent:
+
+    def build_to_absolute_pos_data(self, x_max, y_max, x_step, y_step):
+        for x, y in zip(range(0, x_max, x_step), range(0, y_max, y_step)):
+            result = (x, y)
+            yield x / x_max, y / y_max, x_max, y_max, 0, result
+        for x, y, in zip(range(0, x_max, x_step), range(0, y_max, y_step)):
+            result = (y, x_max - x)
+            yield x / x_max, y / y_max, x_max, y_max, 90, result
+        for x, y, in zip(range(0, x_max, x_step), range(0, y_max, y_step)):
+            result = (x_max - x, y_max - y)
+            yield x / x_max, y / y_max, x_max, y_max, 180, result
+        for x, y, in zip(range(0, x_max, x_step), range(0, y_max, y_step)):
+            result = (y_max - y, x)
+            yield x / x_max, y / y_max, x_max, y_max, 270, result
+
+    def test_to_absolute_pos(self):
+        event = DummyMotionEvent('fake', 'fake1', (0, 0))
+        for item in self.build_to_absolute_pos_data(320, 240, 20, 21):
+            args = item[:-1]
+            expected_x, expected_y = item[-1]
+            x, y = event.to_absolute_pos(*args)
+            message = ('For args {} expected ({}, {}), got ({}, {})'
+                       .format(args, x, y, expected_x, expected_y))
+            correct = isclose(x, expected_x) and isclose(y, expected_y)
+            assert correct, message
+
+    def test_to_absolute_pos_error(self):
+        event = DummyMotionEvent('fake', 'fake1', (0, 0))
+        with pytest.raises(ValueError):
+            event.to_absolute_pos(0, 0, 100, 100, 10)

--- a/kivy/tests/test_motion_event.py
+++ b/kivy/tests/test_motion_event.py
@@ -25,17 +25,17 @@ class TestMotionEvent:
             yield x / x_max, y / y_max, x_max, y_max, 270, result
 
     def test_to_absolute_pos(self):
-        event = DummyMotionEvent('fake', 'fake1', (0, 0))
+        event = DummyMotionEvent('dummy', 'dummy1', (0, 0))
         for item in self.build_to_absolute_pos_data(320, 240, 20, 21):
             args = item[:-1]
             expected_x, expected_y = item[-1]
             x, y = event.to_absolute_pos(*args)
             message = ('For args {} expected ({}, {}), got ({}, {})'
-                       .format(args, x, y, expected_x, expected_y))
+                       .format(args, expected_x, expected_y, x, y))
             correct = isclose(x, expected_x) and isclose(y, expected_y)
             assert correct, message
 
     def test_to_absolute_pos_error(self):
-        event = DummyMotionEvent('fake', 'fake1', (0, 0))
+        event = DummyMotionEvent('dummy', 'dummy1', (0, 0))
         with pytest.raises(ValueError):
             event.to_absolute_pos(0, 0, 100, 100, 10)


### PR DESCRIPTION
Fixes `scale_for_screen` to compute `ox`, `oy`, `oz`, `px`, `py`, `pz` values from their normalized values.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
