### PR TITLE
Graphics.Line: #7656-Line-rounded_rectangle  BugFix

### DIFF
--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -174,7 +174,7 @@ cdef class Line(VertexInstruction):
             self.prebuild_rounded_rectangle()
         elif self._mode == LINE_MODE_BEZIER:
             self.prebuild_bezier()
-        if self._width == 1.0:
+        if self._width <= 1:
             self.build_legacy()
         else:
             self.build_extended()
@@ -1119,7 +1119,8 @@ cdef class Line(VertexInstruction):
             Line(rounded_rectangle=(0, 0, 200, 200, 10, 20, 30, 40, 100))
 
         .. versionadded:: 1.9.0
-        .. versionmodified:: 2.1.0
+        .. versionchanged:: 2.1.0
+            ``resolution`` usage has changed, now it means the ammount of segments to process per corner.
         '''
         def __set__(self, args):
             if args == None:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
This merge request solves #7656.
*improves the class to lock the maximum length between corners based on the minimum value between object length and width.
* adds the missing 4 control points
* made the drawing instruction a loop, that can be easily maintained
* changed the behavior of the `segments` parameter, this parameter now indicates the amount of segment that will be processed for each corner.
* the inner loop starts processing the top-right corner and goes clock backwards wise. But the radius_ parameters works the same. The array inside allows the normal standard behavior across kivy.

Be aware that this means the following
*wh=min(width, height) : minumum value between height and width.
*wh2 = (wh-1)//2 : half the minimum lenght.

New behavior for the `segments` parameter:
* if segment = 0 the canvas will draw a normal rectangle
* if segment >= 1: the canvas will draw a rounded rectangle with the number of segments per corner + the side flat lines.
* if segment > wh2, we use the wh2 value as maximum.

New radius behavior:
* all corner radius are checked to be less or equal to wh2
* all corners limit are wh2, this allows us to avoid some visual issues whenever the line has a specific kind of corner joint.
* all corners have a lower limit of 1 this help us to avoid adding a new logic block for radius_ = 0
* all corners are square. maybe not square corners might be added in the future (if i learn how to plot them).

Maintainer merge checklist
- [x] Title is descriptive/clear for inclusion in release notes.
- [x] Applied a `Component: xxx` label.
- [ ] Applied the `api-deprecation` or `api-break` label.
- [ ] Applied the `release-highlight` label to be highlighted in release notes.
- [ ] Added to the milestone version it was merged into.
- [ ] **Unittests** are included in PR.
- [x] Properly documented, including `versionadded`, `versionchanged` as needed.
