### PR TITLE
Textinput cursor fixes

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -490,7 +490,7 @@ class TextInput(FocusBehavior, Widget):
             self._update_graphics, -1)
         self._trigger_adjust_viewport = triggered(timeout=-1)(self._adjust_viewport)
         self.is_focusable = kwargs.get('is_focusable', True)
-        self._cursor = [0, 0]
+        self._cursor = 0, 0
         self._selection = False
         self._selection_finished = True
         self._selection_touch = None
@@ -2528,7 +2528,6 @@ class TextInput(FocusBehavior, Widget):
     def on_size(self, instance, value):
         # if the size change, we might do invalid scrolling / text split
         # size the text maybe be put after size_hint have been resolved.
-        self._trigger_refresh_text()
         self._refresh_hint_text()
         self.scroll_x = self.scroll_y = 0
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2113,7 +2113,7 @@ class TextInput(FocusBehavior, Widget):
         if self._refresh_text_from_property_ev is not None:
             self._refresh_text_from_property_ev.cancel()
         self._refresh_text_from_property_ev = Clock.schedule_once(
-            lambda dt: self._refresh_text_from_property(*largs))
+            lambda dt: self._refresh_text_from_property(*largs), -1)
 
     def _update_text_options(self, *largs):
         Cache_remove('textinput.width')

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -488,6 +488,7 @@ class TextInput(FocusBehavior, Widget):
     def __init__(self, **kwargs):
         self._update_graphics_ev = Clock.create_trigger(
             self._update_graphics, -1)
+        self._trigger_adjust_viewport = triggered(timeout=-1)(self._adjust_viewport)
         self.is_focusable = kwargs.get('is_focusable', True)
         self._cursor = [0, 0]
         self._selection = False
@@ -3140,7 +3141,7 @@ class TextInput(FocusBehavior, Widget):
 
         # adjust scrollview to ensure that the cursor will be always inside our
         # viewport.
-        self._adjust_viewport(cc, cr)
+        self._trigger_adjust_viewport(cc, cr)
 
         if self._cursor == cursor:
             return
@@ -3148,7 +3149,6 @@ class TextInput(FocusBehavior, Widget):
         self._cursor = cursor
         return True
 
-    @triggered(timeout=-1)
     def _adjust_viewport(self, cc, cr):
         padding_left = self.padding[0]
         padding_right = self.padding[2]


### PR DESCRIPTION
Fixed:

1. All TextInput instances have the same __adjust_viewport_ trigger, so if one changes cursors in several TextInput widgets simultaneously, it only scrolls to the new cursor position in the last widget.
2. Text "trembling" when resizing TextInput.
The reason is that currently it scrolls to the beginning before the next frame and then to the cursor after the next frame.
![textinput resize trembling](https://user-images.githubusercontent.com/73047043/140320508-85dd3698-25c9-409b-98bb-52fbbd4f63d9.gif)
3. Minor fixes.
a) self.cursor is in fact a tuple, so it should be initially set as tuple, not list;
b) When widget size changes `self._trigger_refresh_text()` is already called in `self._update_text_options` (which is bound to 'size' in `__init__`), so no need to duplicate it.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
