### PR TITLE
Add support for Apple Silicon on CI/CD [build wheel osx] [build app osx]

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -17,50 +17,81 @@ download_cache_curl() {
   fi
 }
 
-download_cache_aria2() {
-  fname="$1"
-  key="$2"
-  url_prefix="$3"
 
-  if [ ! -f $key/$fname ]; then
-    if [ ! -d $key ]; then
-      mkdir "$key"
-    fi
-    /usr/local/aria2/bin/aria2c -x 10 "$url_prefix/$fname"
-    cp "$fname" "$key"
-  else
-    cp "$key/$fname" .
+arm64_set_path_and_python_version(){
+  python_version="$1"
+  if [[ $(/usr/bin/arch) = arm64 ]]; then
+      export PATH=/opt/homebrew/bin:$PATH
+      eval "$(pyenv init --path)"
+      pyenv install $python_version -s
+      pyenv global $python_version
+      export PATH=$(pyenv prefix)/bin:$PATH
   fi
 }
 
-install_kivy_test_run_sys_deps() {
-  download_cache_curl "aria2-$ARIAL2-osx-darwin.dmg" "osx-cache" "https://github.com/aria2/aria2/releases/download/release-$ARIAL2"
-  hdiutil attach aria2-$ARIAL2-osx-darwin.dmg
-  sudo installer -package "/Volumes/aria2 $ARIAL2 Intel/aria2.pkg" -target /
+build_and_install_universal_kivy_sys_deps() {
 
-  download_cache_curl "SDL2-$SDL2.dmg" "osx-cache" "https://www.libsdl.org/release"
-  download_cache_curl "SDL2_image-$SDL2_IMAGE.dmg" "osx-cache" "https://www.libsdl.org/projects/SDL_image/release"
-  download_cache_curl "SDL2_mixer-$SDL2_MIXER.dmg" "osx-cache" "https://www.libsdl.org/projects/SDL_mixer/release"
-  download_cache_curl "SDL2_ttf-$SDL2_TTF.dmg" "osx-cache" "https://www.libsdl.org/projects/SDL_ttf/release"
+  rm -rf deps_build
+  mkdir deps_build
 
-  hdiutil attach SDL2-$SDL2.dmg
-  sudo cp -a /Volumes/SDL2/SDL2.framework /Library/Frameworks/
-  hdiutil attach SDL2_image-$SDL2_IMAGE.dmg
-  sudo cp -a /Volumes/SDL2_image/SDL2_image.framework /Library/Frameworks/
-  hdiutil attach SDL2_ttf-$SDL2_TTF.dmg
-  sudo cp -a /Volumes/SDL2_ttf/SDL2_ttf.framework /Library/Frameworks/
-  hdiutil attach SDL2_mixer-$SDL2_MIXER.dmg
-  sudo cp -a /Volumes/SDL2_mixer/SDL2_mixer.framework /Library/Frameworks/
+  pushd deps_build
+  download_cache_curl "${SDL2}.tar.gz" "osx-cache" "https://github.com/libsdl-org/SDL/archive/refs/tags"
+  download_cache_curl "${SDL2_MIXER}.tar.gz" "osx-cache" "https://github.com/libsdl-org/SDL_mixer/archive"
+  download_cache_curl "${SDL2_IMAGE}.tar.gz" "osx-cache" "https://github.com/libsdl-org/SDL_image/archive"
+  download_cache_curl "${SDL2_TTF}.tar.gz" "osx-cache" "https://github.com/libsdl-org/SDL_ttf/archive"
 
-  download_cache_aria2 "gstreamer-1.0-$GSTREAMER-x86_64.pkg" "osx-cache" "https://gstreamer.freedesktop.org/data/pkg/osx/$GSTREAMER"
-  download_cache_aria2 "gstreamer-1.0-devel-$GSTREAMER-x86_64.pkg" "osx-cache-gst-devel" "https://gstreamer.freedesktop.org/data/pkg/osx/$GSTREAMER"
+  echo "-- Build SDL2 (Universal)"
+  tar -xvf "${SDL2}.tar.gz"
+  mv "SDL-${SDL2}" "SDL"
+  pushd "SDL"
+  xcodebuild ONLY_ACTIVE_ARCH=NO -project Xcode/SDL/SDL.xcodeproj -target Framework -configuration Release
+  popd
 
-  sudo installer -package gstreamer-1.0-$GSTREAMER-x86_64.pkg -target /
-  sudo installer -package gstreamer-1.0-devel-$GSTREAMER-x86_64.pkg -target /
+  echo "-- Copy SDL2.framework to /Library/Frameworks"
+  sudo cp -r SDL/Xcode/SDL/build/Release/SDL2.framework /Library/Frameworks
+
+  echo "-- Build SDL2_mixer (Universal)"
+  tar -xvf "${SDL2_MIXER}.tar.gz"
+  mv "SDL_mixer-${SDL2_MIXER}" "SDL_mixer"
+  pushd "SDL_mixer"
+  xcodebuild ONLY_ACTIVE_ARCH=NO \
+          -project Xcode/SDL_mixer.xcodeproj -target Framework -configuration Release
+  popd
+
+  echo "-- Copy SDL2_mixer.framework to /Library/Frameworks"
+  sudo cp -r SDL_mixer/Xcode/build/Release/SDL2_mixer.framework /Library/Frameworks
+
+  echo "-- Build SDL2_image (Universal)"
+  tar -xvf "${SDL2_IMAGE}.tar.gz"
+  mv "SDL_image-${SDL2_IMAGE}" "SDL_image"
+  pushd "SDL_image"
+  xcodebuild ONLY_ACTIVE_ARCH=NO \
+          -project Xcode/SDL_image.xcodeproj -target Framework -configuration Release
+  popd
+
+  echo "-- Copy SDL2_image.framework to /Library/Frameworks"
+  sudo cp -r SDL_image/Xcode/build/Release/SDL2_image.framework /Library/Frameworks
+
+  echo "-- Build SDL2_ttf (Universal)"
+  tar -xvf "${SDL2_TTF}.tar.gz"
+  mv "SDL_ttf-${SDL2_TTF}" "SDL_ttf"
+  pushd "SDL_ttf"
+  xcodebuild ONLY_ACTIVE_ARCH=NO \
+          -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release
+  popd
+
+  echo "-- Copy SDL2_ttf.framework to /Library/Frameworks"
+  sudo cp -r SDL_ttf/Xcode/build/Release/SDL2_ttf.framework /Library/Frameworks
+
+  popd
+}
+
+install_ffpyplayer_sys_deps() {
+  brew install ffmpeg
 }
 
 install_platypus() {
-  download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "http://www.sveinbjorn.org/files/software/platypus"
+  download_cache_curl "platypus$PLATYPUS.zip" "osx-cache" "https://github.com/sveinbjornt/Platypus/releases/download/$PLATYPUS"
 
   unzip "platypus$PLATYPUS.zip"
   gunzip Platypus.app/Contents/Resources/platypus_clt.gz
@@ -72,52 +103,6 @@ install_platypus() {
   cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
   cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
   chmod -R 755 /usr/local/share/platypus
-}
-
-generate_osx_wheels() {
-  python3 -m pip install git+http://github.com/tito/osxrelocator
-  python3 -m pip install --upgrade delocate
-  python3 setup.py bdist_wheel
-
-  delocate-wheel dist/*.whl
-  zip_dir="$(basename dist/*.whl .whl)"
-  unzip dist/*.whl -d dist/$zip_dir
-  rm dist/$zip_dir/kivy/.dylibs/libg*
-  rm dist/$zip_dir/kivy/.dylibs/GStreamer
-
-  cp /Library/Frameworks/SDL2.framework/Versions/A/Frameworks/hidapi.framework/Versions/A/hidapi dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_image.framework/Versions/A/Frameworks/webp.framework/Versions/A/webp dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/FLAC.framework/Versions/A/FLAC dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_ttf.framework/Versions/A/Frameworks/FreeType.framework/Versions/A/FreeType dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/Ogg.framework/Versions/A/Ogg dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/Vorbis.framework/Versions/A/Vorbis dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/modplug.framework/Versions/A/modplug dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/mpg123.framework/Versions/A/mpg123 dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/Opus.framework/Versions/A/Opus dist/$zip_dir/kivy/.dylibs/
-  cp /Library/Frameworks/SDL2_mixer.framework/Versions/A/Frameworks/OpusFile.framework/Versions/A/OpusFile dist/$zip_dir/kivy/.dylibs/
-
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/SDL2.framework/Versions/A/SDL2 @loader_path/SDL2
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/hidapi.framework/Versions/A/hidapi @loader_path/hidapi
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/webp.framework/Versions/A/webp @loader_path/webp
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/FLAC.framework/Versions/A/FLAC @loader_path/FLAC
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/modplug.framework/Versions/A/modplug @loader_path/modplug
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/mpg123.framework/Versions/A/mpg123 @loader_path/mpg123
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Opus.framework/Versions/A/Opus @loader_path/Opus
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/OpusFile.framework/Versions/A/OpusFile @loader_path/OpusFile
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/FreeType.framework/Versions/A/FreeType @loader_path/FreeType
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Vorbis.framework/Versions/A/Vorbis @loader_path/Vorbis
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/../../../../SDL2.framework/Versions/A/SDL2 @loader_path/SDL2
-  python3 -m osxrelocator.__init__ dist/$zip_dir/kivy/.dylibs @rpath/Ogg.framework/Versions/A/Ogg @loader_path/Ogg
-
-  codesign -fs - "dist/$zip_dir/kivy/.dylibs/hidapi"
-
-  rm dist/$zip_dir.whl
-  pushd dist
-  python3 -c "from delocate import delocating; delocating.dir2zip('$zip_dir', '$zip_dir.whl')"
-  rm -rf $zip_dir
-  popd
-
-  delocate-addplat --rm-orig -x 10_9 -x 10_10 dist/*.whl
 }
 
 generate_osx_app_bundle() {
@@ -133,7 +118,7 @@ generate_osx_app_bundle() {
 
 generate_osx_app_dmg_from_bundle() {
   pushd ../kivy-sdk-packager/osx
-  ./create-osx-dmg.sh Kivy.app Kivy
+  ./create-osx-dmg.sh build/Kivy.app Kivy
   popd
 
   mkdir app

--- a/.ci/osx_versions.sh
+++ b/.ci/osx_versions.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-export ARIAL2=1.35.0
-export SDL2=2.0.12
-export SDL2_IMAGE=2.0.5
-export SDL2_MIXER=2.0.4
-export SDL2_TTF=2.0.15
-export GSTREAMER=1.16.2
+export SDL2="release-2.0.18"
+export SDL2_IMAGE="168ceb577c245c91801c1bcaf970ef31c9b4d7ba"
+export SDL2_MIXER="64120a41f62310a8be9bb97116e15a95a892e39d"
+export SDL2_TTF="393fdc91e6827905b75a6b267851c03f35914eab"
 export PLATYPUS=5.3

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -82,7 +82,6 @@ install_kivy_examples_wheel() {
 install_kivy_wheel() {
   root="$(pwd)"
   cd ~
-
   version=$(python3 -c "import sys; print('{}{}'.format(sys.version_info.major, sys.version_info.minor))")
   kivy_fname=$(ls "$root"/dist/Kivy-*$version*.whl | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | head -n1)
   python3 -m pip install "${kivy_fname}[full,dev]"

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -14,19 +14,17 @@ env:
   CXX: clang
   FFLAGS: '-ff2c'
   USE_SDL2: 1
-  USE_GSTREAMER: 1
-  GST_REGISTRY: '~/registry.bin'
 
 jobs:
   kivy_examples_create:
     # we need examples wheel for tests, but only windows actually uploads kivy-examples to pypi/server
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
@@ -42,65 +40,78 @@ jobs:
         path: dist
 
   osx_wheels_create:
-    runs-on: macos-10.15
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    env:
+      CIBW_BUILD: "cp37-macosx_x86_64 cp38-macosx_universal2 cp39-macosx_universal2"
+      CIBW_ARCHS_MACOS: "x86_64 universal2"
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+        DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
+        DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
     strategy:
       matrix:
-        python: [ '3.6', '3.7', '3.8', '3.9' ]
+        include:
+          - runs_on: macos-11
+            python: '3.9'
+          # Fix for macOS 12 is here, but not merged yet: https://github.com/matthew-brett/delocate/pull/130
+          # - runs_on: apple-silicon-m1
+          #  run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+          #  python: 3.9.7
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
+      # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
+      if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Cache OSX deps
+    - name: Cache macOS deps downloads
       uses: actions/cache@v2
       with:
         path: osx-cache
         key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}
-    - name: Cache OSX gst-devel deps
-      uses: actions/cache@v2
-      with:
-        path: osx-cache-gst-devel
-        key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
     - name: Generate version metadata
       run: |
         source .ci/ubuntu_ci.sh
         update_version_metadata
-    - name: Install dependencies
+    - name: Build universal Kivy dependencies
       run: |
         source .ci/ubuntu_ci.sh
         source .ci/osx_versions.sh
         source .ci/osx_ci.sh
-        install_kivy_test_run_sys_deps
-        install_kivy_test_run_pip_deps
-    - name: Install Kivy
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        build_and_install_universal_kivy_sys_deps
+    - name: Install cibuildwheel
       run: |
-        source .ci/ubuntu_ci.sh
-        install_kivy
-    - name: Make wheels
-      run: |
-        source .ci/osx_versions.sh
         source .ci/osx_ci.sh
-        generate_osx_wheels
-    - name: Upload wheels as artifact
-      uses: actions/upload-artifact@v2
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        python -m pip install cibuildwheel==2.3.1
+    - name: Build wheels
+      run: |
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        export REPAIR_LIBRARY_PATH=/Library/Frameworks:/Library/Frameworks/SDL2_mixer.framework/Frameworks
+        python -m cibuildwheel --output-dir wheelhouse
+    - uses: actions/upload-artifact@v2
       with:
         name: osx_wheels
-        path: dist
+        path: ./wheelhouse/*.whl
 
   osx_wheel_upload:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: osx_wheels_create
     if: github.event_name != 'pull_request'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.x
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.9'
     - uses: actions/download-artifact@v2
       with:
         name: osx_wheels
@@ -134,16 +145,33 @@ jobs:
         upload_artifacts_to_pypi
 
   osx_wheel_test:
-    runs-on: macos-10.15
     needs: [ osx_wheels_create, kivy_examples_create ]
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
     strategy:
       matrix:
-        python: [ '3.6', '3.7', '3.8', '3.9' ]
+        include:
+          - runs_on: macos-11     
+            python: '3.7'
+          - runs_on: macos-11     
+            python: '3.8'
+          - runs_on: macos-11     
+            python: '3.9'
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+            python: '3.8.12'
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+            python: '3.9.7'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
+        # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
+        if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
@@ -154,10 +182,21 @@ jobs:
       - name: Install test dependencies
         run: |
           source .ci/ubuntu_ci.sh
+          source .ci/osx_ci.sh
+          arm64_set_path_and_python_version ${{ matrix.python }}
           install_kivy_test_wheel_run_pip_deps
+      - name: Install ffpyplayer dependencies (Apple Silicon)
+        # ffpyplayer doesn't provides a wheel with Apple Silicon support (yet).
+        if: ${{ matrix.runs_on  == 'apple-silicon-m1' }}
+        run: |
+          source .ci/osx_ci.sh
+          arm64_set_path_and_python_version ${{ matrix.python }}
+          install_ffpyplayer_sys_deps
       - name: Install Kivy wheel
         run: |
           source .ci/ubuntu_ci.sh
+          source .ci/osx_ci.sh
+          arm64_set_path_and_python_version ${{ matrix.python }}
           install_kivy_wheel
       - uses: actions/download-artifact@v2
         with:
@@ -166,14 +205,18 @@ jobs:
       - name: Install kivy-examples wheel
         run: |
           source .ci/ubuntu_ci.sh
+          source .ci/osx_ci.sh
+          arm64_set_path_and_python_version ${{ matrix.python }}
           install_kivy_examples_wheel
       - name: Test Kivy wheel
         run: |
           source .ci/ubuntu_ci.sh
+          source .ci/osx_ci.sh
+          arm64_set_path_and_python_version ${{ matrix.python }}
           test_kivy_install
 
   osx_app_create:
-    runs-on: macos-10.15
+    runs-on: macos-11
     if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
     env:
       KIVY_SPLIT_EXAMPLES: 0
@@ -183,16 +226,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Cache OSX deps
+      - name: Cache macOS deps downloads
         uses: actions/cache@v2
         with:
           path: osx-cache
           key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}
-      - name: Cache OSX gst-devel deps
-        uses: actions/cache@v2
-        with:
-          path: osx-cache-gst-devel
-          key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
       - name: Generate version metadata
         run: |
           source .ci/ubuntu_ci.sh
@@ -202,7 +240,6 @@ jobs:
           source .ci/ubuntu_ci.sh
           source .ci/osx_versions.sh
           source .ci/osx_ci.sh
-          install_kivy_test_run_sys_deps
           install_platypus
           install_kivy_test_run_pip_deps
       - name: Make app bundle
@@ -223,7 +260,7 @@ jobs:
           path: app
 
   osx_app_upload_test:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: [osx_app_create, kivy_examples_create]
     env:
       KIVY_GL_BACKEND: 'mock'
@@ -232,7 +269,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.9'
       - uses: actions/download-artifact@v2
         with:
           name: osx_app

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -145,6 +145,7 @@ jobs:
         upload_artifacts_to_pypi
 
   osx_wheel_test:
+    name: "osx_wheel_test (${{ matrix.runs_on }}, ${{ matrix.python }})"
     needs: [ osx_wheels_create, kivy_examples_create ]
     defaults:
       run:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   unit_test:
+    name: "unit_test (${{ matrix.runs_on }}, ${{ matrix.python }})"
     defaults:
       run:
         shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -9,39 +9,52 @@ env:
   CXX: clang
   FFLAGS: '-ff2c'
   USE_SDL2: 1
-  USE_GSTREAMER: 1
 
 jobs:
   unit_test:
-    runs-on: macos-10.15
+    defaults:
+      run:
+        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
+    runs-on: ${{ matrix.runs_on || 'macos-11' }}
+    strategy:
+      matrix:
+        include:
+          - runs_on: macos-11
+            python: '3.9'
+          - runs_on: apple-silicon-m1
+            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
+            python: '3.9.7'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x
+      # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
+      if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
-    - name: Cache OSX deps
+        python-version: ${{ matrix.python }}
+    - name: Cache macOS deps downloads
       uses: actions/cache@v2
       with:
         path: osx-cache
         key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}
-    - name: Cache OSX gst-devel deps
-      uses: actions/cache@v2
-      with:
-        path: osx-cache-gst-devel
-        key: gst-devel-${{ runner.OS }}-build-${{ hashFiles('.ci/osx_versions.sh') }}-gst-devel
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
         source .ci/osx_versions.sh
         source .ci/osx_ci.sh
-        install_kivy_test_run_sys_deps
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        build_and_install_universal_kivy_sys_deps
+        install_ffpyplayer_sys_deps
         install_kivy_test_run_pip_deps
     - name: Install Kivy
       run: |
         source .ci/ubuntu_ci.sh
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
         install_kivy
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
         test_kivy

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -173,8 +173,7 @@ To activate it so you can use python, like any normal virtualenv, do::
 On the default mac (zsh) shell you **must** be in the bin directory containing ``activate`` to be
 able to ``activate`` the virtualenv, hence why we changed the directory temporarily.
 
-``kivy_activate`` sets up the environment to be able to run Kivy, by setting the kivy home,
-gstreamer, and other variables.
+``kivy_activate`` sets up the environment to be able to run Kivy, by setting the kivy home, and other variables.
 
 Start any Kivy Application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR provides support for CI/CD on Apple Silicon M1 via a self-hosted runner.

Major changes:
- `Gstreamer` support is NOT included anymore in our `wheels` and `Kivy.app`.
- Instead of our custom `generate_osx_wheels`, now wheels build and dependencies delocation is done via `cibuildwheel`
- Kivy dependencies for macOS wheels are now built from source. This is (at this time) the only way to have `SDL2`, `SDL2_mixer`, `SDL2_image`, `SDL2_ttf` universal frameworks.
- We now provide macOS wheels for : `cp37 (x86_64)`, `cp38 (universal2)`, `cp39 (universal2)` .

Known issues:
- We're at this time unable to build `universal2` wheels on our M1 self hosted runner (macOS 12 Monterey based) due to an issue when delocating deps (https://github.com/matthew-brett/delocate/pull/130), 
- We're including `ffmpeg` dependency download on M1, during tests, cause `full` version of kivy ships with `ffpyplayer` and `ffpyplayer` doesn't have a `universal2` wheel, so needs to be built from sources.

Todo:

- [x] Fix `Kivy.app` job
- [x] Do runtime tests locally. (on Apple Silicon and Intel)
- [x] Fix documentation regarding gstreamer changes.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
