### PR TITLE
MotionEvent: Fix calculation of z values in scale_for_screen method

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -369,13 +369,10 @@ class MotionEvent(MotionEventBase):
         self.x, self.y = absolute(self.sx, self.sy, x_max, y_max, rotation)
         self.ox, self.oy = absolute(self.osx, self.osy, x_max, y_max, rotation)
         self.px, self.py = absolute(self.psx, self.psy, x_max, y_max, rotation)
-        # Update z values
-        if p is not None:
-            z_max = max(0, p - 1)
-            self.z = self.sz * z_max
-            self.oz = self.osz * z_max
-            self.pz = self.psz * z_max
-            self.dz = self.z - self.pz
+        z_max = 0 if p is None else max(0, p - 1)
+        self.z = self.sz * z_max
+        self.oz = self.osz * z_max
+        self.pz = self.psz * z_max
         if smode:
             # Adjust y for keyboard height
             if smode == 'pan':
@@ -387,9 +384,10 @@ class MotionEvent(MotionEventBase):
                 self.y += offset
                 self.oy += offset
                 self.py += offset
-        # Update delta for x and y
+        # Update delta values
         self.dx = self.x - self.px
         self.dy = self.y - self.py
+        self.dz = self.z - self.pz
         # Cache position
         self.pos = self.x, self.y
 


### PR DESCRIPTION
`MotionEvent` attributes `z`, `oz`, `pz`, `dz` will be set to `0` when `p` is `None`. Follow-up on https://github.com/kivy/kivy/pull/7659.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
