### PR TITLE
Enable pressure for touches in android (and ios?)

### DIFF
--- a/examples/demo/touchtracer/main.py
+++ b/examples/demo/touchtracer/main.py
@@ -57,7 +57,7 @@ class Touchtracer(FloatLayout):
 
     def normalize_pressure(self, pressure):
         print(pressure)
-        # this might mean we are on a device whose pressure value is
+        # this might mean we are on a device whose pressure value is
         # incorrectly reported by SDL2, like recent iOS devices.
         if pressure == 0.0:
             return 1
@@ -102,7 +102,7 @@ class Touchtracer(FloatLayout):
                 points = ud['lines'][index].points
                 oldx, oldy = points[-2], points[-1]
                 break
-            except:
+            except IndexError:
                 index -= 1
 
         points = calculate_points(oldx, oldy, touch.x, touch.y)
@@ -110,7 +110,10 @@ class Touchtracer(FloatLayout):
         # if pressure changed create a new point instruction
         if 'pressure' in ud:
             old_pressure = ud['pressure']
-            if not old_pressure or not .99 < (touch.pressure / old_pressure) < 1.01:
+            if (
+                not old_pressure
+                or not .99 < (touch.pressure / old_pressure) < 1.01
+            ):
                 g = ud['group']
                 pointsize = self.normalize_pressure(touch.pressure)
                 with self.canvas:

--- a/examples/demo/touchtracer/main.py
+++ b/examples/demo/touchtracer/main.py
@@ -32,6 +32,7 @@ from kivy.app import App
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.label import Label
 from kivy.graphics import Color, Rectangle, Point, GraphicException
+from kivy.metrics import dp
 from random import random
 from math import sqrt
 
@@ -54,14 +55,23 @@ def calculate_points(x1, y1, x2, y2, steps=5):
 
 class Touchtracer(FloatLayout):
 
+    def normalize_pressure(self, pressure):
+        print(pressure)
+        # this might mean we are on a device whose pressure value is
+        # incorrectly reported by SDL2, like recent iOS devices.
+        if pressure == 0.0:
+            return 1
+        return dp(pressure * 10)
+
     def on_touch_down(self, touch):
         win = self.get_parent_window()
         ud = touch.ud
         ud['group'] = g = str(touch.uid)
         pointsize = 5
+        print(touch.profile)
         if 'pressure' in touch.profile:
             ud['pressure'] = touch.pressure
-            pointsize = (touch.pressure * 100000) ** 2
+            pointsize = self.normalize_pressure(touch.pressure)
         ud['color'] = random()
 
         with self.canvas:
@@ -99,9 +109,10 @@ class Touchtracer(FloatLayout):
 
         # if pressure changed create a new point instruction
         if 'pressure' in ud:
-            if not .95 < (touch.pressure / ud['pressure']) < 1.05:
+            old_pressure = ud['pressure']
+            if not old_pressure or not .99 < (touch.pressure / old_pressure) < 1.01:
                 g = ud['group']
-                pointsize = (touch.pressure * 100000) ** 2
+                pointsize = self.normalize_pressure(touch.pressure)
                 with self.canvas:
                     Color(ud['color'], 1, 1, mode='hsv', group=g)
                     ud['lines'].append(

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -641,13 +641,15 @@ cdef class _WindowSDL2Storage:
             fid = event.tfinger.fingerId
             x = event.tfinger.x
             y = event.tfinger.y
-            return ('fingermotion', fid, x, y)
+            pressure = event.tfinger.pressure
+            return ('fingermotion', fid, x, y, pressure)
         elif event.type == SDL_FINGERDOWN or event.type == SDL_FINGERUP:
             fid = event.tfinger.fingerId
             x = event.tfinger.x
             y = event.tfinger.y
+            pressure = event.tfinger.pressure
             action = 'fingerdown' if event.type == SDL_FINGERDOWN else 'fingerup'
-            return (action, fid, x, y)
+            return (action, fid, x, y, pressure)
         elif event.type == SDL_JOYAXISMOTION:
             return (
                 'joyaxismotion',

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -107,8 +107,8 @@ SDLK_F15 = 1073741896
 class SDL2MotionEvent(MotionEvent):
     def depack(self, args):
         self.is_touch = True
-        self.profile = ('pos', )
-        self.sx, self.sy = args
+        self.profile = ('pos', 'pressure', )
+        self.sx, self.sy, self.pressure = args
         win = EventLoop.window
         super(SDL2MotionEvent, self).depack(args)
 
@@ -126,13 +126,15 @@ class SDL2MotionEventProvider(MotionEventProvider):
             except IndexError:
                 return
 
-            action, fid, x, y = value
+            action, fid, x, y, pressure = value
             y = 1 - y
             if fid not in touchmap:
-                touchmap[fid] = me = SDL2MotionEvent('sdl', fid, (x, y))
+                touchmap[fid] = me = SDL2MotionEvent(
+                    'sdl', fid, (x, y, pressure)
+                )
             else:
                 me = touchmap[fid]
-                me.move((x, y))
+                me.move((x, y, pressure))
             if action == 'fingerdown':
                 dispatch_fn('begin', me)
             elif action == 'fingerup':


### PR DESCRIPTION
Touch pressure on android worked back when we were using the pygame bootsrtap, but seem to have been lost since the switch to sdl2, this PR adds back the support using info from the SDL event.

Tested on two android devices, the value are very different from what we had with pygame, but seems more reasonable, so i updated the example rather than trying to mimic the previous range.

This shouldn't have any impact on desktop as we don't use the SDL events for touches there.

![image](https://user-images.githubusercontent.com/22759/141386721-d86bb867-bec7-4cc9-9917-7b9accbe8839.png)

 
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
