### PR TITLE
Fix Scatter rotation and scaling of child widgets when using multitouch

### DIFF
--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -367,26 +367,35 @@ class MotionEvent(MotionEventBase):
         x_max, y_max = max(0, w - 1), max(0, h - 1)
         absolute = self.to_absolute_pos
         self.x, self.y = absolute(self.sx, self.sy, x_max, y_max, rotation)
-        self.ox, self.oy = absolute(self.osx, self.osy, x_max, y_max, rotation)
-        self.px, self.py = absolute(self.psx, self.psy, x_max, y_max, rotation)
+        opos_ppos_updated = False
+        if self.ox is None:
+            self.ox, self.oy = absolute(self.osx, self.osy, x_max, y_max,
+                                        rotation)
+            self.px, self.py = absolute(self.psx, self.psy, x_max, y_max,
+                                        rotation)
+            opos_ppos_updated = True
         # Update z values
         if p is not None:
             z_max = max(0, p - 1)
             self.z = self.sz * z_max
-            self.oz = self.osz * z_max
-            self.pz = self.psz * z_max
+            if self.oz is None:
+                self.oz = self.osz * z_max
+            if self.pz is None:
+                self.pz = self.psz * z_max
             self.dz = self.z - self.pz
         if smode:
             # Adjust y for keyboard height
             if smode == 'pan':
                 self.y -= kheight
-                self.oy -= kheight
-                self.py -= kheight
+                if opos_ppos_updated:
+                    self.oy -= kheight
+                    self.py -= kheight
             elif smode == 'scale':
                 offset = kheight * (self.y - h) / (h - kheight)
                 self.y += offset
-                self.oy += offset
-                self.py += offset
+                if opos_ppos_updated:
+                    self.oy += offset
+                    self.py += offset
         # Update delta for x and y
         self.dx = self.x - self.px
         self.dy = self.y - self.py


### PR DESCRIPTION
Instead of calculating the origin and previous position every time the "scale_for_screen"
method is called it is only calculated when a "on_touch_down" event is triggered

This bug was introduced in: e8725996ac8cc8d533ba91f1e8325b74928d0b7d

The method "transform_with_touch" in "Scatter" is relying on the "touch.ppos" to only get updated
when the screen is initially touched and not when the finger is moved

Fixes #7685

To be honest if feels like a hack, but I suspect that a lot of other widgets are relying on the old behavior.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
