### PR TITLE
MotionEvent: Fix keeping of the previous normalized position

### DIFF
--- a/kivy/base.py
+++ b/kivy/base.py
@@ -302,6 +302,7 @@ class EventLoopBase(EventDispatcher):
             if wid != root_window and root_window is not None:
                 me.pop()
         me.grab_state = False
+        me.dispatch_done()
 
     def _dispatch_input(self, *ev):
         # remove the save event for the touch if exist
@@ -327,9 +328,7 @@ class EventLoopBase(EventDispatcher):
         pop = input_events.pop
         post_dispatch_input = self.post_dispatch_input
         while input_events:
-            etype, me = pop(0)
-            post_dispatch_input(etype, me)
-            me.dispatch_done()
+            post_dispatch_input(*pop(0))
 
     def mainloop(self):
         while not self.quit and self.status == 'started':

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -327,7 +327,9 @@ class EventLoopBase(EventDispatcher):
         pop = input_events.pop
         post_dispatch_input = self.post_dispatch_input
         while input_events:
-            post_dispatch_input(*pop(0))
+            etype, me = pop(0)
+            post_dispatch_input(etype, me)
+            me.dispatch_done()
 
     def mainloop(self):
         while not self.quit and self.status == 'started':

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -309,8 +309,10 @@ class MotionEvent(MotionEventBase):
 
     def depack(self, args):
         '''Depack `args` into attributes of the class'''
-        # set initial position and last position
-        if self.osx is None:
+        if self.osx is None \
+                or self.sync_with_dispatch and not self._first_dispatch_done:
+            # Sync original/previous/current positions until the first
+            # dispatch (etype == 'begin') is done.
             self.psx = self.osx = self.sx
             self.psy = self.osy = self.sy
             self.psz = self.osz = self.sz
@@ -384,13 +386,6 @@ class MotionEvent(MotionEventBase):
             self.psx, self.psy, self.psz = self.sx, self.sy, self.sz
         self.time_update = time()
         self.depack(args)
-        if self.sync_with_dispatch and not self._first_dispatch_done:
-            # Sync original/previous/current positions until the first
-            # dispatch (etype == 'begin') is done.
-            self.osx = self.psx = self.sx
-            self.osy = self.psy = self.sy
-            self.osz = self.psz = self.sz
-            self.dsx = self.dsy = self.dsz = 0.0
 
     def scale_for_screen(self, w, h, p=None, rotation=0,
                          smode='None', kheight=0):

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -311,11 +311,11 @@ class MotionEvent(MotionEventBase):
         '''Depack `args` into attributes of the class'''
         if self.osx is None \
                 or self.sync_with_dispatch and not self._first_dispatch_done:
-            # Sync original/previous/current positions until the first
+            # Sync origin/previous/current positions until the first
             # dispatch (etype == 'begin') is done.
-            self.psx = self.osx = self.sx
-            self.psy = self.osy = self.sy
-            self.psz = self.osz = self.sz
+            self.osx = self.psx = self.sx
+            self.osy = self.psy = self.sy
+            self.osz = self.psz = self.sz
         # update the delta
         self.dsx = self.sx - self.psx
         self.dsy = self.sy - self.psy

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -377,19 +377,20 @@ class MotionEvent(MotionEventBase):
         '''Move the touch to an another position.
         '''
         if self.sync_with_dispatch:
-            if not self._first_dispatch_done:
-                # Sync original/previous/current positions until the first
-                # dispatch (etype == 'begin') is done
-                self.osx = self.psx = self.sx
-                self.osy = self.psy = self.sy
-                self.osz = self.psz = self.sz
-            elif self._keep_prev_pos:
+            if self._keep_prev_pos:
                 self.psx, self.psy, self.psz = self.sx, self.sy, self.sz
                 self._keep_prev_pos = False
         else:
             self.psx, self.psy, self.psz = self.sx, self.sy, self.sz
         self.time_update = time()
         self.depack(args)
+        if self.sync_with_dispatch and not self._first_dispatch_done:
+            # Sync original/previous/current positions until the first
+            # dispatch (etype == 'begin') is done.
+            self.osx = self.psx = self.sx
+            self.osy = self.psy = self.sy
+            self.osz = self.psz = self.sz
+            self.dsx = self.dsy = self.dsz = 0.0
 
     def scale_for_screen(self, w, h, p=None, rotation=0,
                          smode='None', kheight=0):

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -296,9 +296,9 @@ class MotionEvent(MotionEventBase):
         #: latest previous position. See :meth:`MotionEvent.move`.
         #:
         #: .. versionadded:: 2.1.0
-        self.keep_first_prev_pos = True
+        self.sync_with_dispatch = True
 
-        #: Keep first previous position if :attr:`keep_first_prev_pos` is
+        #: Keep first previous position if :attr:`sync_with_dispatch` is
         #: `True`.
         self._keep_prev_pos = True
 
@@ -376,7 +376,7 @@ class MotionEvent(MotionEventBase):
     def move(self, args):
         '''Move the touch to an another position.
         '''
-        if self.keep_first_prev_pos:
+        if self.sync_with_dispatch:
             if not self._first_dispatch_done:
                 # Sync original/previous/current positions until the first
                 # dispatch (etype == 'begin') is done

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -302,6 +302,9 @@ class MotionEvent(MotionEventBase):
         #: `True`.
         self._keep_prev_pos = True
 
+        #: Flag that first dispatch of this event is done.
+        self._first_dispatch_done = False
+
         self.depack(args)
 
     def depack(self, args):
@@ -368,12 +371,19 @@ class MotionEvent(MotionEventBase):
         .. versionadded:: 2.1.0
         '''
         self._keep_prev_pos = True
+        self._first_dispatch_done = True
 
     def move(self, args):
         '''Move the touch to an another position.
         '''
         if self.keep_first_prev_pos:
-            if self._keep_prev_pos:
+            if not self._first_dispatch_done:
+                # Sync original/previous/current positions until the first
+                # dispatch (etype == 'begin') is done
+                self.osx = self.psx = self.sx
+                self.osy = self.psy = self.sy
+                self.osz = self.psz = self.sz
+            elif self._keep_prev_pos:
                 self.psx, self.psy, self.psz = self.sx, self.sy, self.sz
                 self._keep_prev_pos = False
         else:

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -376,7 +376,7 @@ class MotionEvent(MotionEventBase):
         self._first_dispatch_done = True
 
     def move(self, args):
-        '''Move the touch to an another position.
+        '''Move the touch to another position.
         '''
         if self.sync_with_dispatch:
             if self._keep_prev_pos:


### PR DESCRIPTION
Because input provider can make many calls to `MotionEvent.move`  before the event dispatch to the listeners we have to keep first previous position instead of latest one to have a consistent previous and current values.

Fixes https://github.com/kivy/kivy/issues/7685.

### Additional info:

This update is needed to synchronize normalized values and their absolute counterparts because even before https://github.com/kivy/kivy/pull/7659 only sx, sy, sz were in sync with x, y, z with others being in sync only for case when method `move` is called once per event dispatch.

Before the https://github.com/kivy/kivy/pull/7659 method `move` would assign current absolute x, y, z values to px, py, pz and scale_for_screen would set ox, oy, oz on the first call and make them equal to px, py, pz and x, y, z respectively. While this approach does work, it has issues:
- Method `move` is used by input provider and should only work with normalized values because providers work with normalized values. It should not change absolute values as those are set in `scale_for_screen`.
- Method `scale_for_screen` should only read normalized values and assign absolute values to respective attributes for current screen size, rotation and other arguments. Otherwise, because different arguments can be used to "scale the event" and then origin/previous values will be incorrect between the event update/move.
- It relies on `WindowBase.on_motion` method not to wrap transformation of the event with `push/pop` calls. Link https://github.com/kivy/kivy/blob/6fcf41729ce4abc6625bc732846f2c4d1d92ea3f/kivy/core/window/__init__.py#L1532-L1546


This changes will ensure that:
- Origin/previous/current normalized positions are the same at the time of the first dispatch and are equal to latest current position. This means that latest position will be used if `move` is called multiple time before the first dispatch.
- Previous normalized position is from the previous dispatch.
- Event managers can manipulate normalized positions to re-dispatch events or to do other behavior (example: https://github.com/pythonic64/hover/blob/14ddf18b9012af0b97aa00b690dff228333b9004/hover_manager.py#L115-L119).


We can remove attribute `sync_with_dispatch` as its value is never changed and just assume synchronized behavior.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
