### PR TITLE
SettingColor: Change method name to get_color_from_hex

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -847,7 +847,7 @@
                 Line:
                     rectangle: self.x,self.y,self.width,self.height
                 Color: 
-                    rgba: kivy.utils.get_color(root.value) if root.value else (1,1,1,1.) 
+                    rgba: kivy.utils.get_color_from_hex(root.value) if root.value else (1,1,1,1.)
                 Rectangle:
                     pos: self.pos
                     size: self.size 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Code was added by PR  #4546 to the master branch.

Commit that changed the line in question is commit [1320d8ef48](https://github.com/kivy/kivy/pull/4546/commits/1320d8ef48eb19fd8a2edb35bf7d1087e3499180#diff-ca1209e949ddd010d5f6af1e88f26da5119d58acaf246401b47bdc59eb70308aR850)

The method name should be updated from `get_color` to `get_color_from_hex`. The `get_color` was an alias from the import and accidentally not changed in that commit.

Using the color option in settings will cause the following error and crashes the app:
```
[...] rgba: kivy.utils.get_color(root.value) if root.value else (1,1,1,1.)
 AttributeError: module 'kivy.utils' has no attribute 'get_color'
```

## Test code
The following [Gist](https://gist.github.com/AWolf81/f3f03e4478ec713381678a06f20be74c) can be used to test the color picker setting.

## Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
