### PR TITLE
Add an option  to force a custom search path for SDL2 frameworks + fixes ARCHFLAGS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -419,15 +419,6 @@ if platform == 'ios':
 elif platform == 'android':
     c_options['use_android'] = True
 
-elif platform == 'darwin':
-    if c_options['use_osx_frameworks']:
-        if osx_arch == "i386":
-            print("Warning: building with frameworks fail on i386")
-        else:
-            print(f"OSX framework used, force to {osx_arch} only")
-            environ["ARCHFLAGS"] = environ.get("ARCHFLAGS", f"-arch {osx_arch}")
-            print("OSX ARCHFLAGS are: {}".format(environ["ARCHFLAGS"]))
-
 # detect gstreamer, only on desktop
 # works if we forced the options or in autodetection
 if platform not in ('ios', 'android') and (c_options['use_gstreamer']
@@ -490,19 +481,22 @@ if c_options['use_sdl2'] or (
     sdl2_valid = False
     if c_options['use_osx_frameworks'] and platform == 'darwin':
         # check the existence of frameworks
+        sdl2_frameworks_search_path = environ.get(
+            "KIVY_SDL2_FRAMEWORKS_SEARCH_PATH", "/Library/Frameworks"
+        )
         sdl2_valid = True
         sdl2_flags = {
             'extra_link_args': [
-                '-F/Library/Frameworks',
+                '-F{}'.format(sdl2_frameworks_search_path),
                 '-Xlinker', '-rpath',
-                '-Xlinker', '/Library/Frameworks',
+                '-Xlinker', sdl2_frameworks_search_path,
                 '-Xlinker', '-headerpad',
                 '-Xlinker', '190'],
             'include_dirs': [],
-            'extra_compile_args': ['-F/Library/Frameworks']
+            'extra_compile_args': ['-F{}'.format(sdl2_frameworks_search_path)]
         }
         for name in ('SDL2', 'SDL2_ttf', 'SDL2_image', 'SDL2_mixer'):
-            f_path = '/Library/Frameworks/{}.framework'.format(name)
+            f_path = '{}/{}.framework'.format(sdl2_frameworks_search_path, name)
             if not exists(f_path):
                 print('Missing framework {}'.format(f_path))
                 sdl2_valid = False

--- a/setup.py
+++ b/setup.py
@@ -103,11 +103,6 @@ build_examples = build_examples or \
 
 platform = sys.platform
 
-if sys.platform == 'darwin':
-    from platform import machine
-    osx_arch = machine()
-
-
 # Detect Python for android project (http://github.com/kivy/python-for-android)
 ndkplatform = environ.get('NDKPLATFORM')
 if ndkplatform is not None and environ.get('LIBLINK'):
@@ -622,8 +617,7 @@ def determine_gl_flags():
         flags['libraries'] = ['GLESv2']
         flags['extra_link_args'] = ['-framework', 'OpenGLES']
     elif platform == 'darwin':
-        flags['extra_link_args'] = ['-framework', 'OpenGL', '-arch', osx_arch]
-        flags['extra_compile_args'] = ['-arch', osx_arch]
+        flags['extra_link_args'] = ['-framework', 'OpenGL']
     elif platform.startswith('freebsd'):
         flags['libraries'] = ['GL']
     elif platform.startswith('openbsd'):


### PR DESCRIPTION
This PR allows us to build against SDL2 frameworks that are not placed into the standard `/Library/Frameworks` path.
Also removes the forcing of the `ARCHFLAGS`, so we can safely build `universal2` binaries. (And `i386` on `darwin` is definitely out of support)

**WARNING:** Needs a 🟢 status on CI (`Github Hosted x86_64 macos-latest`) before merging. 

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
