### PR TITLE
MouseMotionEventProvider: Update simulated touch graphics on window resize or rotate

### DIFF
--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -211,6 +211,8 @@ class MouseMotionEventProvider(MotionEventProvider):
         fbind('on_mouse_down', self.on_mouse_press)
         fbind('on_mouse_move', self.on_mouse_motion)
         fbind('on_mouse_up', self.on_mouse_release)
+        fbind('on_rotate', self.update_touch_graphics)
+        fbind('system_size', self.update_touch_graphics)
         if not self.disable_hover:
             self._start_hover_events()
         self._running = True
@@ -232,6 +234,8 @@ class MouseMotionEventProvider(MotionEventProvider):
         funbind('on_mouse_down', self.on_mouse_press)
         funbind('on_mouse_move', self.on_mouse_motion)
         funbind('on_mouse_up', self.on_mouse_release)
+        funbind('on_rotate', self.update_touch_graphics)
+        funbind('system_size', self.update_touch_graphics)
         if not self.disable_hover:
             self._stop_hover_events()
         self._running = False
@@ -381,6 +385,10 @@ class MouseMotionEventProvider(MotionEventProvider):
         if self.alt_touch:
             self.remove_touch(win, self.alt_touch)
             self.alt_touch = None
+
+    def update_touch_graphics(self, win, *args):
+        for touch in self.touches.values():
+            touch.update_graphics(win)
 
     def begin_or_update_hover_event(self, win, *args):
         etype = 'update' if self.hover_event else 'begin'


### PR DESCRIPTION
Simulated touch graphics are not updated on window resize/rotate which makes graphics keep same position and thus makes difficult to left-click on touch graphics to cancel the simulated touch. This request fixes that case by binding to window's `on_rotate` event and `system_size` property and invoking `update_graphics` method for all touches once the binded callbacks are triggered. 

Should we update touch graphics when window's `softinput_mode` or `keyboard_height` change? Currently only window's size and rotation are used to compute absolute position for the touch graphics. Code reference: https://github.com/kivy/kivy/blob/6fcf41729ce4abc6625bc732846f2c4d1d92ea3f/kivy/input/providers/mouse.py#L132-L142

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
