### PR TITLE
Window.softinput_mode fix for "pan" and "below_target" modes when using kivy virtual keyboard.

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -640,10 +640,8 @@ class WindowBase(EventDispatcher):
                 if isinstance(w, VKeyboard):
                     vkeyboard_height = w.height * w.scale
                     if smode == 'pan':
-                        w.top = 0
                         return vkeyboard_height
                     elif smode == 'below_target':
-                        w.top = w.target.y
                         return vkeyboard_height - w.target.y
         return 0
 
@@ -2151,6 +2149,13 @@ class WindowBase(EventDispatcher):
             # only after add, do dock mode
             keyboard.widget.docked = self.docked_vkeyboard
             keyboard.widget.setup_mode()
+
+            # sets vkeyboard position according to Window.softinput_mode
+            smode = self.softinput_mode
+            if smode == 'pan':
+                keyboard.widget.top = 0
+            elif smode == 'below_target':
+                keyboard.widget.top = keyboard.target.y
 
         else:
             # system keyboard, just register the callback.

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -631,18 +631,20 @@ class WindowBase(EventDispatcher):
 
     def _get_kivy_vkheight(self):
         mode = Config.get('kivy', 'keyboard_mode')
-        smode = self.softinput_mode
         if (
-            (mode == 'dock' or mode == 'systemanddock')
+            mode in ['dock', 'systemanddock']
             and self._vkeyboard_cls is not None
         ):
             for w in self.children:
                 if isinstance(w, VKeyboard):
                     vkeyboard_height = w.height * w.scale
-                    if smode == 'pan':
+                    if self.softinput_mode == 'pan':
                         return vkeyboard_height
-                    elif smode == 'below_target':
-                        return vkeyboard_height - w.target.y
+                    elif (
+                        self.softinput_mode == 'below_target'
+                        and w.target.y < vkeyboard_height
+                    ):
+                            return vkeyboard_height - w.target.y
         return 0
 
     def _get_kheight(self):
@@ -1627,7 +1629,7 @@ class WindowBase(EventDispatcher):
         w2, h2 = w / 2., h / 2.
         r = radians(self.rotation)
 
-        x, y = 0, 0
+        y = 0
         _h = h
         if smode == 'pan':
             y = kheight
@@ -2149,10 +2151,9 @@ class WindowBase(EventDispatcher):
             keyboard.widget.setup_mode()
 
             # sets vkeyboard position according to Window.softinput_mode
-            smode = self.softinput_mode
-            if smode == 'pan':
+            if self.softinput_mode == 'pan':
                 keyboard.widget.top = 0
-            elif smode == 'below_target':
+            elif self.softinput_mode == 'below_target':
                 keyboard.widget.top = keyboard.target.y
 
         else:

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -644,7 +644,7 @@ class WindowBase(EventDispatcher):
                         self.softinput_mode == 'below_target'
                         and w.target.y < vkeyboard_height
                     ):
-                            return vkeyboard_height - w.target.y
+                        return vkeyboard_height - w.target.y
         return 0
 
     def _get_kheight(self):

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -650,9 +650,7 @@ class WindowBase(EventDispatcher):
             return self._get_android_kheight()
         elif platform == 'ios':
             return self._get_ios_kheight()
-        else:
-            return self._get_kivy_vkheight()
-        return 0
+        return self._get_kivy_vkheight()
 
     keyboard_height = AliasProperty(_get_kheight, bind=('_keyboard_changed',))
     '''Returns the height of the softkeyboard/IME on mobile platforms.

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -406,7 +406,7 @@ class MotionEvent(MotionEventBase):
         self.pz = self.psz * z_max
         if smode:
             # Adjust y for keyboard height
-            if smode == 'pan':
+            if smode == 'pan' or smode == 'below_target':
                 self.y -= kheight
                 self.oy -= kheight
                 self.py -= kheight


### PR DESCRIPTION
Fixes inconsistent Kivy Virtual Keyboard display when using `Window.softinput_mode = 'below_target'`  or `Window.softinput_mode = "pan"`, with the docked keyboard mode enabled.

Fixes: #7700

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
