### PR TITLE
CodeInput: fixed disappearing lines after inserting text

### DIFF
--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -129,7 +129,7 @@ class CodeInput(CodeNavigationBehavior, TextInput):
             ntext = u'*' * len(ntext)
         ntext = self._get_bbcode(ntext)
         kw = self._get_line_options()
-        cid = u'{}\0{}\0{}'.format(ntext, self.password, kw)
+        cid = u'{}\0{}\0{}'.format(text, self.password, kw)
         texture = Cache_get('textinput.label', cid)
 
         if texture is None:


### PR DESCRIPTION
Fixed: Last CodeInput line disappears when inserting text ended with "\n" to the end of the CodeInput's text.

How to reproduce:
1) Select part of the text ended with the linebreak:
![CodeInput insert bug](https://user-images.githubusercontent.com/73047043/148297114-b2e774b8-c32d-45c9-90ce-8913f4370f1d.png)
2) Put cursor at the end of the text (after the last "b" character) and press Ctrl+V (paste). Last line disappeared:
![CodeInput insert bug 2](https://user-images.githubusercontent.com/73047043/148297686-9fc4c8b7-0b49-435e-bf33-7b6d88b038e2.png)


Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
