### PR TITLE
TextInput: easier tokenize delimiters setting; quotes removed from default delimiters

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2688,11 +2688,13 @@ class TextInput(FocusBehavior, Widget):
             Cache_append('textinput.label', cid, texture)
         return texture
 
+    _tokenize_delimiters = u' .,:;!?\r\t'
+
     def _tokenize(self, text):
         # Tokenize a text string from some delimiters
         if text is None:
             return
-        delimiters = u' .,:;!?\'"\r\t'
+        delimiters = self._tokenize_delimiters
         old_index = 0
         prev_char = ''
         for index, char in enumerate(text):


### PR DESCRIPTION
1) Added opportunity to change tokenize delimiters: user can override `_tokenize_delimiters` attribute in a child class.
In some cases user may want to create custom tokenize delimiters, e.g. "+":
![Plus delimiter](https://user-images.githubusercontent.com/73047043/148623752-27548a6e-ebe7-4536-b89a-b9103be992ea.png)

2) Quotes (`'"', '\''`) removed from default delimiters. Otherwise line can end with an opening quote:
![Wrap after quote](https://user-images.githubusercontent.com/73047043/148623776-c8fffd08-687e-4bf3-a618-6bcd06db970d.png)

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
