### PR TITLE
Change default input_type to null. Add some warning regarding TYPE_TEXT_FLAG_NO_SUGGESTIONS

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -2070,7 +2070,7 @@ class WindowBase(EventDispatcher):
 
                 .. note::
 
-                    `input_type` is currently only honored on mobile devices.
+                    `input_type` is currently only honored on Android.
 
                 .. versionadded:: 1.8.0
 

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -2065,13 +2065,17 @@ class WindowBase(EventDispatcher):
 
             `input_type`: string
                 Choose the type of soft keyboard to request. Can be one of
-                'text', 'number', 'url', 'mail', 'datetime', 'tel', 'address'.
+                'null', 'text', 'number', 'url', 'mail', 'datetime', 'tel',
+                'address'.
 
                 .. note::
 
                     `input_type` is currently only honored on mobile devices.
 
                 .. versionadded:: 1.8.0
+
+                .. versionchanged:: 2.1.0
+                    Added `null` to soft keyboard types.
 
             `keyboard_suggestions`: bool
                 If True provides auto suggestions on top of keyboard.

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -554,6 +554,7 @@ cdef class _WindowSDL2Storage:
                 TYPE_CLASS_NUMBER = 2
                 TYPE_CLASS_PHONE = 3
                 TYPE_CLASS_TEXT = 1
+                TYPE_CLASS_NULL = 0
 
                 TYPE_TEXT_VARIATION_EMAIL_ADDRESS = 32
                 TYPE_TEXT_VARIATION_URI = 16
@@ -562,6 +563,7 @@ cdef class _WindowSDL2Storage:
                 TYPE_TEXT_FLAG_NO_SUGGESTIONS = 524288
 
                 input_type_value = {
+                                "null": TYPE_CLASS_NULL,
                                 "text": TYPE_CLASS_TEXT,
                                 "number": TYPE_CLASS_NUMBER,
                                 "url":
@@ -580,6 +582,10 @@ cdef class _WindowSDL2Storage:
                 text_keyboards = {"text", "url", "mail", "address"}
 
                 if not keyboard_suggestions and input_type in text_keyboards:
+                    """
+                    Looks like some (major) device vendors and keyboards are de-facto ignoring this flag,
+                    so we can't really rely on this one to disable suggestions.
+                    """
                     input_type_value |= TYPE_TEXT_FLAG_NO_SUGGESTIONS
 
                 mActivity.changeKeyboard(input_type_value)

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -354,8 +354,12 @@ class FocusBehavior(object):
     .. versionchanged:: 2.1.0
         Changed default value from `text` to `null`. Added `null` to options.
 
+        .. warning::
+            As the default value has been changed, you may need to adjust
+            `input_type` in your code.
+
     :attr:`input_type` is an :class:`~kivy.properties.OptionsProperty` and
-    defaults to 'text'. Can be one of 'text', 'number', 'url', 'mail',
+    defaults to 'null'. Can be one of 'null', 'text', 'number', 'url', 'mail',
     'datetime', 'tel' or 'address'.
     '''
 

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -344,12 +344,15 @@ class FocusBehavior(object):
     defaults to 'auto'. Can be one of 'auto' or 'managed'.
     '''
 
-    input_type = OptionProperty('text', options=('text', 'number', 'url',
-                                                 'mail', 'datetime', 'tel',
-                                                 'address'))
+    input_type = OptionProperty('null', options=('null', 'text', 'number',
+                                                 'url', 'mail', 'datetime',
+                                                 'tel', 'address'))
     '''The kind of input keyboard to request.
 
     .. versionadded:: 1.8.0
+
+    .. versionchanged:: 2.1.0
+        Changed default value from `text` to `null`. Added `null` to options.
 
     :attr:`input_type` is an :class:`~kivy.properties.OptionsProperty` and
     defaults to 'text'. Can be one of 'text', 'number', 'url', 'mail',


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

Some info regarding this PR:

- Issue https://github.com/kivy/kivy/issues/7337 has been introduced via https://github.com/kivy/kivy/pull/7231.
- Some (major) soft keyboard vendors are de-facto ignoring the `TYPE_TEXT_FLAG_NO_SUGGESTIONS`, so the workaround of disabling the suggestions doesn't work.
- There are some issues on SDL regarding IME and `SDL_TEXTEDITING`, that we should track: https://github.com/libsdl-org/SDL/issues/4847, https://github.com/libsdl-org/SDL/issues/3385, https://github.com/libsdl-org/SDL/issues/3377
- `input_type` is a great addition and is a step forward to support non-latin languages.
- Some events from SDL2 are missing in order to fully support suggestions and swipes.
- This PR should be considered as a temp fix, that reverts the default keyboard behaviour to the one we had prior to https://github.com/kivy/kivy/pull/7231, without completely reverting the great additions that have been made by @dwmoffatt. A new Kivy release, will likely land quite soon, and this is a main blocker.

The following code snipped could be used for testing:

```
from kivy.app import App
from kivy.lang import Builder


kv = """
BoxLayout:
    orientation: 'vertical'
    spacing: dp(20)
    TextInput:
        size_hint_y: None
        height: dp(45)
        hint_text: "input_type:null (default) and keyboard_suggestions: False"
        write_tab: False
        keyboard_suggestions: False
    TextInput:
        size_hint_y: None
        height: dp(45)
        hint_text: "input_type:null (default) and keyboard_suggestions: True"
        write_tab: False
        keyboard_suggestions: True
    TextInput:
        size_hint_y: None
        height: dp(45)
        hint_text: "input_type:text and keyboard_suggestions: False"
        write_tab: False
        input_type: 'text'
        keyboard_suggestions: False
    TextInput:
        size_hint_y: None
        height: dp(45)
        hint_text: "input_type:text and keyboard_suggestions: True"
        write_tab: False
        input_type: 'text'
        keyboard_suggestions: True
    BoxLayout:
        size_hint: 1, 1/2
"""


class Test(App):
    def build(self):
        return Builder.load_string(kv)


Test().run()
```
