### PR TITLE
ModalView: on_dismiss runs before on_open if user dismisses popup before opening animation completes

### DIFF
--- a/kivy/uix/modalview.py
+++ b/kivy/uix/modalview.py
@@ -204,7 +204,7 @@ class ModalView(AnchorLayout):
 
         """
         from kivy.core.window import Window
-        if self._is_open:
+        if self._is_open or self._anim_alpha > 0:
             return
         self._window = Window
         self._is_open = True
@@ -239,7 +239,7 @@ class ModalView(AnchorLayout):
             view.dismiss(animation=False)
 
         """
-        if not self._is_open:
+        if not self._is_open or self._anim_alpha < 1:
             return
         self.dispatch('on_pre_dismiss')
         if self.dispatch('on_dismiss') is True:


### PR DESCRIPTION
The reason is that `on_open` only runs when opening animation completes, which can take some time if `_anim_duration` parameter is high.
Such a behavior seems counterintuitive, it's expected that `on_open` should always precede `on_dismiss`.
Also it worth noting that dismissing doesn't stop opening animation, so both animations run together.

To avoid these issues it's suggested not to dismiss the popup if opening animation is in progress and vice versa not to open if dismissing animation still runs.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
