### PR TITLE
Removed Python3.6 from the supported ones, it reached EOL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ logging-level=DEBUG
 cython_min=0.24
 cython_max=0.29.26
 cython_exclude=0.27,0.27.2
-python_versions=3.6 - 3.10
+python_versions=3.7 - 3.10
 
 [coverage:run]
 parallel = True
@@ -21,7 +21,7 @@ plugins =
 concurrency = thread, multiprocessing
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     Kivy-Garden>=0.1.4
     docutils

--- a/setup.py
+++ b/setup.py
@@ -1085,7 +1085,6 @@ if not build_examples:
             'Operating System :: Microsoft :: Windows',
             'Operating System :: POSIX :: BSD :: FreeBSD',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Python 3.6 reached EOL on 23 Dec 2021.
This PR removes it from the supported ones.