### PR TITLE
Add support for older Sphinx versions

### DIFF
--- a/doc/sources/sphinxext/preprocess.py
+++ b/doc/sources/sphinxext/preprocess.py
@@ -6,6 +6,7 @@ import re
 import types
 import sys
 from os.path import dirname, join
+import sphinx
 from sphinx.ext.autodoc import MethodDocumenter
 
 class CythonMethodDocumenter(MethodDocumenter):
@@ -109,7 +110,10 @@ def setup(app):
     sys.path += [join(dirname(kivy.__file__), 'extras')]
     from highlight import KivyLexer
 
-    app.add_lexer('kv', KivyLexer)
+    if sphinx.version_info[0] >= 3:
+        app.add_lexer('kv', KivyLexer)
+    else:
+        app.add_lexer('kv', KivyLexer())
     app.add_autodocumenter(CythonMethodDocumenter)
     app.connect('autodoc-process-docstring', callback_docstring)
     app.connect('autodoc-process-signature', callback_signature)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

>Sphinx.add_lexer:
Changed in version 2.1: Take a lexer class as an argument. An instance of lexers are still supported until Sphinx-3.x.

Ubuntu 20.04 and 18.04 (which are LTS) doc builds on PPA were failing due to an older version of sphinx.
This PR adds back-compatibility for Sphinx versions prior to 3.