### PR TITLE
WindowBase: Update bind list of properties: system_size, size, width, height and center

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -490,7 +490,7 @@ class WindowBase(EventDispatcher):
             return _size[0]
         return _size[1]
 
-    width = AliasProperty(_get_width, bind=('_rotation', '_size'))
+    width = AliasProperty(_get_width, bind=('_rotation', '_size', '_density'))
     '''Rotated window width.
 
     :attr:`width` is a read-only :class:`~kivy.properties.AliasProperty`.
@@ -507,7 +507,8 @@ class WindowBase(EventDispatcher):
             return _size[1] - kb
         return _size[0] - kb
 
-    height = AliasProperty(_get_height, bind=('_rotation', '_size'))
+    height = AliasProperty(_get_height,
+                           bind=('_rotation', '_size', '_density'))
     '''Rotated window height.
 
     :attr:`height` is a read-only :class:`~kivy.properties.AliasProperty`.
@@ -516,9 +517,7 @@ class WindowBase(EventDispatcher):
     def _get_center(self):
         return self.width / 2., self.height / 2.
 
-    center = AliasProperty(_get_center,
-                           bind=('width', 'height', '_density'),
-                           cache=True)
+    center = AliasProperty(_get_center, bind=('width', 'height'))
     '''Center of the rotated window.
 
     .. versionadded:: 1.0.9

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -445,9 +445,7 @@ class WindowBase(EventDispatcher):
     and defaults to True.
     '''
 
-    size = AliasProperty(_get_size, _set_size,
-                         bind=('_size', '_rotation', 'softinput_mode',
-                               'keyboard_height'))
+    size = AliasProperty(_get_size, _set_size, bind=('_size', '_rotation'))
     '''Get the rotated size of the window. If :attr:`rotation` is set, then the
     size will change to reflect the rotation.
 
@@ -492,7 +490,7 @@ class WindowBase(EventDispatcher):
             return _size[0]
         return _size[1]
 
-    width = AliasProperty(_get_width, None, bind=('_rotation', '_size'))
+    width = AliasProperty(_get_width, bind=('_rotation', '_size'))
     '''Rotated window width.
 
     :attr:`width` is a read-only :class:`~kivy.properties.AliasProperty`.
@@ -509,9 +507,7 @@ class WindowBase(EventDispatcher):
             return _size[1] - kb
         return _size[0] - kb
 
-    height = AliasProperty(_get_height, None,
-                           bind=('_rotation', '_size', 'softinput_mode',
-                                 'keyboard_height'))
+    height = AliasProperty(_get_height, bind=('_rotation', '_size'))
     '''Rotated window height.
 
     :attr:`height` is a read-only :class:`~kivy.properties.AliasProperty`.
@@ -697,9 +693,7 @@ class WindowBase(EventDispatcher):
         return self._size
 
     system_size = AliasProperty(_get_system_size, _set_system_size,
-                                bind=('_size', 'softinput_mode',
-                                      'keyboard_height'),
-                                cache=True)
+                                bind=('_size',))
     '''Real size of the window ignoring rotation. If the density is
     not 1, the :attr:`system_size` is the :attr:`size` divided by
     density.


### PR DESCRIPTION
Changelog:
- Removes `softinput_mode` and `keyboard_height` from bind lists to address https://github.com/kivy/kivy/commit/2284c2a6a501575f525981692bf243c1f0214298#r33486046 comment
- Adds `_density` to bind lists of `width` and `height` and removes it from `center` as `center` depends on `width`/`height` which makes dependency on `_density` implied
- Not caching `center` because of `width` and `height` won't trigger caching in all cases.


Property `center` and caching problem: https://github.com/kivy/kivy/pull/6433


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
