### PR TITLE
Explain the '--' separator for option parsing.

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -162,7 +162,10 @@ def kivy_register_post_configuration(callback):
 
 
 def kivy_usage():
-    '''Kivy Usage: %s [OPTION...]::
+    '''Kivy Usage: %s [KIVY OPTION...] [-- PROGRAM OPTIONS]::
+
+            Options placed after a '-- ' separator, will not be touched by kivy,
+            and instead passed to your program.
 
             Set KIVY_NO_ARGS=1 in your environment or before you import Kivy to
             disable Kivy's argument parser.


### PR DESCRIPTION
Document the '-- ' separator for extra options

```
$ python main.py -t
[INFO   ] [Logger      ] Record log in /home/gabriel/.kivy/logs/kivy_22-01-27_3.txt
[ERROR  ] [Core        ] option -t not recognized
Kivy Usage: main.py [KIVY OPTION...] [-- PROGRAM OPTIONS]::

            Options placed after a '-- ' separator, will not be touched by kivy,
            and instead passed to your program.

            Set KIVY_NO_ARGS=1 in your environment or before you import Kivy to
            disable Kivy's argument parser.

        -h, --help
            Prints this help message.
…
```
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
