### PR TITLE
Fix widget.disabled handling of value change of equal truthiness

### DIFF
--- a/kivy/tests/test_widget.py
+++ b/kivy/tests/test_widget.py
@@ -118,3 +118,10 @@ class WidgetTestCase(unittest.TestCase):
         rmtree(tmp)
 
         self.root.remove_widget(wid)
+
+    def test_disabled(self):
+        from kivy.uix.widget import Widget
+        w = Widget(disabled=None)
+        w.disabled = False
+        w.disabled = True
+        self.assertEqual(w.disabled, True)

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -1433,6 +1433,9 @@ class Widget(WidgetBase):
         return self._disabled_count > 0
 
     def set_disabled(self, value):
+        # Necessary to ensure a change between value of equal truthiness
+        # doesn't mess up the count
+        value = bool(value)
         if value != self._disabled_value:
             self._disabled_value = value
             if value:


### PR DESCRIPTION
Comparing for equality is too strict, when what we want is to know if
thue value is Truthy or Falsy, this mismatch in condition created cases
where a widget was set to disabled, but wasn't, as well as widgets
staying disabled, when they should have been enabled again.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
