### PR TITLE
Don't let 'ScrollEffect.reset()' set 'is_manual' to True

### DIFF
--- a/kivy/effects/scroll.py
+++ b/kivy/effects/scroll.py
@@ -19,6 +19,7 @@ class as a base effect for our :class:`~kivy.uix.scrollview.ScrollView` widget.
 __all__ = ('ScrollEffect', )
 
 
+from time import time
 from kivy.effects.kinetic import KineticEffect
 from kivy.uix.widget import Widget
 from kivy.properties import NumericProperty, ObjectProperty
@@ -91,7 +92,7 @@ class ScrollEffect(KineticEffect):
         self.velocity = 0
         if self.history:
             val = self.history[-1][1]
-            super(ScrollEffect, self).start(val, None)
+            self.history = [(time(), val)]
 
     def on_value(self, *args):
         scroll_min = self.min

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -621,7 +621,10 @@ class ScrollView(StencilView):
         if not vp or not self.effect_x:
             return
 
-        sw = vp.width - self.width
+        if self.effect_x.is_manual:
+            sw = vp.width - self._effect_x_start_width
+        else:
+            sw = vp.width - self.width
         if sw < 1 and not (self.always_overscroll and self.do_scroll_x):
             return
         if sw != 0:
@@ -633,7 +636,10 @@ class ScrollView(StencilView):
         vp = self._viewport
         if not vp or not self.effect_y:
             return
-        sh = vp.height - self.height
+        if self.effect_y.is_manual:
+            sh = vp.height - self._effect_y_start_height
+        else:
+            sh = vp.height - self.height
 
         if sh < 1 and not (self.always_overscroll and self.do_scroll_y):
             return

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -621,10 +621,7 @@ class ScrollView(StencilView):
         if not vp or not self.effect_x:
             return
 
-        if self.effect_x.is_manual:
-            sw = vp.width - self._effect_x_start_width
-        else:
-            sw = vp.width - self.width
+        sw = vp.width - self.width
         if sw < 1 and not (self.always_overscroll and self.do_scroll_x):
             return
         if sw != 0:
@@ -636,10 +633,7 @@ class ScrollView(StencilView):
         vp = self._viewport
         if not vp or not self.effect_y:
             return
-        if self.effect_y.is_manual:
-            sh = vp.height - self._effect_y_start_height
-        else:
-            sh = vp.height - self.height
+        sh = vp.height - self.height
 
         if sh < 1 and not (self.always_overscroll and self.do_scroll_y):
             return


### PR DESCRIPTION
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Fixes #7721.
 This is a substitute for #7727.

### The cause of the issue

`KineticEffect.is_manual` should be True only when there is a touch performing a scroll. But under a certain circumstance, it can be True even though no touch events are in progress. You can confirm it by watching the `is_manual` property while running the #7721 example and resizing the window like shown in the #7721 video.

```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout
from kivy.uix.button import Button

KV = """
<BugScroll>:
    ScrollView:
        id: sv
        effect_cls:'ScrollEffect'
        BoxLayout:
            size_hint_y:None
            height:self.minimum_height
            orientation:'vertical'
            id:box
            always_overscroll: False
"""
Builder.load_string(KV)

class BugScroll(BoxLayout):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        for i in range(100):
            self.ids.box.add_widget(Button(size_hint_y=None, height=55, text=str(i)))

class Program(App):
    def build(self):
        return BugScroll()
    def on_start(self):
        self.root.ids.sv.effect_y.bind(is_manual=lambda __, value: print(f"is_manual: {value}"))
        

if __name__ == '__main__':
    Program().run()
```

https://user-images.githubusercontent.com/26050135/151686061-fd6a457d-87e6-470b-beb4-27f1fe1547a9.mp4

Because of that, ScrollView uses its previous size while re-positioning its content when it gets resized. The following code is where it happens.

https://github.com/kivy/kivy/blob/315b7425657d002cf9c35cf2e8b67fb00f9cb030/kivy/uix/scrollview.py#L624-L627
https://github.com/kivy/kivy/blob/315b7425657d002cf9c35cf2e8b67fb00f9cb030/kivy/uix/scrollview.py#L639-L642

### How is_manual ends up being True after a touch performing a scroll ends

1. When a touch performing a scroll ends, `is_manual` is set to False
2. The momentum of the scroll still exists so `ScrollEffect.value` will be updated for a while.
3. If `ScrollEffect.value` exceeds the bounds(`ScrollEffect.min`,`ScrollEffect.max`), `ScrollEffect.reset()` gets called and `is_manual` will be set to True.

### Why the issue doesn't occur when DampedScrollEffect is being used

It overwrites [on_value()](https://github.com/kivy/kivy/blob/fe9cd8898e107e3394fb8cd226a220425e82f00d/kivy/effects/dampedscroll.py#L94) but doesn't call `super().on_value()`, which is the one who calls `reset()`.

https://github.com/kivy/kivy/blob/fe9cd8898e107e3394fb8cd226a220425e82f00d/kivy/effects/scroll.py#L96-L109