### PR TITLE
WindowBase: Don't return motion event in transform_motion_event_2d method

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1472,8 +1472,8 @@ class WindowBase(EventDispatcher):
         )
 
     def transform_motion_event_2d(self, me, widget=None):
-        '''Returns transformed motion event `me` to this window size and then
-        if `widget` is passed transforms `me` to `widget`'s local coordinates.
+        '''Transforms the motion event `me` to this window size and then if
+        `widget` is passed transforms `me` to `widget`'s local coordinates.
 
         :raises:
             `AttributeError`: If widget's ancestor is ``None``.
@@ -1493,22 +1493,20 @@ class WindowBase(EventDispatcher):
             smode=self.softinput_mode,
             kheight=self.keyboard_height
         )
-        if widget is None:
-            return me
-        parent = widget.parent
-        try:
-            if parent:
-                me.apply_transform_2d(parent.to_widget)
-            else:
-                me.apply_transform_2d(widget.to_widget)
-                me.apply_transform_2d(widget.to_parent)
-        except AttributeError:
-            # when using inner window, an app have grab the touch
-            # but app is removed. The touch can't access
-            # to one of the parent. (i.e, self.parent will be None)
-            # and BAM the bug happen.
-            raise
-        return me
+        if widget is not None:
+            parent = widget.parent
+            try:
+                if parent:
+                    me.apply_transform_2d(parent.to_widget)
+                else:
+                    me.apply_transform_2d(widget.to_widget)
+                    me.apply_transform_2d(widget.to_parent)
+            except AttributeError:
+                # when using inner window, an app have grab the touch
+                # but app is removed. The touch can't access
+                # to one of the parent. (i.e, self.parent will be None)
+                # and BAM the bug happen.
+                raise
 
     def _apply_transform(self, m):
         return m


### PR DESCRIPTION
Motion event is transformed inplace, new instance is not created so returning the same one is not needed.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
