### PR TITLE
PyInstaller develop version isn't needed anymore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ dev =
     pytest_asyncio!=0.11.0
     pytest-timeout
     pytest-benchmark
-    PyInstaller @ https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+    pyinstaller
     sphinx
     sphinxcontrib-blockdiag
     sphinxcontrib-seqdiag


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
