### PR TITLE
Input providers: Assign type_id to MotionEvent subclasses

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -105,12 +105,16 @@ SDLK_F15 = 1073741896
 
 
 class SDL2MotionEvent(MotionEvent):
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+        self.profile = ('pos', 'pressure')
+
     def depack(self, args):
-        self.is_touch = True
-        self.profile = ('pos', 'pressure', )
         self.sx, self.sy, self.pressure = args
-        win = EventLoop.window
-        super(SDL2MotionEvent, self).depack(args)
+        super().depack(args)
 
 
 class SDL2MotionEventProvider(MotionEventProvider):

--- a/kivy/input/providers/androidjoystick.py
+++ b/kivy/input/providers/androidjoystick.py
@@ -30,14 +30,18 @@ if 'KIVY_DOC' not in os.environ:
 
 class AndroidMotionEvent(MotionEvent):
 
-    def depack(self, args):
-        self.is_touch = True
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
         self.profile = ['pos', 'pressure', 'shape']
+
+    def depack(self, args):
         self.sx, self.sy, self.pressure, radius = args
         self.shape = ShapeRect()
         self.shape.width = radius
         self.shape.height = radius
-        super(AndroidMotionEvent, self).depack(args)
+        super().depack(args)
 
 
 class AndroidMotionEventProvider(MotionEventProvider):

--- a/kivy/input/providers/hidinput.py
+++ b/kivy/input/providers/hidinput.py
@@ -59,8 +59,12 @@ Keyboard = None
 
 class HIDMotionEvent(MotionEvent):
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+
     def depack(self, args):
-        self.is_touch = True
         self.sx = args['x']
         self.sy = args['y']
         self.profile = ['pos']
@@ -75,8 +79,7 @@ class HIDMotionEvent(MotionEvent):
         if 'button' in args:
             self.button = args['button']
             self.profile.append('button')
-
-        super(HIDMotionEvent, self).depack(args)
+        super().depack(args)
 
     def __str__(self):
         return '<HIDMotionEvent id=%d pos=(%f, %f) device=%s>' \

--- a/kivy/input/providers/leapfinger.py
+++ b/kivy/input/providers/leapfinger.py
@@ -22,17 +22,21 @@ def normalize(value, a, b):
 
 class LeapFingerEvent(MotionEvent):
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+        self.profile = ('pos', 'pos3d',)
+
     def depack(self, args):
-        super(LeapFingerEvent, self).depack(args)
+        super().depack(args)
         if args[0] is None:
             return
-        self.profile = ('pos', 'pos3d', )
         x, y, z = args
         self.sx = normalize(x, -150, 150)
         self.sy = normalize(y, 40, 460)
         self.sz = normalize(z, -350, 350)
         self.z = z
-        self.is_touch = True
 
 
 class LeapFingerEventProvider(MotionEventProvider):

--- a/kivy/input/providers/linuxwacom.py
+++ b/kivy/input/providers/linuxwacom.py
@@ -34,8 +34,12 @@ from kivy.input.shape import ShapeRect
 
 class LinuxWacomMotionEvent(MotionEvent):
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+
     def depack(self, args):
-        self.is_touch = True
         self.sx = args['x']
         self.sy = args['y']
         self.profile = ['pos']
@@ -47,7 +51,7 @@ class LinuxWacomMotionEvent(MotionEvent):
         if 'pressure' in args:
             self.pressure = args['pressure']
             self.profile.append('pressure')
-        super(LinuxWacomMotionEvent, self).depack(args)
+        super().depack(args)
 
     def __str__(self):
         return '<LinuxWacomMotionEvent id=%d pos=(%f, %f) device=%s>' \

--- a/kivy/input/providers/mactouch.py
+++ b/kivy/input/providers/mactouch.py
@@ -93,14 +93,18 @@ class MacMotionEvent(MotionEvent):
     and shape profiles.
     '''
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+        self.profile = ('pos', 'shape')
+
     def depack(self, args):
-        self.is_touch = True
         self.shape = ShapeRect()
         self.sx, self.sy = args[0], args[1]
         self.shape.width = args[2]
         self.shape.height = args[2]
-        self.profile = ('pos', 'shape')
-        super(MacMotionEvent, self).depack(args)
+        super().depack(args)
 
     def __str__(self):
         return '<MacMotionEvent id=%d pos=(%f, %f) device=%s>' \

--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -53,8 +53,12 @@ from kivy.input.shape import ShapeRect
 
 class MTDMotionEvent(MotionEvent):
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+
     def depack(self, args):
-        self.is_touch = True
         if 'x' in args:
             self.sx = args['x']
         else:
@@ -72,7 +76,7 @@ class MTDMotionEvent(MotionEvent):
         if 'pressure' in args:
             self.pressure = args['pressure']
             self.profile.append('pressure')
-        super(MTDMotionEvent, self).depack(args)
+        super().depack(args)
 
     def __str__(self):
         i, sx, sy, d = (self.id, self.sx, self.sy, self.device)

--- a/kivy/input/providers/tuio.py
+++ b/kivy/input/providers/tuio.py
@@ -61,8 +61,6 @@ class TuioMotionEventProvider(MotionEventProvider):
         # Create a class to handle the new TUIO type/path
         # Replace NEWPATH with the pathname you want to handle
         class TuioNEWPATHMotionEvent(MotionEvent):
-            def __init__(self, id, args):
-                super(TuioNEWPATHMotionEvent, self).__init__(id, args)
 
             def depack(self, args):
                 # In this method, implement 'unpacking' for the received
@@ -73,7 +71,7 @@ class TuioMotionEventProvider(MotionEventProvider):
                     self.sx, self.sy = args
                     self.profile = ('pos', )
                 self.sy = 1 - self.sy
-                super(TuioNEWPATHMotionEvent, self).depack(args)
+                super().depack(args)
 
         # Register it with the TUIO MotionEvent provider.
         # You obviously need to replace the PATH placeholders appropriately.
@@ -90,9 +88,9 @@ class TuioMotionEventProvider(MotionEventProvider):
     __handlers__ = {}
 
     def __init__(self, device, args):
-        super(TuioMotionEventProvider, self).__init__(device, args)
+        super().__init__(device, args)
         args = args.split(',')
-        if len(args) <= 0:
+        if len(args) == 0:
             Logger.error('Tuio: Invalid configuration for TUIO provider')
             Logger.error('Tuio: Format must be ip:port (eg. 127.0.0.1:3333)')
             err = 'Tuio: Current configuration is <%s>' % (str(','.join(args)))
@@ -220,8 +218,10 @@ class TuioMotionEvent(MotionEvent):
     '''
     __attrs__ = ('a', 'b', 'c', 'X', 'Y', 'Z', 'A', 'B', 'C', 'm', 'r')
 
-    def __init__(self, device, id, args):
-        super(TuioMotionEvent, self).__init__(device, id, args)
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
         # Default argument for TUIO touches
         self.a = 0.0
         self.b = 0.0
@@ -246,11 +246,7 @@ class TuioMotionEvent(MotionEvent):
 class Tuio2dCurMotionEvent(TuioMotionEvent):
     '''A 2dCur TUIO touch.'''
 
-    def __init__(self, device, id, args):
-        super(Tuio2dCurMotionEvent, self).__init__(device, id, args)
-
     def depack(self, args):
-        self.is_touch = True
         if len(args) < 5:
             self.sx, self.sy = list(map(float, args[0:2]))
             self.profile = ('pos', )
@@ -269,18 +265,14 @@ class Tuio2dCurMotionEvent(TuioMotionEvent):
             self.shape.width = width
             self.shape.height = height
         self.sy = 1 - self.sy
-        super(Tuio2dCurMotionEvent, self).depack(args)
+        super().depack(args)
 
 
 class Tuio2dObjMotionEvent(TuioMotionEvent):
     '''A 2dObj TUIO object.
     '''
 
-    def __init__(self, device, id, args):
-        super(Tuio2dObjMotionEvent, self).__init__(device, id, args)
-
     def depack(self, args):
-        self.is_touch = True
         if len(args) < 5:
             self.sx, self.sy = args[0:2]
             self.profile = ('pos', )
@@ -301,7 +293,7 @@ class Tuio2dObjMotionEvent(TuioMotionEvent):
                 self.shape.width = width
                 self.shape.height = height
         self.sy = 1 - self.sy
-        super(Tuio2dObjMotionEvent, self).depack(args)
+        super().depack(args)
 
 
 class Tuio2dBlbMotionEvent(TuioMotionEvent):
@@ -311,22 +303,20 @@ class Tuio2dBlbMotionEvent(TuioMotionEvent):
     /tuio/2Dblb set s   x y a w h f X Y A m r
     '''
 
-    def __init__(self, device, id, args):
-        super(Tuio2dBlbMotionEvent, self).__init__(device, id, args)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.profile = ('pos', 'angle', 'mov', 'rot', 'rotacc', 'acc', 'shape')
 
     def depack(self, args):
-        self.is_touch = True
         self.sx, self.sy, self.a, self.X, self.Y, sw, sh, sd, \
             self.A, self.m, self.r = args
         self.Y = -self.Y
-        self.profile = ('pos', 'angle', 'mov', 'rot', 'rotacc',
-                        'acc', 'shape')
         if self.shape is None:
             self.shape = ShapeRect()
             self.shape.width = sw
             self.shape.height = sh
         self.sy = 1 - self.sy
-        super(Tuio2dBlbMotionEvent, self).depack(args)
+        super().depack(args)
 
 
 # registers

--- a/kivy/input/providers/wm_pen.py
+++ b/kivy/input/providers/wm_pen.py
@@ -16,10 +16,15 @@ from kivy.input.motionevent import MotionEvent
 class WM_Pen(MotionEvent):
     '''MotionEvent representing the WM_Pen event. Supports the pos profile.'''
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+        self.profile = ['pos']
+
     def depack(self, args):
-        self.is_touch = True
         self.sx, self.sy = args[0], args[1]
-        super(WM_Pen, self).depack(args)
+        super().depack(args)
 
     def __str__(self):
         i, u, s, d = (self.id, self.uid, str(self.spos), self.device)

--- a/kivy/input/providers/wm_touch.py
+++ b/kivy/input/providers/wm_touch.py
@@ -22,16 +22,19 @@ class WM_MotionEvent(MotionEvent):
     '''
     __attrs__ = ('size', )
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
+        self.profile = ('pos', 'shape', 'size')
+
     def depack(self, args):
-        self.is_touch = True
         self.shape = ShapeRect()
         self.sx, self.sy = args[0], args[1]
         self.shape.width = args[2][0]
         self.shape.height = args[2][1]
         self.size = self.shape.width * self.shape.height
-        self.profile = ('pos', 'shape', 'size')
-
-        super(WM_MotionEvent, self).depack(args)
+        super().depack(args)
 
     def __str__(self):
         args = (self.id, self.uid, str(self.spos), self.device)

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -427,18 +427,20 @@ class UnitTestTouch(MotionEvent):
         '''Create a MotionEvent instance with X and Y of the first
         position a touch is at.
         '''
-
         from kivy.base import EventLoop
         self.eventloop = EventLoop
         win = EventLoop.window
-
         super(UnitTestTouch, self).__init__(
             # device, (tuio) id, args
             self.__class__.__name__, 99, {
                 "x": x / (win.width - 1.0),
                 "y": y / (win.height - 1.0),
-            }
+            },
+            is_touch=True,
+            type_id='touch'
         )
+        # set profile to accept x, y and pos properties
+        self.profile = ['pos']
 
     def touch_down(self, *args):
         self.eventloop.post_dispatch_input("begin", self)
@@ -455,27 +457,27 @@ class UnitTestTouch(MotionEvent):
         self.eventloop.post_dispatch_input("end", self)
 
     def depack(self, args):
-        # set MotionEvent to touch
-        self.is_touch = True
-
         # set sx/sy properties to ratio (e.g. X / win.width)
         self.sx = args['x']
         self.sy = args['y']
+        # run depack after we set the values
+        super().depack(args)
 
-        # set profile to accept x, y and pos properties
+
+# https://gist.github.com/tito/f111b6916aa6a4ed0851
+# subclass for touch event in unit test
+class UTMotionEvent(MotionEvent):
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('is_touch', True)
+        kwargs.setdefault('type_id', 'touch')
+        super().__init__(*args, **kwargs)
         self.profile = ['pos']
 
-        # run depack after we set the values
-        super(UnitTestTouch, self).depack(args)
-
-
-class UTMotionEvent(MotionEvent):
     def depack(self, args):
-        self.is_touch = True
         self.sx = args['x']
         self.sy = args['y']
-        self.profile = ['pos']
-        super(UTMotionEvent, self).depack(args)
+        super().depack(args)
 
 
 def async_run(func=None, app_cls_func=None):

--- a/kivy/tests/test_uix_actionbar.py
+++ b/kivy/tests/test_uix_actionbar.py
@@ -1,9 +1,8 @@
-from kivy.tests.common import GraphicUnitTest
+from kivy.tests.common import GraphicUnitTest, UTMotionEvent
 
 from kivy.lang import Builder
 from kivy.base import EventLoop
 from kivy.weakproxy import WeakProxy
-from kivy.input.motionevent import MotionEvent
 from time import sleep
 
 DropDown = None
@@ -53,26 +52,15 @@ FloatLayout:
 '''
 
 
-class UTMotionEvent(MotionEvent):
-    def depack(self, args):
-        self.is_touch = True
-        self.sx = args['x']
-        self.sy = args['y']
-        self.profile = ['pos']
-        super(UTMotionEvent, self).depack(args)
-
-
 class TouchPoint(UTMotionEvent):
     def __init__(self, raw_x, raw_y):
         win = EventLoop.window
-
-        super(UTMotionEvent, self).__init__(
+        super().__init__(
             "unittest", 1, {
                 "x": raw_x / float(win.width),
                 "y": raw_y / float(win.height),
             }
         )
-
         # press & release
         EventLoop.post_dispatch_input("begin", self)
         EventLoop.post_dispatch_input("end", self)

--- a/kivy/tests/test_uix_relativelayout.py
+++ b/kivy/tests/test_uix_relativelayout.py
@@ -6,20 +6,8 @@ uix.relativelayout tests
 import unittest
 
 from kivy.base import EventLoop
-from kivy.input.motionevent import MotionEvent
+from kivy.tests import UTMotionEvent
 from kivy.uix.relativelayout import RelativeLayout
-
-
-# https://gist.github.com/tito/f111b6916aa6a4ed0851
-# subclass for touch event in unit test
-class UTMotionEvent(MotionEvent):
-
-    def depack(self, args):
-        self.is_touch = True
-        self.sx = args['x']
-        self.sy = args['y']
-        self.profile = ['pos']
-        super(UTMotionEvent, self).depack(args)
 
 
 class UixRelativeLayoutTest(unittest.TestCase):

--- a/kivy/tests/test_uix_slider.py
+++ b/kivy/tests/test_uix_slider.py
@@ -1,18 +1,8 @@
-from kivy.tests.common import GraphicUnitTest
+from kivy.tests.common import GraphicUnitTest, UTMotionEvent
 
-from kivy.input.motionevent import MotionEvent
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.slider import Slider
 from kivy.base import EventLoop
-
-
-class UTMotionEvent(MotionEvent):
-    def depack(self, args):
-        self.is_touch = True
-        self.sx = args['x']
-        self.sy = args['y']
-        self.profile = ['pos']
-        super(UTMotionEvent, self).depack(args)
 
 
 class _TestSliderHandle(Slider):


### PR DESCRIPTION
Assigns "touch" as a default `type_id` and cleans-up the `depack` method in the following `MotionEvent` subclasses:
- SDL2MotionEvent
- AndroidMotionEvent
- HIDMotionEvent
- LeapFingerEvent
- LinuxWacomMotionEvent
- MacMotionEvent
- MTDMotionEvent
- TuioMotionEvent
- Tuio2dCurMotionEvent
- Tuio2dObjMotionEvent
- Tuio2dBlbMotionEvent
- WM_Pen (added "pos" in `profile` which was missing)
- WM_MotionEvent
- UnitTestTouch
- UTMotionEvent (removed duplicates)

Follow up on https://github.com/kivy/kivy/pull/7658.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist:
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
