### PR TITLE
updated old url for editable install

### DIFF
--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -186,7 +186,7 @@ system dependencies listed for each OS: :ref:`Windows<install-source-win>`,
 :ref:`RPi<install-source-rpi>`.
 
 Then change to the kivy directory and install Kivy as an
-`editable install <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_::
+`editable install (i.e.  setuptools "develop mode") <https://setuptools.pypa.io/en/latest/userguide/development_mode.html>`_::
 
     cd kivy
     python -m pip install -e ".[dev,full]"


### PR DESCRIPTION
The old url now redirects to new [editable-installs](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs) which finally leads to setup tools [development_mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html)

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
