### PR TITLE
made Generic Prompt unselectable

### DIFF
--- a/doc/sources/.static/fresh.css
+++ b/doc/sources/.static/fresh.css
@@ -558,8 +558,8 @@ code.docutils{
 	border-radius: .5em;
 }
 
-.linenos::before {
-	content: attr(data-line-number);
+.linenos::before, .gp::before {
+	content: attr(unselectable-data);
 }
 
 @media (min-width: 640px) {

--- a/doc/sources/.static/kivy.js
+++ b/doc/sources/.static/kivy.js
@@ -226,9 +226,9 @@ $(function() {
 	}
 	// Hack to add an attrib to all linenos,
 	// this is needed in order to avoid certain browsers (Ex: Safari) that treat the line-number as a copyable item.
-    $(".linenos").each(function(){
+    $(".linenos, .gp").each(function(){
         let $this = $(this);
-        $this.attr("data-line-number", $this.text());
+        $this.attr("unselectable-data", $this.text());
 		$this.contents().filter(function(){
     			return this.nodeType === 3; //https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
 		}).remove();


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

## Before  

![image](https://user-images.githubusercontent.com/22869882/153729122-437d7c60-3dc7-45f1-9df8-18702bb7cc68.png)  


## After  


![image](https://user-images.githubusercontent.com/22869882/153729131-82db8a37-723e-4beb-8320-eea7b7a321df.png)  
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
