### PR TITLE
Use the `KIVY_RPI_VERSION` env variable to force the build of `egl_rpi` in non Raspi CI builds

### DIFF
--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -83,15 +83,17 @@ Cross-Compilation for Raspberry Pi 1-3 headless installation on Raspbian Buster
 The Raspberry OS project uses `pi-gen` project to create bootable images for Raspberry PI.
 
 Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that uses the (now deprecated but still useful) DISPMANX API is only compiled when running on a Raspberry Pi.
+In order to build Kivy in such `pi-gen` environment, the auto-detection of the Raspberry Pi hardware version needs to be disabled.
 
-When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `USE_RPI` to `1`.
+When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `FORCE_RPI_VERSION` to any number < 4, e.g. `3`.
 
 The install command then looks something like this::
 
-    apt install build-essential libraspberrypi-dev raspberrypi-kernel-headers 
-    USE_RPI=1 python -m pip install "kivy[base]" kivy_examples --no-binary kivy
+    apt install build-essential libraspberrypi-dev raspberrypi-kernel-headers
+    FORCE_RPI_VERSION=3 python -m pip install "kivy[base]" kivy_examples --no-binary kivy
 
 Please note that the `egl_rpi` window handler is not supported on Raspberry Pi 4 and higher.
+The existing version check will refuse to compile the `egl_rpi` provider when detecting or forcing the Raspberry Pi version to 4 or higher.
 
 Raspberry Pi 4 headless installation on Raspbian Buster
 *******************************************************

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -77,6 +77,21 @@ then install SDL2 from apt::
 
     sudo apt install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
 
+Cross-Compilation for Raspberry Pi 1-3 headless installation on Raspbian Buster
+*******************************************************************************
+
+The Raspberry OS project uses `pi-gen` project to create bootable images for Raspberry PI.
+
+Kivy determines automatically, which libraries to add based on the environment it is run. The `egl_rpi` renderer that uses the (now deprecated but still useful) DISPMANX API is only compiled in when running on a Raspberry Pi.
+
+When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `USE_RPI` to `1`.
+
+The install command then looks something like this::
+
+    apt install build-essential libraspberrypi-dev raspberrypi-kernel-headers 
+    USE_RPI=1 python -m pip install "kivy[base]" kivy_examples --no-binary kivy
+
+Please note that the `egl_rpi` window handler is not supported on Raspberry Pi 4 and higher.
 
 Raspberry Pi 4 headless installation on Raspbian Buster
 *******************************************************

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -82,7 +82,7 @@ Cross-Compilation for Raspberry Pi 1-3 headless installation on Raspbian Buster
 
 The Raspberry OS project uses `pi-gen` project to create bootable images for Raspberry PI.
 
-Kivy determines automatically, which libraries to add based on the environment it is run. The `egl_rpi` renderer that uses the (now deprecated but still useful) DISPMANX API is only compiled in when running on a Raspberry Pi.
+Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that uses the (now deprecated but still useful) DISPMANX API is only compiled when running on a Raspberry Pi.
 
 When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `USE_RPI` to `1`.
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -85,12 +85,12 @@ The Raspberry OS project uses `pi-gen` project to create bootable images for Ras
 Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that uses the (now deprecated but still useful) DISPMANX API is only compiled when running on a Raspberry Pi.
 In order to build Kivy in such `pi-gen` environment, the auto-detection of the Raspberry Pi hardware version needs to be disabled.
 
-When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `FORCE_RPI_VERSION` to any number < 4, e.g. `3`.
+When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `KIVY_RPI_VERSION` to any number < 4, e.g. `3`.
 
 The install command then looks something like this::
 
     apt install build-essential libraspberrypi-dev raspberrypi-kernel-headers
-    FORCE_RPI_VERSION=3 python -m pip install "kivy[base]" kivy_examples --no-binary kivy
+    KIVY_RPI_VERSION=3 python -m pip install "kivy[base]" kivy_examples --no-binary kivy
 
 Please note that the `egl_rpi` window handler is not supported on Raspberry Pi 4 and higher.
 The existing version check will refuse to compile the `egl_rpi` provider when detecting or forcing the Raspberry Pi version to 4 or higher.

--- a/setup.py
+++ b/setup.py
@@ -114,12 +114,8 @@ if kivy_ios_root is not None:
 if exists('/opt/vc/include/bcm_host.h'):
     used_pi_version = pi_version
     # Force detected Raspberry Pi version for cross-builds, if needed
-    if 'FORCE_RPI_VERSION' in environ:
-        try:
-            used_pi_version = int(environ.get('FORCE_RPI_VERSION'))
-        except:
-            print("Could not override Raspberry Pi version "
-                 f"to {environ.get('FORCE_RPI_VERSION')}")
+    if 'KIVY_RPI_VERSION' in environ:
+        used_pi_version = int(environ['KIVY_RPI_VERSION'])
     # The proprietary broadcom video core drivers are not available on the
     # Raspberry Pi 4
     if (used_pi_version or 4) < 4:

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ if kivy_ios_root is not None:
 if exists('/opt/vc/include/bcm_host.h'):
     # The proprietary broadcom video core drivers are not available on the
     # Raspberry Pi 4
-    if (pi_version or 4) < 4:
+    if (pi_version or 4) < 4 or int(environ.get('USE_RPI', "0")) == 1:
         platform = 'rpi'
 # use mesa video core drivers
 if environ.get('VIDEOCOREMESA', None) == '1':

--- a/setup.py
+++ b/setup.py
@@ -112,9 +112,17 @@ if kivy_ios_root is not None:
     platform = 'ios'
 # proprietary broadcom video core drivers
 if exists('/opt/vc/include/bcm_host.h'):
+    used_pi_version = pi_version
+    # Force detected Raspberry Pi version for cross-builds, if needed
+    if 'FORCE_RPI_VERSION' in environ:
+        try:
+            used_pi_version = int(environ.get('FORCE_RPI_VERSION'))
+        except:
+            print("Could not override Raspberry Pi version "
+                 f"to {environ.get('FORCE_RPI_VERSION')}")
     # The proprietary broadcom video core drivers are not available on the
     # Raspberry Pi 4
-    if (pi_version or 4) < 4 or int(environ.get('USE_RPI', "0")) == 1:
+    if (used_pi_version or 4) < 4:
         platform = 'rpi'
 # use mesa video core drivers
 if environ.get('VIDEOCOREMESA', None) == '1':


### PR DESCRIPTION
Forces the `pi_version` variable in `setup.py` to a user provided value when the `FORCE_RPI_VERSION` environment variable is set.

Resolves #7797.

A new environment variable is introduced that allows circumventing the Raspberry Pi version detection on non-raspberry Pi hardware that still has the full Raspberry Pi software stack.

The [RPi-Distro/Pi-gen](https://github.com/RPi-Distro/Pi-gen) project is used for building bootable images for Raspberry Pi and internally uses `qemu-static` to execute ARM binaries on x86 hardware in order to run compilers, packages, etc. in the correct format. 

Currently, the `setup.py` uses the `/proc/cpuinfo` pseudofile to determine, which Raspberry Pi version it is running on. In the `pi-gen` environment, this pseudofile is used from the host machine (or Docker container) though, and will not contain any Raspberry Pi relevant CPU information.

By forcing the Raspberry Pi version, the rest of setup.py behaves as if it is running on a raspberry pi, and given all the required dependencies creates a runnable image for Raspberry Pi with full `egl_rpi` window support, GLES2, etc. This is suitable for Raspberry Pi < 4, as `egl_rpi` is not supported from Raspberry Pi 4 on. The version check for Raspberry Pi < 4 remains intact, even with the override.

When the `FORCE_RPI_VERSION` is not set there is no change in behaviour.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
