### PR TITLE
Add the LINK_SUFFIX to Sphinx template to restore search result links

### DIFF
--- a/doc/sources/.templates/layout.html
+++ b/doc/sources/.templates/layout.html
@@ -113,6 +113,7 @@
                   LANGUAGE:'{{ language }}', 
                   COLLAPSE_INDEX:false, 
                   FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}', 
+                  LINK_SUFFIX:'{{ link_suffix }}', 
                   HAS_SOURCE:  {{ has_source|lower }}, 
                   SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}' 
               }; 


### PR DESCRIPTION
Corrects the broken page links on the search results page, which contain `undefined` because the LINK_SUFFIX is currently not set.

The setting was introduced with Sphinx 0.6.0 and likely the template was not adapted. This PR fixes that.

Tested by:
- not changing any settings in the `docs/conf.py` and getting links ending with `.html` (instead if `undefined`, confirming the fix)
- setting `html_link_suffix` to `.link` in the `doc/conf.py` getting links ending in `.link`
- setting `html_file_suffix` to `.xhtml` in the `doc/conf.py` getting links ending in `.xhtml`.

When no setting is provided in the conf.py, sphinx defaults to `.html`, which is the desired and expected behaviour.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
