### PR TITLE
Track whether the clock has started

### DIFF
--- a/kivy/_clock.pxd
+++ b/kivy/_clock.pxd
@@ -95,6 +95,7 @@ cdef class CyClockBase(object):
     cdef public object _lock_acquire
     cdef public object _lock_release
 
+    cdef public int has_started
     cdef public int has_ended
     cdef public object _del_safe_lock
     cdef public int _del_safe_done

--- a/kivy/_clock.pyx
+++ b/kivy/_clock.pyx
@@ -260,6 +260,7 @@ cdef class CyClockBase(object):
         self._del_safe_lock = RLock()
         self._del_safe_done = False
         self.has_ended = False
+        self.has_started = False
 
     def start_clock(self):
         """Must be called to start the clock.
@@ -268,7 +269,10 @@ cdef class CyClockBase(object):
         """
         self._lock_acquire()
         try:
-            pass
+            if self.has_started:
+                return
+
+            self.has_started = True
             # for now don't raise an exception when restarting because kivy's
             # graphical tests are not setup to handle clock isolation so they try
             # to restart the clock


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


This adds a variable that tracks whether the kivy clock has started. Previously I added a similar variable to track whether the clock has ended. This is required for interfacing with async code (and threading) where we need to be sure that the async code or thread is not stuck forever waiting for kivy to finish a callback that will never happen because the clock has not started (and potentially never will) or if it finished.

Introducing `has_ended` allowed us to be notified by special callback when the clock finishes allowing any waiting async code that are waiting on a kivy callback to be canceled/timed out. By adding `has_started`, it will enable async code to raise an error if it checks that the clock has not started, meaning it won't be safe for it to schedule a callback and wait, as it may wait forever.


While this is technically a new feature, I would really like if we can get this into 2.1.0 because it's needed for my [kivy_trio](https://github.com/matham/kivy-trio/) library that interfaces kivy with trio async code. And it's not really much of a functional change (it's not even publicly documented as I don't expect users to use it) so it can't break anything existing. But if people think it's not a good idea we can wait until after the release.