### PR TITLE
Bump cython and kivy_deps versions to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
 requires = [
     "setuptools", "wheel",
-    "cython>=0.24,<=0.29.26,!=0.27,!=0.27.2",
+    "cython>=0.24,<=0.29.28,!=0.27,!=0.27.2",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2_dev~=0.4.4; sys_platform == "win32"',
-    'kivy_deps.glew_dev~=0.3.0; sys_platform == "win32"',
+    'kivy_deps.sdl2_dev~=0.4.5; sys_platform == "win32"',
+    'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
     'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2~=0.4.4; sys_platform == "win32"',
-    'kivy_deps.glew~=0.3.0; sys_platform == "win32"',
+    'kivy_deps.sdl2~=0.4.5; sys_platform == "win32"',
+    'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
 ]
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ logging-level=DEBUG
 
 [kivy]
 cython_min=0.24
-cython_max=0.29.26
+cython_max=0.29.28
 cython_exclude=0.27,0.27.2
 python_versions=3.7 - 3.10
 
@@ -26,9 +26,9 @@ install_requires =
     Kivy-Garden>=0.1.4
     docutils
     pygments
-    kivy_deps.angle~=0.3.1; sys_platform == "win32"
-    kivy_deps.sdl2~=0.4.4; sys_platform == "win32"
-    kivy_deps.glew~=0.3.0; sys_platform == "win32"
+    kivy_deps.angle~=0.3.2; sys_platform == "win32"
+    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
 
@@ -48,17 +48,17 @@ dev =
     sphinxcontrib-nwdiag
     funcparserlib==1.0.0a0
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
-    kivy_deps.sdl2_dev~=0.4.4; sys_platform == "win32"
-    kivy_deps.glew_dev~=0.3.0; sys_platform == "win32"
+    kivy_deps.sdl2_dev~=0.4.5; sys_platform == "win32"
+    kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"
     flake8
     pre-commit
 base =
     pillow
     docutils
     pygments
-    kivy_deps.angle~=0.3.1; sys_platform == "win32"
-    kivy_deps.sdl2~=0.4.4; sys_platform == "win32"
-    kivy_deps.glew~=0.3.0; sys_platform == "win32"
+    kivy_deps.angle~=0.3.2; sys_platform == "win32"
+    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 media =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
@@ -68,19 +68,19 @@ full =
     docutils
     pygments
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    kivy_deps.angle~=0.3.1; sys_platform == "win32"
-    kivy_deps.sdl2~=0.4.4; sys_platform == "win32"
-    kivy_deps.glew~=0.3.0; sys_platform == "win32"
+    kivy_deps.angle~=0.3.2; sys_platform == "win32"
+    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.glew~=0.3.1; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
     pypiwin32; sys_platform == "win32"
 gstreamer =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
 angle =
-    kivy_deps.angle~=0.3.1; sys_platform == "win32"
+    kivy_deps.angle~=0.3.2; sys_platform == "win32"
 sdl2 =
-    kivy_deps.sdl2~=0.4.4; sys_platform == "win32"
+    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
 glew =
-    kivy_deps.glew~=0.3.0; sys_platform == "win32"
+    kivy_deps.glew~=0.3.1; sys_platform == "win32"
 
 [flake8]
 ignore = E125,E126,E127,E128,E402,E741,E731,W503,F401,W504,F841,E722


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

This bumps cython to the latest version. Similarly, I had released new kivy_deps  last week or so to fix the windows store issue. Kivy currently would pull it because it uses a tilda in the version specifier, but this is making the bump explicit.