### PR TITLE
:zap: Prevent crash (overflow error) when scrollbar is hidden

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -933,7 +933,7 @@ class ScrollView(StencilView):
             if not touch.ud['sv.handled']['y'] and self.do_scroll_y \
                     and self.effect_y:
                 height = self.height
-                if touch.ud.get('in_bar_y', False):
+                if touch.ud.get('in_bar_y', False) and self.vbar[1] != 1.0:
                     dy = touch.dy / float(height - height * self.vbar[1])
                     self.scroll_y = min(max(self.scroll_y + dy, 0.), 1.)
                     self._trigger_update_from_scroll()


### PR DESCRIPTION
## Background

This PR fixes a crash when the scrollbar is hidden but the user clicks in that area to scroll.

Please see: https://github.com/kivy/kivy/issues/7803

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
