### PR TITLE
Increase timeout to avoid failing tests on windows-2022

### DIFF
--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -106,7 +106,7 @@ function Install-kivy-sdist {
 }
 
 function Test-kivy {
-    python -m pytest --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+    python -m pytest --timeout=400 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
 }
 
 function Test-kivy-benchmark {
@@ -120,7 +120,7 @@ function Test-kivy-installed {
     cd "$test_path"
 
     echo "[run]`nplugins = kivy.tools.coverage`n" > .coveragerc
-    raise-only-error -Func {python -m pytest --timeout=300 .}
+    raise-only-error -Func {python -m pytest --timeout=400 .}
 }
 
 function Upload-artifacts-to-pypi {


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Increases timeout, in order to avoid tests to fail on `windows-2022` runners.

Tested on an Azure Windows Server 2022 instance and did not fail after 30+ runs.
