### PR TITLE
Fix VKeyboard missing with custom keyboard class

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -647,7 +647,7 @@ class WindowBase(EventDispatcher):
             and self._vkeyboard_cls is not None
         ):
             for w in self.children:
-                if isinstance(w, VKeyboard):
+                if isinstance(w, self._vkeyboard_cls):
                     vkeyboard_height = w.height * w.scale
                     if self.softinput_mode == 'pan':
                         return vkeyboard_height


### PR DESCRIPTION
In `window/__init__.py` the VKeyboard class is only imported when needed, which only happens in `request_keyboard()`. If a custom keyboard class is set using `set_vkeyboard_class()`, it is never imported. In that case the function `_get_kivy_vkheight()` that was introduced in #7726 fails, because VKeyboard is still None. This change instead compares to `self._vkeyboard_cls` which is ensured above to not be None. If no custom class is set, this should still be just VKeyboard.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.