### PR TITLE
Fixes 3.8.x pyenv install due to a recent change in clang [build wheel osx]

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -162,7 +162,7 @@ jobs:
             python: '3.10'
           - runs_on: apple-silicon-m1
             run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
-            python: '3.8.12'
+            python: '3.8.13'
           - runs_on: apple-silicon-m1
             run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: '3.9.7'


### PR DESCRIPTION
The Apple Clang included with Xcode 13.3 now supports `--print-multiarch`.

This is causing configure to fail on `CPython 3.8.12` when installing it via `pyenv` during tests (that only happens on our self-hosted `apple-silicon-m1` runner).

`3.8.13` includes a fix for that takes care about these changes.

For further information, see: https://github.com/python/cpython/pull/31889

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
