### PR TITLE
iOS camera provider enhancements

### DIFF
--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -160,7 +160,7 @@ class CameraAVFoundation(CameraBase):
         self._metadata_callback = callback
         avf_camera_attempt_start_metadata_analysis(storage.camera)
         
-    def get_video_orientation(self):
+    def get_device_orientation(self):
         if platform == 'ios':
             return avf_camera_get_video_orientation()
         return 0

--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -21,6 +21,11 @@ cdef extern from "camera_avfoundation_implem.h":
     void avf_camera_get_metadata(camera_t camera, char **metatype, char **data)
     bint avf_camera_have_new_metadata(camera_t camera);
     bint avf_camera_set_video_orientation(camera_t camera, int orientation)
+    int avf_camera_get_video_orientation()
+    void avf_camera_change_input(camera_t camera, int _cameraNum)
+    void avf_camera_zoom_level(camera_t camera, float zoomLevel)
+    char *avf_camera_documents_directory()
+    void avf_camera_save_pixels(camera_t camera, unsigned char *pixels, int width, int height, char *path, float quality)
 
 
 from kivy.logger import Logger
@@ -154,3 +159,32 @@ class CameraAVFoundation(CameraBase):
         cdef _AVStorage storage = <_AVStorage>self._storage
         self._metadata_callback = callback
         avf_camera_attempt_start_metadata_analysis(storage.camera)
+        
+    def get_video_orientation(self):
+        if platform == 'ios':
+            return avf_camera_get_video_orientation()
+        return 0
+
+    def change_camera_input(self, index):
+        cdef _AVStorage storage = <_AVStorage>self._storage
+        if platform == 'ios':
+            avf_camera_change_input(storage.camera, index)
+
+    def zoom_level(self, level):
+        cdef _AVStorage storage = <_AVStorage>self._storage
+        if platform == 'ios':
+            avf_camera_zoom_level(storage.camera, level)
+
+    def get_app_documents_directory(self):
+        if platform == 'ios':
+             return str(avf_camera_documents_directory().decode('utf-8'))
+        return ''
+
+    def save_texture(self, texture, filepath = '', quality = 0.9):
+        # With texture argument only: Save texture to iOS Photos App
+        # With texture and filepath arguments: Save texture as jpg; filepath root must be app documents directory,
+        #     sub-directories in filepath must exist, filepath last element is filename.jpg
+        cdef _AVStorage storage = <_AVStorage>self._storage
+        if platform == 'ios':
+            avf_camera_save_pixels(storage.camera, bytearray(texture.pixels), int(texture.width), int(texture.height),
+                                   filepath.encode('utf-8'), quality)

--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -21,7 +21,7 @@ cdef extern from "camera_avfoundation_implem.h":
     void avf_camera_get_metadata(camera_t camera, char **metatype, char **data)
     bint avf_camera_have_new_metadata(camera_t camera);
     bint avf_camera_set_video_orientation(camera_t camera, int orientation)
-    int avf_camera_get_video_orientation()
+    int avf_camera_get_device_orientation()
     void avf_camera_change_input(camera_t camera, int _cameraNum)
     void avf_camera_zoom_level(camera_t camera, float zoomLevel)
     char *avf_camera_documents_directory()
@@ -161,30 +161,28 @@ class CameraAVFoundation(CameraBase):
         avf_camera_attempt_start_metadata_analysis(storage.camera)
         
     def get_device_orientation(self):
-        if platform == 'ios':
-            return avf_camera_get_video_orientation()
-        return 0
+        # iOS only
+        return avf_camera_get_device_orientation()
 
     def change_camera_input(self, index):
+        # iOS only
         cdef _AVStorage storage = <_AVStorage>self._storage
-        if platform == 'ios':
-            avf_camera_change_input(storage.camera, index)
+        avf_camera_change_input(storage.camera, index)
 
     def zoom_level(self, level):
+        # iOS only
         cdef _AVStorage storage = <_AVStorage>self._storage
-        if platform == 'ios':
-            avf_camera_zoom_level(storage.camera, level)
+        avf_camera_zoom_level(storage.camera, level)
 
     def get_app_documents_directory(self):
-        if platform == 'ios':
-             return str(avf_camera_documents_directory().decode('utf-8'))
-        return ''
+        # iOS only
+        return str(avf_camera_documents_directory().decode('utf-8'))
 
     def save_texture(self, texture, filepath = '', quality = 0.9):
+        # iOS only
         # With texture argument only: Save texture to iOS Photos App
         # With texture and filepath arguments: Save texture as jpg; filepath root must be app documents directory,
         #     sub-directories in filepath must exist, filepath last element is filename.jpg
         cdef _AVStorage storage = <_AVStorage>self._storage
-        if platform == 'ios':
-            avf_camera_save_pixels(storage.camera, bytearray(texture.pixels), int(texture.width), int(texture.height),
-                                   filepath.encode('utf-8'), quality)
+        avf_camera_save_pixels(storage.camera, bytearray(texture.pixels), int(texture.width), int(texture.height),
+                               filepath.encode('utf-8'), quality)

--- a/kivy/core/camera/camera_avfoundation_implem.h
+++ b/kivy/core/camera/camera_avfoundation_implem.h
@@ -12,3 +12,8 @@ bool avf_camera_attempt_start_metadata_analysis(camera_t camera);
 void avf_camera_get_metadata(camera_t camera, char **metatype, char **data);
 bool avf_camera_have_new_metadata(camera_t camera);
 bool avf_camera_set_video_orientation(camera_t camera, int orientation);
+int avf_camera_get_video_orientation();
+void avf_camera_change_input(camera_t camera, int _cameraNum);
+void avf_camera_zoom_level(camera_t camera, float zoomLevel);
+char *avf_camera_documents_directory();
+void avf_camera_save_pixels(camera_t camera, unsigned char *pixels, int width, int height, char *path, float quality);

--- a/kivy/core/camera/camera_avfoundation_implem.h
+++ b/kivy/core/camera/camera_avfoundation_implem.h
@@ -12,7 +12,7 @@ bool avf_camera_attempt_start_metadata_analysis(camera_t camera);
 void avf_camera_get_metadata(camera_t camera, char **metatype, char **data);
 bool avf_camera_have_new_metadata(camera_t camera);
 void avf_camera_set_video_orientation(camera_t camera, int orientation);
-int avf_camera_get_video_orientation();
+int avf_camera_get_device_orientation();
 void avf_camera_change_input(camera_t camera, int _cameraNum);
 void avf_camera_zoom_level(camera_t camera, float zoomLevel);
 char *avf_camera_documents_directory();

--- a/kivy/core/camera/camera_avfoundation_implem.h
+++ b/kivy/core/camera/camera_avfoundation_implem.h
@@ -11,7 +11,7 @@ bool avf_camera_attempt_capture_preset(camera_t camera, char* preset);
 bool avf_camera_attempt_start_metadata_analysis(camera_t camera);
 void avf_camera_get_metadata(camera_t camera, char **metatype, char **data);
 bool avf_camera_have_new_metadata(camera_t camera);
-bool avf_camera_set_video_orientation(camera_t camera, int orientation);
+void avf_camera_set_video_orientation(camera_t camera, int orientation);
 int avf_camera_get_video_orientation();
 void avf_camera_change_input(camera_t camera, int _cameraNum);
 void avf_camera_zoom_level(camera_t camera, float zoomLevel);

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -5,6 +5,8 @@
  *
  * TODO:
  * - add iOS native photo and video capture
+ * - add support for telephoto and wide angle lenses
+ *     needs iOS10 AVCaptureDeviceDiscoverySession   discoverySessionWithDeviceTypes:mediaType:position: 
  * I've let the code concerning caps, even if it's not yet used. uncomment
  * WITH_CAMERA_CAPS to compile with it.
  */

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -796,8 +796,8 @@ bool avf_camera_have_new_metadata(camera_t camera){
     return ((Camera *)camera)->haveNewMetadata();
 }
 
-bool avf_camera_set_video_orientation(camera_t camera, int orientation){
-    return ((Camera *)camera)->setVideoOrientation(orientation);
+void avf_camera_set_video_orientation(camera_t camera, int orientation){
+    ((Camera *)camera)->setVideoOrientation(orientation);
 }
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -4,12 +4,8 @@
  * by Mathieu Virbel
  *
  * TODO:
- * - add interface for setting some capabilities as focus/exposure/...
- * I've let the code concerning caps, even if it's not yet used. uncomment
- * WITH_CAMERA_CAPS to compile with it.
+ * - add iOS native photo and video capture
  */
-
-//#define WITH_CAMERA_CAPS
 
 
 #import <AVFoundation/AVFoundation.h>

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -5,15 +5,17 @@
  *
  * TODO:
  * - add iOS native photo and video capture
+ * I've let the code concerning caps, even if it's not yet used. uncomment
+ * WITH_CAMERA_CAPS to compile with it.
  */
 
+//#define WITH_CAMERA_CAPS
 
 #import <AVFoundation/AVFoundation.h>
 #import <Foundation/NSException.h>
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 #import <UIKit/UIKit.h>
-#define WITH_CAMERA_CAPS
 #endif
 
 #ifdef WITH_CAMERA_CAPS

--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -796,26 +796,38 @@ void avf_camera_set_video_orientation(camera_t camera, int orientation){
     ((Camera *)camera)->setVideoOrientation(orientation);
 }
 
+int avf_camera_get_device_orientation() {
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-int avf_camera_get_video_orientation() {
     return (int)[[UIDevice currentDevice] orientation];
+#else
+    return 0;
+#endif
 }
 
 void avf_camera_change_input(camera_t camera, int _cameraNum) {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     ((Camera *)camera)->changeCameraInput(_cameraNum);
+#endif
 }
 
 void avf_camera_zoom_level(camera_t camera, float zoomLevel) {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     ((Camera *)camera)->zoomLevel(zoomLevel);
+#endif
 }
 
 char *avf_camera_documents_directory() {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *basePath = paths.firstObject;
     return (char *)[basePath UTF8String];
+#else
+    return "";
+#endif
 }
 
 void avf_camera_save_pixels(camera_t camera, unsigned char *pixels, int width, int height, char *path, float quality) {
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     int size = width * height * 4;
     if (strcmp(path,"") == 0) {
         unsigned char *local_pixels = pixels;
@@ -850,5 +862,5 @@ void avf_camera_save_pixels(camera_t camera, unsigned char *pixels, int width, i
     CGColorSpaceRelease(colorSpaceRef);
     CGDataProviderRelease(provider);
     CGImageRelease(imageRef);
-}
 #endif
+}


### PR DESCRIPTION
iOS camera provider enhancements, these are iOS only but implemented in the camera provider shared by iOS and MacOS.

The additional apis implement basic mobile camera functionality, this is not currently implemented.

To provide basic camera services on iOS, this PR adds
```
 def get_device_orientation(self):

 def change_camera_input(self, index):

 def zoom_level(self, level):

 def get_app_documents_directory(self):

 def save_texture(self, texture, filepath = '', quality = 0.9):
   # saves to iOS Photos App if filepath not specified,
   # or app documents directory if filepath is specified.
```

The fork also builds and runs on MacOS, indicating it is unlikely the changes have broken the MacOS camera provider.


TODO, but not part of this PR:

~~1) `kivy-ios` does not load the camera provider, the Camera widget fails. Assuming this PR is accepted in a timely fashion, I will implement `kivy-ios` PR that fixes the load and references this enhanced camera provider.~~

2) iOS has native photo and video capture apis, these are not currently implemented in this camera provider. 
