### PR TITLE
Ellipse: update angle_start, angle_end to explicit floats

### DIFF
--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -1124,9 +1124,9 @@ cdef class Ellipse(Rectangle):
         `segments`: int, defaults to 180
             Define how many segments are needed for drawing the ellipse.
             The drawing will be smoother if you have many segments.
-        `angle_start`: int, defaults to 0
+        `angle_start`: float, defaults to 0
             Specifies the starting angle, in degrees, of the disk portion.
-        `angle_end`: int, defaults to 360
+        `angle_end`: float, defaults to 360
             Specifies the ending angle, in degrees, of the disk portion.
     '''
     cdef int _segments

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -1124,9 +1124,9 @@ cdef class Ellipse(Rectangle):
         `segments`: int, defaults to 180
             Define how many segments are needed for drawing the ellipse.
             The drawing will be smoother if you have many segments.
-        `angle_start`: float, defaults to 0
+        `angle_start`: float, defaults to 0.0
             Specifies the starting angle, in degrees, of the disk portion.
-        `angle_end`: float, defaults to 360
+        `angle_end`: float, defaults to 360.0
             Specifies the ending angle, in degrees, of the disk portion.
     '''
     cdef int _segments
@@ -1137,8 +1137,8 @@ cdef class Ellipse(Rectangle):
         Rectangle.__init__(self, **kwargs)
         self.batch.set_mode('triangle_fan')
         self._segments = kwargs.get('segments') or 180
-        self._angle_start = kwargs.get('angle_start') or 0
-        self._angle_end = kwargs.get('angle_end') or 360
+        self._angle_start = kwargs.get('angle_start') or 0.0
+        self._angle_end = kwargs.get('angle_end') or 360.0
 
     cdef void build(self):
         cdef float *tc = self._tex_coords


### PR DESCRIPTION
Ellipse parameters `angle_start` and `angle_end` are now called as `float` in docs instead of `int`

This is effectively a typo fix, see the `cdef` definitions directly below these changes:

```cpython
    cdef float _angle_start
    cdef float _angle_end
```

EDIT: additionally, the default values for these parameters have been explicitly set as floats for clarity.