### PR TITLE
Documentation: bump Gentoo install instructions

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -193,19 +193,32 @@ OpenSuSE
 Gentoo
 ~~~~~~
 
-#. There is a kivy ebuild (kivy stable version)
+#. **Add** the `raiagent overlay <https://github.com/leycec/raiagent>`_
+   packaging the `full Kivy + KivyMD + Buildozer + python-for-android stack
+   <https://github.com/kivy/kivy/issues/7868>`_.
 
-   emerge Kivy
+   .. code-block:: bash
 
-#. available USE-flags are:
+      eselect repository enable raiagent
 
-   `cairo: Standard flag, let kivy use cairo graphical libraries.`
-   `camera: Install libraries needed to support camera.`
-   `doc: Standard flag, will make you build the documentation locally.`
-   `examples: Standard flag, will give you kivy examples programs.`
-   `garden: Install garden tool to manage user maintained widgets.`
-   `gstreamer: Standard flag, kivy will be able to use audio/video streaming libraries.`
-   `spell: Standard flag, provide enchant to use spelling in kivy apps.`
+#. **Synchronize** (i.e., fetch) this overlay.
+
+   .. code-block:: bash
+
+      emerge --sync raiagent
+
+#. Install **Kivy** and optionally **KivyMD**, **Buildozer**, and
+   **python-for-android**.
+
+   .. code-block:: bash
+
+      emerge --ask --autounmask Kivy kivymd buildozer python-for-android
+
+#. (\ *Optional*\ ) Describe all **USE flags** supported by these ebuilds.
+
+   .. code-block:: bash
+
+      equery u Kivy kivymd buildozer python-for-android
 
 
 Device permissions


### PR DESCRIPTION
This PR revises Kivy's Gentoo Linux-specific installation instructions to reference the [`raiagent` overlay now hosting Gentoo ebuilds packaging the full Kivy stack](https://github.com/leycec/raiagent), resolving issue #7868.

Much gratitude and :heart_eyes: to @misl6 for his effusive support, ceaseless volunteerism, and boisterous enthusiasm for the good work we *very* tired packagers do. This PR's for you, Mirko.

Incidentally, did anyone else know [Mirko means "the peaceful one"](https://en.wikipedia.org/wiki/Mirko)? Sounds about right. I didn't that, but now I do – *and I'm better for it*.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
