### PR TITLE
Re-implements the Bubble widget.

### DIFF
--- a/examples/demo/kivycatalog/container_kvs/PopupContainer.kv
+++ b/examples/demo/kivycatalog/container_kvs/PopupContainer.kv
@@ -12,16 +12,19 @@ BoxLayout:
             pos: self.pos
     Bubble:
         size_hint: (None, None)
-        size: (150, 50)
+        size: (150, self.content_height + self.arrow_margin_y)
         pos_hint: {'center_x': .5, 'y': .6}
         arrow_pos: 'bottom_mid'
-        orientation: 'horizontal'
-        BubbleButton:
-            text: 'This is'
-        BubbleButton:
-            text: 'a'
-        BubbleButton:
-            text: 'Bubble'
+        BubbleContent:
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: self.minimum_height
+            BubbleButton:
+                text: 'This is'
+            BubbleButton:
+                text: 'a'
+            BubbleButton:
+                text: 'Bubble'
     Button:
         text: 'press to show popup'
         on_release: root.popup.open()

--- a/examples/demo/showcase/data/screens/bubbles.kv
+++ b/examples/demo/showcase/data/screens/bubbles.kv
@@ -3,14 +3,18 @@ ShowcaseScreen:
 
     Bubble:
         size_hint_y: None
-        height: '48dp'
+        height: self.content_height + self.arrow_margin_y
 
-        BubbleButton:
-            text: 'Cut'
-        BubbleButton:
-            text: 'Copy'
-        BubbleButton:
-            text: 'Paste'
+        BubbleContent:
+            size_hint_y: None
+            height: self.minimum_height
+
+            BubbleButton:
+                text: 'Cut'
+            BubbleButton:
+                text: 'Copy'
+            BubbleButton:
+                text: 'Paste'
 
     Widget:
         size_hint_y: None
@@ -24,5 +28,6 @@ ShowcaseScreen:
 
         Bubble:
             arrow_pos: 'left_mid'
-            Label:
-                text: 'World'
+            BubbleContent:
+                Label:
+                    text: 'World'

--- a/examples/widgets/bubble_test.py
+++ b/examples/widgets/bubble_test.py
@@ -16,12 +16,16 @@ Builder.load_string('''
     size_hint: (None, None)
     size: (160, 120)
     pos_hint: {'center_x': .5, 'y': .6}
-    BubbleButton:
-        text: 'Cut'
-    BubbleButton:
-        text: 'Copy'
-    BubbleButton:
-        text: 'Paste'
+    BubbleContent:
+        BubbleButton:
+            text: 'Cut'
+            size_hint_y: 1
+        BubbleButton:
+            text: 'Copy'
+            size_hint_y: 1
+        BubbleButton:
+            text: 'Paste'
+            size_hint_y: 1
 ''')
 
 

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -29,16 +29,16 @@
 
 <BubbleContent>
     opacity: .7 if self.disabled else 1
-    rows: 1
+    orientation: "horizontal"
     canvas:
         Color:
-            rgba: self.parent.background_color if self.parent else (1, 1, 1, 1)
+            rgba: self.background_color
         BorderImage:
-            border: self.parent.border if self.parent else (16, 16, 16, 16)
-            texture: root.parent._bk_img.texture if root.parent else None
+            border: self.border
+            source: self.background_image
             size: self.size
             pos: self.pos
-            auto_scale: root.parent.border_auto_scale if self.parent else 'off'
+            auto_scale: self.border_auto_scale
 
 <BubbleButton>:
     background_normal: 'atlas://data/images/defaulttheme/bubble_btn'
@@ -46,6 +46,8 @@
     background_disabled_normal: 'atlas://data/images/defaulttheme/bubble_btn'
     background_disabled_down: 'atlas://data/images/defaulttheme/bubble_btn_pressed'
     border: (0, 0, 0, 0)
+    size_hint_y: None
+    height: dp(30)
 
 <Slider>:
     canvas:
@@ -846,12 +848,12 @@
                     rgba: (1,1,1,1.)
                 Line:
                     rectangle: self.x,self.y,self.width,self.height
-                Color: 
+                Color:
                     rgba: kivy.utils.get_color_from_hex(root.value) if root.value else (1,1,1,1.)
                 Rectangle:
                     pos: self.pos
-                    size: self.size 
-        
+                    size: self.size
+
         Label:
             text: root.value or ''
             pos: root.pos

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -1,22 +1,425 @@
+'''
+Bubble unit tests
+=================
+author: Anthony Zimmermann (Anthony.Zimmermann@protonmail.com)
+'''
+
 import pytest
+from kivy.tests.common import GraphicUnitTest
+
+from kivy.base import EventLoop
+
+from kivy.uix.bubble import Bubble
+from kivy.uix.bubble import BubbleContent
+from kivy.uix.bubble import BubbleButton
 
 
-@pytest.mark.parametrize('prop_name', (
-    '_fills_row_first',
-    '_fills_from_left_to_right',
-    '_fills_from_top_to_bottom',
-))
-def test_a_certain_properties_from_the_super_class_are_overwritten(prop_name):
-    from kivy.uix.bubble import Bubble
-    from kivy.uix.gridlayout import GridLayout
-    assert issubclass(Bubble, GridLayout)
-    assert getattr(Bubble, prop_name) is not getattr(GridLayout, prop_name)
+class _TestBubbleButton(BubbleButton):
+
+    def __init__(self, button_size=(None, None), *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        size_x, size_y = button_size
+        if size_x is not None:
+            self.size_hint_x = None
+            self.width = size_x
+        if size_y is not None:
+            self.size_hint_y = None
+            self.height = size_y
 
 
-@pytest.mark.parametrize('orientation', ('vertical', 'horizontal'))
-def test_always_lr_tb(orientation):
-    from kivy.uix.bubble import Bubble
-    b = Bubble(orientation=orientation)
-    assert b._fills_row_first
-    assert b._fills_from_left_to_right
-    assert b._fills_from_top_to_bottom
+class _TestBubbleContent(BubbleContent):
+
+    def update_size(self, instance, value):
+        self.size = self.minimum_size
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.bind(minimum_size=self.update_size)
+
+
+class _TestBubble(Bubble):
+
+    @property
+    def arrow_length(self):
+        return self._arrow_image.height
+
+    @property
+    def arrow_width(self):
+        return self._arrow_image.width
+
+    @property
+    def arrow_rotation(self):
+        return self._arrow_image_scatter.rotation
+
+    @property
+    def arrow_layout_pos(self):
+        return self._arrow_image_layout.pos
+
+    @property
+    def arrow_layout_size(self):
+        return self._arrow_image_layout.size
+
+    @property
+    def arrow_center_pos_within_arrow_layout(self):
+        x = self._arrow_image_scatter_wrapper.center_x
+        y = self._arrow_image_scatter_wrapper.center_y
+        return x, y
+
+
+# (bubble_width, button_height, arrow_pos)
+bubble_layout_with_predefined_arrow_pos_test_params = [
+    (158.9, 34.3, "bottom_left"),   # noqa: E201,E241
+    (651.4, 26.1, "bottom_mid"),    # noqa: E201,E241
+    (  6.5, 44.7, "bottom_right"),  # noqa: E201,E241
+    (754.6, 50.6, "top_left"),      # noqa: E201,E241
+    (957.8, 74.1, "top_mid"),       # noqa: E201,E241
+    (852.1, 33.1, "top_right"),     # noqa: E201,E241
+    (472.9, 45.1, "left_top"),      # noqa: E201,E241
+    (578.3, 52.7, "left_mid"),      # noqa: E201,E241
+    (687.8, 17.7, "left_bottom"),   # noqa: E201,E241
+    (313.7,  8.6, "right_top"),     # noqa: E201,E241
+    (194.3, 46.4, "right_mid"),     # noqa: E201,E241
+    ( 59.3, 29.7, "right_bottom"),  # noqa: E201,E241
+]
+
+bubble_layout_with_flex_arrow_pos_test_params = [
+    (101.3, 346.0,   0.0,  73.6, "l"),  # noqa: E201,E241
+    (489.0, 535.1,   0.0, 442.1, "l"),  # noqa: E201,E241
+    (390.9, 728.1,   0.0, 114.3, "l"),  # noqa: E201,E241
+    (224.5, 675.5,   0.0, 560.6, "l"),  # noqa: E201,E241
+    (264.9, 677.3,   0.0,   8.3, "l"),  # noqa: E201,E241
+    (544.6, 126.0,   0.0, 120.9, "l"),  # noqa: E201,E241
+    (290.9, 962.6,   0.0, 275.5, "l"),  # noqa: E201,E241
+    (358.4, 514.4,   0.0, 427.1, "l"),  # noqa: E201,E241
+    (604.3, 648.2,   0.0, 226.1, "l"),  # noqa: E201,E241
+    (287.4, 875.6,   0.0, 446.5, "l"),  # noqa: E201,E241
+    (755.7, 103.5, 444.6,   0.0, "b"),  # noqa: E201,E241
+    (307.9, 471.7,  80.9,   0.0, "b"),  # noqa: E201,E241
+    (849.9, 194.8, 652.7,   0.0, "b"),  # noqa: E201,E241
+    (975.7, 691.0, 120.9,   0.0, "b"),  # noqa: E201,E241
+    (539.1, 903.3, 530.6,   0.0, "b"),  # noqa: E201,E241
+    ( 37.5, 727.5,  37.0,   0.0, "b"),  # noqa: E201,E241
+    (856.5, 779.0, 565.5,   0.0, "b"),  # noqa: E201,E241
+    (536.7, 228.3,  48.4,   0.0, "b"),  # noqa: E201,E241
+    (170.9, 870.4, 127.6,   0.0, "b"),  # noqa: E201,E241
+    (955.7, 530.6, 526.0,   0.0, "b"),  # noqa: E201,E241
+    (878.1, 690.4, 878.1,  18.8, "r"),  # noqa: E201,E241
+    (771.6, 365.2, 771.6,  31.1, "r"),  # noqa: E201,E241
+    (679.7, 305.4, 679.7, 259.6, "r"),  # noqa: E201,E241
+    (700.2, 614.6, 700.2, 105.4, "r"),  # noqa: E201,E241
+    (444.1, 864.5, 444.1, 152.3, "r"),  # noqa: E201,E241
+    (189.0, 790.4, 189.0, 602.9, "r"),  # noqa: E201,E241
+    (376.0, 993.9, 376.0, 486.4, "r"),  # noqa: E201,E241
+    (518.5, 338.5, 518.5, 194.6, "r"),  # noqa: E201,E241
+    (982.1, 666.1, 982.1, 282.5, "r"),  # noqa: E201,E241
+    (926.4, 565.1, 926.4, 187.3, "r"),  # noqa: E201,E241
+    (375.2, 746.6,  36.2, 746.6, "t"),  # noqa: E201,E241
+    (448.9, 228.5, 297.4, 228.5, "t"),  # noqa: E201,E241
+    (792.3, 593.5, 746.2, 593.5, "t"),  # noqa: E201,E241
+    (856.1,  89.7,  23.1,  89.7, "t"),  # noqa: E201,E241
+    (721.3, 319.0, 356.5, 319.0, "t"),  # noqa: E201,E241
+    (127.7, 355.7,  69.3, 355.7, "t"),  # noqa: E201,E241
+    (412.3, 493.8, 163.2, 493.8, "t"),  # noqa: E201,E241
+    ( 40.8, 115.8,  15.8, 115.8, "t"),  # noqa: E201,E241
+    (233.9, 148.5, 189.4, 148.5, "t"),  # noqa: E201,E241
+    (982.4, 661.5, 105.9, 661.5, "t"),  # noqa: E201,E241
+]
+
+
+class BubbleTest(GraphicUnitTest):
+
+    def move_frames(self, t):
+        for i in range(t):
+            EventLoop.idle()
+
+    def test_no_content(self):
+        bubble = Bubble()
+        self.render(bubble)
+
+    def test_add_remove_content(self):
+        bubble = Bubble()
+        content = BubbleContent()
+        bubble.add_widget(content)
+        self.render(bubble)
+
+        bubble.remove_widget(content)
+        self.render(bubble)
+
+    def test_add_arbitrary_content(self):
+        from kivy.uix.gridlayout import GridLayout
+        bubble = Bubble()
+        content = GridLayout()
+        bubble.add_widget(content)
+        self.render(bubble)
+
+    def test_add_two_content_widgets_fails(self):
+        from kivy.uix.bubble import BubbleException
+        bubble = Bubble()
+        content_1 = BubbleContent()
+        content_2 = BubbleContent()
+        bubble.add_widget(content_1)
+        with self.assertRaises(BubbleException):
+            bubble.add_widget(content_2)
+
+    def test_add_content_with_buttons(self):
+        bubble = Bubble()
+
+        content = BubbleContent()
+        content.add_widget(BubbleButton(text="Option A"))
+        content.add_widget(BubbleButton(text="Option B"))
+
+        bubble.add_widget(content)
+        self.render(bubble)
+
+    def assertSequenceAlmostEqual(self, seq1, seq2, delta=None):
+        assert len(seq1) == len(seq2)
+        for a, b in zip(seq1, seq2):
+            self.assertAlmostEqual(a, b, delta=delta)
+
+    def assertTestBubbleLayoutWithPredifinedArrowPos(self, bubble):
+        arrow_length = bubble.arrow_length
+        arrow_width = bubble.arrow_width
+        bubble_width = bubble.test_bubble_width
+        button_height = bubble.test_button_height
+
+        # assert content size
+        expected_content_size = {
+            "bottom_left": (bubble_width, button_height),
+            "bottom_mid": (bubble_width, button_height),
+            "bottom_right": (bubble_width, button_height),
+            "top_left": (bubble_width, button_height),
+            "top_mid": (bubble_width, button_height),
+            "top_right": (bubble_width, button_height),
+            "left_top": (bubble_width - arrow_length, button_height),
+            "left_mid": (bubble_width - arrow_length, button_height),
+            "left_bottom": (bubble_width - arrow_length, button_height),
+            "right_top": (bubble_width - arrow_length, button_height),
+            "right_mid": (bubble_width - arrow_length, button_height),
+            "right_bottom": (bubble_width - arrow_length, button_height),
+        }[bubble.arrow_pos]
+        self.assertSequenceAlmostEqual(
+            bubble.content.size,
+            expected_content_size,
+        )
+
+        # assert arrow layout size
+        expected_arrow_layout_size = {
+            "bottom_left": (bubble_width, arrow_length),
+            "bottom_mid": (bubble_width, arrow_length),
+            "bottom_right": (bubble_width, arrow_length),
+            "top_left": (bubble_width, arrow_length),
+            "top_mid": (bubble_width, arrow_length),
+            "top_right": (bubble_width, arrow_length),
+            "left_top": (arrow_length, button_height),
+            "left_mid": (arrow_length, button_height),
+            "left_bottom": (arrow_length, button_height),
+            "right_top": (arrow_length, button_height),
+            "right_mid": (arrow_length, button_height),
+            "right_bottom": (arrow_length, button_height),
+        }[bubble.arrow_pos]
+        self.assertSequenceAlmostEqual(
+            bubble.arrow_layout_size,
+            expected_arrow_layout_size,
+        )
+
+        # assert content position
+        expected_content_position = {
+            "bottom_left": (0, arrow_length),
+            "bottom_mid": (0, arrow_length),
+            "bottom_right": (0, arrow_length),
+            "top_left": (0, 0),
+            "top_mid": (0, 0),
+            "top_right": (0, 0),
+            "left_top": (arrow_length, 0),
+            "left_mid": (arrow_length, 0),
+            "left_bottom": (arrow_length, 0),
+            "right_top": (0, 0),
+            "right_mid": (0, 0),
+            "right_bottom": (0, 0),
+        }[bubble.arrow_pos]
+        self.assertSequenceAlmostEqual(
+            bubble.content.pos,
+            expected_content_position,
+        )
+
+        # assert arrow layout position
+        expected_arrow_layout_position = {
+            "bottom_left": (0, 0),
+            "bottom_mid": (0, 0),
+            "bottom_right": (0, 0),
+            "top_left": (0, button_height),
+            "top_mid": (0, button_height),
+            "top_right": (0, button_height),
+            "left_top": (0, 0),
+            "left_mid": (0, 0),
+            "left_bottom": (0, 0),
+            "right_top": (bubble_width - arrow_length, 0),
+            "right_mid": (bubble_width - arrow_length, 0),
+            "right_bottom": (bubble_width - arrow_length, 0),
+        }[bubble.arrow_pos]
+        self.assertSequenceAlmostEqual(
+            bubble.arrow_layout_pos,
+            expected_arrow_layout_position,
+        )
+
+        # assert arrow position within arrow layout
+        hal = arrow_length / 2  # hal := half arrow length
+        x_offset = 0.05 * bubble_width
+        y_offset = 0.05 * button_height
+        expected_arrow_center_pos_within_arrow_layout = {
+            "bottom_left": (x_offset + arrow_width / 2, hal),
+            "bottom_mid": (bubble_width / 2, hal),
+            "bottom_right": (bubble_width - arrow_width / 2 - x_offset, hal),
+            "top_left": (x_offset + arrow_width / 2, hal),
+            "top_mid": (bubble_width / 2, hal),
+            "top_right": (bubble_width - arrow_width / 2 - x_offset, hal),
+            "left_top": (hal, button_height - arrow_width / 2 - y_offset),
+            "left_mid": (hal, button_height / 2),
+            "left_bottom": (hal, y_offset + arrow_width / 2),
+            "right_top": (hal, button_height - arrow_width / 2 - y_offset),
+            "right_mid": (hal, button_height / 2),
+            "right_bottom": (hal, y_offset + arrow_width / 2),
+        }[bubble.arrow_pos]
+        self.assertSequenceAlmostEqual(
+            bubble.arrow_center_pos_within_arrow_layout,
+            expected_arrow_center_pos_within_arrow_layout,
+        )
+
+        # assert arrow rotation
+        expected_arrow_rotation = {
+            "bottom_left": 0,
+            "bottom_mid": 0,
+            "bottom_right": 0,
+            "top_left": 180,
+            "top_mid": 180,
+            "top_right": 180,
+            "left_top": 270,
+            "left_mid": 270,
+            "left_bottom": 270,
+            "right_top": 90,
+            "right_mid": 90,
+            "right_bottom": 90,
+        }[bubble.arrow_pos]
+        self.assertAlmostEqual(
+            bubble.arrow_rotation,
+            expected_arrow_rotation,
+        )
+
+    def test_bubble_layout_with_predefined_arrow_pos(self):
+
+        for params in bubble_layout_with_predefined_arrow_pos_test_params:
+            bubble_width, button_height, arrow_pos = params
+
+            with self.subTest():
+                print(
+                    "(bubble_width={}, button_height={}, arrow_pos={})".format(
+                        *params
+                    )
+                )
+                bubble = _TestBubble(arrow_pos=arrow_pos)
+                bubble.size_hint = (None, None)
+                bubble.test_bubble_width = bubble_width
+                bubble.test_button_height = button_height
+
+                def update_bubble_size(instance, value):
+                    w = bubble_width
+                    h = bubble.content_height + bubble.arrow_margin_y
+                    bubble.size = (w, h)
+                bubble.bind(
+                    content_size=update_bubble_size,
+                    arrow_margin=update_bubble_size,
+                )
+
+                content = _TestBubbleContent()
+                for i in range(3):
+                    content.add_widget(
+                        _TestBubbleButton(
+                            button_size=(None, button_height),
+                            text="Option {}".format(i)
+                        )
+                    )
+
+                bubble.add_widget(content)
+                self.render(bubble)
+
+                self.assertTestBubbleLayoutWithPredifinedArrowPos(bubble)
+
+    def test_bubble_layout_without_arrow(self):
+        bubble_width = 200
+        button_height = 30
+
+        bubble = _TestBubble(show_arrow=False)
+        bubble.size_hint = (None, None)
+
+        def update_bubble_size(instance, value):
+            w = bubble_width
+            h = bubble.content_height
+            bubble.size = (w, h)
+        bubble.bind(content_size=update_bubble_size)
+
+        content = _TestBubbleContent(orientation="vertical")
+        for i in range(7):
+            content.add_widget(
+                _TestBubbleButton(
+                    button_size=(None, button_height),
+                    text="Option_{}".format(i)
+                )
+            )
+
+        bubble.add_widget(content)
+        self.render(bubble)
+
+        # assert content size
+        self.assertSequenceAlmostEqual(
+            bubble.content.size,
+            (bubble_width, 7 * button_height),
+        )
+
+        # assert content position
+        self.assertSequenceAlmostEqual(
+            bubble.content.pos,
+            (0, 0),
+        )
+
+    def test_bubble_layout_with_flex_arrow_pos(self):
+        for params in bubble_layout_with_flex_arrow_pos_test_params:
+            bubble_size = params[:2]
+            flex_arrow_pos = params[2:4]
+            arrow_side = params[4]
+            with self.subTest():
+                print("(w={}, h={}, x={}, y={}, side={})".format(*params))
+
+                bubble = _TestBubble()
+                bubble.size_hint = (None, None)
+                bubble.size = bubble_size
+                bubble.flex_arrow_pos = flex_arrow_pos
+
+                content = _TestBubbleContent(orientation="vertical")
+                content.size_hint = (1, 1)
+
+                button = _TestBubbleButton(
+                    button_size=(None, None),
+                    text="Option",
+                )
+                button.size_hint_y = 1
+
+                content.add_widget(button)
+                bubble.add_widget(content)
+
+                self.render(bubble)
+
+                haw = bubble.arrow_width / 2  # half arrow_width
+                if arrow_side in ["l", "r"]:
+                    self.assertSequenceAlmostEqual(
+                        bubble.arrow_center_pos_within_arrow_layout,
+                        (haw, flex_arrow_pos[1]),
+                        delta=haw,
+                    )
+                elif arrow_side in ["b", "t"]:
+                    self.assertSequenceAlmostEqual(
+                        bubble.arrow_center_pos_within_arrow_layout,
+                        (flex_arrow_pos[0], haw),
+                        delta=haw,
+                    )

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -7,11 +7,25 @@ Bubble
 .. image:: images/bubble.jpg
     :align: right
 
-The Bubble widget is a form of menu or a small popup where the menu options
-are stacked either vertically or horizontally.
+The Bubble widget is a form of menu or a small popup with an arrow arranged on
+one side of the BubbleContent. The BubbleContent is a styled BoxLayout that can
+be used to add e.g., BubbleButtons as menu items.
 
-The :class:`Bubble` contains an arrow pointing in the direction you
-choose.
+The :class:`Bubble` contains an arrow attached to the content
+(e.g., BubbleContent) pointing in the direction you choose. It can be placed
+either at a predifined location or flexibly by specifying a relative position
+on the border of the widget.
+
+The :class:`BubbleContent` is a styled BoxLayout and is thought to be added to
+the :class:`Bubble` as a child widget. The :class:`Bubble` will then arrange
+an arrow around the content as desired. Instead of the class:`BubbleContent`,
+you can theoretically use any other :class:`Widget` as well as long as it
+supports the 'bind' and 'unbind' function of the :class:`EventDispatcher` and
+is compatible with Kivy to be placed inside a :class:`BoxLayout`.
+
+The :class:`BubbleButton`is a styled Button. It suits to the style of
+:class:`Bubble` and :class:`BubbleContent`. Feel free to place other Widgets
+inside the 'content' of the :class:`Bubble`.
 
 Simple example
 --------------
@@ -25,29 +39,8 @@ Customize the Bubble
 You can choose the direction in which the arrow points::
 
     Bubble(arrow_pos='top_mid')
-
-The widgets added to the Bubble are ordered horizontally by default, like a
-Boxlayout. You can change that by::
-
-    orientation = 'vertical'
-
-To add items to the bubble::
-
-    bubble = Bubble(orientation = 'vertical')
-    bubble.add_widget(your_widget_instance)
-
-To remove items::
-
-    bubble.remove_widget(widget)
     or
-    bubble.clear_widgets()
-
-To access the list of children, use content.children::
-
-    bubble.content.children
-
-.. warning::
-  This is important! Do not use bubble.children
+    Bubble(size=(200, 40), flex_arrow_pos=(175, 40))
 
 To change the appearance of the bubble::
 
@@ -55,27 +48,37 @@ To change the appearance of the bubble::
     bubble.border = [0, 0, 0, 0]
     background_image = 'path/to/background/image'
     arrow_image = 'path/to/arrow/image'
+
+-----------------------------
 '''
 
 __all__ = ('Bubble', 'BubbleButton', 'BubbleContent')
 
 from kivy.uix.image import Image
-from kivy.uix.widget import Widget
 from kivy.uix.scatter import Scatter
-from kivy.uix.gridlayout import GridLayout
 from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.relativelayout import RelativeLayout
 from kivy.uix.button import Button
-from kivy.properties import ObjectProperty, StringProperty, OptionProperty, \
-    ListProperty, BooleanProperty, ColorProperty
-from kivy.clock import Clock
+from kivy.properties import ObjectProperty
+from kivy.properties import StringProperty
+from kivy.properties import OptionProperty
+from kivy.properties import ListProperty
+from kivy.properties import BooleanProperty
+from kivy.properties import ColorProperty
+from kivy.properties import NumericProperty
+from kivy.properties import ReferenceListProperty
 from kivy.base import EventLoop
 from kivy.metrics import dp
 
 
+class BubbleException(Exception):
+    pass
+
+
 class BubbleButton(Button):
-    '''A button intended for use in a Bubble widget.
-    You can use a "normal" button class, but it will not look good unless
-    the background is changed.
+    '''A button intended for use in a BubbleContent widget.
+    You can use a "normal" button class, but it will not look good unless the
+    background is changed.
 
     Rather use this BubbleButton widget that is already defined and provides a
     suitable background for you.
@@ -83,24 +86,20 @@ class BubbleButton(Button):
     pass
 
 
-class BubbleContent(GridLayout):
-    pass
-
-
-class Bubble(GridLayout):
-    '''Bubble class. See module documentation for more information.
-    '''
-
+class BubbleContent(BoxLayout):
     background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a). To use it you have to set
-    either :attr:`background_image` or :attr:`arrow_image` first.
+    :attr:`background_image` first.
 
     :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
+    '''
 
-    .. versionchanged:: 2.0.0
-        Changed from :class:`~kivy.properties.ListProperty` to
-        :class:`~kivy.properties.ColorProperty`.
+    background_image = StringProperty('atlas://data/images/defaulttheme/bubble')
+    '''Background image of the bubble.
+
+    :attr:`background_image` is a :class:`~kivy.properties.StringProperty` and
+    defaults to 'atlas://data/images/defaulttheme/bubble'.
     '''
 
     border = ListProperty([16, 16, 16, 16])
@@ -115,20 +114,52 @@ class Bubble(GridLayout):
     (16, 16, 16, 16)
     '''
 
-    background_image = StringProperty(
-        'atlas://data/images/defaulttheme/bubble')
-    '''Background image of the bubble.
+    border_auto_scale = OptionProperty(
+        'both_lower',
+        options=[
+            'off', 'both', 'x_only', 'y_only', 'y_full_x_lower',
+            'x_full_y_lower', 'both_lower'
+        ]
+    )
+    '''Specifies the :attr:`kivy.graphics.BorderImage.auto_scale`
+    value on the background BorderImage.
 
-    :attr:`background_image` is a :class:`~kivy.properties.StringProperty` and
-    defaults to 'atlas://data/images/defaulttheme/bubble'.
+    :attr:`border_auto_scale` is a
+    :class:`~kivy.properties.OptionProperty` and defaults to
+    'both_lower'.
+    '''
+
+
+class Bubble(BoxLayout):
+    '''Bubble class. See module documentation for more information.
+    '''
+
+    content = ObjectProperty(allownone=True)
+    '''This is the object where the main content of the bubble is held.
+
+    The content of the Bubble set by 'add_widget' and removed with
+    'remove_widget' similarly to the :class:`ActionView` which is placed into
+    a class:`ActionBar`
+
+    :attr:`content` is a :class:`~kivy.properties.ObjectProperty` and defaults
+    to None.
     '''
 
     arrow_image = StringProperty(
-        'atlas://data/images/defaulttheme/bubble_arrow')
+        'atlas://data/images/defaulttheme/bubble_arrow'
+    )
     ''' Image of the arrow pointing to the bubble.
 
     :attr:`arrow_image` is a :class:`~kivy.properties.StringProperty` and
     defaults to 'atlas://data/images/defaulttheme/bubble_arrow'.
+    '''
+
+    arrow_color = ColorProperty([1, 1, 1, 1])
+    '''Arrow color, in the format (r, g, b, a). To use it you have to set
+    :attr:`background_image` first.
+
+    :attr:`arrow_color` is a :class:`~kivy.properties.ColorProperty` and
+    defaults to [1, 1, 1, 1].
     '''
 
     show_arrow = BooleanProperty(True)
@@ -140,32 +171,32 @@ class Bubble(GridLayout):
     defaults to `True`.
     '''
 
-    arrow_pos = OptionProperty('bottom_mid', options=(
-        'left_top', 'left_mid', 'left_bottom', 'top_left', 'top_mid',
-        'top_right', 'right_top', 'right_mid', 'right_bottom',
-        'bottom_left', 'bottom_mid', 'bottom_right'))
-    '''Specifies the position of the arrow relative to the bubble.
+    arrow_pos = OptionProperty(
+        'bottom_mid',
+        options=(
+            'left_top', 'left_mid', 'left_bottom',
+            'top_left', 'top_mid', 'top_right',
+            'right_top', 'right_mid', 'right_bottom',
+            'bottom_left', 'bottom_mid', 'bottom_right',
+        )
+    )
+    '''Specifies the position of the arrow as predefined relative position to
+    the bubble.
     Can be one of: left_top, left_mid, left_bottom top_left, top_mid, top_right
     right_top, right_mid, right_bottom bottom_left, bottom_mid, bottom_right.
 
     :attr:`arrow_pos` is a :class:`~kivy.properties.OptionProperty` and
     defaults to 'bottom_mid'.
     '''
+    flex_arrow_pos = ListProperty(None)
+    '''Specifies the position of the arrow as flex coordinate around the
+    border of the :class:`Bubble` Widget.
+    If this property is set to a proper position (relative pixel coordinates
+    within the :class:`Bubble` widget, it overwrites the setting
+    :attr:`arrow_pos`.
 
-    content = ObjectProperty(None)
-    '''This is the object where the main content of the bubble is held.
-
-    :attr:`content` is a :class:`~kivy.properties.ObjectProperty` and
-    defaults to 'None'.
-    '''
-
-    orientation = OptionProperty('horizontal',
-                                 options=('horizontal', 'vertical'))
-    '''This specifies the manner in which the children inside bubble
-    are arranged. Can be one of 'vertical' or 'horizontal'.
-
-    :attr:`orientation` is a :class:`~kivy.properties.OptionProperty` and
-    defaults to 'horizontal'.
+    :attr:`flex_arrow_pos` is a :class:`~kivy.properties.ListProperty` and
+    defaults to None.
     '''
 
     limit_to = ObjectProperty(None, allownone=True)
@@ -173,230 +204,289 @@ class Bubble(GridLayout):
 
     .. versionadded:: 1.6.0
 
-    :attr:`limit_to` is a :class:`~kivy.properties.ObjectProperty` and
-    defaults to 'None'.
+    :attr:`limit_to` is a :class:`~kivy.properties.ObjectProperty` and defaults
+    to 'None'.
     '''
 
-    border_auto_scale = OptionProperty(
-        'both_lower',
-        options=[
-            'off', 'both', 'x_only', 'y_only', 'y_full_x_lower',
-            'x_full_y_lower', 'both_lower'
-        ]
-    )
-    '''Specifies the :attr:`kivy.graphics.BorderImage.auto_scale`
-    value on the background BorderImage.
+    arrow_margin_x = NumericProperty(0)
+    '''Automatically computed margin in x direction that the arrow widget
+    occupies in pixel.
 
-    .. versionadded:: 1.11.0
+    In combination with the :attr:`content_width`, this property can be used
+    to determine the correct width of the Bubble to exactly enclose the
+    arrow + content by adding :attr:`content_width` and :attr:`arrow_margin_x`
 
-    :attr:`border_auto_scale` is a
-    :class:`~kivy.properties.OptionProperty` and defaults to
-    'both_lower'.
+    :attr:`arrow_margin_x` is a :class:`~kivy.properties.NumericProperty` and
+    represents the added margin in x direction due to the arrow widget.
+    It defaults to 0 and is read only.
     '''
+
+    arrow_margin_y = NumericProperty(0)
+    '''Automatically computed margin in y direction that the arrow widget
+    occupies in pixel.
+
+    In combination with the :attr:`content_height`, this property can be used
+    to determine the correct height of the Bubble to exactly enclose the
+    arrow + content by adding :attr:`content_height` and :attr:`arrow_margin_y`
+
+    :attr:`arrow_margin_y` is a :class:`~kivy.properties.NumericProperty` and
+    represents the added margin in y direction due to the arrow widget.
+    It defaults to 0 and is read only.
+    '''
+
+    arrow_margin = ReferenceListProperty(arrow_margin_x, arrow_margin_y)
+    '''Automatically computed margin that the arrow widget occupies in
+    x and y direction in pixel.
+
+    Check the description of :attr:`arrow_margin_x` and :attr:`arrow_margin_y`.
+
+    :attr:`arrow_margin` is a :class:`~kivy.properties.ReferenceListProperty`
+    of (:attr:`arrow_margin_x`, :attr:`arrow_margin_y`) properties.
+    It is read only.
+    '''
+
+    content_width = NumericProperty(0)
+    '''The width of the content Widget.
+
+    :attr:`content_width` is a :class:`~kivy.properties.NumericProperty` and
+    is the same as self.content.width if content is not None, else it defaults
+    to 0. It is read only.
+    '''
+
+    content_height = NumericProperty(0)
+    '''The height of the content Widget.
+
+    :attr:`content_height` is a :class:`~kivy.properties.NumericProperty` and
+    is the same as self.content.height if content is not None, else it defaults
+    to 0. It is read only.
+    '''
+
+    content_size = ReferenceListProperty(content_width, content_height)
+    ''' The size of the content Widget.
+
+    :attr:`content_size` is a :class:`~kivy.properties.ReferenceListProperty`
+    of (:attr:`content_width`, :attr:`content_height`) properties.
+    It is read only.
+    '''
+
+    # Internal map that specifies the different parameters for fixed arrow
+    # position layouts. The flex_arrow_pos uses these parameter sets
+    # as a template.
+    # 0: orientation of the children of Bubble ([content, arrow])
+    # 1: order of widgets to add to the BoxLayout (default: [content, arrow])
+    # 2: size_hint of _arrow_image_layout
+    # 3: rotation of the _arrow_image
+    # 4: pos_hint of the _arrow_image_layout
+    ARROW_LAYOUTS = {
+        "bottom_left":  (   "vertical",  1, (   1, None),   0, {   "top": 1.0,        "x": 0.05}),  # noqa: E201,E241,E501
+        "bottom_mid":   (   "vertical",  1, (   1, None),   0, {   "top": 1.0, "center_x": 0.50}),  # noqa: E201,E241,E501
+        "bottom_right": (   "vertical",  1, (   1, None),   0, {   "top": 1.0,    "right": 0.95}),  # noqa: E201,E241,E501
+        "right_bottom": ( "horizontal",  1, (None,    1),  90, {  "left": 0.0,        "y": 0.05}),  # noqa: E201,E241,E501
+        "right_mid":    ( "horizontal",  1, (None,    1),  90, {  "left": 0.0, "center_y": 0.50}),  # noqa: E201,E241,E501
+        "right_top":    ( "horizontal",  1, (None,    1),  90, {  "left": 0.0,      "top": 0.95}),  # noqa: E201,E241,E501
+        "top_left":     (   "vertical", -1, (   1, None), 180, {"bottom": 0.0,        "x": 0.05}),  # noqa: E201,E241,E501
+        "top_mid":      (   "vertical", -1, (   1, None), 180, {"bottom": 0.0, "center_x": 0.50}),  # noqa: E201,E241,E501
+        "top_right":    (   "vertical", -1, (   1, None), 180, {"bottom": 0.0,    "right": 0.95}),  # noqa: E201,E241,E501
+        "left_bottom":  ( "horizontal", -1, (None,    1), -90, {"right":  1.0,        "y": 0.05}),  # noqa: E201,E241,E501
+        "left_mid":     ( "horizontal", -1, (None,    1), -90, {"right":  1.0, "center_y": 0.50}),  # noqa: E201,E241,E501
+        "left_top":     ( "horizontal", -1, (None,    1), -90, {"right":  1.0,      "top": 0.95}),  # noqa: E201,E241,E501
+    }
 
     def __init__(self, **kwargs):
-        self._prev_arrow_pos = None
-        self._arrow_layout = BoxLayout()
-        self._bk_img = Image(
-            source=self.background_image, allow_stretch=True,
-            keep_ratio=False, color=self.background_color)
-        self.background_texture = self._bk_img.texture
-        self._arrow_img = Image(source=self.arrow_image,
-                                allow_stretch=True,
-                                color=self.background_color)
-        self.content = content = BubbleContent(parent=self)
-        super(Bubble, self).__init__(**kwargs)
-        content.parent = None
-        self.add_widget(content)
-        self.on_arrow_pos()
+        self.content = None
+
+        self._flex_arrow_layout_params = None
+        self._temporarily_ignore_limits = False
+
+        self._arrow_image = Image(
+            source=self.arrow_image,
+            allow_stretch=False,
+            color=self.arrow_color
+        )
+        self._arrow_image.width = self._arrow_image.texture_size[0]
+        self._arrow_image.height = dp(self._arrow_image.texture_size[1])
+        self._arrow_image_scatter = Scatter(
+            size_hint=(None, None),
+            do_scale=False,
+            do_rotation=False,
+            do_translation=False,
+        )
+        self._arrow_image_scatter.add_widget(self._arrow_image)
+        self._arrow_image_scatter.size = self._arrow_image.texture_size
+        self._arrow_image_scatter_wrapper = BoxLayout(
+            size_hint=(None, None),
+        )
+        self._arrow_image_scatter_wrapper.add_widget(self._arrow_image_scatter)
+        self._arrow_image_layout = RelativeLayout()
+        self._arrow_image_layout.add_widget(self._arrow_image_scatter_wrapper)
+
+        self._arrow_layout = None
+
+        super().__init__(**kwargs)
+        self.reposition_inner_widgets()
 
     def add_widget(self, widget, *args, **kwargs):
-        content = self.content
-        if content is None:
-            return
-        if widget == content or widget == self._arrow_img\
-                or widget == self._arrow_layout:
-            super(Bubble, self).add_widget(widget, *args, **kwargs)
+        if self.content is None:
+            self.content = widget
+            self.content_size = widget.size
+            self.content.bind(size=self.update_content_size)
+            self.reposition_inner_widgets()
         else:
-            content.add_widget(widget, *args, **kwargs)
+            raise BubbleException(
+                "Bubble can only contain a single Widget or Layout"
+            )
 
     def remove_widget(self, widget, *args, **kwargs):
+        if widget == self.content:
+            self.content.unbind(size=self.update_content_size)
+            self.content = None
+            self.content_size = [0, 0]
+            self.reposition_inner_widgets()
+            return
+        super().remove_widget(widget, *args, **kwargs)
+
+    def on_content_size(self, instance, value):
+        self.adjust_position()
+
+    def on_limit_to(self, instance, value):
+        self.adjust_position()
+
+    def on_pos(self, instance, value):
+        self.adjust_position()
+
+    def on_size(self, instance, value):
+        self.reposition_inner_widgets()
+
+    def on_arrow_image(self, instance, value):
+        self._arrow_image.source = self.arrow_image
+        self.reposition_inner_widgets()
+
+    def on_arrow_color(self, instance, value):
+        self._arrow_image.color = self.arrow_color
+
+    def on_arrow_pos(self, instance, value):
+        self.reposition_inner_widgets()
+
+    def on_flex_arrow_pos(self, instance, value):
+        self._flex_arrow_layout_params = self.get_flex_arrow_layout_params()
+        self.reposition_inner_widgets()
+
+    def get_flex_arrow_layout_params(self):
+        pos = self.flex_arrow_pos
+
+        if pos is None:
+            return None
+
+        x, y = pos
+        if not (0 <= x <= self.width and 0 <= y <= self.height):
+            return None
+
+        # the order of the following list defines the side that the arrow
+        # will be attached to in case of ambiguity (same distances)
+        base_layouts_map = [
+            ("bottom_mid", y),
+            ("top_mid", self.height - y),
+            ("left_mid", x),
+            ("right_mid", self.width - x),
+        ]
+        base_layout_key = min(base_layouts_map, key=lambda val: val[1])[0]
+        arrow_layout = list(Bubble.ARROW_LAYOUTS[base_layout_key])
+
+        arrow_width = self._arrow_image.width
+
+        # This function calculates the proper value for pos_hint, i.e., the
+        # arrow texture does not 'overflow' and stays entirely connected to
+        # the side of the content.
+        def calc_x0(x, length):
+            return x * (length - arrow_width) / (length * length)
+
+        if base_layout_key == "bottom_mid":
+            arrow_layout[-1] = {"top": 1.0, "x": calc_x0(x, self.width)}
+        elif base_layout_key == "top_mid":
+            arrow_layout[-1] = {"bottom": 0.0, "x": calc_x0(x, self.width)}
+        elif base_layout_key == "left_mid":
+            arrow_layout[-1] = {"right": 1.0, "y": calc_x0(y, self.height)}
+        elif base_layout_key == "right_mid":
+            arrow_layout[-1] = {"left": 0.0, "y": calc_x0(y, self.height)}
+        return arrow_layout
+
+    def update_content_size(self, instance, value):
+        self.content_size = self.content.size
+
+    def adjust_position(self):
+        if self.limit_to is not None and not self._temporarily_ignore_limits:
+            if self.limit_to is EventLoop.window:
+                lim_x, lim_y = 0, 0
+                lim_top, lim_right = self.limit_to.size
+            else:
+                lim_x = self.limit_to.x
+                lim_y = self.limit_to.y
+                lim_top = self.limit_to.top
+                lim_right = self.limit_to.right
+
+            self._temporarily_ignore_limits = True
+
+            if not (lim_x > self.x and lim_right < self.right):
+                self.x = max(lim_x, min(lim_right - self.width, self.x))
+
+            if not (lim_y > self.y and lim_right < self.right):
+                self.y = min(lim_top - self.height, max(lim_y, self.y))
+
+            self._temporarily_ignore_limits = False
+
+    def reposition_inner_widgets(self):
+        arrow_image_layout = self._arrow_image_layout
+        arrow_image_scatter = self._arrow_image_scatter
+        arrow_image_scatter_wrapper = self._arrow_image_scatter_wrapper
         content = self.content
-        if not content:
+
+        # Remove the children of the Bubble (BoxLayout) as a first step
+        for child in list(self.children):
+            super().remove_widget(child)
+
+        if self.canvas is None or content is None:
             return
-        if widget == content or widget == self._arrow_img\
-                or widget == self._arrow_layout:
-            super(Bubble, self).remove_widget(widget, *args, **kwargs)
+
+        # find the layout parameters that define a specific bubble setup
+        if self._flex_arrow_layout_params is not None:
+            layout_params = self._flex_arrow_layout_params
         else:
-            content.remove_widget(widget, *args, **kwargs)
+            layout_params = Bubble.ARROW_LAYOUTS[self.arrow_pos]
+        (bubble_orientation,
+         widget_order,
+         arrow_size_hint,
+         arrow_rotation,
+         arrow_pos_hint) = layout_params
 
-    def clear_widgets(self, *args, **kwargs):
-        if self.content:
-            self.content.clear_widgets(*args, **kwargs)
+        # rotate the arrow, place it at the right pos and setup the size
+        # of the widget, so the BoxLayout can do the rest.
+        arrow_image_scatter.rotation = arrow_rotation
+        arrow_image_scatter_wrapper.size = arrow_image_scatter.bbox[1]
+        arrow_image_scatter_wrapper.pos_hint = arrow_pos_hint
+        arrow_image_layout.size_hint = arrow_size_hint
+        arrow_image_layout.size = arrow_image_scatter.bbox[1]
 
-    def on_show_arrow(self, instance, value):
-        self._arrow_img.opacity = int(value)
+        # set the orientation of the Bubble (BoxLayout)
+        self.orientation = bubble_orientation
 
-    def on_parent(self, instance, value):
-        Clock.schedule_once(self._update_arrow)
+        # Add the updated children of the Bubble (BoxLayout) and update
+        # properties
+        widgets_to_add = [content, arrow_image_layout]
 
-    def on_pos(self, instance, pos):
-        lt = self.limit_to
-
-        if lt:
-            self.limit_to = None
-            if lt is EventLoop.window:
-                x = y = 0
-                top = lt.height
-                right = lt.width
-            else:
-                x, y = lt.x, lt.y
-                top, right = lt.top, lt.right
-
-            self.x = max(self.x, x)
-            self.right = min(self.right, right)
-            self.top = min(self.top, top)
-            self.y = max(self.y, y)
-            self.limit_to = lt
-
-    def on_background_image(self, *l):
-        self._bk_img.source = self.background_image
-
-    def on_background_color(self, *l):
-        if self.content is None:
-            return
-        self._arrow_img.color = self._bk_img.color = self.background_color
-
-    def on_orientation(self, *l):
-        content = self.content
-        if not content:
-            return
-        if self.orientation[0] == 'v':
-            content.cols = 1
-            content.rows = 99
+        # Set the arrow_margin, so we can use this property for proper sizing
+        # of the Bubble Widget.
+        # Determine whether to add the arrow_image_layout to the
+        # Bubble (BoxLayout) or not.
+        arrow_margin_x, arrow_margin_y = (0, 0)
+        if self.show_arrow:
+            if bubble_orientation[0] == "h":
+                arrow_margin_x = arrow_image_layout.width
+            elif bubble_orientation[0] == "v":
+                arrow_margin_y = arrow_image_layout.height
         else:
-            content.cols = 99
-            content.rows = 1
+            widgets_to_add.pop(1)
 
-    def on_arrow_image(self, *l):
-        self._arrow_img.source = self.arrow_image
+        for widget in widgets_to_add[::widget_order]:
+            super().add_widget(widget)
 
-    def on_arrow_pos(self, *l):
-        self_content = self.content
-        if not self_content:
-            Clock.schedule_once(self.on_arrow_pos)
-            return
-        if self_content not in self.children:
-            Clock.schedule_once(self.on_arrow_pos)
-            return
-        self_arrow_pos = self.arrow_pos
-        if self._prev_arrow_pos == self_arrow_pos:
-            return
-        self._prev_arrow_pos = self_arrow_pos
-
-        self_arrow_layout = self._arrow_layout
-        self_arrow_layout.clear_widgets()
-        self_arrow_img = self._arrow_img
-        self._sctr = self._arrow_img
-        super(Bubble, self).clear_widgets()
-        self_content.parent = None
-
-        self_arrow_img.size_hint = (1, None)
-        self_arrow_img.height = dp(self_arrow_img.texture_size[1])
-        self_arrow_img.pos = 0, 0
-        widget_list = []
-        arrow_list = []
-        parent = self_arrow_img.parent
-        if parent:
-            parent.remove_widget(self_arrow_img)
-
-        if self_arrow_pos[0] == 'b' or self_arrow_pos[0] == 't':
-            self.cols = 1
-            self.rows = 3
-            self_arrow_layout.orientation = 'horizontal'
-            self_arrow_img.width = self.width / 3
-            self_arrow_layout.size_hint = (1, None)
-            self_arrow_layout.height = self_arrow_img.height
-            if self_arrow_pos[0] == 'b':
-                if self_arrow_pos == 'bottom_mid':
-                    widget_list = (self_content, self_arrow_img)
-                else:
-                    if self_arrow_pos == 'bottom_left':
-                        arrow_list = (self_arrow_img, Widget(), Widget())
-                    elif self_arrow_pos == 'bottom_right':
-                        # add two dummy widgets
-                        arrow_list = (Widget(), Widget(), self_arrow_img)
-                    widget_list = (self_content, self_arrow_layout)
-            else:
-                sctr = Scatter(do_translation=False,
-                               rotation=180,
-                               do_rotation=False,
-                               do_scale=False,
-                               size_hint=(None, None),
-                               size=self_arrow_img.size)
-                sctr.add_widget(self_arrow_img)
-                if self_arrow_pos == 'top_mid':
-                    # add two dummy widgets
-                    arrow_list = (Widget(), sctr, Widget())
-                elif self_arrow_pos == 'top_left':
-                    arrow_list = (sctr, Widget(), Widget())
-                elif self_arrow_pos == 'top_right':
-                    arrow_list = (Widget(), Widget(), sctr)
-                widget_list = (self_arrow_layout, self_content)
-        elif self_arrow_pos[0] == 'l' or self_arrow_pos[0] == 'r':
-            self.cols = 3
-            self.rows = 1
-            self_arrow_img.width = self.height / 3
-            self_arrow_layout.orientation = 'vertical'
-            self_arrow_layout.cols = 1
-            self_arrow_layout.size_hint = (None, 1)
-            self_arrow_layout.width = self_arrow_img.height
-
-            rotation = -90 if self_arrow_pos[0] == 'l' else 90
-            self._sctr = sctr = Scatter(do_translation=False,
-                                        rotation=rotation,
-                                        do_rotation=False,
-                                        do_scale=False,
-                                        size_hint=(None, None),
-                                        size=(self_arrow_img.size))
-            sctr.add_widget(self_arrow_img)
-
-            if self_arrow_pos[-4:] == '_top':
-                arrow_list = (Widget(size_hint=(1, .07)),
-                              sctr, Widget(size_hint=(1, .3)))
-            elif self_arrow_pos[-4:] == '_mid':
-                arrow_list = (Widget(), sctr, Widget())
-                Clock.schedule_once(self._update_arrow)
-            elif self_arrow_pos[-7:] == '_bottom':
-                arrow_list = (Widget(), Widget(), sctr)
-
-            if self_arrow_pos[0] == 'l':
-                widget_list = (self_arrow_layout, self_content)
-            else:
-                widget_list = (self_content, self_arrow_layout)
-
-        # add widgets to arrow_layout
-        add = self_arrow_layout.add_widget
-        for widg in arrow_list:
-            add(widg)
-
-        # add widgets to self
-        add = self.add_widget
-        for widg in widget_list:
-            add(widg)
-
-    def _update_arrow(self, *dt):
-        if self.arrow_pos in ('left_mid', 'right_mid'):
-            self._sctr.center_y = self._arrow_layout.center_y
-
-    @property
-    def _fills_row_first(self):
-        return True
-
-    @property
-    def _fills_from_left_to_right(self):
-        return True
-
-    @property
-    def _fills_from_top_to_bottom(self):
-        return True
+        self.arrow_margin = (arrow_margin_x, arrow_margin_y)

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -7,14 +7,13 @@ Bubble
 .. image:: images/bubble.jpg
     :align: right
 
-The Bubble widget is a form of menu or a small popup with an arrow arranged on
-one side of the BubbleContent. The BubbleContent is a styled BoxLayout that can
-be used to add e.g., BubbleButtons as menu items.
+The :class:`Bubble` widget is a form of menu or a small popup with an arrow
+arranged on one side of it's content.
 
 The :class:`Bubble` contains an arrow attached to the content
-(e.g., BubbleContent) pointing in the direction you choose. It can be placed
-either at a predifined location or flexibly by specifying a relative position
-on the border of the widget.
+(e.g., :class:`BubbleContent`) pointing in the direction you choose. It can
+be placed either at a predifined location or flexibly by specifying a relative
+position on the border of the widget.
 
 The :class:`BubbleContent` is a styled BoxLayout and is thought to be added to
 the :class:`Bubble` as a child widget. The :class:`Bubble` will then arrange
@@ -26,6 +25,42 @@ is compatible with Kivy to be placed inside a :class:`BoxLayout`.
 The :class:`BubbleButton`is a styled Button. It suits to the style of
 :class:`Bubble` and :class:`BubbleContent`. Feel free to place other Widgets
 inside the 'content' of the :class:`Bubble`.
+
+
+.. versionchanged:: 2.2.0
+The properties :attr:`background_image`, :attr:`background_color`,
+:attr:`border` and :attr:`border_auto_scale` were removed from :class:`Bubble`.
+These properties had only been used by the content widget that now uses it's
+own properties instead. The color of the arrow is now changed with
+:attr:`arrow_color` instead of :attr:`background_color`.
+These changes makes the :class:`Bubble` transparent to use with other layouts
+as content without any side-effects due to property inheritance.
+
+The property :attr:`flex_arrow_pos` has been added to allow further
+customization of the arrow positioning.
+
+The properties :attr:`arrow_margin`, :attr:`arrow_margin_x`,
+:attr:`arrow_margin_y`, :attr:`content_size`, :attr:`content_width` and
+:attr:`content_height` have been added to ease proper sizing of a
+:class:`Bubble` e.g., based on it's content size.
+
+BubbleContent
+=============
+
+The :class:`BubbleContent` is a styled BoxLayout that can be used to
+add e.g., :class:`BubbleButtons` as menu items.
+
+.. versionchanged:: 2.2.0
+The properties :attr:`background_image`, :attr:`background_color`,
+:attr:`border` and :attr:`border_auto_scale` were added to the
+:class:`BubbleContent`. The :class:`BubbleContent` does no longer rely on these
+properties being present in the parent class.
+
+BubbleButton
+============
+
+The :class:`BubbleButton` is a styled :class:`Button` that can be used to be
+added to the :class:`BubbleContent`.
 
 Simple example
 --------------
@@ -42,12 +77,23 @@ You can choose the direction in which the arrow points::
     or
     Bubble(size=(200, 40), flex_arrow_pos=(175, 40))
 
-To change the appearance of the bubble::
+    Similarly, the corresponding properties in the '.kv' language can be used
+    as well.
 
-    bubble.background_color = (1, 0, 0, .5) #50% translucent red
-    bubble.border = [0, 0, 0, 0]
-    background_image = 'path/to/background/image'
-    arrow_image = 'path/to/arrow/image'
+You can change the appearance of the bubble::
+
+    Bubble(
+        arrow_image='/path/to/arrow/image',
+        arrow_color=(1, 0, 0, .5)),
+    )
+    BubbleContent(
+        background_image='/path/to/background/image',
+        background_color=(1, 0, 0, .5),  # 50% translucent red
+        border=(0,0,0,0),
+    )
+
+    Similarly, the corresponding properties in the '.kv' language can be used
+    as well.
 
 -----------------------------
 '''
@@ -87,9 +133,21 @@ class BubbleButton(Button):
 
 
 class BubbleContent(BoxLayout):
+    '''A styled BoxLayout that can be used as the content widget of a Bubble.
+
+    .. versionchanged:: 2.2.0
+    The graphical appearance of :class:`BubbleContent` is now based on it's
+    own properties :attr:`background_image`, :attr:`background_color`,
+    :attr:`border` and :attr:`border_auto_scale`. The parent widget properties
+    are no longer considered. This makes the BubbleContent a standalone themed
+    BoxLayout.
+    '''
+
     background_color = ColorProperty([1, 1, 1, 1])
     '''Background color, in the format (r, g, b, a). To use it you have to set
     :attr:`background_image` first.
+
+    .. versionadded:: 2.2.0
 
     :attr:`background_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
@@ -97,6 +155,8 @@ class BubbleContent(BoxLayout):
 
     background_image = StringProperty('atlas://data/images/defaulttheme/bubble')
     '''Background image of the bubble.
+
+    .. versionadded:: 2.2.0
 
     :attr:`background_image` is a :class:`~kivy.properties.StringProperty` and
     defaults to 'atlas://data/images/defaulttheme/bubble'.
@@ -109,6 +169,8 @@ class BubbleContent(BoxLayout):
 
     It must be a list of 4 values: (bottom, right, top, left). Read the
     BorderImage instructions for more information about how to use it.
+
+    .. versionadded:: 2.2.0
 
     :attr:`border` is a :class:`~kivy.properties.ListProperty` and defaults to
     (16, 16, 16, 16)
@@ -123,6 +185,8 @@ class BubbleContent(BoxLayout):
     )
     '''Specifies the :attr:`kivy.graphics.BorderImage.auto_scale`
     value on the background BorderImage.
+
+    .. versionadded:: 2.2.0
 
     :attr:`border_auto_scale` is a
     :class:`~kivy.properties.OptionProperty` and defaults to
@@ -156,7 +220,9 @@ class Bubble(BoxLayout):
 
     arrow_color = ColorProperty([1, 1, 1, 1])
     '''Arrow color, in the format (r, g, b, a). To use it you have to set
-    :attr:`background_image` first.
+    :attr:`arrow_image` first.
+
+    .. versionadded:: 2.2.0
 
     :attr:`arrow_color` is a :class:`~kivy.properties.ColorProperty` and
     defaults to [1, 1, 1, 1].
@@ -188,12 +254,15 @@ class Bubble(BoxLayout):
     :attr:`arrow_pos` is a :class:`~kivy.properties.OptionProperty` and
     defaults to 'bottom_mid'.
     '''
+
     flex_arrow_pos = ListProperty(None)
     '''Specifies the position of the arrow as flex coordinate around the
     border of the :class:`Bubble` Widget.
     If this property is set to a proper position (relative pixel coordinates
     within the :class:`Bubble` widget, it overwrites the setting
     :attr:`arrow_pos`.
+
+    .. versionadded:: 2.2.0
 
     :attr:`flex_arrow_pos` is a :class:`~kivy.properties.ListProperty` and
     defaults to None.
@@ -216,6 +285,8 @@ class Bubble(BoxLayout):
     to determine the correct width of the Bubble to exactly enclose the
     arrow + content by adding :attr:`content_width` and :attr:`arrow_margin_x`
 
+    .. versionadded:: 2.2.0
+
     :attr:`arrow_margin_x` is a :class:`~kivy.properties.NumericProperty` and
     represents the added margin in x direction due to the arrow widget.
     It defaults to 0 and is read only.
@@ -229,6 +300,8 @@ class Bubble(BoxLayout):
     to determine the correct height of the Bubble to exactly enclose the
     arrow + content by adding :attr:`content_height` and :attr:`arrow_margin_y`
 
+    .. versionadded:: 2.2.0
+
     :attr:`arrow_margin_y` is a :class:`~kivy.properties.NumericProperty` and
     represents the added margin in y direction due to the arrow widget.
     It defaults to 0 and is read only.
@@ -240,6 +313,8 @@ class Bubble(BoxLayout):
 
     Check the description of :attr:`arrow_margin_x` and :attr:`arrow_margin_y`.
 
+    .. versionadded:: 2.2.0
+
     :attr:`arrow_margin` is a :class:`~kivy.properties.ReferenceListProperty`
     of (:attr:`arrow_margin_x`, :attr:`arrow_margin_y`) properties.
     It is read only.
@@ -247,6 +322,8 @@ class Bubble(BoxLayout):
 
     content_width = NumericProperty(0)
     '''The width of the content Widget.
+
+    .. versionadded:: 2.2.0
 
     :attr:`content_width` is a :class:`~kivy.properties.NumericProperty` and
     is the same as self.content.width if content is not None, else it defaults
@@ -256,6 +333,8 @@ class Bubble(BoxLayout):
     content_height = NumericProperty(0)
     '''The height of the content Widget.
 
+    .. versionadded:: 2.2.0
+
     :attr:`content_height` is a :class:`~kivy.properties.NumericProperty` and
     is the same as self.content.height if content is not None, else it defaults
     to 0. It is read only.
@@ -263,6 +342,8 @@ class Bubble(BoxLayout):
 
     content_size = ReferenceListProperty(content_width, content_height)
     ''' The size of the content Widget.
+
+    .. versionadded:: 2.2.0
 
     :attr:`content_size` is a :class:`~kivy.properties.ReferenceListProperty`
     of (:attr:`content_width`, :attr:`content_height`) properties.
@@ -359,6 +440,9 @@ class Bubble(BoxLayout):
 
     def on_arrow_image(self, instance, value):
         self._arrow_image.source = self.arrow_image
+        self._arrow_image.width = self._arrow_image.texture_size[0]
+        self._arrow_image.height = dp(self._arrow_image.texture_size[1])
+        self._arrow_image_scatter.size = self._arrow_image.texture_size
         self.reposition_inner_widgets()
 
     def on_arrow_color(self, instance, value):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -164,7 +164,7 @@ from kivy.graphics.context_instructions import Transform
 from kivy.graphics.texture import Texture
 
 from kivy.uix.widget import Widget
-from kivy.uix.bubble import Bubble
+from kivy.uix.bubble import Bubble, BubbleContent
 from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.image import Image
 
@@ -306,6 +306,8 @@ class TextInputCutCopyPaste(Bubble):
         super().__init__(**kwargs)
         self._check_parent_ev = Clock.schedule_interval(self._check_parent, .5)
         self.matrix = self.textinput.get_window_matrix()
+        self.bubble_content = BubbleContent
+        self.add_widget(self.bubble_content)
 
         with self.canvas.before:
             Callback(self.update_transform)
@@ -372,7 +374,7 @@ class TextInputCutCopyPaste(Bubble):
         mode = self.mode
 
         if parent:
-            self.clear_widgets()
+            self.bubble_content.clear_widgets()
             if mode == 'paste':
                 # show only paste on long touch
                 self.but_selectall.opacity = 1
@@ -387,7 +389,7 @@ class TextInputCutCopyPaste(Bubble):
                 widget_list = (self.but_cut, self.but_copy, self.but_paste)
 
             for widget in widget_list:
-                self.add_widget(widget)
+                self.bubble_content.add_widget(widget)
 
     def do(self, action):
         textinput = self.textinput


### PR DESCRIPTION
This commit comprises three commits:
- Re-implements the Bubble widge
- Implements tests for the Bubble widget
- Adapts existing code to Bubble changes

The old Bubble widget design was complicated and used a GridLayout with
multiple dummy widgets solely to get an arrow placed as desired.
Multiple magic numbers like 99 columns or 99 rows were undocumented
and unintuitive. Probably some of these numbers even add unnecessary
limitations to the Bubble widget.
The Bubble widget was fused with the 'BubbleContent' which by design
makes the Bubble widget feel very unflexible.
Sizing the Bubble according to the content was unintuitive if not even
unpossible for some cases and the arrow positioning was relying on magic
numbers as well. Lastly, the old implementation lacked test coverage
with very few tests that did not even cover the core logic of the
widget.

The new implementation reduces the core logic (formerly "on_arrow_pos",
~100 lines of code) to ~30 lines plus a well documented lookup structure
without magic but intuitive values. Furthermore, it adds proper inline
documentation for maintainers.

This PR also adds unit tests for the core logic of the Bubble widget.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
