### PR TITLE
Our self-hosted Apple Silicon runner now has been migrated to actions/runner v2.292.0 which now supports arm64 natively

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -41,25 +41,18 @@ jobs:
 
   osx_wheels_create:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
     env:
       CIBW_BUILD: "cp37-macosx_x86_64 cp38-macosx_universal2 cp39-macosx_universal2 cp310-macosx_universal2"
       CIBW_ARCHS_MACOS: "x86_64 universal2"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
         DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
         DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
-    runs-on: ${{ matrix.runs_on || 'macos-11' }}
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
         include:
           - runs_on: macos-11
             python: '3.9'
-          # Fix for macOS 12 is here, but not merged yet: https://github.com/matthew-brett/delocate/pull/130
-          # - runs_on: apple-silicon-m1
-          #  run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
-          #  python: 3.9.7
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -145,10 +138,7 @@ jobs:
   osx_wheel_test:
     name: "osx_wheel_test (${{ matrix.runs_on }}, ${{ matrix.python }})"
     needs: [ osx_wheels_create, kivy_examples_create ]
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
-    runs-on: ${{ matrix.runs_on || 'macos-11' }}
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
         include:
@@ -161,13 +151,10 @@ jobs:
           - runs_on: macos-11     
             python: '3.10'
           - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: '3.8.13'
           - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: '3.9.7'
           - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: '3.10.1'
     env:
       KIVY_GL_BACKEND: 'mock'

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -13,17 +13,13 @@ env:
 jobs:
   unit_test:
     name: "unit_test (${{ matrix.runs_on }}, ${{ matrix.python }})"
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
-    runs-on: ${{ matrix.runs_on || 'macos-11' }}
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
         include:
           - runs_on: macos-11
             python: '3.9'
           - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: '3.9.7'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- https://github.com/actions/runner/releases/tag/v2.292.0 now supports Apple Silicon natively. 🥳 

- The `run_wrapper` that was enforcing `arm64` on top of a `x86_64` process is now un-needed.

- There's a pending PR in `actions/python-versions` which is expected to introduce support for `universal2` versions of Python, so hopefully, we will be able to rely on `actions/setup-python` also for our self hosted runner in a while..

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
