### PR TITLE
Fix TextInputCutCopyPaste widget

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -46,8 +46,6 @@
     background_disabled_normal: 'atlas://data/images/defaulttheme/bubble_btn'
     background_disabled_down: 'atlas://data/images/defaulttheme/bubble_btn_pressed'
     border: (0, 0, 0, 0)
-    size_hint_y: None
-    height: dp(30)
 
 <Slider>:
     canvas:
@@ -201,6 +199,7 @@
             rgba: self.disabled_foreground_color if self.disabled else (self.hint_text_color if not self.text else self.foreground_color)
 
 <TextInputCutCopyPaste>:
+    content: content.__self__
     but_cut: cut.__self__
     but_copy: copy.__self__
     but_paste: paste.__self__
@@ -208,22 +207,24 @@
 
     size_hint: None, None
     size: '150sp', '50sp'
-    BubbleButton:
-        id: cut
-        text: 'Cut'
-        on_release: root.do('cut')
-    BubbleButton:
-        id: copy
-        text: 'Copy'
-        on_release: root.do('copy')
-    BubbleButton:
-        id: paste
-        text: 'Paste'
-        on_release: root.do('paste')
-    BubbleButton:
-        id: selectall
-        text: 'Select All'
-        on_release: root.do('selectall')
+    BubbleContent:
+        id: content
+        BubbleButton:
+            id: cut
+            text: 'Cut'
+            on_release: root.do('cut')
+        BubbleButton:
+            id: copy
+            text: 'Copy'
+            on_release: root.do('copy')
+        BubbleButton:
+            id: paste
+            text: 'Paste'
+            on_release: root.do('paste')
+        BubbleButton:
+            id: selectall
+            text: 'Select All'
+            on_release: root.do('selectall')
 
 <CodeInput>:
     font_name: 'data/fonts/RobotoMono-Regular.ttf'

--- a/kivy/tests/test_uix_textinput.py
+++ b/kivy/tests/test_uix_textinput.py
@@ -8,7 +8,7 @@ from itertools import count
 
 from kivy.core.window import Window
 from kivy.tests.common import GraphicUnitTest, UTMotionEvent
-from kivy.uix.textinput import TextInput
+from kivy.uix.textinput import TextInput, TextInputCutCopyPaste
 from kivy.uix.widget import Widget
 from kivy.clock import Clock
 
@@ -545,6 +545,13 @@ class TextInputGraphicTest(GraphicUnitTest):
         ti.height = ti_height_for_x_lines(ti, n_lines_to_show)
         self.advance_frames(1)
         return ti
+
+    def test_cutcopypastebubble_content(self):
+        tibubble = TextInputCutCopyPaste(textinput=TextInput())
+        assert tibubble.but_copy.parent == tibubble.content
+        assert tibubble.but_cut.parent == tibubble.content
+        assert tibubble.but_paste.parent == tibubble.content
+        assert tibubble.but_selectall.parent == tibubble.content
 
 
 def ti_height_for_x_lines(ti, x):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -164,7 +164,7 @@ from kivy.graphics.context_instructions import Transform
 from kivy.graphics.texture import Texture
 
 from kivy.uix.widget import Widget
-from kivy.uix.bubble import Bubble, BubbleContent
+from kivy.uix.bubble import Bubble
 from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.image import Image
 
@@ -306,8 +306,6 @@ class TextInputCutCopyPaste(Bubble):
         super().__init__(**kwargs)
         self._check_parent_ev = Clock.schedule_interval(self._check_parent, .5)
         self.matrix = self.textinput.get_window_matrix()
-        self.bubble_content = BubbleContent
-        self.add_widget(self.bubble_content)
 
         with self.canvas.before:
             Callback(self.update_transform)
@@ -374,7 +372,7 @@ class TextInputCutCopyPaste(Bubble):
         mode = self.mode
 
         if parent:
-            self.bubble_content.clear_widgets()
+            self.content.clear_widgets()
             if mode == 'paste':
                 # show only paste on long touch
                 self.but_selectall.opacity = 1
@@ -389,7 +387,7 @@ class TextInputCutCopyPaste(Bubble):
                 widget_list = (self.but_cut, self.but_copy, self.but_paste)
 
             for widget in widget_list:
-                self.bubble_content.add_widget(widget)
+                self.content.add_widget(widget)
 
     def do(self, action):
         textinput = self.textinput


### PR DESCRIPTION
The changes introduced in PR #7882 have broken the usage of the `TextInputCutCopyPaste` widget in a `TextInput`.

**Minimal runnable example that reproduces the issue fixed in this PR:**
```kv
TextInput:
    use_bubble: True
    text: "This is a test"
```
**Error log:**
```
Traceback (most recent call last):
   File "/Users/mirko/Documents/projects/kivy/examples/demo/kivycatalog/main.py", line 192, in <module>
     KivyCatalogApp().run()
   File "/Users/mirko/Documents/projects/kivy/kivy/app.py", line 955, in run
     runTouchApp()
   File "/Users/mirko/Documents/projects/kivy/kivy/base.py", line 574, in runTouchApp
     EventLoop.mainloop()
   File "/Users/mirko/Documents/projects/kivy/kivy/base.py", line 339, in mainloop
     self.idle()
   File "/Users/mirko/Documents/projects/kivy/kivy/base.py", line 379, in idle
     Clock.tick()
   File "/Users/mirko/Documents/projects/kivy/kivy/clock.py", line 733, in tick
     self.post_idle(ts, self.idle())
   File "/Users/mirko/Documents/projects/kivy/kivy/clock.py", line 776, in post_idle
     self._process_events()
   File "kivy/_clock.pyx", line 620, in kivy._clock.CyClockBase._process_events
     cpdef _process_events(self):
   File "kivy/_clock.pyx", line 653, in kivy._clock.CyClockBase._process_events
     self.handle_exception(e)
   File "kivy/_clock.pyx", line 649, in kivy._clock.CyClockBase._process_events
     event.tick(self._last_tick)
   File "kivy/_clock.pyx", line 218, in kivy._clock.ClockEvent.tick
     ret = callback(self._dt)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/textinput.py", line 1488, in long_touch
     self._show_cut_copy_paste(
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/textinput.py", line 1895, in _show_cut_copy_paste
     self._bubble = bubble = TextInputCutCopyPaste(textinput=self)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/textinput.py", line 306, in __init__
     super().__init__(**kwargs)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/bubble.py", line 406, in __init__
     super().__init__(**kwargs)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/boxlayout.py", line 145, in __init__
     super(BoxLayout, self).__init__(**kwargs)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/layout.py", line 76, in __init__
     super(Layout, self).__init__(**kwargs)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/widget.py", line 366, in __init__
     self.apply_class_lang_rules(
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/widget.py", line 470, in apply_class_lang_rules
     Builder.apply(
   File "/Users/mirko/Documents/projects/kivy/kivy/lang/builder.py", line 540, in apply
     self._apply_rule(
   File "/Users/mirko/Documents/projects/kivy/kivy/lang/builder.py", line 659, in _apply_rule
     widget.add_widget(child)
   File "/Users/mirko/Documents/projects/kivy/kivy/uix/bubble.py", line 416, in add_widget
     raise BubbleException(
 kivy.uix.bubble.BubbleException: Bubble can only contain a single Widget or Layout
```

Additionally, a layout issue was also introduced:

**Expected:**

![Image 21-06-22 at 21 35](https://user-images.githubusercontent.com/8177736/174891789-795ba0ee-57fa-414b-ac32-8a18cd27c742.jpg)

**After the changes introduced in #7882:**

![Image 21-06-22 at 22 32](https://user-images.githubusercontent.com/8177736/174892244-588e9860-fac6-4c08-8c3c-aeaa56c3730a.jpg)

⚠️  After PR #7882, the bubble arrow may need some fixes to properly show on retina displays. It may be necessary to change the resource in order to avoid pixelation. (I have a retina-display-related WIP, so it will be managed separately)

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
