### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -296,8 +296,7 @@ def add_dep_paths():
             try:
                 mod = importer.find_module(modname).load_module(modname)
             except ImportError as e:
-                logging.warn(
-                    "deps: Error importing dependency: {}".format(str(e)))
+                logging.warning(f"deps: Error importing dependency: {e}")
                 continue
 
             if hasattr(mod, 'dep_bins'):
@@ -314,7 +313,7 @@ def add_dep_paths():
         try:
             mod = importer.find_module(modname).load_module(modname)
         except ImportError as e:
-            logging.warn("deps: Error importing dependency: {}".format(str(e)))
+            logging.warning(f"deps: Error importing dependency: {e}")
             continue
 
         if hasattr(mod, 'dep_bins'):
@@ -358,7 +357,7 @@ def _find_gst_binaries():
         plugin_filepaths.extend(
             glob.glob(os.path.join(plugin_dir, 'libgst*')))
     if len(plugin_filepaths) == 0:
-        logging.warn('Could not find GStreamer plugins. ' +
+        logging.warning('Could not find GStreamer plugins. ' +
                      'Possible solution: set GST_PLUGIN_PATH')
         return []
 


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444

<!--


Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
