### PR TITLE
Speed up SmoothLine creation by ~2.5x

### DIFF
--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -14,8 +14,12 @@ DEF LINE_MODE_RECTANGLE = 3
 DEF LINE_MODE_ROUNDED_RECTANGLE = 4
 DEF LINE_MODE_BEZIER = 5
 
+from kivy.cache import Cache
 from kivy.graphics.stencil_instructions cimport StencilUse, StencilUnUse, StencilPush, StencilPop
 import itertools
+
+# register graphics texture cache
+Cache.register('kv.graphics.texture')
 
 cdef float PI = <float>3.1415926535
 
@@ -1282,9 +1286,12 @@ cdef class SmoothLine(Line):
         self.texture = self.premultiplied_texture()
 
     def premultiplied_texture(self):
-        texture = Texture.create(size=(4, 1), colorfmt="rgba")
-        texture.add_reload_observer(self._smooth_reload_observer)
-        self._smooth_reload_observer(texture)
+        texture = Cache.get('kv.graphics.texture', 'smoothline')
+        if not texture:
+            texture = Texture.create(size=(4, 1), colorfmt="rgba")
+            texture.add_reload_observer(self._smooth_reload_observer)
+            self._smooth_reload_observer(texture)
+            Cache.append('kv.graphics.texture', 'smoothline', texture)
         return texture
 
     cpdef _smooth_reload_observer(self, texture):


### PR DESCRIPTION
This PR uses texture caching technique to speed up SmoothLine creation.

Running the code below, inside Kivy's event loop, it was noticeable an improvement of approximately 2.5x in the time needed to create the SmoothLine. Each code was executed 10 times, and then the arithmetic average was taken.

```python
timeit(lambda: SmoothLine(), number=10000)
```

> Kivy 2.1.0 → 0.13423057s
> Current PR → 0.05471651229997769s
> Speed up → ~ **2.45x**
> 

```python
timeit(lambda: SmoothLine(), number=100000)
```

> Kivy 2.1.0 → 1.3100188999999998s
> Current PR → 0.5150082429000008s
> Speed up → ~ **2.54x**
> 

<br>

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
