### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
-    - name: Upload benchamrks as artifact
+    - name: Upload benchmarks as artifact
       uses: actions/upload-artifact@v2
       with:
         name: benchmarks

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           . .\.ci\windows_ci.ps1
           Test-kivy-benchmark
-      - name: Upload benchamrks as artifact
+      - name: Upload benchmarks as artifact
         uses: actions/upload-artifact@v2
         with:
           name: benchmarks

--- a/doc/sources/contribute-unittest.rst
+++ b/doc/sources/contribute-unittest.rst
@@ -5,7 +5,7 @@ Tests are located in the `kivy/tests` folder. If you find a bug in Kivy, a good
 thing to do can be to write a minimal case showing the issue and to ask core
 devs if the behaviour shown is intended or a real bug. If you write your code
 as a `unittest <http://docs.python.org/2/library/unittest.html>`_
-, it will prevent the bug from coming back unnoticed in the future, and wil
+, it will prevent the bug from coming back unnoticed in the future, and will
 make Kivy a better, stronger project. Writing a unittest may be a really good
 way to get familiar with Kivy while doing something useful.
 

--- a/doc/sources/guide/licensing.rst
+++ b/doc/sources/guide/licensing.rst
@@ -1,7 +1,7 @@
 Package licensing
 =================
 
-.. warning:: This is not a legally authoratative guide! The Kivy organisation,
+.. warning:: This is not a legally authoritative guide! The Kivy organisation,
    authors and contributors take no responsibility for any lack of knowledge,
    information or advice presented here. The guide is merely informative and is
    meant to protect inexperienced users.

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -85,7 +85,7 @@ The Raspberry OS project uses `pi-gen` project to create bootable images for Ras
 Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that uses the (now deprecated but still useful) DISPMANX API is only compiled when running on a Raspberry Pi.
 In order to build Kivy in such `pi-gen` environment, the auto-detection of the Raspberry Pi hardware version needs to be disabled.
 
-When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variabel `KIVY_RPI_VERSION` to any number < 4, e.g. `3`.
+When cross-compiling using e.g. `pi-gen`, the build system can be forced into compiling for Raspberry Pi with `egl_rpi` support by setting the environment variable `KIVY_RPI_VERSION` to any number < 4, e.g. `3`.
 
 The install command then looks something like this::
 

--- a/examples/gestures/gesture_board.py
+++ b/examples/gestures/gesture_board.py
@@ -21,7 +21,7 @@ def simplegesture(name, point_list):
 class GestureBoard(FloatLayout):
     """
     Our application main widget, derived from touchtracer example, use data
-    constructed from touches to match symboles loaded from my_gestures.
+    constructed from touches to match symbols loaded from my_gestures.
 
     """
     def __init__(self, *args, **kwargs):

--- a/kivy/_event.pyx
+++ b/kivy/_event.pyx
@@ -1239,7 +1239,7 @@ cdef class EventObservers:
         If dispatch_reverse is True, we dispatch starting with last bound callback,
         otherwise we start with the first.
 
-        The logic and reason for locking callbacks is as followes. During a dispatch,
+        The logic and reason for locking callbacks is as follows. During a dispatch,
         arbitrary code can be executed, therefore, as we traverse and execute
         each callback, the callback may in turn bind. unbind or even cause a
         new dispatch recursively many times. Therefore, our goal should be to

--- a/kivy/core/text/text_pango.py
+++ b/kivy/core/text/text_pango.py
@@ -61,7 +61,7 @@ Known limitations
 * Kivy's text layout is used, not Pango. This means we do not use Pango's
   line-breaking feature (which is superior to Kivy's), and we can't use
   Pango's bidirectional cursor helpers in TextInput.
-* Font family collissions can happen. For example, if you use a `system://`
+* Font family collisions can happen. For example, if you use a `system://`
   context and add a custom `Arial.ttf`, using `arial` as the `font_family`
   may or may not draw with your custom font (depending on whether or not
   there is already a system-wide "arial" font installed)

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -2050,7 +2050,7 @@ class WindowBase(EventDispatcher):
                 Cursor y position, relative to the window :attr:`top`, at the
                 time of the drop.
             `*args`: `tuple`
-                Additional arugments.
+                Additional arguments.
 
         .. note::
             This event works with sdl2 window provider.
@@ -2076,7 +2076,7 @@ class WindowBase(EventDispatcher):
                 Cursor y position, relative to the window :attr:`top`, at the
                 time of the drop.
             `*args`: `tuple`
-                Additional arugments.
+                Additional arguments.
 
         .. warning::
             This event currently works with sdl2 window provider, on pygame
@@ -2125,7 +2125,7 @@ class WindowBase(EventDispatcher):
                 Cursor y position, relative to the window :attr:`top`, at the
                 time of the drop.
             `*args`: `tuple`
-                Additional arugments.
+                Additional arguments.
 
         .. note::
             This event works with sdl2 window provider on x11 window.
@@ -2155,7 +2155,7 @@ class WindowBase(EventDispatcher):
                 Cursor y position, relative to the window :attr:`top`, at the
                 time of the drop.
             `*args`: `tuple`
-                Additional arugments.
+                Additional arguments.
 
         .. note::
             This event works with sdl2 window provider.

--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -283,7 +283,7 @@ else:
 
             invert_x = int(bool(drs('invert_x', 0)))
             invert_y = int(bool(drs('invert_y', 0)))
-            Logger.info('MTD: <%s> axes invertion: X is %d, Y is %d' %
+            Logger.info('MTD: <%s> axes inversion: X is %d, Y is %d' %
                         (_fn, invert_x, invert_y))
 
             rotation = drs('rotation', 0)

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -634,7 +634,7 @@ cdef class NumericProperty(Property):
 
     It does not support numpy numbers so they must be manually converted to int/float.
     E.g. ``widget.num = np.arange(4)[0]`` will raise an exception. Numpy arrays are not
-    supported at all, even by ObjectProperty because their comparision does not return
+    supported at all, even by ObjectProperty because their comparison does not return
     a bool. But if you must use a Kivy property, use a ObjectProperty with ``comparator``
     set to ``np.array_equal``. E.g.::
 

--- a/kivy/tests/test_filechooser_unicode.py
+++ b/kivy/tests/test_filechooser_unicode.py
@@ -28,7 +28,7 @@ class FileChooserUnicodeTestCase(unittest.TestCase):
         self.assertIsInstance(basepathb, bytes)
         self.basepathb = basepathb
 
-        # this will test creating unicode and bytes filesnames
+        # this will test creating unicode and bytes filenames
         ufiles = [u'कीवीtestu',
                   u'कीवीtestu' + unicode_char(0xEEEE),
                   u'कीवीtestu' + unicode_char(0xEEEE - 1),

--- a/kivy/tests/test_kivy_init.py
+++ b/kivy/tests/test_kivy_init.py
@@ -24,7 +24,7 @@ def test_kivy_get_includes():
 
 
 def test_kivy_usage():
-    """Test the kivy_usage commmand."""
+    """Test the kivy_usage command."""
     with patch('kivy.print') as mock_print:
         kivy_usage()
         mock_print.assert_called()

--- a/kivy/tools/image-testsuite/README.md
+++ b/kivy/tools/image-testsuite/README.md
@@ -85,7 +85,7 @@ performing (drawing opaque pixels only), see test names below.
 Test names
 ----------
 
-* `OPAQUE` tests opaque pixels (normal RGB) (lossess formats)
+* `OPAQUE` tests opaque pixels (normal RGB) (lossless formats)
 * `BINARY` tests opaque + fully transparent pixels (GIF etc)
 * `ALPHA` tests semi-transparent pixels (normal RGBA) (PNG32 etc)
 * `GRAY-OPAQUE` tests opaque grayscale only (various PNG, tga, )

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -265,7 +265,7 @@ class CompoundSelectionBehavior(object):
 
     _anchor = None  # the last anchor node selected (e.g. shift relative node)
     # the idx may be out of sync
-    _anchor_idx = 0  # cache indexs in case list hasn't changed
+    _anchor_idx = 0  # cache indexes in case list hasn't changed
     _last_selected_node = None  # the absolute last node selected
     _last_node_idx = 0
     _ctrl_down = False  # if it's pressed - for e.g. shift selection

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -12,7 +12,7 @@ arranged on one side of it's content.
 
 The :class:`Bubble` contains an arrow attached to the content
 (e.g., :class:`BubbleContent`) pointing in the direction you choose. It can
-be placed either at a predifined location or flexibly by specifying a relative
+be placed either at a predefined location or flexibly by specifying a relative
 position on the border of the widget.
 
 The :class:`BubbleContent` is a styled BoxLayout and is thought to be added to

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -546,7 +546,7 @@ class Label(Widget):
     you can load the system fonts by specifying a font context starting
     with the special string `system://`. This will load the system
     fontconfig configuration, and add your application-specific fonts on
-    top of it (this imposes a signifficant risk of family name collision,
+    top of it (this imposes a significant risk of family name collision,
     Pango may not use your custom font file, but pick one from the system)
 
     .. note::

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -1323,7 +1323,7 @@ if __name__ == '__main__':
             {
                 'type': 'color',
                 'title': 'Test color',
-                'desc': 'Your choosen Color',
+                'desc': 'Your chosen Color',
                 'section': 'colorselection',
                 'key': 'testcolor'
             }])

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -3662,7 +3662,7 @@ class TextInput(FocusBehavior, Widget):
     you can load the system fonts by specifying a font context starting
     with the special string `system://`. This will load the system
     fontconfig configuration, and add your application-specific fonts on
-    top of it (this imposes a signifficant risk of family name collision,
+    top of it (this imposes a significant risk of family name collision,
     Pango may not use your custom font file, but pick one from the system)
 
     .. note::


### PR DESCRIPTION
Found via `codespell -q 3 -S ./doc/sources/changelog.rst -L als,ba,childrens,childs,co-ordinate,co-ordinates,datas,enew,everytime,inout,iself,quitted,tesselate,tesselated,tesselator,ths`