### PR TITLE
Fixes NO DOCUMENTATION (module kivy.uix.recycleview)

### DIFF
--- a/doc/autobuild.py
+++ b/doc/autobuild.py
@@ -15,7 +15,8 @@ ignore_list = (
     'kivy.graphics.vertex',
     'kivy.uix.recycleview.__init__',
     'kivy.setupconfig',
-    'kivy.version'
+    'kivy.version',
+    'kivy._version'
 )
 
 import os
@@ -241,7 +242,7 @@ refid = 0
 for module in m:
     summary = extract_summary_line(sys.modules[module].__doc__)
     if summary is None or summary == '':
-        summary = 'NO DOCUMENTATION (module %s)' % package
+        summary = 'NO DOCUMENTATION (module %s)' % module
 
     # search examples
     example_output = []


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

While reading docs, the user may find a **"NO DOCUMENTATION (module kivy.uix.recycleview)"** statement:
![Image 17-07-22 at 15 07](https://user-images.githubusercontent.com/8177736/179399815-0563a3a1-33f1-4d5e-840d-950a1326cdd2.jpg)

The `kivy.uix.recycleview` docs are fine, instead the error was generated by the `kivy._version`  module, which doesn't have a valid docstring.
