### PR TITLE
When using pytest_asyncio for tests, function should be decorated with `pytest_asyncio.fixture`

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -498,7 +498,7 @@ def async_run(func=None, app_cls_func=None):
         if kivy_eventloop == 'asyncio':
             try:
                 import pytest_asyncio
-                return pytest.mark.asyncio(func)
+                return pytest.mark.asyncio(pytest_asyncio.fixture(func))
             except ImportError:
                 return pytest.mark.skip(
                     reason='KIVY_EVENTLOOP == "asyncio" but '


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

From [pytest-asyncio](https://github.com/pytest-dev/pytest-asyncio) release notes:

> Starting from pytest-asyncio>=0.17, three modes are provided: auto, strict and legacy. Starting from pytest-asyncio>=0.19 the strict mode is the default.

> When the mode is auto, all discovered async tests are considered asyncio-driven even if they have no @pytest.mark.asyncio marker.
All async fixtures are considered asyncio-driven as well, even if they are decorated with a regular `@pytest.fixture` decorator instead of dedicated @pytest_asyncio.fixture counterpart.

See: https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.19.0