### PR TITLE
Fix minor typo in pong tutorial code comments

### DIFF
--- a/examples/tutorials/pong/steps/step5/main.py
+++ b/examples/tutorials/pong/steps/step5/main.py
@@ -40,7 +40,7 @@ class PongGame(Widget):
     def update(self, dt):
         self.ball.move()
 
-        # bounce of paddles
+        # bounce off paddles
         self.player1.bounce_ball(self.ball)
         self.player2.bounce_ball(self.ball)
 
@@ -48,7 +48,7 @@ class PongGame(Widget):
         if (self.ball.y < self.y) or (self.ball.top > self.top):
             self.ball.velocity_y *= -1
 
-        # went of to a side to score point?
+        # went off to a side to score point?
         if self.ball.x < self.x:
             self.player2.score += 1
             self.serve_ball(vel=(4, 0))


### PR DESCRIPTION
While reading through the pong tutorial code, I noticed that `of` should
have been `off` in code comments.  This commit fixes the issue.

This PR is submitted in the hope that it is helpful.  If you would like anything changed, please don't hesitate to let me know and I'll update the PR as appropriate and resubmit.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
