### PR TITLE
Add missing closing paren in hint text

### DIFF
--- a/doc/sources/tutorials/pong.rst
+++ b/doc/sources/tutorials/pong.rst
@@ -455,7 +455,7 @@ you could do:
   :class:`~kivy.uix.button.Button` and
   :class:`~kivy.uix.label.Label`
   classes, and figure out how to use their `add_widget` and `remove_widget`
-  functions to add or remove widgets dynamically.
+  functions to add or remove widgets dynamically.)
 
 * Make it a 4 player Pong Game.  Most tablets have Multi-Touch support, so
   wouldn't it be cool to have a player on each side and have four 


### PR DESCRIPTION
The hint at the end of the pong tutorial associated with making the game
end after a certain score was missing its closing parenthesis.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
