### PR TITLE
Use consistent source code notes in pong tutorial

### DIFF
--- a/doc/sources/tutorials/pong.rst
+++ b/doc/sources/tutorials/pong.rst
@@ -466,5 +466,5 @@ you could do:
 
 .. note::
 
-    You can find the entire source code and source code files for each step in
-    the Kivy examples directory under tutorials/pong/
+    You can find the entire source code--and source code files for each step--in
+    the Kivy examples directory under `tutorials/pong/`.

--- a/doc/sources/tutorials/pong.rst
+++ b/doc/sources/tutorials/pong.rst
@@ -35,8 +35,8 @@ steps and go straight to step 3.
 
 .. note::
 
-    the Kivy examples directory under `tutorials/pong/`
     You can find the entire source code--and source code files for each step--in
+    the Kivy examples directory under `tutorials/pong/`.
 
 Ready? Sweet, let's get started!
 

--- a/doc/sources/tutorials/pong.rst
+++ b/doc/sources/tutorials/pong.rst
@@ -35,8 +35,8 @@ steps and go straight to step 3.
 
 .. note::
 
-    You can find the entire source code, and source code files for each step in
     the Kivy examples directory under `tutorials/pong/`
+    You can find the entire source code--and source code files for each step--in
 
 Ready? Sweet, let's get started!
 


### PR DESCRIPTION
While reading through the pong tutorial documentation I noticed that the notes mentioning where one can find the source code for the examples (at the top and the bottom of the tutorial) were formatted differently and thought it might be helpful for the reader if they were formatted consistently.  I also changed some punctuation to hopefully improve the note text.  I've put these changes in separate commits if you want to cherry pick the commits. If you would like anything changed in this PR, please simply let me know and I'll be more than happy to update and resubmit as appropriate.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
