### PR TITLE
Fixes some E275 - assert is a keyword. + other minor PEP8 fixes

### DIFF
--- a/examples/widgets/sequenced_images/uix/custom_button.py
+++ b/examples/widgets/sequenced_images/uix/custom_button.py
@@ -81,7 +81,7 @@ class AnimatedButton(Label):
     def on_touch_up(self, touch):
         if touch.grab_current is not self:
             return
-        assert(repr(self) in touch.ud)
+        assert repr(self) in touch.ud
         touch.ungrab(self)
         _animdelay = self.img._coreimage.anim_delay
         self.img.source = self.background_normal

--- a/kivy/atlas.py
+++ b/kivy/atlas.py
@@ -198,7 +198,7 @@ class Atlas(EventDispatcher):
 
         # must be a name finished by .atlas ?
         filename = self._filename
-        assert(filename.endswith('.atlas'))
+        assert filename.endswith('.atlas')
         filename = filename.replace('/', os.sep)
 
         Logger.debug('Atlas: Load <%s>' % filename)

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -557,7 +557,7 @@ class ConfigParser(PythonConfigParser, object):
     def adddefaultsection(self, section):
         '''Add a section if the section is missing.
         '''
-        assert("_" not in section)
+        assert "_" not in section
         if self.has_section(section):
             return
         self.add_section(section)

--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -59,7 +59,7 @@ class CameraAndroid(CameraBase):
         self.fps = 30.
 
         pf = params.getPreviewFormat()
-        assert(pf == ImageFormat.NV21)  # default format is NV21
+        assert pf == ImageFormat.NV21  # default format is NV21
         self._bufsize = int(ImageFormat.getBitsPerPixel(pf) / 8. *
                             width * height)
 

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -188,7 +188,7 @@ class ImageData(object):
         '''
         if level == 0:
             return (self.width, self.height, self.data, self.rowlength)
-        assert(level < len(self.mipmaps))
+        assert level < len(self.mipmaps)
         return self.mipmaps[level]
 
     def iterate_mipmaps(self):

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -571,7 +571,7 @@ class LabelBase(object):
     def clear_texture(self):
         self._render_begin()
         data = self._render_end()
-        assert(data)
+        assert data
         if data is not None and data.width > 1:
             self.texture.blit_data(data)
         return
@@ -682,7 +682,7 @@ class LabelBase(object):
 
         # get data from provider
         data = self._render_end()
-        assert(data)
+        assert data
         self.options = old_opts
 
         # If the text is 1px width, usually, the data is black.

--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -167,7 +167,7 @@ class GardenImporter(object):
             return self
 
     def load_module(self, fullname):
-        assert(fullname.startswith('kivy.garden'))
+        assert fullname.startswith('kivy.garden')
 
         moddir = join(garden_kivy_dir, fullname.split('.', 2)[-1])
         if exists(moddir):

--- a/kivy/graphics/opengl.pyx
+++ b/kivy/graphics/opengl.pyx
@@ -1159,8 +1159,8 @@ def glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
     We support only GL_RGB/GL_RGBA as a format and GL_UNSIGNED_BYTE as a
     type.
     '''
-    assert(format in (GL_RGB, GL_RGBA))
-    assert(type == GL_UNSIGNED_BYTE)
+    assert format in (GL_RGB, GL_RGBA)
+    assert type == GL_UNSIGNED_BYTE
 
     cdef object py_pixels = None
     cdef long size

--- a/kivy/graphics/vertex_instructions.pyx
+++ b/kivy/graphics/vertex_instructions.pyx
@@ -1045,7 +1045,7 @@ cdef class BorderImage(Rectangle):
         # set the vertex data
         # WARNING we are allocating the vertices as a float
         # because we know exactly the format.
-        assert(sizeof(vertex_t) == 4 * sizeof(float))
+        assert sizeof(vertex_t) == 4 * sizeof(float)
         cdef float *vertices = [
             hs[0], vs[0], ths[0], tvs[0], #v0
             hs[1], vs[0], ths[1], tvs[0], #v1

--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -944,7 +944,7 @@ cdef class Line(VertexInstruction):
             segments += 2
         else:
             x = y = w = h = 0
-            assert(0)
+            assert 0
 
         if angle_end > angle_start:
             angle_dir = 1
@@ -1027,7 +1027,7 @@ cdef class Line(VertexInstruction):
             segments += 1
         else:
             x = y = r = 0
-            assert(0)
+            assert 0
 
         if angle_end > angle_start:
             angle_dir = 1
@@ -1094,7 +1094,7 @@ cdef class Line(VertexInstruction):
             x, y, width, height = args
         else:
             x = y = width = height = 0
-            assert(0)
+            assert 0
 
         self._points = [x, y, x + width, y, x + width, y + height, x, y + height]
         self._close = 1

--- a/kivy/input/recorder.py
+++ b/kivy/input/recorder.py
@@ -283,7 +283,7 @@ class Recorder(EventDispatcher):
         dt = time() - self.play_time
         while self.play_data:
             event = self.play_data[0]
-            assert(len(event) == 4)
+            assert len(event) == 4
             if event[0] > dt:
                 return
 

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -555,13 +555,13 @@ class BuilderBase(object):
         # rootrule: the current root rule (for children of a rule)
 
         # will collect reference to all the id in children
-        assert(rule not in self.rulectx)
+        assert rule not in self.rulectx
         self.rulectx[rule] = rctx = {
             'ids': {'root': widget.proxy_ref},
             'set': [], 'hdl': []}
 
         # extract the context of the rootrule (not rule!)
-        assert(rootrule in self.rulectx)
+        assert rootrule in self.rulectx
         rctx = self.rulectx[rootrule]
 
         # if a template context is passed, put it as "ctx"
@@ -687,7 +687,7 @@ class BuilderBase(object):
             rule = None
             for widget_set, rules in reversed(rctx['set']):
                 for rule in rules:
-                    assert(isinstance(rule, ParserRuleProperty))
+                    assert isinstance(rule, ParserRuleProperty)
                     key = rule.name
                     value = rule.co_value
                     if type(value) is CodeType:
@@ -716,8 +716,8 @@ class BuilderBase(object):
             crule = None
             for widget_set, rules in rctx['hdl']:
                 for crule in rules:
-                    assert(isinstance(crule, ParserRuleProperty))
-                    assert(crule.name.startswith('on_'))
+                    assert isinstance(crule, ParserRuleProperty)
+                    assert crule.name.startswith('on_')
                     key = crule.name
                     if not widget_set.is_event_type(key):
                         key = key[3:]

--- a/kivy/lib/ddsfile.py
+++ b/kivy/lib/ddsfile.py
@@ -316,16 +316,16 @@ class DDSFile(object):
                 fd.write(image)
 
     def add_image(self, level, bpp, fmt, width, height, data):
-        assert(bpp == 32)
-        assert(fmt in ('rgb', 'rgba', 'dxt1', 'dxt2', 'dxt3', 'dxt4', 'dxt5'))
-        assert(width > 0)
-        assert(height > 0)
-        assert(level >= 0)
+        assert bpp == 32
+        assert fmt in ('rgb', 'rgba', 'dxt1', 'dxt2', 'dxt3', 'dxt4', 'dxt5')
+        assert width > 0
+        assert height > 0
+        assert level >= 0
 
         meta = self.meta
         images = self.images
         if len(images) == 0:
-            assert(level == 0)
+            assert level == 0
 
             # first image, set defaults !
             for k in meta.keys():
@@ -350,8 +350,8 @@ class DDSFile(object):
             meta.pf_aBitMask = 0xff000000
 
             if fmt in ('rgb', 'rgba'):
-                assert(True)
-                assert(bpp == 32)
+                assert True
+                assert bpp == 32
                 meta.pf_flags |= DDPF_RGB
                 meta.pf_rgbBitCount = 32
                 meta.pf_rBitMask = 0x00ff0000
@@ -376,8 +376,8 @@ class DDSFile(object):
 
             images.append(data)
         else:
-            assert(level == len(images))
-            assert(fmt == self._fmt)
+            assert level == len(images)
+            assert fmt == self._fmt
 
             images.append(data)
 

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -564,7 +564,7 @@ class UrlRequest(Thread):
                         func(self)
 
             else:
-                assert(0)
+                assert 0
 
     @property
     def is_finished(self):

--- a/kivy/tests/test_uix_asyncimage.py
+++ b/kivy/tests/test_uix_asyncimage.py
@@ -22,7 +22,7 @@ class AsyncImageTestCase(GraphicUnitTest):
     def setUp(self):
         from kivy.config import Config
         self.maxfps = Config.getint('graphics', 'maxfps')
-        assert(self.maxfps > 0)
+        assert self.maxfps > 0
         super(AsyncImageTestCase, self).setUp()
 
     def zip_frames(self, path):

--- a/kivy/uix/behaviors/button.py
+++ b/kivy/uix/behaviors/button.py
@@ -161,7 +161,7 @@ class ButtonBehavior(object):
     def on_touch_up(self, touch):
         if touch.grab_current is not self:
             return super(ButtonBehavior, self).on_touch_up(touch)
-        assert(self in touch.ud)
+        assert self in touch.ud
         touch.ungrab(self)
         self.last_touch = touch
 

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -255,10 +255,10 @@ class CompoundSelectionBehavior(object):
     '''
 
     text_entry_timeout = NumericProperty(1.)
-    '''When typing characters in rapid succession (i.e. the time difference since
-    the last character is less than :attr:`text_entry_timeout`), the keys get
-    concatenated and the combined text is passed as the key argument of
-    :meth:`goto_node`.
+    '''When typing characters in rapid succession (i.e. the time difference
+    since the last character is less than :attr:`text_entry_timeout`), the
+    keys get concatenated and the combined text is passed as the key argument
+    of :meth:`goto_node`.
 
     .. versionadded:: 1.10.0
     '''

--- a/kivy/uix/behaviors/touchripple.py
+++ b/kivy/uix/behaviors/touchripple.py
@@ -289,7 +289,7 @@ class TouchRippleButtonBehavior(TouchRippleBehavior):
     def on_touch_up(self, touch):
         if touch.grab_current is not self:
             return super(TouchRippleButtonBehavior, self).on_touch_up(touch)
-        assert(self in touch.ud)
+        assert self in touch.ud
         touch.ungrab(self)
         self.last_touch = touch
         if self.disabled:

--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -1098,7 +1098,7 @@ class _Visitor(nodes.NodeVisitor):
             label = RstTitle(section=self.section, document=self.root)
             self.current.add_widget(label)
             self.push(label)
-            # assert(self.text == '')
+            # assert self.text == ''
 
         elif cls is nodes.Text:
             # check if parent isn't a special directive
@@ -1165,7 +1165,7 @@ class _Visitor(nodes.NodeVisitor):
             box = RstBlockQuote()
             self.current.add_widget(box)
             self.push(box.content)
-            assert(self.text == '')
+            assert self.text == ''
 
         elif cls is nodes.enumerated_list:
             box = RstList()
@@ -1201,13 +1201,13 @@ class _Visitor(nodes.NodeVisitor):
             label = RstWarning()
             self.current.add_widget(label)
             self.push(label.content)
-            assert(self.text == '')
+            assert self.text == ''
 
         elif cls is nodes.note:
             label = RstNote()
             self.current.add_widget(label)
             self.push(label.content)
-            assert(self.text == '')
+            assert self.text == ''
 
         elif cls is nodes.image:
             # docutils parser breaks path with spaces
@@ -1256,13 +1256,13 @@ class _Visitor(nodes.NodeVisitor):
             self.push(lst)
 
         elif cls is nodes.term:
-            assert(isinstance(self.current, RstDefinitionList))
+            assert isinstance(self.current, RstDefinitionList)
             term = RstTerm(document=self.root)
             self.current.add_widget(term)
             self.push(term)
 
         elif cls is nodes.definition:
-            assert(isinstance(self.current, RstDefinitionList))
+            assert isinstance(self.current, RstDefinitionList)
             definition = RstDefinition(document=self.root)
             definition.add_widget(RstDefinitionSpace(document=self.root))
             self.current.add_widget(definition)
@@ -1331,7 +1331,7 @@ class _Visitor(nodes.NodeVisitor):
             self.section -= 1
 
         elif cls is nodes.title:
-            assert(isinstance(self.current, RstTitle))
+            assert isinstance(self.current, RstTitle)
             if not self.title:
                 self.title = self.text
             self.set_text(self.current, 'title')
@@ -1342,12 +1342,12 @@ class _Visitor(nodes.NodeVisitor):
 
         elif cls is nodes.paragraph:
             self.do_strip_text = False
-            assert(isinstance(self.current, RstParagraph))
+            assert isinstance(self.current, RstParagraph)
             self.set_text(self.current, 'paragraph')
             self.pop()
 
         elif cls is nodes.literal_block:
-            assert(isinstance(self.current, RstLiteralBlock))
+            assert isinstance(self.current, RstLiteralBlock)
             self.set_text(self.current.content, 'literal_block')
             self.pop()
 
@@ -1386,7 +1386,7 @@ class _Visitor(nodes.NodeVisitor):
             self.pop()
 
         elif cls is nodes.term:
-            assert(isinstance(self.current, RstTerm))
+            assert isinstance(self.current, RstTerm)
             self.set_text(self.current, 'term')
             self.pop()
 
@@ -1397,7 +1397,7 @@ class _Visitor(nodes.NodeVisitor):
             self.pop()
 
         elif cls is nodes.field_name:
-            assert(isinstance(self.current, RstFieldName))
+            assert isinstance(self.current, RstFieldName)
             self.set_text(self.current, 'field_name')
             self.pop()
 

--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -1142,7 +1142,7 @@ class ScreenManager(FloatLayout):
 
         .. versionadded: 1.8.0
         '''
-        assert(screen is not None)
+        assert screen is not None
 
         if not isinstance(screen, Screen):
             raise ScreenManagerException(

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2101,7 +2101,7 @@ class TextInput(FocusBehavior, Widget):
 
     def _delete_line(self, idx):
         """Delete current line, and fix cursor position"""
-        assert(idx < len(self._lines))
+        assert idx < len(self._lines)
         self._lines_flags.pop(idx)
         self._lines_labels.pop(idx)
         self._lines.pop(idx)

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ glew =
 [flake8]
 ignore = E125,E126,E127,E128,E402,E741,E731,W503,F401,W504,F841,E722
 max-line-length = 80
-exclude = __pycache__,.tox,.git/,doc/,build/,.eggs/
+exclude = __pycache__,.tox,.git/,doc/,build/,.eggs/,venv/
 statistics = true
 show-source = true
 count = true


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Like https://github.com/kivy/python-for-android/pull/2647:

- Assert is a keyword and a space is needed + the parentheses are not needed.
- A recent change in `pycodestyle` (See: https://github.com/PyCQA/pycodestyle/pull/1063) introduced this check.
- CI runs started to fail this recently. (See: https://github.com/kivy/kivy/runs/7679002182)

Additionally:
- Adds `venv` to `flake8` excluded folders.
- Fixes an E501 issue in `kivy/uix/behaviors/compoundselection.py`
