### PR TITLE
Pygments, support background color from style

### DIFF
--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -105,13 +105,23 @@ class CodeInput(CodeNavigationBehavior, TextInput):
         # use text_color as foreground color
         text_color = kwargs.get('foreground_color')
         if text_color:
-            self.text_color = get_hex_from_color(text_color)
+            # Avoid crashing the app if the user provided a color as HEX
+            if type(text_color) is str: self.text_color = text_color
+            else: self.text_color = get_hex_from_color(text_color)
         # set foreground to white to allow text colors to show
         # use text_color as the default color in bbcodes
         self.use_text_color = False
         self.foreground_color = [1, 1, 1, .999]
+        
+        # If background color was not provided
         if not kwargs.get('background_color'):
-            self.background_color = [.9, .92, .92, 1]
+            # Get pygments background color from style, if provided
+            # (some pygments default style have them defined)
+            try: self.background_color = get_color_from_hex(style.background_color)
+            # If the background color was not provided, set a default one
+            except Exception: self.background_color = [.9, .92, .92, 1]
+        # Otherwise, get the provided color
+        else: self.background_color = kwargs.get("background_color")
 
     def on_style_name(self, *args):
         self.style = styles.get_style_by_name(self.style_name)

--- a/kivy/uix/codeinput.py
+++ b/kivy/uix/codeinput.py
@@ -18,6 +18,10 @@ well as code highlighting for `languages supported by pygments
 <http://pygments.org/docs/lexers/>`_ along with `KivyLexer` for
 :mod:`kivy.lang` highlighting.
 
+.. versionadded:: 2.1.0
+    Added support for :mod:`pygments.style.background_color` to be
+    used by default if provided.
+
 Usage example
 -------------
 


### PR DESCRIPTION
Supporting pygments background color from style if provided. On some default pygments styles the background is provided, but kivy forgot to get advantage of this.
Also added try statement on text color to avoid crashing the app if the user provide color as HEX.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
