### PR TITLE
Color from hex, doc and futures.

### DIFF
--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -124,7 +124,7 @@ def get_color_from_hex(s):
         as a grey scale.
 
     >>> get_color_from_hex("#009933FF")     # [0.0, 0.6, 0.2, 1.0]
-    >>> get_color_from_hex("093F")          # [0.0, 0.6, 0.2, 1.0]
+    >>> get_color_from_hex("093")           # [0.0, 0.6, 0.2, 1.0]
     >>> get_color_from_hex("#FF")           # [1.0, 1.0, 1.0, 1.0]
     >>> get_color_from_hex("0")             # [0.0, 0.0, 0.0, 0.0]
     '''

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -113,14 +113,36 @@ def rgba(s, *args):
 def get_color_from_hex(s):
     '''Transform a hex string color to a kivy
     :class:`~kivy.graphics.Color`.
-    '''
-    if s.startswith('#'):
-        return get_color_from_hex(s[1:])
 
+    .. versionadded:: 2.1.0
+
+    Added support and for 3-4 HEX values, because :mod:`pygments.styles`
+    also support this and also because is common on web development.
+
+    .. note::
+        If provided values has 1-2 characters, that will be treated
+        as a grey scale.
+
+    >>> get_color_from_hex("#009933FF")     # [0.0, 0.6, 0.2, 1.0]
+    >>> get_color_from_hex("093F")          # [0.0, 0.6, 0.2, 1.0]
+    >>> get_color_from_hex("#FF")           # [1.0, 1.0, 1.0, 1.0]
+    >>> get_color_from_hex("0")             # [0.0, 0.0, 0.0, 0.0]
+    '''
+    # Remove the usually HEX prefix
+    if s.startswith('#'): return get_color_from_hex(s[1:])
+
+    # If provided color have 1-2 values, treat it as a gray scale
+    if len(s) < 3: return get_color_from_hex(6 // len(s) * s)
+    # In case the color have 3-4 values, double the values
+    elif len(s) < 5: return get_color_from_hex("{}{}{}".format(*[6 // len(s) * value for value in s]))
+
+    # Compute the values
     value = [int(x, 16) / 255.
              for x in split('([0-9a-f]{2})', s.lower()) if x != '']
-    if len(value) == 3:
-        value.append(1.0)
+
+    # If the alpha value is missing, add it by default
+    if len(value) == 3: value.append(1.0)
+
     return value
 
 


### PR DESCRIPTION
I added support for HEX values like "#ABC" instead of "#AABBCC", but because of used logic with HEX values, was a problem with values of 1-2 characters, like was accepting them as hex values but with wrong expectations and for that reason I added also the "gray scale" future.
I documented the function it self, with code example also and I provided comments inside the logic to be easy in the future to understand what is happen there.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
