### PR TITLE
fix bug for cursor position on padding

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2607,7 +2607,7 @@ class TextInput(FocusBehavior, Widget):
     def _get_cursor_visual_pos(self):
         # Return the position of the cursor's top visible point
         cx, cy = map(int, self.cursor_pos)
-        max_y = self.top - self.padding[3]
+        max_y = self.top - self.padding[1]
         return [cx, min(max_y, cy)]
 
     def _get_line_options(self):


### PR DESCRIPTION
If the bottom padding was bigger then the top one, the cursor was not reach the top page visually. The cursor row and text changes was in the right spot, just the cursor position was offset ed because was used wrong index for padding subtraction.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
