### PR TITLE
Config is not available when generating docs + Use `getdefault` instead of `has_option` + `get`

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -56,6 +56,7 @@ If you want a synchronous request, you can call the wait() method.
 
 '''
 
+import os
 from base64 import b64encode
 from collections import deque
 from http.client import HTTPConnection
@@ -783,9 +784,11 @@ implementation_map = {
     "urllib": UrlRequestUrllib,
 }
 
-if Config.has_option('network', 'implementation'):
-    prefered_implementation = Config.get("network", "implementation")
-    UrlRequest = implementation_map.get(prefered_implementation)
-
+if not os.environ.get("KIVY_DOC_INCLUDE"):
+    prefered_implementation = Config.getdefault(
+        "network", "implementation", "default"
+    )
 else:
-    UrlRequest = implementation_map["default"]
+    prefered_implementation = "default"
+
+UrlRequest = implementation_map.get(prefered_implementation)


### PR DESCRIPTION

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


- `gen_docs` step started to fail after #7913 (See: https://github.com/kivy/kivy/runs/7962835314)
- `Config` is not available during docs generation
- Use `Config.getdefault` instead of `Config.has_option` + `Config.get` to get the `prefered_implementation `
