### PR TITLE
Support KivyLogMode environment variable for logging testing

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -101,11 +101,14 @@ install_kivy_sdist() {
 
 test_kivy() {
   rm -rf kivy/tests/build || true
-  KIVY_NO_ARGS=1 python3 -m pytest --maxfail=10 --timeout=300 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+  # Tests with default environment variables.
+  env KIVY_NO_ARGS=1 python3 -m pytest --maxfail=10 --timeout=300 --cov=kivy --cov-branch --cov-report= "$(pwd)/kivy/tests"
+  # Logging tests, with KIVY_LOG_MODE=TEST.
+  env KIVY_NO_ARGS=1 KIVY_LOG_MODE=TEST python3 -m pytest -m logmodetest --maxfail=10 --timeout=300 --cov=kivy --cov-append --cov-report=term --cov-branch "$(pwd)/kivy/tests"
 }
 
 test_kivy_benchmark() {
-  KIVY_NO_ARGS=1 pytest --pyargs kivy.tests --benchmark-only
+  env KIVY_NO_ARGS=1 pytest --pyargs kivy.tests --benchmark-only
 }
 
 test_kivy_install() {

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -106,7 +106,11 @@ function Install-kivy-sdist {
 }
 
 function Test-kivy {
-    python -m pytest --timeout=400 --cov=kivy --cov-report term --cov-branch "$(pwd)/kivy/tests"
+    # Tests with default environment variables.
+    python -m pytest --timeout=400 --cov=kivy --cov-branch --cov-report= "$(pwd)/kivy/tests"
+    # Logging tests, with KIVY_LOG_MODE=TEST.
+    $env:KIVY_LOG_MODE = 'TEST'
+    python -m pytest -m logmodetest --timeout=400 --cov=kivy --cov-append --cov-report=term --cov-branch "$(pwd)/kivy/tests"
 }
 
 function Test-kivy-benchmark {

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -1,4 +1,4 @@
-'''
+"""
 Logger object
 =============
 
@@ -83,13 +83,11 @@ messages::
 
     print(LoggerHistory.history)
 
-'''
+"""
 
 import logging
 import os
 import sys
-import copy
-from random import randint
 from functools import partial
 import pathlib
 
@@ -97,35 +95,36 @@ import kivy
 
 
 __all__ = (
-    'Logger', 'LOG_LEVELS', 'COLORS', 'LoggerHistory', 'file_log_handler')
-
-try:
-    PermissionError
-except NameError:  # Python 2
-    PermissionError = OSError, IOError
+    "Logger",
+    "LOG_LEVELS",
+    "COLORS",
+    "LoggerHistory",
+    "file_log_handler",
+)
 
 Logger = None
 
 previous_stderr = sys.stderr
 
 
-logging.addLevelName(9, 'TRACE')
+logging.addLevelName(9, "TRACE")
 logging.TRACE = 9
 LOG_LEVELS = {
-    'trace': logging.TRACE,
-    'debug': logging.DEBUG,
-    'info': logging.INFO,
-    'warning': logging.WARNING,
-    'error': logging.ERROR,
-    'critical': logging.CRITICAL}
+    "trace": logging.TRACE,
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
 
 
 class FileHandler(logging.Handler):
     history = []
-    filename = 'log.txt'
+    filename = "log.txt"
     fd = None
-    log_dir = ''
-    encoding = 'utf-8'
+    log_dir = ""
+    encoding = "utf-8"
 
     def purge_logs(self):
         """Purge logs which exceed the maximum amount of log files,
@@ -136,6 +135,7 @@ class FileHandler(logging.Handler):
             return
 
         from kivy.config import Config
+
         maxfiles = Config.getint("kivy", "log_maxfiles")
 
         # Get path to log directory
@@ -147,12 +147,15 @@ class FileHandler(logging.Handler):
         Logger.info("Logger: Purge log fired. Processing...")
 
         # Get all files from log directory and corresponding creation timestamps
-        files = [(item, item.stat().st_ctime)
-                 for item in log_dir.iterdir() if item.is_file()]
+        files = [
+            (item, item.stat().st_ctime)
+            for item in log_dir.iterdir()
+            if item.is_file()
+        ]
         # Sort files by ascending timestamp
         files.sort(key=lambda x: x[1])
 
-        for file, _ in files[:(-maxfiles or len(files))]:
+        for file, _ in files[: (-maxfiles or len(files))]:
             # More log files than allowed maximum,
             # delete files, starting with oldest creation timestamp
             # (or edit-timestamp on Linux)
@@ -166,8 +169,9 @@ class FileHandler(logging.Handler):
     def _configure(self, *largs, **kwargs):
         from time import strftime
         from kivy.config import Config
-        log_dir = Config.get('kivy', 'log_dir')
-        log_name = Config.get('kivy', 'log_name')
+
+        log_dir = Config.get("kivy", "log_dir")
+        log_name = Config.get("kivy", "log_name")
 
         _dir = kivy.kivy_home_dir
         if log_dir and os.path.isabs(log_dir):
@@ -178,16 +182,16 @@ class FileHandler(logging.Handler):
             os.makedirs(_dir)
         self.log_dir = _dir
 
-        pattern = log_name.replace('%_', '@@NUMBER@@')
+        pattern = log_name.replace("%_", "@@NUMBER@@")
         pattern = os.path.join(_dir, strftime(pattern))
         n = 0
         while True:
-            filename = pattern.replace('@@NUMBER@@', str(n))
+            filename = pattern.replace("@@NUMBER@@", str(n))
             if not os.path.exists(filename):
                 break
             n += 1
             if n > 10000:  # prevent maybe flooding ?
-                raise Exception('Too many logfile, remove them')
+                raise Exception("Too many logfile, remove them")
 
         if FileHandler.filename == filename and FileHandler.fd is not None:
             return
@@ -195,8 +199,8 @@ class FileHandler(logging.Handler):
         FileHandler.filename = filename
         if FileHandler.fd not in (None, False):
             FileHandler.fd.close()
-        FileHandler.fd = open(filename, 'w', encoding=FileHandler.encoding)
-        Logger.info('Logger: Record log in %s' % filename)
+        FileHandler.fd = open(filename, "w", encoding=FileHandler.encoding)
+        Logger.info("Logger: Record log in %s" % filename)
 
     def _write_message(self, record):
         if FileHandler.fd in (None, False):
@@ -205,7 +209,7 @@ class FileHandler(logging.Handler):
         msg = self.format(record)
         stream = FileHandler.fd
         fs = "%s\n"
-        stream.write('[%-7s] ' % record.levelname)
+        stream.write("[%-7s] " % record.levelname)
         stream.write(fs % msg)
         stream.flush()
 
@@ -224,14 +228,15 @@ class FileHandler(logging.Handler):
             try:
                 self._configure()
                 from kivy.config import Config
-                Config.add_callback(self._configure, 'kivy', 'log_dir')
-                Config.add_callback(self._configure, 'kivy', 'log_name')
+
+                Config.add_callback(self._configure, "kivy", "log_dir")
+                Config.add_callback(self._configure, "kivy", "log_name")
             except Exception:
                 # deactivate filehandler...
                 if FileHandler.fd not in (None, False):
                     FileHandler.fd.close()
                 FileHandler.fd = False
-                Logger.exception('Error while activating FileHandler logger')
+                Logger.exception("Error while activating FileHandler logger")
                 return
             while FileHandler.history:
                 _message = FileHandler.history.pop()
@@ -257,13 +262,12 @@ class LoggerHistory(logging.Handler):
 
 
 class ConsoleHandler(logging.StreamHandler):
-
     def filter(self, record):
         try:
             msg = record.msg
-            k = msg.split(':', 1)
-            if k[0] == 'stderr' and len(k) == 2:
-                previous_stderr.write(k[1] + '\n')
+            k = msg.split(":", 1)
+            if k[0] == "stderr" and len(k) == 2:
+                previous_stderr.write(k[1] + "\n")
                 return False
         except:
             pass
@@ -271,21 +275,20 @@ class ConsoleHandler(logging.StreamHandler):
 
 
 class LogFile(object):
-
     def __init__(self, channel, func):
-        self.buffer = ''
+        self.buffer = ""
         self.func = func
         self.channel = channel
-        self.errors = ''
+        self.errors = ""
 
     def write(self, s):
         s = self.buffer + s
         self.flush()
         f = self.func
         channel = self.channel
-        lines = s.split('\n')
+        lines = s.split("\n")
         for l in lines[:-1]:
-            f('%s: %s' % (channel, l))
+            f("%s: %s" % (channel, l))
         self.buffer = lines[-1]
 
     def flush(self):
@@ -297,7 +300,7 @@ class LogFile(object):
 
 def logger_config_update(section, key, value):
     if LOG_LEVELS.get(value) is None:
-        raise AttributeError('Loglevel {0!r} doesn\'t exists'.format(value))
+        raise AttributeError("Loglevel {0!r} doesn't exists".format(value))
     Logger.setLevel(level=LOG_LEVELS.get(value))
 
 
@@ -356,8 +359,9 @@ class ColoredLogRecord(logging.LogRecord):
 
     @classmethod
     def _format_message(cls, message):
-        return message.replace(
-            "$RESET", cls.RESET_SEQ).replace("$BOLD", cls.BOLD_SEQ)
+        return message.replace("$RESET", cls.RESET_SEQ).replace(
+            "$BOLD", cls.BOLD_SEQ
+        )
 
     @classmethod
     def _format_levelname(cls, levelname):
@@ -421,48 +425,46 @@ class KivyFormatter(logging.Formatter):
     def __init__(self, *args, use_color=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._coloring_cls = (
-            ColoredLogRecord if use_color else UncoloredLogRecord)
+            ColoredLogRecord if use_color else UncoloredLogRecord
+        )
 
     def format(self, record):
         return super().format(
-            self._coloring_cls(ColonSplittingLogRecord(record)))
+            self._coloring_cls(ColonSplittingLogRecord(record))
+        )
 
 
 #: Kivy default logger instance
-Logger = logging.getLogger('kivy')
+Logger = logging.getLogger("kivy")
 Logger.logfile_activated = None
 Logger.trace = partial(Logger.log, logging.TRACE)
-
-# set the Kivy logger as the default
-logging.root = Logger
 
 # add default kivy logger
 Logger.addHandler(LoggerHistory())
 file_log_handler = None
-if 'KIVY_NO_FILELOG' not in os.environ:
+if "KIVY_NO_FILELOG" not in os.environ:
     file_log_handler = FileHandler()
     Logger.addHandler(file_log_handler)
 
 # Use the custom handler instead of streaming one.
-if 'KIVY_NO_CONSOLELOG' not in os.environ:
-    if hasattr(sys, '_kivy_logging_handler'):
-        Logger.addHandler(getattr(sys, '_kivy_logging_handler'))
+if "KIVY_NO_CONSOLELOG" not in os.environ:
+    if hasattr(sys, "_kivy_logging_handler"):
+        Logger.addHandler(getattr(sys, "_kivy_logging_handler"))
     else:
         use_color = (
-            (
-                os.environ.get("WT_SESSION") or
-                os.environ.get("COLORTERM") == 'truecolor' or
-                os.environ.get('PYCHARM_HOSTED') == '1' or
-                os.environ.get('TERM') in (
-                    'rxvt',
-                    'rxvt-256color',
-                    'rxvt-unicode',
-                    'rxvt-unicode-256color',
-                    'xterm',
-                    'xterm-256color',
-                )
-            ) and os.environ.get('KIVY_BUILD') not in ('android', 'ios')
-        )
+            os.environ.get("WT_SESSION")
+            or os.environ.get("COLORTERM") == "truecolor"
+            or os.environ.get("PYCHARM_HOSTED") == "1"
+            or os.environ.get("TERM")
+            in (
+                "rxvt",
+                "rxvt-256color",
+                "rxvt-unicode",
+                "rxvt-unicode-256color",
+                "xterm",
+                "xterm-256color",
+            )
+        ) and os.environ.get("KIVY_BUILD") not in ("android", "ios")
         if not use_color:
             # No additional control characters will be inserted inside the
             # levelname field, 7 chars will fit "WARNING"
@@ -476,5 +478,9 @@ if 'KIVY_NO_CONSOLELOG' not in os.environ:
         console.setFormatter(formatter)
         Logger.addHandler(console)
 
-# install stderr handlers
-sys.stderr = LogFile('stderr', Logger.warning)
+if os.environ.get("KIVY_LOG_MODE", None) != "TEST":
+    # set the Kivy logger as the default
+    logging.root = Logger
+
+    # install stderr handlers
+    sys.stderr = LogFile("stderr", Logger.warning)

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -1,4 +1,4 @@
-"""
+'''
 Logger object
 =============
 
@@ -83,7 +83,7 @@ messages::
 
     print(LoggerHistory.history)
 
-"""
+'''
 
 import logging
 import os
@@ -95,36 +95,30 @@ import kivy
 
 
 __all__ = (
-    "Logger",
-    "LOG_LEVELS",
-    "COLORS",
-    "LoggerHistory",
-    "file_log_handler",
-)
+    'Logger', 'LOG_LEVELS', 'COLORS', 'LoggerHistory', 'file_log_handler')
 
 Logger = None
 
 previous_stderr = sys.stderr
 
 
-logging.addLevelName(9, "TRACE")
+logging.addLevelName(9, 'TRACE')
 logging.TRACE = 9
 LOG_LEVELS = {
-    "trace": logging.TRACE,
-    "debug": logging.DEBUG,
-    "info": logging.INFO,
-    "warning": logging.WARNING,
-    "error": logging.ERROR,
-    "critical": logging.CRITICAL,
-}
+    'trace': logging.TRACE,
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL}
 
 
 class FileHandler(logging.Handler):
     history = []
-    filename = "log.txt"
+    filename = 'log.txt'
     fd = None
-    log_dir = ""
-    encoding = "utf-8"
+    log_dir = ''
+    encoding = 'utf-8'
 
     def purge_logs(self):
         """Purge logs which exceed the maximum amount of log files,
@@ -135,7 +129,6 @@ class FileHandler(logging.Handler):
             return
 
         from kivy.config import Config
-
         maxfiles = Config.getint("kivy", "log_maxfiles")
 
         # Get path to log directory
@@ -147,15 +140,12 @@ class FileHandler(logging.Handler):
         Logger.info("Logger: Purge log fired. Processing...")
 
         # Get all files from log directory and corresponding creation timestamps
-        files = [
-            (item, item.stat().st_ctime)
-            for item in log_dir.iterdir()
-            if item.is_file()
-        ]
+        files = [(item, item.stat().st_ctime)
+                 for item in log_dir.iterdir() if item.is_file()]
         # Sort files by ascending timestamp
         files.sort(key=lambda x: x[1])
 
-        for file, _ in files[: (-maxfiles or len(files))]:
+        for file, _ in files[:(-maxfiles or len(files))]:
             # More log files than allowed maximum,
             # delete files, starting with oldest creation timestamp
             # (or edit-timestamp on Linux)
@@ -169,9 +159,8 @@ class FileHandler(logging.Handler):
     def _configure(self, *largs, **kwargs):
         from time import strftime
         from kivy.config import Config
-
-        log_dir = Config.get("kivy", "log_dir")
-        log_name = Config.get("kivy", "log_name")
+        log_dir = Config.get('kivy', 'log_dir')
+        log_name = Config.get('kivy', 'log_name')
 
         _dir = kivy.kivy_home_dir
         if log_dir and os.path.isabs(log_dir):
@@ -182,16 +171,16 @@ class FileHandler(logging.Handler):
             os.makedirs(_dir)
         self.log_dir = _dir
 
-        pattern = log_name.replace("%_", "@@NUMBER@@")
+        pattern = log_name.replace('%_', '@@NUMBER@@')
         pattern = os.path.join(_dir, strftime(pattern))
         n = 0
         while True:
-            filename = pattern.replace("@@NUMBER@@", str(n))
+            filename = pattern.replace('@@NUMBER@@', str(n))
             if not os.path.exists(filename):
                 break
             n += 1
             if n > 10000:  # prevent maybe flooding ?
-                raise Exception("Too many logfile, remove them")
+                raise Exception('Too many logfile, remove them')
 
         if FileHandler.filename == filename and FileHandler.fd is not None:
             return
@@ -199,8 +188,8 @@ class FileHandler(logging.Handler):
         FileHandler.filename = filename
         if FileHandler.fd not in (None, False):
             FileHandler.fd.close()
-        FileHandler.fd = open(filename, "w", encoding=FileHandler.encoding)
-        Logger.info("Logger: Record log in %s" % filename)
+        FileHandler.fd = open(filename, 'w', encoding=FileHandler.encoding)
+        Logger.info('Logger: Record log in %s' % filename)
 
     def _write_message(self, record):
         if FileHandler.fd in (None, False):
@@ -209,7 +198,7 @@ class FileHandler(logging.Handler):
         msg = self.format(record)
         stream = FileHandler.fd
         fs = "%s\n"
-        stream.write("[%-7s] " % record.levelname)
+        stream.write('[%-7s] ' % record.levelname)
         stream.write(fs % msg)
         stream.flush()
 
@@ -228,15 +217,14 @@ class FileHandler(logging.Handler):
             try:
                 self._configure()
                 from kivy.config import Config
-
-                Config.add_callback(self._configure, "kivy", "log_dir")
-                Config.add_callback(self._configure, "kivy", "log_name")
+                Config.add_callback(self._configure, 'kivy', 'log_dir')
+                Config.add_callback(self._configure, 'kivy', 'log_name')
             except Exception:
                 # deactivate filehandler...
                 if FileHandler.fd not in (None, False):
                     FileHandler.fd.close()
                 FileHandler.fd = False
-                Logger.exception("Error while activating FileHandler logger")
+                Logger.exception('Error while activating FileHandler logger')
                 return
             while FileHandler.history:
                 _message = FileHandler.history.pop()
@@ -262,12 +250,13 @@ class LoggerHistory(logging.Handler):
 
 
 class ConsoleHandler(logging.StreamHandler):
+
     def filter(self, record):
         try:
             msg = record.msg
-            k = msg.split(":", 1)
-            if k[0] == "stderr" and len(k) == 2:
-                previous_stderr.write(k[1] + "\n")
+            k = msg.split(':', 1)
+            if k[0] == 'stderr' and len(k) == 2:
+                previous_stderr.write(k[1] + '\n')
                 return False
         except:
             pass
@@ -275,20 +264,21 @@ class ConsoleHandler(logging.StreamHandler):
 
 
 class LogFile(object):
+
     def __init__(self, channel, func):
-        self.buffer = ""
+        self.buffer = ''
         self.func = func
         self.channel = channel
-        self.errors = ""
+        self.errors = ''
 
     def write(self, s):
         s = self.buffer + s
         self.flush()
         f = self.func
         channel = self.channel
-        lines = s.split("\n")
+        lines = s.split('\n')
         for l in lines[:-1]:
-            f("%s: %s" % (channel, l))
+            f('%s: %s' % (channel, l))
         self.buffer = lines[-1]
 
     def flush(self):
@@ -300,7 +290,7 @@ class LogFile(object):
 
 def logger_config_update(section, key, value):
     if LOG_LEVELS.get(value) is None:
-        raise AttributeError("Loglevel {0!r} doesn't exists".format(value))
+        raise AttributeError('Loglevel {0!r} doesn\'t exists'.format(value))
     Logger.setLevel(level=LOG_LEVELS.get(value))
 
 
@@ -359,9 +349,8 @@ class ColoredLogRecord(logging.LogRecord):
 
     @classmethod
     def _format_message(cls, message):
-        return message.replace("$RESET", cls.RESET_SEQ).replace(
-            "$BOLD", cls.BOLD_SEQ
-        )
+        return message.replace(
+            "$RESET", cls.RESET_SEQ).replace("$BOLD", cls.BOLD_SEQ)
 
     @classmethod
     def _format_levelname(cls, levelname):
@@ -425,46 +414,45 @@ class KivyFormatter(logging.Formatter):
     def __init__(self, *args, use_color=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._coloring_cls = (
-            ColoredLogRecord if use_color else UncoloredLogRecord
-        )
+            ColoredLogRecord if use_color else UncoloredLogRecord)
 
     def format(self, record):
         return super().format(
-            self._coloring_cls(ColonSplittingLogRecord(record))
-        )
+            self._coloring_cls(ColonSplittingLogRecord(record)))
 
 
 #: Kivy default logger instance
-Logger = logging.getLogger("kivy")
+Logger = logging.getLogger('kivy')
 Logger.logfile_activated = None
 Logger.trace = partial(Logger.log, logging.TRACE)
 
 # add default kivy logger
 Logger.addHandler(LoggerHistory())
 file_log_handler = None
-if "KIVY_NO_FILELOG" not in os.environ:
+if 'KIVY_NO_FILELOG' not in os.environ:
     file_log_handler = FileHandler()
     Logger.addHandler(file_log_handler)
 
 # Use the custom handler instead of streaming one.
-if "KIVY_NO_CONSOLELOG" not in os.environ:
-    if hasattr(sys, "_kivy_logging_handler"):
-        Logger.addHandler(getattr(sys, "_kivy_logging_handler"))
+if 'KIVY_NO_CONSOLELOG' not in os.environ:
+    if hasattr(sys, '_kivy_logging_handler'):
+        Logger.addHandler(getattr(sys, '_kivy_logging_handler'))
     else:
         use_color = (
-            os.environ.get("WT_SESSION")
-            or os.environ.get("COLORTERM") == "truecolor"
-            or os.environ.get("PYCHARM_HOSTED") == "1"
-            or os.environ.get("TERM")
-            in (
-                "rxvt",
-                "rxvt-256color",
-                "rxvt-unicode",
-                "rxvt-unicode-256color",
-                "xterm",
-                "xterm-256color",
-            )
-        ) and os.environ.get("KIVY_BUILD") not in ("android", "ios")
+            (
+                os.environ.get("WT_SESSION") or
+                os.environ.get("COLORTERM") == 'truecolor' or
+                os.environ.get('PYCHARM_HOSTED') == '1' or
+                os.environ.get('TERM') in (
+                    'rxvt',
+                    'rxvt-256color',
+                    'rxvt-unicode',
+                    'rxvt-unicode-256color',
+                    'xterm',
+                    'xterm-256color',
+                )
+            ) and os.environ.get('KIVY_BUILD') not in ('android', 'ios')
+        )
         if not use_color:
             # No additional control characters will be inserted inside the
             # levelname field, 7 chars will fit "WARNING"

--- a/kivy/tests/pytest.ini
+++ b/kivy/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    logmodetest: mark a test as a test of the logger
+    incremental: mark a test as incremental
+

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -4,6 +4,9 @@ Logger tests
 """
 
 import logging
+import os
+import sys
+
 import pytest
 import pathlib
 import time
@@ -152,9 +155,8 @@ def test_colonsplittinglogrecord_with_colon():
     )
     shimmedlogrecord = ColonSplittingLogRecord(originallogrecord)
     assert (
-        str(shimmedlogrecord)
-        == '<LogRecord: kivy.test, 10, test.py, 1, '
-           '"[Part1       ] Part2: Part 3">'
+        str(shimmedlogrecord) == "<LogRecord: kivy.test, 10, test.py, 1, "
+        '"[Part1       ] Part2: Part 3">'
     )
 
 
@@ -257,9 +259,8 @@ def test_coloredlogrecord_with_markup():
     shimmedlogrecord = ColoredLogRecord(originallogrecord)
     # Bolding has been added to message.
     assert (
-        str(shimmedlogrecord)
-        == '<LogRecord: kivy.test, 20, test.py, 1, '
-           '"Part1: \x1b[1mPart2\x1b[0m Part 3">'
+        str(shimmedlogrecord) == "<LogRecord: kivy.test, 20, test.py, 1, "
+        '"Part1: \x1b[1mPart2\x1b[0m Part 3">'
     )
     # And there is a change in the levelname
     assert originallogrecord.levelname != shimmedlogrecord.levelname
@@ -286,3 +287,22 @@ def test_kivyformatter_colon_color():
         log_output.getvalue()
         == "[\x1b[1;32mINFO\x1b[0m   ] [Fancy       ] \x1b[1mmess\x1b[0mage\n"
     )
+
+
+@pytest.mark.logmodetest
+@pytest.mark.skipif(
+    os.environ.get("KIVY_LOG_MODE", None) != "TEST",
+    reason="Requires KIVY_LOG_MODE=TEST to run.",
+)
+def test_kivy_log_mode_marker_on():
+    """
+    This is a test of the pytest marker "logmodetest".
+    This should only be invoked if the environment variable is properly set
+    (before pytest is run).
+
+    Also, tests that kivy.logger paid attention to the environment variable
+    """
+    from kivy.logger import previous_stderr
+
+    assert sys.stderr == previous_stderr, "Kivy.logging override stderr"
+    assert logging.root.parent is None, "Kivy.logging override root logger"


### PR DESCRIPTION
Address #7970 by setting up an (undocumented, unsupported) environment variable to allow logging unit tests to run without logging being "installed".

A single test added, to show the new scheme works.

This has no impact on the API.

Also:
* Remove unused imports.
* Remove Python 2 only code.
* Run through `black` (with line-length overridden to match PEP8) to canonicalize formatting.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
