### PR TITLE
Bump KIVY_CONFIG_VERSION and add a warning for future changes.

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -386,7 +386,7 @@ from kivy.utils import platform
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 24
+KIVY_CONFIG_VERSION = 25
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -917,6 +917,8 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         elif version == 24:
             Config.setdefault("network", "implementation", "default")
 
+        # WARNING: When adding a new version migration here,
+        # don't forget to increment KIVY_CONFIG_VERSION !
         else:
             # for future.
             break


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

PR #7913 added a new config migration, without incrementing `KIVY_CONFIG_VERSION`.
That leads to a missed migration, resulting in an incomplete config.

I've also added a warning that may help future contributors.