### PR TITLE
Light clean up of stderr handling code.

### DIFF
--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -5,11 +5,10 @@ Logger tests
 
 import logging
 import os
-import sys
-
-import pytest
 import pathlib
 import time
+
+import pytest
 
 
 @pytest.fixture
@@ -302,7 +301,19 @@ def test_kivy_log_mode_marker_on():
 
     Also, tests that kivy.logger paid attention to the environment variable
     """
-    from kivy.logger import previous_stderr
+    assert logging.root.parent is None, "Overrode root logger"
 
-    assert sys.stderr == previous_stderr, "Kivy.logging override stderr"
-    assert logging.root.parent is None, "Kivy.logging override root logger"
+
+@pytest.mark.skipif(
+    os.environ.get("KIVY_LOG_MODE", None) == "TEST",
+    reason="Requires KIVY_LOG_MODE!=TEST to run.",
+)
+def test_kivy_log_mode_marker_off():
+    """
+    This is a test of the pytest marker "logmodetest".
+    This should only be invoked if the environment variable is properly set
+    (before pytest is run).
+
+    Also, tests that kivy.logger paid attention to the environment variable
+    """
+    assert logging.root.parent is not None, "Did not override root logger"


### PR DESCRIPTION
I have a confession. I think the LogFile and ConsoleHandler code is ugly. I completely rewrote it with some re-usable classes, with meaningful names, low-coupling, and lots of unit tests. It was beautiful.

But, at the last minute, when I went to write a detailed explanation of what the old code did and justify why my solution was better, despite being 5x the amount of code, I decided the problems weren't *that* bad. I was being unfair.

So I took a much lighter approach than I had intended.

What I did do:

	* LogFile is neither a file, nor does it do any logging. It is a stream-like object that processes each line with a function. Renamed to ProcessingStream.
	* Generally added comments and docstrings.
	* ConsoleHandler relied on a global constant, despite having a
	  local reference to the same value. Removed the constant.
	* Added a comment to not rely on KIVY_LOG_MODE=TEST.
	* Don't catch keyboard interrupt exceptions and the like.
	* 'l' is considered a poor choice of variable name, not least because it lookes like 1 and I.
	* Updated test to not rely on constant.
	* Added missing test to ensure that root logger *is* overridden.
	

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
