### PR TITLE
Use `SDL_WINDOWEVENT_DISPLAY_CHANGED` to notice about window switching display to update `_density` an `dpi`

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -720,6 +720,11 @@ cdef class _WindowSDL2Storage:
                     'windowmoved',
                     event.window.data1, event.window.data2
                 )
+            elif event.window.event == SDL_WINDOWEVENT_DISPLAY_CHANGED:
+                action = (
+                    'windowdisplaychanged',
+                    event.window.data1, event.window.data2
+                )
             else:
                 #    print('receive unknown sdl window event', event.type)
                 pass

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -226,6 +226,10 @@ cdef extern from "SDL.h":
         SDL_WINDOWEVENT_FOCUS_LOST     #< Window has lost keyboard focus */
         SDL_WINDOWEVENT_CLOSE          #< The window manager requests that the
                                         # window be closed */
+        SDL_WINDOWEVENT_TAKE_FOCUS     #< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore) */
+        SDL_WINDOWEVENT_HIT_TEST       #< Window had a hit test that wasn't SDL_HITTEST_NORMAL */
+        SDL_WINDOWEVENT_ICCPROF_CHANGED # [Added in SDL 2.0.18] < The ICC profile of the window's display has changed. */
+        SDL_WINDOWEVENT_DISPLAY_CHANGED # [Added in SDL 2.0.18] < Window has been moved to display data1. */
 
     ctypedef enum SDL_HintPriority:
         SDL_HINT_DEFAULT


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

🔴 It was supposed to be "Ready to Merge", but the CI is failing. We should consider how the SDL2 dep is managed on Ubuntu and other Linux distros.

⚠️ `SDL_WINDOWEVENT_DISPLAY_CHANGED` has been added on SDL `2.0.18` but needs SDL `2.24.0` to work as expected on macOS, as previously was using a non-macOS compatible logic to compute the display on which the window is really attached to (https://github.com/kivy/kivy/pull/7974 bumps SDL2 to `2.24.0`).

💡 Since now `SDL2` seems to be aware of `DPI` on all platforms (including Windows), we may want to update how `dpi` gets computed.

- Added missing `SDL_WINDOWEVENT_*` declarations for future usage.
- Handle `SDL_WINDOWEVENT_DISPLAY_CHANGED` so we can notice about a window that changed the display is attached to.
- Extract a method `_update_density_and_dpi` which updates `_density` and `dpi` to avoid DRY violations

Previously:
![no_dpi](https://user-images.githubusercontent.com/8177736/187024949-e5ea9db5-cd4d-439f-a372-b1b472f51e99.png)

After:
![ok_dpi](https://user-images.githubusercontent.com/8177736/187024956-e90b2f96-9be4-461c-b14e-4f6f0d49d42c.png)

