### PR TITLE
Handle non-strings in logs.

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -361,7 +361,7 @@ class ColoredLogRecord(logging.LogRecord):
 
     @classmethod
     def _format_message(cls, message):
-        return message.replace(
+        return str(message).replace(
             "$RESET", cls.RESET_SEQ).replace("$BOLD", cls.BOLD_SEQ)
 
     @classmethod
@@ -401,7 +401,7 @@ class UncoloredLogRecord(logging.LogRecord):
 
     @classmethod
     def _format_message(cls, message):
-        return message.replace("$RESET", "").replace("$BOLD", "")
+        return str(message).replace("$RESET", "").replace("$BOLD", "")
 
     def __init__(self, logrecord):
         super().__init__(

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -177,6 +177,22 @@ def test_colonsplittinglogrecord_without_colon():
     # No colons means no change.
     assert str(originallogrecord) == str(shimmedlogrecord)
 
+    # Try a non-string (Issue #7984)
+    originallogrecord = logging.LogRecord(
+        name="kivy.test",
+        level=logging.DEBUG,
+        pathname="test.py",
+        lineno=1,
+        msg=1,
+        args=None,
+        exc_info=None,
+        func="test_colon_splitting",
+        sinfo=None,
+    )
+    shimmedlogrecord = ColonSplittingLogRecord(originallogrecord)
+    # No colons means no change.
+    assert str(originallogrecord) == str(shimmedlogrecord)
+
 
 def test_uncoloredlogrecord_without_markup():
     from kivy.logger import UncoloredLogRecord
@@ -194,6 +210,21 @@ def test_uncoloredlogrecord_without_markup():
     )
     shimmedlogrecord = UncoloredLogRecord(originallogrecord)
     # No markup means no change.
+    assert str(originallogrecord) == str(shimmedlogrecord)
+
+    # Try a non-string (Issue #7984)
+    originallogrecord = logging.LogRecord(
+        name="kivy.test",
+        level=logging.DEBUG,
+        pathname="test.py",
+        lineno=1,
+        msg=1,
+        args=None,
+        exc_info=None,
+        func="test_colon_splitting",
+        sinfo=None,
+    )
+    shimmedlogrecord = UncoloredLogRecord(originallogrecord)
     assert str(originallogrecord) == str(shimmedlogrecord)
 
 
@@ -239,6 +270,21 @@ def test_coloredlogrecord_without_markup():
     # But there is a change in the levelname
     assert originallogrecord.levelname != shimmedlogrecord.levelname
     assert shimmedlogrecord.levelname == "\x1b[1;36mDEBUG\x1b[0m"
+
+    # Try a non-string (Issue #7984)
+    originallogrecord = logging.LogRecord(
+        name="kivy.test",
+        level=logging.DEBUG,
+        pathname="test.py",
+        lineno=1,
+        msg=1,
+        args=None,
+        exc_info=None,
+        func="test_colon_splitting",
+        sinfo=None,
+    )
+    shimmedlogrecord = ColoredLogRecord(originallogrecord)
+    assert str(originallogrecord) == str(shimmedlogrecord)
 
 
 def test_coloredlogrecord_with_markup():


### PR DESCRIPTION
Fixes #7984 

LogRecords may contain non-string messages (not just non-string args) that aren't converted to strings until the last moment (to save expensive effort if the log message is never emitted).

Bug introduced recently with Colored/UncoloredLogRecords did not convert to str before replacing color markings (if any).

* str() added.
* Unit tests added (used to fail, now pass)

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
