### PR TITLE
Add colored emoji support for TextInputs

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -196,7 +196,7 @@
             pos: self._cursor_visual_pos
             size: root.cursor_width, -self._cursor_visual_height
         Color:
-            rgba: self.disabled_foreground_color if self.disabled else (self.hint_text_color if not self.text else self.foreground_color)
+            rgba: (1, 1, 1, 1)
 
 <TextInputCutCopyPaste>:
     content: content.__self__

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -566,6 +566,9 @@ class TextInput(FocusBehavior, Widget):
         fbind('font_family', refresh_line_options)
         fbind('base_direction', refresh_line_options)
         fbind('text_language', refresh_line_options)
+        fbind('foreground_color', refresh_line_options)
+        fbind('disabled_foreground_color', refresh_line_options)
+        fbind('hint_text_color', refresh_line_options)
 
         def handle_readonly(instance, value):
             if value and (not _is_desktop or not self.allow_copy):
@@ -2638,7 +2641,7 @@ class TextInput(FocusBehavior, Widget):
 
         kw = self._get_line_options()
         kw['color'] = self.disabled_foreground_color if self.disabled\
-            else (self.hint_text_color if not text else self.foreground_color)
+            else (self.hint_text_color if hint else self.foreground_color)
         cid = '%s\0%s' % (ntext, str(kw))
         texture = Cache_get('textinput.label', cid)
 

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2637,6 +2637,8 @@ class TextInput(FocusBehavior, Widget):
             ntext = self.password_mask * len(ntext)
 
         kw = self._get_line_options()
+        kw['color'] = self.disabled_foreground_color if self.disabled\
+            else (self.hint_text_color if not text else self.foreground_color)
         cid = '%s\0%s' % (ntext, str(kw))
         texture = Cache_get('textinput.label', cid)
 


### PR DESCRIPTION
## Description

This PR aims at answering the following issue: https://github.com/kivy/kivy/issues/7995

Currently, Labels render colored emojis correctly but not TextInputs. I believe the origin of the problem is that when a TextInput creates Labels to get the textures for each line, it does not do it in the same way as if it were a standard stand-alone Label. More specifically, the Labels are created without a value for the `color` property. As a result, the texture is made of pixels in shades of grey (except for emojis). Later, when the textures are added to the Canvas of the TextInput, they are colored by a Color instruction based on the value of the `foreground_color` property of TextInput. That way, the whome texture is made in shades of that given color. This is not a problem for regular text but that does not work for emojis that end being recolored monochromatically.

The solution is to treat Labels used in TextInputs like regular Labels by setting a value the `color` property following the same logic that was contained in the Color instruction (the graphic provider will not apply the `color` to emojis by itself I believe). Then, the Color instruction of the canvas is set to (1, 1, 1, 1) such that the texture's color are not modified.

## Testing
The tests `test_uix_textinput` are successful and the few tests I've done with the example in the issue work fine

## Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
