### PR TITLE
Modify layout fix bug in how long text without space is cut 

### DIFF
--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -397,7 +397,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     cdef int lhh, lww, k, bare_h, dwn = append_down, pos = 0
     cdef object line, ln, val, indices
     cdef LayoutLine _line
-    cdef int is_space = 0
+    cdef int is_space
     uw = text_size[0] if text_size[0] is not None else -1
     uh = text_size[1] if text_size[1] is not None else -1
 
@@ -419,6 +419,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     # split into lines and find how many line wraps each line requires
     indices = range(n) if dwn else reversed(range(n))
     for i in indices:
+        is_space = 0
         k = <int>len(lines)
         if (max_lines > 0 and k > max_lines or uh != -1 and
             h > uh and k > 1):


### PR DESCRIPTION
This PR aims at answering the following issue: https://github.com/kivy/kivy/issues/7998

As explained in the issue, the function `layout_text` cuts a line at the wrong place in certain cases. Upon reading the code source for this function, I came to the conclusion that it's probably caused by the fact that the value of the variable `is_space` is not reset to 0 at each iteration over the lines. I think so because:
- The change I propose below solved the example presented in the issue and did not cause any problem in the tests I've done (which consisted in trying out many random strings)
- I can't make sense of why we would initially give the value 0 to `is_space` but then not set this starting value again for each line leading to a situation in which lines can influence each other's layout
However, there's a lot I do not understand in this file, so maybe there's just something I don't get

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
