### PR TITLE
Bump kivy_deps.sdl2 and kivy_deps.sdl2_dev to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ requires = [
     "setuptools", "wheel",
     "cython>=0.24,<=0.29.28,!=0.27,!=0.27.2",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2_dev~=0.4.5; sys_platform == "win32"',
+    'kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"',
     'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
     'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2~=0.4.5; sys_platform == "win32"',
+    'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
     'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     docutils
     pygments
     kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
@@ -48,7 +48,7 @@ dev =
     sphinxcontrib-nwdiag
     funcparserlib==1.0.0a0
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
-    kivy_deps.sdl2_dev~=0.4.5; sys_platform == "win32"
+    kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"
     kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"
     flake8
     pre-commit
@@ -59,7 +59,7 @@ base =
     docutils
     pygments
     kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 media =
@@ -71,7 +71,7 @@ full =
     pygments
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
     pypiwin32; sys_platform == "win32"
@@ -80,7 +80,7 @@ gstreamer =
 angle =
     kivy_deps.angle~=0.3.2; sys_platform == "win32"
 sdl2 =
-    kivy_deps.sdl2~=0.4.5; sys_platform == "win32"
+    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
 glew =
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

- Now also Windows relies on latest SDL2 update. See: https://github.com/kivy/kivy/pull/7974
- We released `kivy_deps.sdl2` this morning: https://pypi.org/project/kivy-deps.sdl2/0.5.0/#files