### PR TITLE
fix TypeError regarding the VKeyboard

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -647,7 +647,7 @@ class WindowBase(EventDispatcher):
             and self._vkeyboard_cls is not None
         ):
             for w in self.children:
-                if isinstance(w, VKeyboard):
+                if isinstance(w, type(VKeyboard)):
                     vkeyboard_height = w.height * w.scale
                     if self.softinput_mode == 'pan':
                         return vkeyboard_height


### PR DESCRIPTION
When porting my app from kivy 2.0.0 to 2.1.0 I encountered the following exception during startup. The app uses a custom keyboard class with self.root_window.set_vkeyboard_class(CustomKeyboard).
The proposed change fixes the issue

Traceback (most recent call last):
  File "kivy/_clock.pyx", line 649, in kivy._clock.CyClockBase._process_events
  File "kivy/_clock.pyx", line 218, in kivy._clock.ClockEvent.tick
  File "/home/pi/servoklippo/klippy-environment/lib/python3.10/site-packages/kivy/core/window/__init__.py", line 628, in _upd_kbd_height
    self._keyboard_changed = not self._keyboard_changed
  File "kivy/properties.pyx", line 520, in kivy.properties.Property.__set__
  File "kivy/properties.pyx", line 567, in kivy.properties.Property.set
  File "kivy/properties.pyx", line 606, in kivy.properties.Property._dispatch
  File "kivy/_event.pyx", line 1307, in kivy._event.EventObservers.dispatch
  File "kivy/_event.pyx", line 1213, in kivy._event.EventObservers._dispatch
  File "kivy/properties.pyx", line 1639, in kivy.properties.AliasProperty.trigger_change
  File "kivy/properties.pyx", line 1641, in kivy.properties.AliasProperty.trigger_change
  File "/home/pi/servoklippo/klippy-environment/lib/python3.10/site-packages/kivy/core/window/__init__.py", line 666, in _get_kheight
    return self._get_kivy_vkheight()
  File "/home/pi/servoklippo/klippy-environment/lib/python3.10/site-packages/kivy/core/window/__init__.py", line 650, in _get_kivy_vkheight
    if isinstance(w, VKeyboard):
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
