### PR TITLE
Release the GIL when performing SDL_GL_SwapWindow call.

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -746,7 +746,13 @@ cdef class _WindowSDL2Storage:
             pass
 
     def flip(self):
-        SDL_GL_SwapWindow(self.win)
+        # On Android (and potentially other platforms), SDL_GL_SwapWindow may
+        # lock the thread waiting for a mutex from another thread to be
+        # released. Calling SDL_GL_SwapWindow with the GIL released allow the
+        # other thread to run (e.g. to process the event filter callback) and
+        # release the mutex SDL_GL_SwapWindow is waiting for.
+        with nogil:
+            SDL_GL_SwapWindow(self.win)
 
     def save_bytes_in_png(self, filename, data, int width, int height):
         cdef SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -627,7 +627,7 @@ cdef extern from "SDL.h":
     cdef SDL_GLContext SDL_GL_GetCurrentContext()
     cdef int SDL_GL_SetSwapInterval(int interval)
     cdef int SDL_GL_GetSwapInterval()
-    cdef void SDL_GL_SwapWindow(SDL_Window * window)
+    cdef void SDL_GL_SwapWindow(SDL_Window * window) nogil
     cdef void SDL_GL_DeleteContext(SDL_GLContext context)
 
     cdef int SDL_NumJoysticks()


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

**TL;DR;** On Android, `SDL` implemented an Activity lock guard (`SDL_LockMutex(Android_ActivityMutex);`), and that does not fit well with Python GIL ( for a specific reason).

This change is not needed with the current `python-for-android` release, but it will be needed when upgrading to a newer SDL2 version: https://github.com/kivy/python-for-android/pull/2673.

Thanks to the SDL team who helped with the debugging, I found a deadlock condition that was causing the app to freeze.

## Preface:

We use `SDL_SetEventFilter` so we can catch some events before they are added to the queue. (And that may need some rework)
https://github.com/kivy/kivy/blob/fd12906efa5b4eb3f56c6b3d2c737b79228aa48a/kivy/core/window/_window_sdl2.pyx#L259
The callback passed to `SDL_SetEventFilter` requires the GIL.
https://github.com/kivy/kivy/blob/fd12906efa5b4eb3f56c6b3d2c737b79228aa48a/kivy/core/window/_window_sdl2.pyx#L27-L28

## Analysis:

On SDL side, the `onNativeTouch` callback is called, but `Android_ActivityMutex` is already locked by `Android_GLES_SwapWindow` (from a different thread), so it waits until `Android_ActivityMutex` gets unlocked.
```
10-01 13:51:11.327  5356  5356 V SDL     : onNativeTouch()-Lock
10-01 13:51:11.328  5356  5386 V SDL     : Android_GLES_SwapWindow()-Unlock
10-01 13:51:11.328  5356  5386 V SDL     : Android_GLES_SwapWindow()-UnlockED
```
The `Android_GLES_SwapWindow` finishes and unlocks `Android_ActivityMutex` so `onNativeTouch` can now lock `Android_ActivityMutex`. The touch event then gets pushed via `SDL_PushEvent`, where 
```
10-01 13:51:11.328  5356  5356 V SDL     : onNativeTouch()-LockED
10-01 13:51:11.328  5356  5356 V SDL     : in SDL_PushEvent -> Type: 1024
10-01 13:51:11.328  5356  5356 V SDL     : in SDL_LockMutex(SDL_event_watchers_lock) -> Type: 1024
10-01 13:51:11.328  5356  5356 V SDL     : in SDL_LockMutex(SDL_event_watchers_lock) [LOCKED] -> Type: 1024
```

the `SDL_EventOK.callback` (which as said before requires the GIL on the Python side), gets called but looks stuck.
```c
if (!SDL_event_watchers_lock || SDL_LockMutex(SDL_event_watchers_lock) == 0) {
        if (SDL_EventOK.callback && !SDL_EventOK.callback(SDL_EventOK.userdata, event)) {  \\ <--- We are now here
            if (SDL_event_watchers_lock) {
                SDL_UnlockMutex(SDL_event_watchers_lock);
            }
            return 0;
        }
```

Why? Well, meanwhile on thread `5386` our `flip` method, which is calling `SDL_GL_SwapWindow` have the GIL locked, and can't release it as `Android_GLES_SwapWindow` is stuck on `SDL_LockMutex(Android_ActivityMutex);`, waiting for `onNativeTouch` to unlock the `Android_ActivityMutex`.
```
10-01 13:51:11.332  5356  5386 V SDL     : Android_GLES_SwapWindow()-Lock
```
Ouch. deadlocked.

For more info, see: https://github.com/libsdl-org/SDL/issues/3679

## Results after these changes:

Why you resurrected an old test app from issue https://github.com/kivy/python-for-android/issues/2002 ? (https://github.com/jere-botes/KivyBench)

Well looks like we previously reverted a PR (Original: https://github.com/kivy/kivy/pull/4219, Reverts it: https://github.com/kivy/kivy/pull/6578) that added `nogil` when calling `SDL_GL_SwapWindow`, so I was afraid to re-introduce an issue.

From my tests, the `nogil` on `SDL_GL_SwapWindow ` does not create any performance drop. (Tested on `Samsung S10e Android 12` and `Android Emulator (arm64): Pixel 6 Pro API 33` (even with 200 widgets runs at 60fps).

Before these changes (freeze):

https://user-images.githubusercontent.com/8177736/193445245-ff2096db-1474-4835-acc4-d598ae3dc078.mov

After these changes (no freeze and 60fps with 200 widgets):

https://user-images.githubusercontent.com/8177736/193445265-3063a353-50c7-4918-9516-23434b7f5404.mov


