### PR TITLE
Bump SDL2 to `2.24.1` on Linux and macOS

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 # macOS SDL2
-MACOS__SDL2__VERSION="2.24.0"
+MACOS__SDL2__VERSION="2.24.1"
 MACOS__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MACOS__SDL2__VERSION/SDL2-$MACOS__SDL2__VERSION.tar.gz"
 MACOS__SDL2__FOLDER="SDL2-$MACOS__SDL2__VERSION"
 

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 # manylinux SDL2
-MANYLINUX__SDL2__VERSION="2.24.0"
+MANYLINUX__SDL2__VERSION="2.24.1"
 MANYLINUX__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MANYLINUX__SDL2__VERSION/SDL2-$MANYLINUX__SDL2__VERSION.tar.gz"
 MANYLINUX__SDL2__FOLDER="SDL2-$MANYLINUX__SDL2__VERSION"
 


### PR DESCRIPTION
This update is to include some fix on shader compilation using the OpenGL ES2 renderer (see https://github.com/libsdl-org/SDL/releases/tag/release-2.24.1).

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.