### PR TITLE
Bump again SDL2 to 2.24.2 on Linux and macOS

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 # macOS SDL2
-MACOS__SDL2__VERSION="2.24.0"
+MACOS__SDL2__VERSION="2.24.1"
 MACOS__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MACOS__SDL2__VERSION/SDL2-$MACOS__SDL2__VERSION.tar.gz"
 MACOS__SDL2__FOLDER="SDL2-$MACOS__SDL2__VERSION"
 

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 # macOS SDL2
-MACOS__SDL2__VERSION="2.24.1"
+MACOS__SDL2__VERSION="2.24.2"
 MACOS__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MACOS__SDL2__VERSION/SDL2-$MACOS__SDL2__VERSION.tar.gz"
 MACOS__SDL2__FOLDER="SDL2-$MACOS__SDL2__VERSION"
 

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 # manylinux SDL2
-MANYLINUX__SDL2__VERSION="2.24.1"
+MANYLINUX__SDL2__VERSION="2.24.2"
 MANYLINUX__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MANYLINUX__SDL2__VERSION/SDL2-$MANYLINUX__SDL2__VERSION.tar.gz"
 MANYLINUX__SDL2__FOLDER="SDL2-$MANYLINUX__SDL2__VERSION"
 

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -2,7 +2,7 @@
 set -e -x
 
 # manylinux SDL2
-MANYLINUX__SDL2__VERSION="2.24.0"
+MANYLINUX__SDL2__VERSION="2.24.1"
 MANYLINUX__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MANYLINUX__SDL2__VERSION/SDL2-$MANYLINUX__SDL2__VERSION.tar.gz"
 MANYLINUX__SDL2__FOLDER="SDL2-$MANYLINUX__SDL2__VERSION"
 


### PR DESCRIPTION
SDL 2.24.1 said that they fixed shader compilation using the OpenGL ES2 renderer (see https://github.com/libsdl-org/SDL/releases/tag/release-2.24.1), but when I check all the commit, I saw nothing about Open GL. Now a new release was made by SDL (https://github.com/libsdl-org/SDL/releases/tag/release-2.24.2) and I found the commit that fix the Open GL compilation (see https://github.com/libsdl-org/SDL/commit/bc57d3e35ce0067a1098ef72857351fcf93469b3).

The only thing I'm not sure about my PR is the SDK minimal required in SDL 2.24.2. Now they said that the minimal requirement is SDK>=31 (https://github.com/libsdl-org/SDL/commit/e6864d17b6519b70bb7c6c627832902b50d0e472). It is a problem?
