### PR TITLE
Makes Windows DPI aware of scale changes

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -420,7 +420,7 @@ class WindowBase(EventDispatcher):
     def _get_size(self):
         r = self._rotation
         w, h = self._size
-        if self._density != 1:
+        if platform == 'win' or self._density != 1:
             w, h = self._win._get_gl_size()
         if self.softinput_mode == 'resize':
             h -= self.keyboard_height
@@ -519,7 +519,7 @@ class WindowBase(EventDispatcher):
     # make some property read-only
     def _get_width(self):
         _size = self._size
-        if self._density != 1:
+        if platform == 'win' or self._density != 1:
             _size = self._win._get_gl_size()
         r = self._rotation
         if r == 0 or r == 180:
@@ -536,7 +536,7 @@ class WindowBase(EventDispatcher):
         '''Rotated window height'''
         r = self._rotation
         _size = self._size
-        if self._density != 1:
+        if platform == 'win' or self._density != 1:
             _size = self._win._get_gl_size()
         kb = self.keyboard_height if self.softinput_mode == 'resize' else 0
         if r == 0 or r == 180:
@@ -739,13 +739,13 @@ class WindowBase(EventDispatcher):
     '''
 
     def _get_effective_size(self):
-        '''On density=1 and non-ios displays, return :attr:`system_size`,
-        else return scaled / rotated :attr:`size`.
+        '''On density=1 and non-ios / non-Windows displays,
+        return :attr:`system_size`, else return scaled / rotated :attr:`size`.
 
         Used by MouseMotionEvent.update_graphics() and WindowBase.on_motion().
         '''
         w, h = self.system_size
-        if platform == 'ios' or self._density != 1:
+        if platform in ('ios', 'win') or self._density != 1:
             w, h = self.size
 
         return w, h

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -112,7 +112,7 @@ cdef class _WindowSDL2Storage:
         
         # makes dpi aware of scale changes
         if platform == "win":
-            SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS , b'permonitorv2')
+            SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, b"1")
 
         if SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0:
             self.die()

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -109,6 +109,10 @@ cdef class _WindowSDL2Storage:
 
         SDL_SetHintWithPriority(b'SDL_ANDROID_TRAP_BACK_BUTTON', b'1',
                                 SDL_HINT_OVERRIDE)
+        
+        # makes dpi aware of scale changes
+        if platform == "win":
+            SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS , b'permonitorv2')
 
         if SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0:
             self.die()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -392,8 +392,6 @@ class WindowSDL(WindowBase):
             self._win_dpi_watch.start()
 
     def _update_density_and_dpi(self):
-        old_dpi = self.dpi
-
         if platform == 'win':
             from ctypes import windll
             self._density = 1.
@@ -402,21 +400,10 @@ class WindowSDL(WindowBase):
                 self.dpi = float(windll.user32.GetDpiForWindow(hwnd))
             except AttributeError:
                 pass
-            self._update_initial_size_on_dpi_change(old_dpi)
-
         else:
             self._density = self._win._get_gl_size()[0] / self._size[0]
             if self._is_desktop:
                 self.dpi = self._density * 96.
-
-    def _update_initial_size_on_dpi_change(self, old_dpi):
-        if not self.initialized:
-
-            def update_size(_):
-                ratio = self.dpi / old_dpi
-                self.size = ratio * self.size[0], ratio * self.size[1]
-
-            Clock.schedule_once(update_size, -1)
 
     def close(self):
         self._win.teardown_window()
@@ -994,8 +981,6 @@ class _WindowsSysDPIWatch:
         from ctypes import windll
 
         if msg == WM_DPICHANGED:
-            ow, oh = self.window.size
-            old_dpi = self.window.dpi
 
             def clock_callback(*args):
                 if x_dpi != y_dpi:
@@ -1003,10 +988,6 @@ class _WindowsSysDPIWatch:
                         'Can only handle DPI that are same for x and y')
 
                 self.window.dpi = x_dpi
-
-                # maintain the same window size
-                ratio = x_dpi / old_dpi
-                self.window.size = ratio * ow, ratio * oh
 
             x_dpi = wParam & 0xFFFF
             y_dpi = wParam >> 16

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -392,6 +392,8 @@ class WindowSDL(WindowBase):
             self._win_dpi_watch.start()
 
     def _update_density_and_dpi(self):
+        old_dpi = self.dpi
+
         if platform == 'win':
             from ctypes import windll
             self._density = 1.
@@ -400,10 +402,21 @@ class WindowSDL(WindowBase):
                 self.dpi = float(windll.user32.GetDpiForWindow(hwnd))
             except AttributeError:
                 pass
+            self._update_initial_size_on_dpi_change(old_dpi)
+
         else:
             self._density = self._win._get_gl_size()[0] / self._size[0]
             if self._is_desktop:
                 self.dpi = self._density * 96.
+
+    def _update_initial_size_on_dpi_change(self, old_dpi):
+        if not self.initialized:
+
+            def update_size(_):
+                ratio = self.dpi / old_dpi
+                self.size = ratio * self.size[0], ratio * self.size[1]
+
+            Clock.schedule_once(update_size, -1)
 
     def close(self):
         self._win.teardown_window()

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -480,6 +480,7 @@ cdef extern from "SDL.h":
     cdef char *SDL_HINT_VIDEO_WIN_D3DCOMPILER
     cdef char *SDL_HINT_ACCELEROMETER_AS_JOYSTICK
     cdef char *SDL_HINT_ANDROID_TRAP_BACK_BUTTON
+    cdef char *SDL_HINT_WINDOWS_DPI_AWARENESS
 
     cdef int SDL_QUERY               = -1
     cdef int SDL_IGNORE              =  0

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -481,6 +481,7 @@ cdef extern from "SDL.h":
     cdef char *SDL_HINT_ACCELEROMETER_AS_JOYSTICK
     cdef char *SDL_HINT_ANDROID_TRAP_BACK_BUTTON
     cdef char *SDL_HINT_WINDOWS_DPI_AWARENESS
+    cdef char *SDL_HINT_WINDOWS_DPI_SCALING
 
     cdef int SDL_QUERY               = -1
     cdef int SDL_IGNORE              =  0


### PR DESCRIPTION
On Windows, changing the scale factor will result in the window stretching, rather than changing kivy's internal DPI metrics. As a result, the window appears with a blurred interface.


### Below is the behavior when setting the scale to 125%.

- **Previously (kivy → `2.1.0`):**

  ![master](https://user-images.githubusercontent.com/73297572/202256287-d63058fc-3265-40e5-8f84-f581088102a7.png)

- **After this PR:**

  ![pr](https://user-images.githubusercontent.com/73297572/222928887-501f8bbd-3f81-4bb7-b3e9-0b32b137cdcc.png)

<br>

[SDL_HINT_WINDOWS_DPI_SCALING](https://github.com/libsdl-org/SDL/blob/0dfc829a6b75b5a3c4c1d49fb943b622c12d67bc/include/SDL_hints.h#L2082) was introduced in SDL `2.24.0`, with two options:

- `"0"` - SDL coordinates equal Windows coordinates. No automatic window resizing when dragging between monitors with different scale factors (unless this is performed by Windows itself, which is the case when the process is DPI unaware).
- `"1"` - SDL coordinates are in DPI-scaled points. Automatically resize windows as needed on displays with non-100% scale factors.

Setting SDL_HINT_WINDOWS_DPI_SCALING to "1" will automatically request process DPI awareness and enable the SDL_WINDOW_ALLOW_HIGHDPI flag for all windows.

This change updates the SDL coordinate system units to use DPI-scaled points instead of pixels on Windows. This ensures that windows are appropriately sized regardless of the display's DPI scaling settings, such as on high-DPI displays.

For example, requesting a 640x480px window on a display with 125% scaling will result in an window with 800x600px.

With these modifications, a previous workaround that resized the screen on every DPI change has been removed.


For testing:

```python
from kivy.app import App
from kivy.uix.button import Button
from kivy.metrics import dp


class TestDPI(App):
    def build(self):
        return Button(text=f"1dp is equivalent to {dp(1)}dp", font_size=40)


TestDPI().run()
```

<br>

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
