### PR TITLE
Use `find_spec`, `module_from_spec` and `exec_module` instead of `find_module` and `load_module` since are deprecated.

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -36,6 +36,7 @@ from os import environ, mkdir
 from os.path import dirname, join, basename, exists, expanduser
 import pkgutil
 import re
+import importlib
 from kivy.logger import Logger, LOG_LEVELS
 from kivy.utils import platform
 from kivy._version import __version__, RELEASE as _KIVY_RELEASE, \
@@ -314,7 +315,9 @@ except ImportError:
 _logging_msgs = []
 for importer, modname, package in _packages:
     try:
-        mod = importer.find_module(modname).load_module(modname)
+        module_spec = importer.find_spec(modname)
+        mod = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(mod)
 
         version = ''
         if hasattr(mod, '__version__'):

--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -294,7 +294,9 @@ def add_dep_paths():
             if not ispkg:
                 continue
             try:
-                mod = importer.find_module(modname).load_module(modname)
+                module_spec = importer.find_spec(modname)
+                mod = importlib.util.module_from_spec(module_spec)
+                module_spec.loader.exec_module(mod)
             except ImportError as e:
                 logging.warning(f"deps: Error importing dependency: {e}")
                 continue
@@ -311,7 +313,9 @@ def add_dep_paths():
         if not ispkg:
             continue
         try:
-            mod = importer.find_module(modname).load_module(modname)
+            module_spec = importer.find_spec(modname)
+            mod = importlib.util.module_from_spec(module_spec)
+            module_spec.loader.exec_module(mod)
         except ImportError as e:
             logging.warning(f"deps: Error importing dependency: {e}")
             continue


### PR DESCRIPTION
Fixes issue #8060 

> Running any test causes three deprecation warnings for find_module() getting removed in python 3.12

```
<frozen importlib._bootstrap_external>:1523
<frozen importlib._bootstrap_external>:1523
<frozen importlib._bootstrap_external>:1523
<frozen importlib._bootstrap_external>:1523
<frozen importlib._bootstrap_external>:1523
<frozen importlib._bootstrap_external>:1523
<frozen importlib._bootstrap_external>:1523
  <frozen importlib._bootstrap_external>:1523: DeprecationWarning: FileFinder.find_loader() is deprecated and slated for removal in Python 3.12; use find_spec() instead

<frozen importlib._bootstrap>:283
<frozen importlib._bootstrap>:283
<frozen importlib._bootstrap>:283
<frozen importlib._bootstrap>:283
<frozen importlib._bootstrap>:283
<frozen importlib._bootstrap>:283
<frozen importlib._bootstrap>:283
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Additionally of what reported from the user, also updates the `pyinstaller` hook script.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
