### PR TITLE
Fix "ext_modules option must be an Extension instance" error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ if "--build_examples" in sys.argv:
     build_examples = True
     sys.argv.remove("--build_examples")
 
+from setuptools import setup, Extension, find_packages
 from kivy.utils import pi_version
 from copy import deepcopy
 import os
@@ -22,7 +23,6 @@ from time import sleep
 from sysconfig import get_paths
 from pathlib import Path
 import logging
-from setuptools import setup, Extension, find_packages
 
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
Fixes build error:

  distutils.errors.DistutilsSetupError: each element of 'ext_modules' option must be an Extension instance or 2-tuple

I get this error if building the latest master branch in Debian testing.

Apparently, this can occur if distutils is loaded before loading setuptools. See:

  https://stackoverflow.com/questions/21594925/error-each-element-of-ext-modules-option-must-be-an-extension-instance-or-2-t

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
