### PR TITLE
Remove usage of `distutils` module which is deprecated and slated for removal in 3.12

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -18,7 +18,7 @@ update_version_metadata() {
 }
 
 generate_sdist() {
-  python3 -m pip install cython
+  python3 -m pip install cython packaging
   python3 setup.py sdist --formats=gztar
   python3 -m pip uninstall cython -y
 }

--- a/kivy/tools/packaging/factory.py
+++ b/kivy/tools/packaging/factory.py
@@ -2,9 +2,11 @@ from __future__ import print_function
 
 __all__ = ('FactoryBuild', )
 
-from distutils.cmd import Command
 import fnmatch
 import os
+
+from setuptools import Command
+
 import kivy
 
 ignore_list = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools", "wheel",
+    "setuptools", "wheel", "packaging",
     "cython>=0.24,<=0.29.33,!=0.27,!=0.27.2",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
     'kivy_deps.sdl2_dev~=0.6.0; sys_platform == "win32"',


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `version changed` as needed.

⚠️ ~~Marked as WIP as it needs to be tested along all the supported platforms~~  ⚠️ 

Performed tests:
- [x] macOS
- [x] Linux
- [x] Windows
- [x] Android (`python-for-android`) https://github.com/kivy/python-for-android/pull/2715
- [x] iOS (`kivy-ios`) https://github.com/kivy/kivy-ios/pull/753

That PR follows the migration advice contained in [PEP632](https://peps.python.org/pep-0632/#migration-advice)