### PR TITLE
New Feature: Always On Top

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -249,6 +249,10 @@ Available configuration tokens
         :class:`~kivy.uix.behaviors.buttonbehavior.ButtonBehavior` to
         make sure they display their current visual state for the given
         time.
+    `always_on_top`: int, one of ``0`` or ``1``, defaults to ``0``
+        When enabled, the window will be brought to the front and will keep
+        the window above the rest. Only works for the sdl2 window provider.
+        ``0`` is disabled, ``1`` is enabled.
     `allow_screensaver`: int, one of 0 or 1, defaults to 1
         Allow the device to show a screen saver, or to go to sleep
         on mobile devices. Only works for the sdl2 window provider.
@@ -332,6 +336,9 @@ Available configuration tokens
     Check the specific module's documentation for a list of accepted
     arguments.
 
+.. versionadded:: 2.2.0
+    `always_on_top` have been added to the `graphics` section.
+
 .. versionchanged:: 2.2.0
     `implementation` has been added to the network section.
 
@@ -392,7 +399,7 @@ from kivy.utils import platform
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 25
+KIVY_CONFIG_VERSION = 26
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -922,6 +929,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 24:
             Config.setdefault("network", "implementation", "default")
+
+        elif version == 25:
+            Config.setdefault('graphics', 'always_on_top', '0')
 
         # WARNING: When adding a new version migration here,
         # don't forget to increment KIVY_CONFIG_VERSION !

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -221,6 +221,10 @@ class WindowBase(EventDispatcher):
             Minimum width of the window (only works for sdl2 window provider).
         `minimum_height`: int
             Minimum height of the window (only works for sdl2 window provider).
+        `always_on_top`: bool
+            When enabled, the window will be brought to the front and will keep
+            the window above the rest. If disabled, it will restore the default
+            behavior. Only works for the sdl2 window provider.
         `allow_screensaver`: bool
             Allow the device to show a screen saver, or to go to sleep
             on mobile devices. Defaults to True. Only works for sdl2 window
@@ -449,6 +453,22 @@ class WindowBase(EventDispatcher):
 
     :attr:`minimum_height` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 0.
+    '''
+
+    always_on_top = BooleanProperty(False)
+    '''When enabled, the window will be brought to the front and will keep
+    the window above the rest. If disabled, it will restore the default
+    behavior.
+
+    This option can be toggled freely during the window's lifecycle.
+
+    Only works for the sdl2 window provider. Check the :mod:`~kivy.config`
+    documentation for a more detailed explanation on the values.
+
+    .. versionadded:: 2.2.0
+
+    :attr:`always_on_top` is a :class:`~kivy.properties.BooleanProperty` and
+    defaults to False.
     '''
 
     allow_screensaver = BooleanProperty(True)
@@ -1021,6 +1041,10 @@ class WindowBase(EventDispatcher):
         if 'minimum_height' not in kwargs:
             kwargs['minimum_height'] = Config.getint('graphics',
                                                      'minimum_height')
+        if 'always_on_top' not in kwargs:
+            kwargs['always_on_top'] = Config.getboolean(
+                'graphics', 'always_on_top'
+            )
         if 'allow_screensaver' not in kwargs:
             kwargs['allow_screensaver'] = Config.getboolean(
                 'graphics', 'allow_screensaver')

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -339,6 +339,9 @@ cdef class _WindowSDL2Storage:
     def set_minimum_size(self, w, h):
         SDL_SetWindowMinimumSize(self.win, w, h)
 
+    def set_always_on_top(self, always_on_top):
+        SDL_SetWindowAlwaysOnTop(self.win, SDL_TRUE if always_on_top else SDL_FALSE)
+
     def set_allow_screensaver(self, allow_screensaver):
         if allow_screensaver:
             SDL_EnableScreenSaver()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -214,6 +214,7 @@ class WindowSDL(WindowBase):
                   minimum_height=self._set_minimum_size)
 
         self.bind(allow_screensaver=self._set_allow_screensaver)
+        self.bind(always_on_top=self._set_always_on_top)
 
     def get_window_info(self):
         return self._win.get_window_info()
@@ -227,6 +228,9 @@ class WindowSDL(WindowBase):
             Logger.warning(
                 'Both Window.minimum_width and Window.minimum_height must be '
                 'bigger than 0 for the size restriction to take effect.')
+
+    def _set_always_on_top(self, *args):
+        self._win.set_always_on_top(self.always_on_top)
 
     def _set_allow_screensaver(self, *args):
         self._win.set_allow_screensaver(self.allow_screensaver)
@@ -334,6 +338,7 @@ class WindowSDL(WindowBase):
             self._pos = (0, 0)
             self._set_minimum_size()
             self._set_allow_screensaver()
+            self._set_always_on_top()
 
             if state == 'hidden':
                 self._focus = False

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -597,6 +597,7 @@ cdef extern from "SDL.h":
     cdef void SDL_GetWindowSize(SDL_Window * window, int *w, int *h)
     cdef void SDL_SetWindowMinimumSize(SDL_Window * window, int min_w, int min_h)
     cdef void SDL_SetWindowBordered(SDL_Window * window, SDL_bool bordered)
+    cdef void SDL_SetWindowAlwaysOnTop(SDL_Window * window, SDL_bool on_top)
     cdef void SDL_ShowWindow(SDL_Window * window)
     cdef int SDL_ShowCursor(int toggle)
     cdef void SDL_SetCursor(SDL_Cursor * cursor)


### PR DESCRIPTION
Sets the window to always be on top of others.

<br>

Can be modified at runtime:
- `True` → This will bring the window to the front and keep the window above the rest.
- `False` → Will restore the window's default behavior.

<br>

[SDL_SetWindowAlwaysOnTop](https://wiki.libsdl.org/SDL2/SDL_SetWindowAlwaysOnTop) is available since SDL `2.0.16`.

<br>

For testing:

```python
from kivy.config import Config
Config.set("graphics", "always_on_top", 1)  # The app will start with the window on top

from kivy.app import App
from kivy.uix.button import Button
from kivy.core.window import Window


class AlwaysOnTopApp(App):

    def build(self):

        def do(button_instance):
            Window.always_on_top = not Window.always_on_top
            button_instance.text = f"always_on_top == {Window.always_on_top}"

        b = Button(text=f"always_on_top == {Window.always_on_top}", font_size=40)
        b.bind(on_press=do)

        return b


AlwaysOnTopApp().run()
```

<br>

⚠️ CI is expected to fail as this  [issue](https://github.com/kivy/kivy/issues/7983) needs to be addressed before this PR is merged.

<br>

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
