### PR TITLE
Allow changing `Window.fullscreen` and `Window.borderless` options after setup on iOS

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1439,7 +1439,7 @@ class WindowBase(EventDispatcher):
         self.trigger_create_window.cancel()
 
         # ensure the window creation will not be called twice
-        if platform in ('android', 'ios'):
+        if platform in ('android'):
             self._unbind_create_window()
 
         if not self.initialized:

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -767,6 +767,13 @@ class WindowBase(EventDispatcher):
     .. note::
         The 'fake' option has been deprecated, use the :attr:`borderless`
         property instead.
+
+    .. warning::
+        On iOS, setting :attr:`fullscreen` to `False` will not automatically
+        hide the status bar.
+
+        To achieve this, you must set :attr:`fullscreen` to `False`, and
+        then also set :attr:`borderless` to `False`.
     '''
 
     mouse_pos = ObjectProperty((0, 0))

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -370,8 +370,8 @@ cdef class _WindowSDL2Storage:
             mode = SDL_WINDOW_FULLSCREEN
         else:
             mode = False
-        IF not USE_IOS:
-            SDL_SetWindowFullscreen(self.win, mode)
+
+        SDL_SetWindowFullscreen(self.win, mode)
 
     def set_window_title(self, title):
         SDL_SetWindowTitle(self.win, <bytes>title.encode('utf-8'))


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

As pointed out by a user on Discord, currently we did not allow to switch between `fullscreen` and `windowed` mode on iOS programmatically, but only during startup.

After some tests, looks like this is feasible and doesn't generate any unexpected behavior (like the issue described in https://github.com/kivy/kivy/issues/2710, referring to commit https://github.com/kivy/kivy/commit/c80cbd8f7bf908f820e3c3d6cb5592c89a632ae2)

I've also added some extra docs, explaining how to show / hide the status bar, as `fullscreen` alone is not enough to control the status bar visibility.

`Window.fullscreen = True` and `Window.borderless = True`:
<details>

![IMG_8091](https://user-images.githubusercontent.com/8177736/209555545-fd0ab06f-9528-473e-8990-8efeead1ea00.PNG)

</details>

`Window.fullscreen = False` and `Window.borderless = False`:
<details>

![IMG_8093](https://user-images.githubusercontent.com/8177736/209555814-75570938-c3a4-4701-b5d3-71a992317878.PNG)

</details>
