### PR TITLE
Switch from `ubuntu-18.04` to `ubuntu-latest` as `18.04` runners will be removed on 2023-01-12

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -45,6 +45,7 @@ generate_sdist() {
 
 install_kivy_test_run_apt_deps() {
   sudo apt-get update
+  sudo apt-get -y install libunwind-dev
   sudo apt-get -y install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
   sudo apt-get -y install libgstreamer1.0-dev gstreamer1.0-alsa gstreamer1.0-plugins-base
   sudo apt-get -y install libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff5-dev libx11-dev libmtdev-dev

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   raspberrypi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
 
   always_job:
     name: Always run job
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Always run
         run: |

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   PEP8_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x
@@ -20,7 +20,7 @@ jobs:
         validate_pep8
 
   unit_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       DISPLAY: ':99.0'
     steps:
@@ -64,7 +64,7 @@ jobs:
         path: .benchmarks-kivy
 
   gen_docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

 `ubuntu-18.04` runners will be removed on `2023-01-12`as stated here: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

The majority of tests are already running on `ubuntu-latest`, but seems that we previously decided to pin a specific runner OS version in past for the tests involved in this PR.

Edit: Also "fixes" a dependency issue. The `sdist_test` job, which was already on `ubuntu-latest` was encountering this issue since a while. (For further info: https://bugs.launchpad.net/ubuntu/+source/google-glog/+bug/1991919)