### PR TITLE
Add support for sphinx `6.0.0`

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -16,6 +16,7 @@
 import os
 import sys
 import configparser
+import sphinx
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
@@ -33,7 +34,14 @@ extensions = [
     'autodoc', 'sphinx.ext.todo', 'preprocess', 'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode', 'sphinx.ext.mathjax', 'sphinx.ext.extlinks']
 
-extlinks = {'repo': ('https://github.com/kivy/kivy/issues/%s', '#')}
+if sphinx.version_info[0] >= 4:
+    # In 4.0 and above has been added the support to substitute by ‘%s’ in the caption.
+    # In 6.0 if the caption is a string, it must contain %s exactly once.
+    repo_extlink_caption = '#%s'
+else:
+    repo_extlink_caption = '#'
+
+extlinks = {'repo': ('https://github.com/kivy/kivy/issues/%s', repo_extlink_caption)}
 
 # Todo configuration
 todo_include_todos = True


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Sphinx `6.0.0` has been released on 29 Dec 2022, and our docs CI job started to fail since then on `changelog.rst` file.

In Sphinx 4.0 and above has been added the support to substitute by ‘%s’ in the caption, but even if `%s` wasn't in the caption string, everything worked fine.

Now, the [docs](https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#confval-extlinks) are saying:

> The link caption depends on the second item in the tuple, the caption:
>- If caption is None, the link caption is the full URL.
>- If caption is a string, then it must contain %s exactly once. In this case the link caption is caption with the partial URL substituted for %s – in the above example, the link caption would be issue 123.

So, in our case, `%s` looks mandatory.

Why supporting multiple sphinx versions and not pinning `sphinx >= 4.0.0` ? See: https://github.com/kivy/kivy/pull/7766