### PR TITLE
Add a warning about `keyboard_suggestions` usage on Android

### DIFF
--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -242,6 +242,13 @@ class FocusBehavior(object):
     This will only work if :attr:`input_type` is set to `text`, `url`, `mail` or
     `address`.
 
+    .. warning::
+        On Android, `keyboard_suggestions` relies on
+        `InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS` to work, but some keyboards
+        just ignore this flag. If you want to disable suggestions at all on
+        Android, you can set `input_type` to `null`, which will request the
+        input method to run in a limited "generate key events" mode.
+
     .. versionadded:: 2.1.0
 
     :attr:`keyboard_suggestions` is a :class:`~kivy.properties.BooleanProperty`


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


As discussed [here](https://github.com/kivy/kivy/issues/7337#issuecomment-917662992), some keyboards on Android (even GBoard 🤦)  are just ignoring the `InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS` flag.

That could not be fixed on our side and is not an issue that is only affecting Kivy Apps.

Considering that sometimes we receive bug reports and support requests related to it, better to add a warning on docs.