### PR TITLE
Introduce build script for SDL dependencies and `KIVY_DEPS_ROOT`

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -23,7 +23,10 @@ RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
         ln -s "$KIVY_CROSS_SYSROOT"/opt/vc "$KIVY_CROSS_SYSROOT"/usr; \
     fi
 
+# Build the dependencies (sdl)
+RUN ./tools/build_linux_dependencies.sh
+
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 RUN [ "cross-build-end" ]

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -10,7 +10,7 @@ RUN [ "cross-build-start" ]
 RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple" && \
     install_kivy_test_run_apt_deps && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg libxrender-dev && \
     install_python && \
     install_kivy_test_run_pip_deps'
 

--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -1,26 +1,6 @@
 #!/bin/bash
 set -e -x
 
-# macOS SDL2
-MACOS__SDL2__VERSION="2.24.2"
-MACOS__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MACOS__SDL2__VERSION/SDL2-$MACOS__SDL2__VERSION.tar.gz"
-MACOS__SDL2__FOLDER="SDL2-$MACOS__SDL2__VERSION"
-
-# macOS SDL2_image
-MACOS__SDL2_IMAGE__VERSION="2.6.2"
-MACOS__SDL2_IMAGE__URL="https://github.com/libsdl-org/SDL_image/releases/download/release-$MACOS__SDL2_IMAGE__VERSION/SDL2_image-$MACOS__SDL2_IMAGE__VERSION.tar.gz"
-MACOS__SDL2_IMAGE__FOLDER="SDL2_image-2.6.2"
-
-# macOS SDL2_mixer
-MACOS__SDL2_MIXER__VERSION="2.6.2"
-MACOS__SDL2_MIXER__URL="https://github.com/libsdl-org/SDL_mixer/releases/download/release-$MACOS__SDL2_MIXER__VERSION/SDL2_mixer-$MACOS__SDL2_MIXER__VERSION.tar.gz"
-MACOS__SDL2_MIXER__FOLDER="SDL2_mixer-2.6.2"
-
-# macOS SDL2_ttf
-MACOS__SDL2_TTF__VERSION="2.20.1"
-MACOS__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/release-$MACOS__SDL2_TTF__VERSION/SDL2_ttf-$MACOS__SDL2_TTF__VERSION.tar.gz"
-MACOS__SDL2_TTF__FOLDER="SDL2_ttf-2.20.1"
-
 # macOS Platypus version
 MACOS__PLATYPUS__VERSION=5.4.1
 
@@ -49,55 +29,6 @@ arm64_set_path_and_python_version(){
       pyenv global $python_version
       export PATH=$(pyenv prefix)/bin:$PATH
   fi
-}
-
-build_and_install_universal_kivy_sys_deps() {
-
-  rm -rf deps_build
-  mkdir deps_build
-
-  pushd deps_build
-  download_cache_curl "${MACOS__SDL2__FOLDER}.tar.gz" "osx-cache" $MACOS__SDL2__URL
-  download_cache_curl "${MACOS__SDL2_MIXER__FOLDER}.tar.gz" "osx-cache" $MACOS__SDL2_MIXER__URL
-  download_cache_curl "${MACOS__SDL2_IMAGE__FOLDER}.tar.gz" "osx-cache" $MACOS__SDL2_IMAGE__URL
-  download_cache_curl "${MACOS__SDL2_TTF__FOLDER}.tar.gz" "osx-cache" $MACOS__SDL2_TTF__URL
-
-  echo "-- Build SDL2 (Universal)"
-  tar -xvf "${MACOS__SDL2__FOLDER}.tar.gz"
-  pushd $MACOS__SDL2__FOLDER
-  xcodebuild ONLY_ACTIVE_ARCH=NO -project Xcode/SDL/SDL.xcodeproj -target Framework -configuration Release
-  echo "--- Copy SDL2.framework to /Library/Frameworks"
-  sudo cp -r Xcode/SDL/build/Release/SDL2.framework /Library/Frameworks
-  popd
-
-  echo "-- Build SDL2_mixer (Universal)"
-  tar -xvf "${MACOS__SDL2_MIXER__FOLDER}.tar.gz"
-  pushd $MACOS__SDL2_MIXER__FOLDER
-  xcodebuild ONLY_ACTIVE_ARCH=NO \
-          -project Xcode/SDL_mixer.xcodeproj -target Framework -configuration Release
-  echo "--- Copy SDL2_mixer.framework to /Library/Frameworks"
-  sudo cp -r Xcode/build/Release/SDL2_mixer.framework /Library/Frameworks
-  popd
-
-  echo "-- Build SDL2_image (Universal)"
-  tar -xvf "${MACOS__SDL2_IMAGE__FOLDER}.tar.gz"
-  pushd $MACOS__SDL2_IMAGE__FOLDER
-  xcodebuild ONLY_ACTIVE_ARCH=NO \
-          -project Xcode/SDL_image.xcodeproj -target Framework -configuration Release
-  echo "--- Copy SDL2_image.framework to /Library/Frameworks"
-  sudo cp -r Xcode/build/Release/SDL2_image.framework /Library/Frameworks
-  popd
-
-  echo "-- Build SDL2_ttf (Universal)"
-  tar -xvf "${MACOS__SDL2_TTF__FOLDER}.tar.gz"
-  pushd $MACOS__SDL2_TTF__FOLDER
-  xcodebuild ONLY_ACTIVE_ARCH=NO \
-          -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release
-  echo "--- Copy SDL2_ttf.framework to /Library/Frameworks"
-  sudo cp -r Xcode/build/Release/SDL2_ttf.framework /Library/Frameworks
-  popd
-
-  popd
 }
 
 install_platypus() {

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -1,26 +1,6 @@
 #!/bin/bash
 set -e -x
 
-# manylinux SDL2
-MANYLINUX__SDL2__VERSION="2.24.2"
-MANYLINUX__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MANYLINUX__SDL2__VERSION/SDL2-$MANYLINUX__SDL2__VERSION.tar.gz"
-MANYLINUX__SDL2__FOLDER="SDL2-$MANYLINUX__SDL2__VERSION"
-
-# manylinux SDL2_image
-MANYLINUX__SDL2_IMAGE__VERSION="2.6.2"
-MANYLINUX__SDL2_IMAGE__URL="https://github.com/libsdl-org/SDL_image/releases/download/release-$MANYLINUX__SDL2_IMAGE__VERSION/SDL2_image-$MANYLINUX__SDL2_IMAGE__VERSION.tar.gz"
-MANYLINUX__SDL2_IMAGE__FOLDER="SDL2_image-2.6.2"
-
-# manylinux SDL2_mixer
-MANYLINUX__SDL2_MIXER__VERSION="2.6.2"
-MANYLINUX__SDL2_MIXER__URL="https://github.com/libsdl-org/SDL_mixer/releases/download/release-$MANYLINUX__SDL2_MIXER__VERSION/SDL2_mixer-$MANYLINUX__SDL2_MIXER__VERSION.tar.gz"
-MANYLINUX__SDL2_MIXER__FOLDER="SDL2_mixer-2.6.2"
-
-# manylinux SDL2_ttf
-MANYLINUX__SDL2_TTF__VERSION="2.20.1"
-MANYLINUX__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/release-$MANYLINUX__SDL2_TTF__VERSION/SDL2_ttf-$MANYLINUX__SDL2_TTF__VERSION.tar.gz"
-MANYLINUX__SDL2_TTF__FOLDER="SDL2_ttf-2.20.1"
-
 update_version_metadata() {
   current_time=$(python -c "from time import time; from os import environ; print(int(environ.get('SOURCE_DATE_EPOCH', time())))")
   date=$(python -c "from datetime import datetime; print(datetime.utcfromtimestamp($current_time).strftime('%Y%m%d'))")
@@ -46,7 +26,6 @@ generate_sdist() {
 install_kivy_test_run_apt_deps() {
   sudo apt-get update
   sudo apt-get -y install libunwind-dev
-  sudo apt-get -y install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
   sudo apt-get -y install libgstreamer1.0-dev gstreamer1.0-alsa gstreamer1.0-plugins-base gstreamer1.0-plugins-good
   sudo apt-get -y install libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff5-dev libx11-dev libmtdev-dev
   sudo apt-get -y install build-essential libgl1-mesa-dev libgles2-mesa-dev
@@ -185,56 +164,6 @@ upload_docs_to_server() {
 install_build_deps() {
   yum install -y epel-release;
   yum -y install autoconf automake cmake gcc gcc-c++ git make pkgconfig zlib-devel portmidi portmidi-devel xorg-x11-server-devel mesa-libEGL-devel mtdev-devel mesa-libEGL freetype freetype-devel openjpeg openjpeg-devel libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel dbus-devel dbus ibus-devel ibus libsamplerate-devel libsamplerate libudev-devel libmodplug-devel libmodplug libvorbis-devel libvorbis flac-devel flac libjpeg-turbo-devel libjpeg-turbo wget;
-}
-
-build_and_install_linux_kivy_sys_deps() {
-  install_build_deps
-  mkdir ~/kivy_sources;
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/kivy_build/lib;
-
-  pushd kivy_sources
-  curl -L "$MANYLINUX__SDL2__URL" -o "${MANYLINUX__SDL2__FOLDER}.tar.gz"
-  curl -L "$MANYLINUX__SDL2_MIXER__URL" -o "${MANYLINUX__SDL2_MIXER__FOLDER}.tar.gz"
-  curl -L "$MANYLINUX__SDL2_IMAGE__URL" -o "${MANYLINUX__SDL2_IMAGE__FOLDER}.tar.gz"
-  curl -L "$MANYLINUX__SDL2_TTF__URL" -o "${MANYLINUX__SDL2_TTF__FOLDER}.tar.gz"
-
-  echo "-- Build SDL2"
-  tar -xvf "${MANYLINUX__SDL2__FOLDER}.tar.gz"
-  pushd $MANYLINUX__SDL2__FOLDER
-  ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin"  --enable-alsa-shared=no  --enable-jack-shared=no  --enable-pulseaudio-shared=no  --enable-esd-shared=no  --enable-arts-shared=no  --enable-nas-shared=no  --enable-sndio-shared=no  --enable-fusionsound-shared=no  --enable-libsamplerate-shared=no  --enable-wayland-shared=no --enable-x11-shared=no --enable-directfb-shared=no --enable-kmsdrm-shared=no;
-  make;
-  make install;
-  make distclean;
-  popd
-
-  echo "-- Build SDL2_mixer"
-  tar -xvf "${MANYLINUX__SDL2_MIXER__FOLDER}.tar.gz"
-  pushd $MANYLINUX__SDL2_MIXER__FOLDER
-  PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-mpg123-shared=no;
-  PATH="$HOME/kivy_build/bin:$PATH" make;
-  make install;
-  make distclean;
-  popd
-
-  echo "-- Build SDL2_image"
-  tar -xvf "${MANYLINUX__SDL2_IMAGE__FOLDER}.tar.gz"
-  pushd $MANYLINUX__SDL2_IMAGE__FOLDER
-  PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no;
-  PATH="$HOME/kivy_build/bin:$PATH" make;
-  make install;
-  make distclean;
-  popd
-
-  echo "-- Build SDL2_ttf"
-  tar -xvf "${MANYLINUX__SDL2_TTF__FOLDER}.tar.gz"
-  pushd $MANYLINUX__SDL2_TTF__FOLDER
-  PATH="$HOME/kivy_build/bin:$PATH" PKG_CONFIG_PATH="$HOME/kivy_build/lib/pkgconfig" ./configure --prefix="$HOME/kivy_build" --bindir="$HOME/kivy_build/bin";
-  PATH="$HOME/kivy_build/bin:$PATH" make;
-  make install;
-  make distclean;
-  popd
-
-  popd
 }
 
 generate_armv7l_wheels() {

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -37,12 +37,11 @@ jobs:
 
   manylinux_wheel_create:
     env:
-      CIBW_ENVIRONMENT_LINUX: "KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 PKG_CONFIG_PATH=$HOME/kivy_build/lib/pkgconfig LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/kivy_build/lib"
+      CIBW_ENVIRONMENT_LINUX: "KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies"
       CIBW_BUILD_VERBOSITY_LINUX: 3
       CIBW_BUILD:  ${{ matrix.cibw_build }}
       CIBW_ARCHS: ${{ matrix.cibw_archs }}
       CIBW_BEFORE_ALL_LINUX: >
-        cp -r `pwd`/kivy_build $HOME &&
         source .ci/ubuntu_ci.sh &&
         install_build_deps
     runs-on: ubuntu-latest
@@ -68,13 +67,13 @@ jobs:
     - uses: actions/cache@v2
       id: deps-cache
       with:
-        path: kivy_build
-        key: ${{ runner.os }}-${{ matrix.cibw_archs }}-deps-cache-${{ hashFiles('.ci/ubuntu_ci.sh') }}
+        path: kivy-dependencies
+        key: ${{ runner.os }}-${{ matrix.cibw_archs }}-deps-cache-${{ hashFiles('./tools/build_linux_dependencies.sh') }}
     - name: Build dependencies
       if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
       run: |
         docker run --rm -v `pwd`:/root:rw --workdir=/root \
-           quay.io/pypa/manylinux2014_${{ matrix.cibw_archs }} bash -ec 'source .ci/ubuntu_ci.sh && build_and_install_linux_kivy_sys_deps'
+           quay.io/pypa/manylinux2014_${{ matrix.cibw_archs }} bash -ec './tools/build_linux_dependencies.sh'
     - name: Generate version metadata
       run: |
         source .ci/ubuntu_ci.sh
@@ -199,6 +198,7 @@ jobs:
         run: |
           source .ci/ubuntu_ci.sh
           install_kivy_test_run_apt_deps
+          ./tools/build_linux_dependencies.sh
           install_kivy_test_wheel_run_pip_deps
       - name: Setup env
         run: |
@@ -207,6 +207,7 @@ jobs:
       - name: Install Kivy
         run: |
           source .ci/ubuntu_ci.sh
+          export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
           install_kivy_sdist
       - name: Test Kivy
         run: |

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -75,7 +75,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         source .ci/osx_ci.sh
         arm64_set_path_and_python_version ${{ matrix.python }}
-        build_and_install_universal_kivy_sys_deps
+        ./tools/build_macos_dependencies.sh
     - name: Install cibuildwheel
       run: |
         source .ci/osx_ci.sh
@@ -85,7 +85,8 @@ jobs:
       run: |
         source .ci/osx_ci.sh
         arm64_set_path_and_python_version ${{ matrix.python }}
-        export REPAIR_LIBRARY_PATH=/Library/Frameworks:/Library/Frameworks/SDL2_mixer.framework/Frameworks
+        export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
+        export REPAIR_LIBRARY_PATH=$KIVY_DEPS_ROOT/dist/Frameworks:$KIVY_DEPS_ROOT/dist/Frameworks/SDL2_mixer.framework/Frameworks
         python -m cibuildwheel --output-dir wheelhouse
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -39,13 +39,14 @@ jobs:
         source .ci/ubuntu_ci.sh
         source .ci/osx_ci.sh
         arm64_set_path_and_python_version ${{ matrix.python }}
-        build_and_install_universal_kivy_sys_deps
+        ./tools/build_macos_dependencies.sh
         install_kivy_test_run_pip_deps
     - name: Install Kivy
       run: |
         source .ci/ubuntu_ci.sh
         source .ci/osx_ci.sh
         arm64_set_path_and_python_version ${{ matrix.python }}
+        export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
         install_kivy
     - name: Test Kivy
       run: |

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -33,6 +33,7 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         install_kivy_test_run_apt_deps
+        ./tools/build_linux_dependencies.sh
         install_kivy_test_run_pip_deps
     - name: Setup env
       run: |
@@ -41,6 +42,7 @@ jobs:
     - name: Install Kivy
       run: |
         source .ci/ubuntu_ci.sh
+        export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
         install_kivy
     - name: Test Kivy
       run: |
@@ -75,6 +77,7 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         install_kivy_test_run_apt_deps
+        ./tools/build_linux_dependencies.sh
         install_kivy_test_run_pip_deps
     - name: Setup env
       run: |

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -129,9 +129,61 @@ from source code and compiled directly on your system.
 First install the additional system dependencies listed for each platform:
 :ref:`Windows<install-source-win>`, :ref:`macOS<install-source-osx>`,
 :ref:`Linux<install-source-linux>`, :ref:`*BSD<install-source-bsd>`,
-:ref:`RPi<install-source-rpi>.
+:ref:`RPi<install-source-rpi>`
 
-With the dependencies installed, you can now install Kivy into the virtual environment.
+.. note::
+    In past, for macOS, Linux and BSD Kivy required the installation of the SDL dependencies from package
+    managers (e.g. ``apt`` or ``brew``). However, this is no longer officially supported as the version
+    of SDL provided by the package managers is often outdated and may not work with Kivy as we
+    try to keep up with the latest SDL versions in order to support the latest features and bugfixes.
+
+    **You can still install the SDL dependencies from package managers if you wish, but we no longer
+    offer support for this.**
+
+    Instead, we recommend installing the SDL dependencies from source. This is the same process
+    our CI uses to build the wheels. The SDL dependencies are built from source and installed into a 
+    specific directory.
+
+With all the build tools installed, you can now install the SDL dependencies from source for SDL support
+(this is not needed on Windows as we provide pre-built SDL dependencies for Windows)
+
+In order to do so, we provide a script that will download and build the SDL dependencies
+from source. This script is located in the ``tools`` directory of the Kivy repository.
+
+Create a directory to store the self-built dependencies and change into it::
+
+    mkdir kivy-deps-build && cd kivy-deps-build
+
+Then download the build tool script, according to your platform:
+
+On **macOS**::
+
+    curl -O https://raw.githubusercontent.com/kivy/kivy/master/tools/build_macos_dependencies.sh -o build_kivy_deps.sh
+
+On **Linux**::
+
+    curl -O https://raw.githubusercontent.com/kivy/kivy/master/tools/build_linux_dependencies.sh -o build_kivy_deps.sh
+
+Make the script executable::
+
+    chmod +x build_kivy_deps.sh
+
+Finally, run the script::
+
+    ./build_kivy_deps.sh
+
+The script will download and build the SDL dependencies from source. It will also install
+the dependencies into a directory named `kivy-dependencies`. This directory will be used
+by Kivy to build and install Kivy from source with SDL support.
+
+Kivy will need to know where the SDL dependencies are installed. To do so, you must set
+the ``KIVY_DEPS_ROOT`` environment variable to the path of the ``kivy-dependencies`` directory.
+For example, if you are in the ``kivy-deps-build`` directory, you can set the environment
+variable with::
+
+    export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
+
+With the dependencies installed, and `KIVY_DEPS_ROOT` set you can now install Kivy into the virtual environment.
 
 To install the stable version of Kivy, from the terminal do::
 
@@ -185,13 +237,13 @@ The typical process is to clone Kivy locally with::
 
     git clone https://github.com/kivy/kivy.git
 
-This creates a kivy named folder in your current path. Next, install the additional
-system dependencies listed for each OS: :ref:`Windows<install-source-win>`,
-:ref:`macOS<install-source-osx>`, :ref:`Linux<install-source-linux>`,
-`*BSD<install-source-bsd>`, :ref:`RPi<install-source-rpi>`.
+This creates a kivy named folder in your current path. Next, follow the same steps of the
+:ref:`Installing from source <_kivy-source-install>` above, but instead of installing Kivy via a
+distribution package or zip file, install it as an
+`editable install <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_.
 
-Then change to the kivy directory and install Kivy as an
-`editable install <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_::
+In order to do so, first change into the Kivy folder you just cloned::
+and then install Kivy as an editable install::
 
     cd kivy
     python -m pip install -e ".[dev,full]"

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -47,9 +47,11 @@ The easiest way to install Kivy is with ``pip``, which installs Kivy using eithe
 :ref:`pre-compiled wheel<pip-wheel>`, if available, otherwise from source (see below).
 
 Kivy provides :ref:`pre-compiled wheels<kivy-wheel-install>` for the supported Python
-versions on Windows, macOS, Linux, and RPi. If no wheels are available ``pip`` will
-build the package from sources (i.e. on *BSD). Alternatively, installing
-:ref:`from source<kivy-source-install>` is required for newer Python versions not listed
+versions on Windows, macOS, Linux, and RPi.
+
+If no wheels are available ``pip`` will build the package from sources (i.e. on *BSD).
+
+Alternatively, installing :ref:`from source<kivy-source-install>` is required for newer Python versions not listed
 above or if the wheels do not work or fail to run properly.
 
 Setup terminal and pip

--- a/doc/sources/guide/environment.rst
+++ b/doc/sources/guide/environment.rst
@@ -54,6 +54,32 @@ KIVY_SDL2_PATH
         This path is required for the compilation of Kivy. It is not
         required for program execution.
 
+KIVY_SDL2_FRAMEWORKS_SEARCH_PATH
+    If set, the SDL2 frameworks from this path are used when compiling kivy
+    instead of the ones installed system-wide.
+
+    That path is used only on macOS, and must contain the SDL2.framework,
+    SDL_image.framework, SDL_mixer.framework and SDL_ttf.framework.
+
+    .. versionadded:: 2.1.0
+
+    .. warning::
+
+        This path is required for the compilation of Kivy. It is not
+        required for program execution.
+
+KIVY_DEPS_ROOT
+    If set, during build, Kivy will use this directory as the root one to
+    search for (only SDL ATM) dependencies. Please note that if `KIVY_SDL2_PATH` or
+    `KIVY_SDL2_FRAMEWORKS_SEARCH_PATH` are set, they will be used instead.
+
+    .. versionadded:: 2.2.0
+
+    .. warning::
+
+        This path is required for the compilation of Kivy. It is not
+        required for program execution.
+
 
 Configuration
 -------------

--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -54,7 +54,7 @@ continue installing dependencies::
 Source installation Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To install Kivy from source, please follow the installation guide until you reach the
+To install Kivy from source, please follow the :ref:`installation guide<kivy-wheel-install>` until you reach the
 :ref:`Kivy install step<kivy-source-install>` and then install the dependencies below
 before continuing. Additionally, if you'd like to be able to use the x11 window backend do::
 

--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -17,7 +17,8 @@ main :ref:`pip installation guide<installation-canonical>`, specific to Linux.
 Installing Python
 ^^^^^^^^^^^^^^^^^
 
-Python and python-pip must be installed from the package manager:
+Python and python-pip, git and build tools are required to install Kivy. If you do not have these installed,
+please install them before continuing:
 
 Ubuntu
 ~~~~~~
@@ -66,10 +67,6 @@ Using apt::
 
     # Install necessary system packages
     sudo apt-get install -y \
-        libsdl2-dev \
-        libsdl2-image-dev \
-        libsdl2-mixer-dev \
-        libsdl2-ttf-dev \
         libportmidi-dev \
         libswscale-dev \
         libavformat-dev \
@@ -89,8 +86,7 @@ Fedora
 Using dnf::
 
     # Install necessary system packages
-    sudo dnf install -y ffmpeg-libs SDL2-devel SDL2_image-devel SDL2_mixer-devel \
-    SDL2_ttf-devel portmidi-devel libavdevice libavc1394-devel zlibrary-devel ccache \
+    sudo dnf install -y ffmpeg-libs portmidi-devel libavdevice libavc1394-devel zlibrary-devel ccache \
     mesa-libGL mesa-libGL-devel
     # Install xclip in case you run a kivy app using your computer, and the app requires a CutBuffer provider:
     sudo dnf install -y xclip

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -55,65 +55,10 @@ To install Kivy from source, please follow the installation guide until you reac
 :ref:`Kivy install step<kivy-source-install>` and then install the additional dependencies
 below before continuing.
 
-Homebrew
-~~~~~~~~
+**pkg-config** is required to build Kivy from source. If you're using ``brew`` as your
+package manager, you can install it with::
 
-If you're using Homebrew, you can install the (default) dependencies with::
-
-    brew install pkg-config sdl2 sdl2_image sdl2_ttf sdl2_mixer
-
-MacPorts
-~~~~~~~~
-
-.. note::
-
-    You will have to manually install gstreamer support if you wish to
-    support video playback in your Kivy App. The latest port documents show the
-    following `py-gst-python port <https://trac.macports.org/ticket/44813>`_.
-
-If you're using MacPorts, you can install the dependencies with::
-
-    port install libsdl2 libsdl2_image libsdl2_ttf libsdl2_mixer
-
-Frameworks
-~~~~~~~~~~
-
-If you're installing Python from a framework, you will need to install Kivy's dependencies
-from frameworks as well. You can do that with the following commands (customize as needed)::
-
-    # configure kivy
-    export CC=clang
-    export CXX=clang
-    export FFLAGS='-ff2c'
-    export USE_SDL2=1
-    export USE_GSTREAMER=0
-
-    # get the dependencies
-    export SDL2=2.0.20
-    export SDL2_IMAGE=2.0.5
-    export SDL2_MIXER=2.0.4
-    export SDL2_TTF=2.0.18
-    export GSTREAMER=1.16.2
-
-    curl -O -L "https://www.libsdl.org/release/SDL2-$SDL2.dmg"
-    curl -O -L "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$SDL2_IMAGE.dmg"
-    curl -O -L "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-$SDL2_MIXER.dmg"
-    curl -O -L "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$SDL2_TTF.dmg"
-
-    hdiutil attach SDL2-$SDL2.dmg
-    sudo cp -a /Volumes/SDL2/SDL2.framework /Library/Frameworks/
-    hdiutil attach SDL2_image-$SDL2_IMAGE.dmg
-    sudo cp -a /Volumes/SDL2_image/SDL2_image.framework /Library/Frameworks/
-    hdiutil attach SDL2_ttf-$SDL2_TTF.dmg
-    sudo cp -a /Volumes/SDL2_ttf/SDL2_ttf.framework /Library/Frameworks/
-    hdiutil attach SDL2_mixer-$SDL2_MIXER.dmg
-    sudo cp -a /Volumes/SDL2_mixer/SDL2_mixer.framework /Library/Frameworks/
-
-.. warning::
-    At the time of writing, only certain SDL2 deps are shipped as universal2 frameworks
-    with binaries for both Intel and Apple Silicon Macs. On our CI workflow that
-    builds ``.whl`` and ``Kivy.app`` we're building the Frameworks from source with
-    universal2 support. (See: `create-osx-bundle.sh <https://github.com/kivy/kivy-sdk-packager/blob/master/osx/create-osx-bundle.sh>`_)
+    brew install pkg-config
 
 Now that you have all the dependencies for kivy, you need to make sure
 you have the command line tools installed::

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -51,7 +51,7 @@ installation steps. You can read more about the installation in the
 Source installation Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To install Kivy from source, please follow the installation guide until you reach the
+To install Kivy from source, please follow the :ref:`installation guide<kivy-wheel-install>` until you reach the
 :ref:`Kivy install step<kivy-source-install>` and then install the additional dependencies
 below before continuing.
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -50,7 +50,7 @@ Using pacman::
 Source installation Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To install Kivy from source, please follow the installation guide until you reach the
+To install Kivy from source, please follow the :ref:`installation guide<kivy-wheel-install>` until you reach the
 :ref:`Kivy install step<kivy-source-install>` and then install the dependencies below
 before continuing.
 
@@ -65,17 +65,6 @@ Using apt::
        gstreamer1.0-plugins-{bad,base,good,ugly} \
        gstreamer1.0-{omx,alsa} libmtdev-dev \
        xclip xsel libjpeg-dev
-
-And then install SDL2 using either of the two options below depending on whether you
-will be running Kivy from a headless or desktop environment:
-
-Raspberry Pi 1-4 Desktop environment
-************************************
-
-If you have installed Raspbian with a desktop i.e. if your Raspberry Pi boots into a desktop environment
-then install SDL2 from apt::
-
-    sudo apt install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
 
 Cross-Compilation for Raspberry Pi 1-3 headless installation on Raspbian Buster
 *******************************************************************************
@@ -99,57 +88,20 @@ Raspberry Pi 4 headless installation on Raspbian Buster
 *******************************************************
 
 If you run Kivy from the console and not from a desktop environment, you need to compile SDL2
-from source, as the one bundled with Buster is not compiled with the ``kmsdrm`` backend,
-so it only works under ``X11``.
+with the ``kmsdrm`` backend. This is not the default, so you need add a few extra requirements, and 
+then edit the build script located at `tools/build_linux_dependencies.sh` accordingly.
 
-Install requirements::
+Extra install requirements::
 
     sudo apt-get install libfreetype6-dev libgl1-mesa-dev libgles2-mesa-dev libdrm-dev libgbm-dev libudev-dev libasound2-dev liblzma-dev libjpeg-dev libtiff-dev libwebp-dev git build-essential
     sudo apt-get install gir1.2-ibus-1.0 libdbus-1-dev libegl1-mesa-dev libibus-1.0-5 libibus-1.0-dev libice-dev libsm-dev libsndio-dev libwayland-bin libwayland-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev libxss-dev libxt-dev libxv-dev x11proto-randr-dev x11proto-scrnsaver-dev x11proto-video-dev x11proto-xinerama-dev
 
-Install SDL2::
+Extra flags for `configure` step of ``-- Build SDL2`` build phase ::
 
-    wget https://libsdl.org/release/SDL2-2.0.10.tar.gz
-    tar -zxvf SDL2-2.0.10.tar.gz
-    pushd SDL2-2.0.10
-    ./configure --enable-video-kmsdrm --disable-video-opengl --disable-video-x11 --disable-video-rpi
-    make -j$(nproc)
-    sudo make install
-    popd
+    --enable-video-kmsdrm --disable-video-opengl --disable-video-x11 --disable-video-rpi
 
-Install SDL2_image::
-
-    wget https://libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz
-    tar -zxvf SDL2_image-2.0.5.tar.gz
-    pushd SDL2_image-2.0.5
-    ./configure
-    make -j$(nproc)
-    sudo make install
-    popd
-
-Install SDL2_mixer::
-
-    wget https://libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz
-    tar -zxvf SDL2_mixer-2.0.4.tar.gz
-    pushd SDL2_mixer-2.0.4
-    ./configure
-    make -j$(nproc)
-    sudo make install
-    popd
-
-Install SDL2_ttf::
-
-    wget https://libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz
-    tar -zxvf SDL2_ttf-2.0.15.tar.gz
-    pushd SDL2_ttf-2.0.15
-    ./configure
-    make -j$(nproc)
-    sudo make install
-    popd
-
-Make sure the dynamic libraries cache is updated::
-
-    sudo ldconfig -v
+Hardware acceleration
+---------------------
 
 If you are getting output similar to this when running your app::
 
@@ -165,13 +117,6 @@ You will then see an output similar to this::
     [INFO   ] GL: OpenGL vendor <b'Broadcom'>
     [INFO   ] GL: OpenGL renderer <b'V3D 4.2'>
 
-
-Arch Linux ARM
-~~~~~~~~~~~~~~
-
-Using pacman::
-
-    sudo pacman -S sdl2 sdl2_gfx sdl2_image sdl2_net sdl2_ttf sdl2_mixer
 
 Raspberry Pi window provider and GL backend
 -------------------------------------------

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -31,7 +31,7 @@ and select, which to run, at each invocation.
 Source installation Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To install Kivy from source, please follow the installation guide until you reach the
+To install Kivy from source, please follow the :ref:`installation guide<kivy-wheel-install>` until you reach the
 :ref:`Kivy install step<kivy-source-install>` and then install the compiler below before continuing.
 
 To install kivy from source, you need a compiler. On Windows, the *Visual Studio Build Tools* are

--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -83,6 +83,12 @@ pushd $MANYLINUX__SDL2_IMAGE__FOLDER
     PATH="$DIST_FOLDER/bin:$PATH" make;
     make install;
   popd
+  pushd external/libtiff
+    autoreconf -i;
+    PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"
+    PATH="$DIST_FOLDER/bin:$PATH" make;
+    make install;
+  popd
   autoreconf -i
   PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no LDFLAGS=-Wl,-rpath="$ORIGIN";
   PATH="$DIST_FOLDER/bin:$PATH" make;

--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -67,7 +67,15 @@ popd
 
 echo "-- Build SDL2_mixer"
 pushd $MANYLINUX__SDL2_MIXER__FOLDER
-  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-mpg123-shared=no;
+  ./external/download.sh;
+  echo "-- Build SDL2_mixer - libmodplug"
+  pushd external/libmodplug
+    autoreconf -i;
+    PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin";
+    PATH="$DIST_FOLDER/bin:$PATH" make;
+    make install;
+  popd
+  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-mpg123-shared=no LDFLAGS=-Wl,-rpath="$ORIGIN";
   PATH="$DIST_FOLDER/bin:$PATH" make;
   make install;
   make distclean;
@@ -83,6 +91,7 @@ pushd $MANYLINUX__SDL2_IMAGE__FOLDER
     PATH="$DIST_FOLDER/bin:$PATH" make;
     make install;
   popd
+  echo "-- Build SDL2_image - libtiff"
   pushd external/libtiff
     autoreconf -i;
     PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"

--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -75,7 +75,16 @@ popd
 
 echo "-- Build SDL2_image"
 pushd $MANYLINUX__SDL2_IMAGE__FOLDER
-  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no;
+  ./external/download.sh;
+  echo "-- Build SDL2_image - libwebp"
+  pushd external/libwebp
+    autoreconf -i;
+    PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"
+    PATH="$DIST_FOLDER/bin:$PATH" make;
+    make install;
+  popd
+  autoreconf -i
+  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no LDFLAGS=-Wl,-rpath="$ORIGIN";
   PATH="$DIST_FOLDER/bin:$PATH" make;
   make install;
   make distclean;

--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# manylinux SDL2
+MANYLINUX__SDL2__VERSION="2.24.2"
+MANYLINUX__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MANYLINUX__SDL2__VERSION/SDL2-$MANYLINUX__SDL2__VERSION.tar.gz"
+MANYLINUX__SDL2__FOLDER="SDL2-$MANYLINUX__SDL2__VERSION"
+
+# manylinux SDL2_image
+MANYLINUX__SDL2_IMAGE__VERSION="2.6.2"
+MANYLINUX__SDL2_IMAGE__URL="https://github.com/libsdl-org/SDL_image/releases/download/release-$MANYLINUX__SDL2_IMAGE__VERSION/SDL2_image-$MANYLINUX__SDL2_IMAGE__VERSION.tar.gz"
+MANYLINUX__SDL2_IMAGE__FOLDER="SDL2_image-2.6.2"
+
+# manylinux SDL2_mixer
+MANYLINUX__SDL2_MIXER__VERSION="2.6.2"
+MANYLINUX__SDL2_MIXER__URL="https://github.com/libsdl-org/SDL_mixer/releases/download/release-$MANYLINUX__SDL2_MIXER__VERSION/SDL2_mixer-$MANYLINUX__SDL2_MIXER__VERSION.tar.gz"
+MANYLINUX__SDL2_MIXER__FOLDER="SDL2_mixer-2.6.2"
+
+# manylinux SDL2_ttf
+MANYLINUX__SDL2_TTF__VERSION="2.20.1"
+MANYLINUX__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/release-$MANYLINUX__SDL2_TTF__VERSION/SDL2_ttf-$MANYLINUX__SDL2_TTF__VERSION.tar.gz"
+MANYLINUX__SDL2_TTF__FOLDER="SDL2_ttf-2.20.1"
+
+# Clean the dependencies folder
+rm -r kivy-dependencies
+
+# Create the dependencies folder
+mkdir kivy-dependencies
+
+# Download the dependencies
+echo "Downloading dependencies..."
+mkdir kivy-dependencies/download
+pushd kivy-dependencies/download
+curl -L $MANYLINUX__SDL2__URL -o "${MANYLINUX__SDL2__FOLDER}.tar.gz"
+curl -L $MANYLINUX__SDL2_IMAGE__URL -o "${MANYLINUX__SDL2_IMAGE__FOLDER}.tar.gz"
+curl -L $MANYLINUX__SDL2_MIXER__URL -o "${MANYLINUX__SDL2_MIXER__FOLDER}.tar.gz"
+curl -L $MANYLINUX__SDL2_TTF__URL -o "${MANYLINUX__SDL2_TTF__FOLDER}.tar.gz"
+popd
+
+# Extract the dependencies into build folder
+echo "Extracting dependencies..."
+mkdir kivy-dependencies/build
+pushd kivy-dependencies/build
+tar -xzf ../download/${MANYLINUX__SDL2__FOLDER}.tar.gz
+tar -xzf ../download/${MANYLINUX__SDL2_IMAGE__FOLDER}.tar.gz
+tar -xzf ../download/${MANYLINUX__SDL2_MIXER__FOLDER}.tar.gz
+tar -xzf ../download/${MANYLINUX__SDL2_TTF__FOLDER}.tar.gz
+popd
+
+# Create distribution folder
+echo "Creating distribution folder..."
+mkdir kivy-dependencies/dist
+DIST_FOLDER="$(pwd)/kivy-dependencies/dist"
+
+# Build the dependencies
+pushd kivy-dependencies/build
+
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DIST_FOLDER/lib;
+
+echo "-- Build SDL2"
+pushd $MANYLINUX__SDL2__FOLDER
+./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"  --enable-alsa-shared=no  --enable-jack-shared=no  --enable-pulseaudio-shared=no  --enable-esd-shared=no  --enable-arts-shared=no  --enable-nas-shared=no  --enable-sndio-shared=no  --enable-fusionsound-shared=no  --enable-libsamplerate-shared=no  --enable-wayland-shared=no --enable-x11-shared=no --enable-directfb-shared=no --enable-kmsdrm-shared=no;
+make;
+make install;
+make distclean;
+popd
+
+echo "-- Build SDL2_mixer"
+pushd $MANYLINUX__SDL2_MIXER__FOLDER
+  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-mpg123-shared=no;
+  PATH="$DIST_FOLDER/bin:$PATH" make;
+  make install;
+  make distclean;
+popd
+
+echo "-- Build SDL2_image"
+pushd $MANYLINUX__SDL2_IMAGE__FOLDER
+  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no;
+  PATH="$DIST_FOLDER/bin:$PATH" make;
+  make install;
+  make distclean;
+popd
+
+echo "-- Build SDL2_ttf"
+pushd $MANYLINUX__SDL2_TTF__FOLDER
+  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin";
+  PATH="$DIST_FOLDER/bin:$PATH" make;
+  make install;
+  make distclean;
+popd
+
+popd

--- a/tools/build_macos_dependencies.sh
+++ b/tools/build_macos_dependencies.sh
@@ -1,0 +1,82 @@
+# macOS SDL2
+MACOS__SDL2__VERSION="2.24.2"
+MACOS__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MACOS__SDL2__VERSION/SDL2-$MACOS__SDL2__VERSION.tar.gz"
+MACOS__SDL2__FOLDER="SDL2-${MACOS__SDL2__VERSION}"
+
+# macOS SDL2_image
+MACOS__SDL2_IMAGE__VERSION="2.6.2"
+MACOS__SDL2_IMAGE__URL="https://github.com/libsdl-org/SDL_image/releases/download/release-$MACOS__SDL2_IMAGE__VERSION/SDL2_image-$MACOS__SDL2_IMAGE__VERSION.tar.gz"
+MACOS__SDL2_IMAGE__FOLDER="SDL2_image-2.6.2"
+
+# macOS SDL2_mixer
+MACOS__SDL2_MIXER__VERSION="2.6.2"
+MACOS__SDL2_MIXER__URL="https://github.com/libsdl-org/SDL_mixer/releases/download/release-$MACOS__SDL2_MIXER__VERSION/SDL2_mixer-$MACOS__SDL2_MIXER__VERSION.tar.gz"
+MACOS__SDL2_MIXER__FOLDER="SDL2_mixer-2.6.2"
+
+# macOS SDL2_ttf
+MACOS__SDL2_TTF__VERSION="2.20.1"
+MACOS__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/release-$MACOS__SDL2_TTF__VERSION/SDL2_ttf-$MACOS__SDL2_TTF__VERSION.tar.gz"
+MACOS__SDL2_TTF__FOLDER="SDL2_ttf-2.20.1"
+
+# Clean the dependencies folder
+rm -r kivy-dependencies
+
+# Create the dependencies folder
+mkdir kivy-dependencies
+
+# Download the dependencies
+echo "Downloading dependencies..."
+mkdir kivy-dependencies/download
+pushd kivy-dependencies/download
+curl -L $MACOS__SDL2__URL -o "${MACOS__SDL2__FOLDER}.tar.gz"
+curl -L $MACOS__SDL2_IMAGE__URL -o "${MACOS__SDL2_IMAGE__FOLDER}.tar.gz"
+curl -L $MACOS__SDL2_MIXER__URL -o "${MACOS__SDL2_MIXER__FOLDER}.tar.gz"
+curl -L $MACOS__SDL2_TTF__URL -o "${MACOS__SDL2_TTF__FOLDER}.tar.gz"
+popd
+
+# Extract the dependencies into build folder
+echo "Extracting dependencies..."
+mkdir kivy-dependencies/build
+pushd kivy-dependencies/build
+tar -xzf ../download/${MACOS__SDL2__FOLDER}.tar.gz
+tar -xzf ../download/${MACOS__SDL2_IMAGE__FOLDER}.tar.gz
+tar -xzf ../download/${MACOS__SDL2_MIXER__FOLDER}.tar.gz
+tar -xzf ../download/${MACOS__SDL2_TTF__FOLDER}.tar.gz
+popd
+
+# Create distribution folder
+echo "Creating distribution folder..."
+mkdir kivy-dependencies/dist
+mkdir kivy-dependencies/dist/Frameworks
+
+# Build the dependencies
+pushd kivy-dependencies/build
+
+echo "-- Build SDL2 (Universal)"
+pushd $MACOS__SDL2__FOLDER
+xcodebuild ONLY_ACTIVE_ARCH=NO -project Xcode/SDL/SDL.xcodeproj -target Framework -configuration Release
+cp -r Xcode/SDL/build/Release/SDL2.framework ../../dist/Frameworks
+popd
+
+echo "-- Build SDL2_mixer (Universal)"
+pushd $MACOS__SDL2_MIXER__FOLDER
+xcodebuild ONLY_ACTIVE_ARCH=NO \
+        -project Xcode/SDL_mixer.xcodeproj -target Framework -configuration Release
+cp -r Xcode/build/Release/SDL2_mixer.framework ../../dist/Frameworks
+popd
+
+echo "-- Build SDL2_image (Universal)"
+pushd $MACOS__SDL2_IMAGE__FOLDER
+xcodebuild ONLY_ACTIVE_ARCH=NO \
+        -project Xcode/SDL_image.xcodeproj -target Framework -configuration Release
+cp -r Xcode/build/Release/SDL2_image.framework ../../dist/Frameworks
+popd
+
+echo "-- Build SDL2_ttf (Universal)"
+pushd $MACOS__SDL2_TTF__FOLDER
+xcodebuild ONLY_ACTIVE_ARCH=NO \
+        -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release
+cp -r Xcode/build/Release/SDL2_ttf.framework ../../dist/Frameworks
+popd
+
+popd


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

We needed a way to support a specific SDL version (Ref: https://github.com/kivy/kivy/issues/7983) as some features or bugfixes are only available on latest release. And the latest SDL release is not always available via package managers.

Also, supporting multiple SDL versions may lead to unexpected results which traduce into support requests.

This PR exposes a build script (one for Linux and one for macOS) into the `tool` folder, and adds a build-time `KIVY_DEPS_ROOT` environment variable, which allows the user to set a specific path that Kivy should use in order to build Kivy with SDL support.

It's just a rework of something we already had for our CI/CD pipeline. Now the pipeline and the users share the same exact SDL version and build script.

There's still an issue about Ubuntu PPA `python3-kivy` packages that need to be discussed.

TODO:
- [x] Update environment documentation
- [x] Update macOS install documentation
- [x] Update Linux install documentation
- [x] Update RPi install documentation
- [x] Wait for CI/CD to complete (check produced wheels)
- [x] Discuss about Ubuntu PPA
- [x] Discuss with the team