### PR TITLE
Fix `BoxShadow` shader crashing issue on Adreno GPUs

### DIFF
--- a/kivy/graphics/boxshadow.pyx
+++ b/kivy/graphics/boxshadow.pyx
@@ -149,7 +149,6 @@ cdef class BoxShadow(Fbo):
         self._init_texture()
 
     cdef void _init_texture(self):
-        self.shader.fs = SHADOW_fs
         self._rect = Rectangle(size=(100, 100))
         self._rect.texture = self.texture
         with self:

--- a/kivy/graphics/boxshadow.pyx
+++ b/kivy/graphics/boxshadow.pyx
@@ -89,19 +89,21 @@ void main (void){
 
 float distShadow = sigmoid(
     roundedBoxSDF(
-        tex_coord0 * size - size/2.0, size/2.0 - blur_radius * 1.5 - vec2(2.0),
-        border_radius) / (max(1.0, blur_radius)/4.0
-    )
+        tex_coord0 * size - size/2.0,
+        size/2.0 - blur_radius * 1.5 - vec2(2.0),
+        border_radius
+    ) / (max(1.0, blur_radius) / 4.0)
 );
-
-
-// Some devices require the resulting color to be blended with the texture.
-// Otherwise there will be a compilation issue.
 
 vec4 texture = texture2D(texture0, tex_coord0);
 vec4 shadow = vec4(frag_color.rgb, 1.0 - distShadow) * (frag_color.a * 2.0);
 
-gl_FragColor = mix(texture, shadow, 1.0);
+// This check is required to prevent shader crashing on some Adreno GPUs.
+if (frag_color.a > 0.0) {
+    gl_FragColor = shadow;
+} else {
+    gl_FragColor = texture;
+}
 
 }
 """

--- a/kivy/graphics/boxshadow.pyx
+++ b/kivy/graphics/boxshadow.pyx
@@ -56,7 +56,7 @@ from kivy.graphics.gl_instructions import ClearBuffers, ClearColor
 
 cdef str SHADOW_fs = """
 #ifdef GL_ES
-precision highp float;
+    precision highp float;
 #endif
 
 /* Outputs from the vertex shader */
@@ -95,15 +95,8 @@ float distShadow = sigmoid(
     ) / (max(1.0, blur_radius) / 4.0)
 );
 
-vec4 texture = texture2D(texture0, tex_coord0);
-vec4 shadow = vec4(frag_color.rgb, 1.0 - distShadow) * (frag_color.a * 2.0);
-
-// This check is required to prevent shader crashing on some Adreno GPUs. Reference: https://github.com/kivy/kivy/pull/8098
-if (frag_color.a > 0.0) {
-    gl_FragColor = shadow;
-} else {
-    gl_FragColor = texture;
-}
+vec4 shadow = vec4(1.0, 1.0, 1.0, clamp((1.0 - distShadow) * (frag_color.a * 2.0), 0.0, 1.0));
+gl_FragColor = shadow;
 
 }
 """
@@ -138,7 +131,7 @@ cdef class BoxShadow(Fbo):
     '''
 
     def __init__(self, *args, **kwargs):
-        super(BoxShadow, self).__init__(size=(100, 100))
+        super(BoxShadowTest, self).__init__(size=(100, 100), fs=SHADOW_fs)
         pos = kwargs.get("pos", (0.0, 0.0))
         size = kwargs.get("size", (0.0, 0.0))
         offset = kwargs.get("offset", (0.0, 0.0))

--- a/kivy/graphics/boxshadow.pyx
+++ b/kivy/graphics/boxshadow.pyx
@@ -98,7 +98,7 @@ float distShadow = sigmoid(
 vec4 texture = texture2D(texture0, tex_coord0);
 vec4 shadow = vec4(frag_color.rgb, 1.0 - distShadow) * (frag_color.a * 2.0);
 
-// This check is required to prevent shader crashing on some Adreno GPUs.
+// This check is required to prevent shader crashing on some Adreno GPUs. Reference: https://github.com/kivy/kivy/pull/8098
 if (frag_color.a > 0.0) {
     gl_FragColor = shadow;
 } else {

--- a/kivy/graphics/boxshadow.pyx
+++ b/kivy/graphics/boxshadow.pyx
@@ -131,7 +131,7 @@ cdef class BoxShadow(Fbo):
     '''
 
     def __init__(self, *args, **kwargs):
-        super(BoxShadowTest, self).__init__(size=(100, 100), fs=SHADOW_fs)
+        super(BoxShadow, self).__init__(size=(100, 100), fs=SHADOW_fs)
         pos = kwargs.get("pos", (0.0, 0.0))
         size = kwargs.get("size", (0.0, 0.0))
         offset = kwargs.get("offset", (0.0, 0.0))


### PR DESCRIPTION
As reported by @yunus-ceyhan in this [issue](https://github.com/kivy/python-for-android/issues/2723) . The shader used in the `BoxShadow` graphics instruction may crash on some Adreno GPUs.

The specific cause is still not very clear, however, there are two possibilities:
- Issue in Adreno GPU driver
- Issue in kivy's Shader implementation

The workaround is to check if the alpha channel of the `frag_color` variable is greater than zero. If so, a pure vector can be returned, otherwise, a vector created with texture2D needs to be returned, to avoid crashes.

### As a reference, for future implementations using shaders:

Code that crashes on Adreno GPUs:
```GLSL
void main(void)
{
    vec4 color = vec4(1.0, 0.0, 1.0, 1.0);
    gl_FragColor = color;
}
```

Code that compiles successfully:
```GLSL
void main(void)
{
    vec4 texture = texture2D(texture0, tex_coord0);
    gl_FragColor = texture;
}
```

Workaround:
```GLSL
void main(void)
{
    vec4 texture = texture2D(texture0, tex_coord0);
    vec4 color = vec4(1.0, 0.0, 1.0, 1.0);

     if (frag_color.a > 0.0) {
         gl_FragColor = color;
     } else {
         gl_FragColor = texture;
     }
}
```

<br>

⚠️ Update:

As found by @misl6 , there seems to be a bug in kivy that does not allow a shader initialization/compilation if the fragment shader is not passed as an argument to Fbo during its creation.
If the shader is passed as the initial argument, then crashes will not occur, even using the code below:

```GLSL
void main(void)
{
     vec4 color = vec4(1.0, 0.0, 1.0, 1.0);
     gl_FragColor = color;
}
```

🟢Taking this into account, the recommended for implementations using Fbo and shader is:
```python
fbo = Fbo(size=(width, height), fs=fs_code)
```

❌ Not recommended (may break on Adreno GPUs):
```python
fbo = Fbo(size=(width, height))
fbo.shader.fs = fs_code
```


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
