### PR TITLE
Install twine only when needed [build wheel]

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -68,11 +68,6 @@ install_kivy_test_run_pip_deps() {
       --config "kivy:log_level:error"
   )
   python3 -m pip install -I "$CYTHON_INSTALL" coveralls
-  if [ $(python3 -c 'import sys; print("{}{}".format(*sys.version_info))') -le "35" ]; then
-    python3 -m pip install twine~=1.15.0
-  else
-    python3 -m pip install twine
-  fi
 }
 
 install_kivy_test_wheel_run_pip_deps() {

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -72,7 +72,6 @@ function Install-kivy-test-run-win-deps {
 
 function Install-kivy-test-run-pip-deps {
     python -m pip install pip wheel setuptools --upgrade
-    python -m pip install twine
 }
 
 function Install-kivy {


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Fixes our RPi wheels workflow (which is broken since a while), as we're installing `twine` along with the other pip dependencies and `twine` requires `cryptography`, which is currently unavailable on `piwheels` as requires a rust compiler on their runners.

Considering we're also installing `twine` at the appropriate time (see below), there's no need to keep a duplicated installation.

https://github.com/kivy/kivy/blob/e932a4e987ed1491d531b4ba205564151ac25384/.ci/ubuntu_ci.sh#L300

https://github.com/kivy/kivy/blob/e932a4e987ed1491d531b4ba205564151ac25384/.ci/windows_ci.ps1#L133