### PR TITLE
Fix for changes of Splitter.strip_cls having no effect

### DIFF
--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -202,9 +202,10 @@ class Splitter(BoxLayout):
             sup.remove_widget(instance._strip)
 
         cls = instance.strip_cls
-        if isinstance(cls, string_types):
-            cls = Factory.get(cls)
-        instance._strip = _strp = cls()
+        if not isinstance(_strp, cls):
+            if isinstance(cls, str):
+                cls = Factory.get(cls)
+            instance._strip = _strp = cls()
 
         sz_frm = instance.sizable_from[0]
         if sz_frm in ('l', 'r'):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -200,11 +200,11 @@ class Splitter(BoxLayout):
             self.unbind(disabled=_strp.setter('disabled'))
 
             sup.remove_widget(instance._strip)
-        else:
-            cls = instance.strip_cls
-            if isinstance(cls, string_types):
-                cls = Factory.get(cls)
-            instance._strip = _strp = cls()
+
+        cls = instance.strip_cls
+        if isinstance(cls, string_types):
+            cls = Factory.get(cls)
+        instance._strip = _strp = cls()
 
         sz_frm = instance.sizable_from[0]
         if sz_frm in ('l', 'r'):

--- a/kivy/uix/splitter.py
+++ b/kivy/uix/splitter.py
@@ -45,7 +45,6 @@ if self.horizontal else 'path to vertical pressed image'
 
 __all__ = ('Splitter', )
 
-from kivy.compat import string_types
 from kivy.factory import Factory
 from kivy.uix.button import Button
 from kivy.properties import (OptionProperty, NumericProperty, ObjectProperty,


### PR DESCRIPTION
The current implementation of `kivy.uix.Splitter.strip_cls` only causes `strip_cls` to be instantiated once, when the `_strip` attribute of the Splitter is not yet set. Therefore, any subsequent changes of `strip_cls` have no effect, even though `on_sizable_from()` is called correctly. This also includes setting `strip_cls` in a .kv file, in which case `on_sizable_from()` is called twice: Once with the default strip class, and a second time with the correct one.

As a fix, I am suggesting to remove the else statement preventing `strip_cls` from being instantiated several times. This also matches the code to the implementation of `dropdown_cls` of the Spinner widget, and its refresh mechanism in `kivy.uix.Spinner,_build_dropdown()`.

However, this change also causes re-instantiation of `strip_cls` when the `sizable_from` property is changed. This could theoretically cause loss of data stored in the old instance, but since `sizable_from` is usually only set once during UI creation, this is unlikely to be a problem in practice.
A possible solution for this issue would be to check whether `strip_cls` matches the class of the current `_strip` attribute, and only perform the re-instantiation if that is not the case.
If this is worth the additional complexity, I can update this pull request accordingly.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
