### PR TITLE
Use `font_direction` and `font_script_name` from SDL2_ttf

### DIFF
--- a/examples/widgets/unicode_textinput.py
+++ b/examples/widgets/unicode_textinput.py
@@ -41,7 +41,7 @@ Builder.load_string('''
             background_color: .8811, .8811, .8811, 1
             foreground_color: 0, 0, 0, 1
             font_name: fnt_spnr.font_name
-            font_size: fntsz_spnr.text + 'sp'
+            font_size: sp(fntsz_spnr.text or 0)
             text: root.unicode_string
             size_hint: 1, None
             height: self.minimum_height

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -235,7 +235,8 @@ class LabelBase(object):
         unicode_errors='replace',
         font_hinting='normal', font_kerning=True, font_blended=True,
         outline_width=None, outline_color=None, font_context=None,
-        font_features=None, base_direction=None, text_language=None,
+        font_features=None, base_direction=None, font_direction='ltr',
+        font_script_name='Latin', text_language=None,
         **kwargs):
 
         # Include system fonts_dir in resource paths.
@@ -258,6 +259,8 @@ class LabelBase(object):
                    'font_context': font_context,
                    'font_features': font_features,
                    'base_direction': base_direction,
+                   'font_direction': font_direction,
+                   'font_script_name': font_script_name,
                    'text_language': text_language}
 
         kwargs_get = kwargs.get

--- a/kivy/core/text/_text_sdl2.pyx
+++ b/kivy/core/text/_text_sdl2.pyx
@@ -86,6 +86,19 @@ cdef class _SurfaceContainer:
             if TTF_GetFontKerning(font) != 0:
                 TTF_SetFontKerning(font, 0)
 
+        direction = container.options['font_direction']
+        if direction == 'ltr':
+            TTF_SetFontDirection(font, TTF_DIRECTION_LTR)
+        elif direction == 'rtl':
+            TTF_SetFontDirection(font, TTF_DIRECTION_RTL)
+        elif direction == 'ttb':
+            TTF_SetFontDirection(font, TTF_DIRECTION_TTB)
+        elif direction == 'btt':
+            TTF_SetFontDirection(font, TTF_DIRECTION_BTT)
+
+        fontscript = container.options['font_script_name']
+        TTF_SetFontScriptName(font, fontscript)
+
         if outline_width:
             TTF_SetFontOutline(font, outline_width)
             oc.r = <int>(outline_color[0] * 255)

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -749,6 +749,8 @@ cdef extern from "SDL_ttf.h":
     cdef void  TTF_SetFontStyle(TTF_Font *font, int style)
     cdef int  TTF_GetFontOutline( TTF_Font *font)
     cdef void  TTF_SetFontOutline(TTF_Font *font, int outline)
+    cdef int TTF_SetFontDirection(TTF_Font *font, int direction)
+    cdef int TTF_SetFontScriptName(TTF_Font *font, const char *script)
 
     #Set and retrieve FreeType hinter settings */
     ##define TTF_HINTING_NORMAL    0
@@ -761,6 +763,11 @@ cdef extern from "SDL_ttf.h":
     cdef int TTF_HINTING_NONE
     cdef int  TTF_GetFontHinting( TTF_Font *font)
     cdef void  TTF_SetFontHinting(TTF_Font *font, int hinting)
+
+    cdef int TTF_DIRECTION_LTR
+    cdef int TTF_DIRECTION_RTL
+    cdef int TTF_DIRECTION_TTB
+    cdef int TTF_DIRECTION_BTT
 
     #Get the total height of the font - usually equal to point size
     cdef int  TTF_FontHeight( TTF_Font *font)

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -301,7 +301,8 @@ class Label(Widget):
 
     __events__ = ['on_ref_press']
 
-    _font_properties = ('text', 'font_size', 'font_name', 'bold', 'italic',
+    _font_properties = ('text', 'font_size', 'font_name', 'font_script_name',
+                        'font_direction', 'bold', 'italic',
                         'underline', 'strikethrough', 'font_family', 'color',
                         'disabled_color', 'halign', 'valign', 'padding_x',
                         'padding_y', 'outline_width', 'disabled_outline_color',
@@ -604,6 +605,50 @@ class Label(Widget):
     defaults to 'Roboto'. This value is taken
     from :class:`~kivy.config.Config`.
     '''
+
+    font_script_name = OptionProperty('Latn', options=['Zyyy', 'Latn', 'Hani',
+                'Cyrl', 'Hira', 'Kana', 'Thai', 'Arab', 'Hang', 'Deva', 'Grek',
+                'Hebr', 'Taml', 'Knda', 'Geor', 'Mlym', 'Telu', 'Mymr', 'Gujr',
+                'Beng', 'Guru', 'Laoo', 'Zinh', 'Khmr', 'Tibt', 'Sinh', 'Ethi',
+                'Thaa', 'Orya', 'Zzzz', 'Cans', 'Syrc', 'Bopo', 'Nkoo', 'Cher',
+                'Yiii', 'Samr', 'Copt', 'Mong', 'Glag', 'Vaii', 'Bali', 'Tfng',
+                'Bamu', 'Batk', 'Cham', 'Java', 'Kali', 'Lepc', 'Limb', 'Lisu',
+                'Mand', 'Mtei', 'Talu', 'Olck', 'Saur', 'Sund', 'Sylo', 'Tale',
+                'Lana', 'Avst', 'Brah', 'Bugi', 'Buhd', 'Cari', 'Xsux', 'Cprt',
+                'Dsrt', 'Egyp', 'Goth', 'Hano', 'Armi', 'Phli', 'Prti', 'Kthi',
+                'Khar', 'Linb', 'Lyci', 'Lydi', 'Ogam', 'Ital', 'Xpeo', 'Sarb',
+                'Orkh', 'Osma', 'Phag', 'Phnx', 'Rjng', 'Runr', 'Shaw', 'Tglg',
+                'Tagb', 'Ugar', 'Cakm', 'Merc', 'Mero', 'Plrd', 'Shrd', 'Sora',
+                'Takr', 'Brai', 'Aghb', 'Bass', 'Dupl', 'Elba', 'Gran', 'Khoj',
+                'Lina', 'Mahj', 'Mani', 'Modi', 'Mroo', 'Narb', 'Nbat', 'Palm',
+                'Pauc', 'Perm', 'Phlp', 'Sidd', 'Sind', 'Tirh', 'Wara', 'Ahom',
+                'Hluw', 'Hatr', 'Mult', 'Hung', 'Sgnw', 'Adlm', 'Bhks', 'Marc',
+                'Osge', 'Tang', 'Newa', 'Gonm', 'Nshu', 'Soyo', 'Zanb', 'Dogr',
+                'Gong', 'Rohg', 'Maka', 'Medf', 'Sogo', 'Sogd', 'Elym', 'Hmnp',
+                'Nand', 'Wcho', 'Chrs', 'Diak', 'Kits', 'Yezi', 'Cpmn', 'Ougr',
+                'Tnsa', 'Toto', 'Vith', 'Kawi', 'Nagm'])
+    '''`script_code` from https://bit.ly/TypeScriptCodes .
+
+    .. versionadded:: 2.2.0
+
+    .. warning::
+
+        font_script_name is only currently supported in SDL2 ttf providers.
+
+
+    :attr:`font_script_name` is a :class:`~kivy.properties.OptionProperty` and
+    defaults to 'Latn'.
+    '''
+
+    font_direction = OptionProperty('ltr', options=['rtl', 'ltr', 'ttb', 'btt'])
+    '''Direction for the specific font, can be one of `ltr`, `rtl`, `ttb`,`btt`.
+
+    font_direction currently only works with SDL2 ttf providers.
+
+    .. versionadded:: 2.2.0
+
+    :attr:`font_direction` is a :class:`~kivy.properties.OptionProperty` and
+    defults to 'ltr'. '''
 
     font_size = NumericProperty('15sp')
     '''Font size of the text, in pixels.


### PR DESCRIPTION
This is intentionally kept separate from `base_direction` and `text_language` which are Pango specific.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
