### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -9,9 +9,9 @@ jobs:
   PEP8_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Validate PEP8
@@ -23,10 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DISPLAY: ':99.0'
+      SETUPTOOLS_ENABLE_FEATURES: 'legacy-editable'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -58,7 +59,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
     - name: Upload benchmarks as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: benchmarks
         path: .benchmarks-kivy
@@ -66,9 +67,9 @@ jobs:
   gen_docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -89,7 +90,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         generate_docs
     - name: Upload docs as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: docs
         path: doc/build/html

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DISPLAY: ':99.0'
-      SETUPTOOLS_ENABLE_FEATURES: 'legacy-editable'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.x


### PR DESCRIPTION
[SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"](https://github.com/kivy/kivy/actions/runs/4042476825/jobs/6950226072)

Also fixes warnings on GitHub Actions about using out-of-date Actions.
```
      Updated kivy/include/config.h
      Updated kivy/include/config.pxi
      Updated kivy/setupconfig.py
      Detected compiler is unix
       error: Support for editable installs via PEP 660 was recently introduced
       in `setuptools`. If you are seeing this error, please report to:
      
       https://github.com/pypa/setuptools/issues
      
       Meanwhile you can try the legacy behavior by setting an
       environment variable and trying to install again:
      
       SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building editable for Kivy
ERROR: Could not build wheels for Kivy, which is required to install pyproject.toml-based projects
Failed to build Kivy
```
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
