### PR TITLE
[build wheel] GitHub Actions: Use current Python instead of hardcoded v3.9

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.x
       - name: Install dependencies
         run: |
           source .ci/ubuntu_ci.sh
@@ -61,7 +61,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.x
     - name: Set up QEMU
       if: ${{ matrix.cibw_archs == 'aarch64' }}
       uses: docker/setup-qemu-action@v1
@@ -100,7 +100,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.x
     - uses: actions/download-artifact@v3
       with:
         name: manylinux_wheels
@@ -170,7 +170,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         test_kivy_install
     - name: Test Kivy benchmarks
-      if: matrix.python == '3.9' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
+      if: matrix.python == '3.x' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
       run: |
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
@@ -190,7 +190,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.x
       - name: Generate sdist
         run: |
           source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.x
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
@@ -52,7 +52,7 @@ jobs:
       matrix:
         include:
           - runs_on: macos-11
-            python: '3.9'
+            python: '3.x'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -100,10 +100,10 @@ jobs:
       KIVY_GL_BACKEND: 'mock'
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.x
     - uses: actions/download-artifact@v3
       with:
         name: osx_wheels
@@ -210,7 +210,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.x
       - name: Cache macOS deps downloads
         uses: actions/cache@v3
         with:
@@ -248,10 +248,10 @@ jobs:
       KIVY_GL_BACKEND: 'mock'
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.x
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: 3.x
       - uses: actions/download-artifact@v3
         with:
           name: osx_app

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -157,6 +157,8 @@ jobs:
             python: '3.9.7'
           - runs_on: apple-silicon-m1
             python: '3.10.1'
+          - runs_on: apple-silicon-m1
+            python: '3.11'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - runs_on: macos-11
-            python: '3.9'
+            python: '3.x'
           - runs_on: apple-silicon-m1
             python: '3.9.7'
     steps:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -20,7 +20,7 @@ jobs:
           - runs_on: macos-11
             python: '3.x'
           - runs_on: apple-silicon-m1
-            python: '3.9.7'
+            python: '3.11'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.x
     - name: Validate PEP8
       run: |
         source .ci/ubuntu_ci.sh
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.x
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.x
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.x
       - uses: actions/download-artifact@v3
         with:
           name: windows_wheels
@@ -129,7 +129,7 @@ jobs:
           . .\.ci\windows_ci.ps1
           Test-kivy-installed
       - name: Test Kivy benchmarks
-        if: matrix.python == '3.9' && matrix.arch == 'x64' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
+        if: matrix.python == '3.x' && matrix.arch == 'x64' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
         run: |
           . .\.ci\windows_ci.ps1
           Test-kivy-benchmark
@@ -147,7 +147,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.x
       - uses: actions/download-artifact@v3
         with:
           name: windows_wheels


### PR DESCRIPTION
Reverts #7674

As discussed at https://github.com/kivy/kivy/pull/8120#issuecomment-1416721372

Maybe the performance improvementa will lower test, build, and benchmark times:
https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
