### PR TITLE
initialize our logger inside of kivy/__init__.py

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -380,6 +380,16 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     level = LOG_LEVELS.get(Config.get('kivy', 'log_level'))
     Logger.setLevel(level=level)
 
+    # Initialize our logger, if we do not log anything during this
+    # init sequence then the logger will not be `_configured`. This
+    # can occure when log level is set to a stricter level like `error`
+    # and no errors occur, then when we call the purge_logs function our
+    # handler could be un-configured and not have a log_dir attribute --
+    # resulting in the function bailing out.
+    from kivy.logger import file_log_handler
+    file_log_handler._configure()
+
+
     # Can be overridden in command line
     if ('KIVY_UNITTEST' not in environ and
             'KIVY_PACKAGING' not in environ and

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -387,8 +387,8 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     # handler could be un-configured and not have a log_dir attribute --
     # resulting in the function bailing out.
     from kivy.logger import file_log_handler
-    file_log_handler._configure()
-
+    if file_log_handler is not None:
+        file_log_handler._configure()
 
     # Can be overridden in command line
     if ('KIVY_UNITTEST' not in environ and


### PR DESCRIPTION
The logger can end up not being `_configured` if this is not called. This can occure when log level is set to a stricter level like `error` and no errors occur, then when we call the purge_logs function our handler could be un-configured and not have a log_dir attribute -- resulting in the function bailing out.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
