### PR TITLE
PEP 621: Migrate settings from setup.cfg into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,119 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools", "wheel",
-    "cython>=0.24,<=0.29.32,!=0.27,!=0.27.2",
-    'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"',
-    'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
-    'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
-    'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+  "cython!=0.27,!=0.27.2,<=0.29.32,>=0.24",
+  'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+  'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
+  'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
+  'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
+  'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
+  'kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"',
+  "setuptools>=61.2",
+  "wheel",
 ]
+
+[project]
+name = "kivy"
+requires-python = ">=3.7"
+dynamic = [
+  "version",
+]
+dependencies = [
+  "docutils",
+  "Kivy-Garden>=0.1.4",
+  'kivy_deps.angle~=0.3.2; sys_platform == "win32"',
+  'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+  'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
+  "pygments",
+  'pypiwin32; sys_platform == "win32"',
+]
+[project.optional-dependencies]
+angle = [
+  'kivy_deps.angle~=0.3.2; sys_platform == "win32"',
+]
+base = [
+  "docutils",
+  'kivy_deps.angle~=0.3.2; sys_platform == "win32"',
+  'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+  'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
+  "pillow",
+  "pygments",
+  'pypiwin32; sys_platform == "win32"',
+  "requests",
+]
+dev = [
+  "flake8",
+  "funcparserlib==1.0.0a0",
+  'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
+  'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
+  'kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"',
+  "pre-commit",
+  "pyinstaller",
+  "pytest>=3.6",
+  "pytest-benchmark",
+  "pytest-cov",
+  "pytest-timeout",
+  "pytest_asyncio!=0.11.0",
+  "responses",
+  "sphinx",
+  "sphinxcontrib-actdiag",
+  "sphinxcontrib-blockdiag",
+  "sphinxcontrib-nwdiag",
+  "sphinxcontrib-seqdiag",
+]
+full = [
+  "docutils",
+  'ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"',
+  'kivy_deps.angle~=0.3.2; sys_platform == "win32"',
+  'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+  'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
+  'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
+  "pillow",
+  "pygments",
+  'pypiwin32; sys_platform == "win32"',
+]
+glew = [
+  'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+]
+gstreamer = [
+  'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"', # don't use 0.4.0 because it was deleted
+]
+media = [
+  'ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"',
+  'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
+]
+sdl2 = [
+  'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
+]
+tuio = [
+  "oscpy",
+]
+
+
+[tool.coverage.run]
+branch = true
+concurrency = ["thread", "multiprocessing"]
+omit = ["*/pyinstaller/*_widget/*"]
+parallel = true
+plugins = ["kivy.tools.coverage"]
+
+[tool.kivy]
+cython_exclude = "0.27,0.27.2"
+cython_max = "0.29.32"
+cython_min = "0.24"
+python_versions = "3.7 - 3.11"
+
+[tool.nosetests]
+cover-package = "kivy"
+logging-level = "DEBUG"
+verbosity = "2"
+with-coverage = "1"
+with-id = "1"
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchmarks-kivy --benchmark-save=kivy"
 markers = "incremental: mark a test as incremental."
+
+[tool.setuptools]
+# dependency-links = ["https://github.com/kivy-garden/garden/archive/master.zip"]
+include-package-data = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,94 +1,13 @@
-[nosetests]
-with-coverage=1
-cover-package=kivy
-with-id=1
-verbosity=2
-logging-level=DEBUG
-
 [kivy]
-cython_min=0.24
-cython_max=0.29.32
-cython_exclude=0.27,0.27.2
-python_versions=3.7 - 3.10
-
-[coverage:run]
-parallel = True
-branch = True
-omit =
-    */pyinstaller/*_widget/*
-plugins =
-    kivy.tools.coverage
-concurrency = thread, multiprocessing
-
-[options]
-python_requires = >=3.7
-install_requires =
-    Kivy-Garden>=0.1.4
-    docutils
-    pygments
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
-    pypiwin32; sys_platform == "win32"
-dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
-
-[options.extras_require]
-tuio = oscpy
-dev =
-    pytest>=3.6
-    pytest-cov
-    pytest_asyncio!=0.11.0
-    pytest-timeout
-    pytest-benchmark
-    pyinstaller
-    sphinx
-    sphinxcontrib-blockdiag
-    sphinxcontrib-seqdiag
-    sphinxcontrib-actdiag
-    sphinxcontrib-nwdiag
-    funcparserlib==1.0.0a0
-    kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
-    kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"
-    kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"
-    flake8
-    pre-commit
-    responses
-base =
-    pillow
-    requests
-    docutils
-    pygments
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
-    pypiwin32; sys_platform == "win32"
-media =
-    kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
-full =
-    pillow
-    docutils
-    pygments
-    kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
-    ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
-    pypiwin32; sys_platform == "win32"
-gstreamer =
-    kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    # don't use 0.4.0 because it was deleted
-angle =
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-sdl2 =
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
-glew =
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
+cython_exclude = 0.27,0.27.2
+cython_max = 0.29.32
+cython_min = 0.24
+python_versions = 3.7 - 3.11
 
 [flake8]
+count = true
+exclude = __pycache__,.tox,.git/,doc/,build/,.eggs/,venv/
 ignore = E125,E126,E127,E128,E402,E741,E731,W503,F401,W504,F841,E722
 max-line-length = 80
-exclude = __pycache__,.tox,.git/,doc/,build/,.eggs/,venv/
-statistics = true
 show-source = true
-count = true
+statistics = true


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

Migrate settings from `setup.cfg` into `pyproject.toml` using [ini2toml](https://pypi.org/project/ini2toml) to do the file conversion and running [pyproject-fmt](https://pypi.org/project/pyproject-fmt) and then [validate-pyproject](https://github.com/abravalheri/validate-pyproject) in pre-commit to validate the results.
* Currently, flake8 is not yet compatible with `pyproject.toml` so leave its settings in `setup.cfg`.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
