### PR TITLE
Remove remaining nosetest settings in favor of pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .coverage
-.noseids
 Kivy.egg-info
 Kivy-*.dist-info
 *.so

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,6 @@ clean:
 	-rm -rf build
 	-rm -rf htmlcov
 	-rm -f .coverage
-	-rm -f .noseids
 	-rm -rf kivy/tests/build
 	-find kivy -iname '*.so' -exec rm {} \;
 	-find kivy -iname '*.pyd' -exec rm {} \;
@@ -165,7 +164,7 @@ help:
 	@echo "  install        run a setup.py install"
 	@echo "  mesabuild      for a build with MesaGL"
 	@echo "  style          to check Python code for style issues"
-	@echo "  test           run unittests (nosetests)"
+	@echo "  test           run unittests (pytest)"
 	@echo "  theming        create a default theme atlas"
 	@echo "  "
 	@echo "You can also 'cd doc && make help' to build more documentation types"

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -341,7 +341,7 @@ if any(name in sys.argv[0] for name in (
     environ['KIVY_DOC'] = '1'
 if 'sphinx-build' in sys.argv[0]:
     environ['KIVY_DOC_INCLUDE'] = '1'
-if any(('nosetests' in arg or 'pytest' in arg) for arg in sys.argv):
+if any('pytest' in arg for arg in sys.argv):
     environ['KIVY_UNITTEST'] = '1'
 if any('pyinstaller' in arg.lower() for arg in sys.argv):
     environ['KIVY_PACKAGING'] = '1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[nosetests]
-with-coverage=1
-cover-package=kivy
-with-id=1
-verbosity=2
-logging-level=DEBUG
-
 [kivy]
 cython_min=0.24
 cython_max=0.29.32


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Remove remaining nosetest settings in favor of pytest.
* Nose was dropped in [v1.11.0](https://github.com/kivy/kivy/releases?q=nose&expanded=true)

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
