### PR TITLE
Initialize logger if no log_dir is configured during log purge

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -218,7 +218,10 @@ class FileHandler(logging.Handler):
         """
 
         if not self.log_dir:
-            return
+            # Try configuring our file handler if none is configured
+            self._configure()
+            if not self.log_dir:
+                return
 
         from kivy.config import Config
         maxfiles = Config.getint("kivy", "log_maxfiles")


### PR DESCRIPTION
The logger can end up not being `_configured` if this is not called. This can occure when log level is set to a stricter level like `error` and no errors occur, then when we call the purge_logs function our handler could be un-configured and not have a log_dir attribute -- resulting in the function bailing out.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.