### PR TITLE
New Feature: Allows to hide the taskbar icon

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -405,7 +405,7 @@ from kivy.utils import platform
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 26
+KIVY_CONFIG_VERSION = 27
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -938,6 +938,8 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 25:
             Config.setdefault('graphics', 'always_on_top', '0')
+
+        elif version == 26:
             Config.setdefault("graphics", "show_taskbar_icon", "1")
 
         # WARNING: When adding a new version migration here,

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -253,6 +253,11 @@ Available configuration tokens
         When enabled, the window will be brought to the front and will keep
         the window above the rest. Only works for the sdl2 window provider.
         ``0`` is disabled, ``1`` is enabled.
+    `show_taskbar_icon`: int, one of ``0`` or ``1``, defaults to ``0``
+        Determines whether the app's icon will be added to the taskbar. Only
+        applicable for the SDL2 window provider.
+        ``0`` means the icon will not be shown in the taskbar and ``1`` means
+        it will.
     `allow_screensaver`: int, one of 0 or 1, defaults to 1
         Allow the device to show a screen saver, or to go to sleep
         on mobile devices. Only works for the sdl2 window provider.
@@ -338,6 +343,7 @@ Available configuration tokens
 
 .. versionadded:: 2.2.0
     `always_on_top` have been added to the `graphics` section.
+    `show_taskbar_icon` have been added to the `graphics` section.
 
 .. versionchanged:: 2.2.0
     `implementation` has been added to the network section.
@@ -932,6 +938,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 25:
             Config.setdefault('graphics', 'always_on_top', '0')
+            Config.setdefault("graphics", "show_taskbar_icon", "1")
 
         # WARNING: When adding a new version migration here,
         # don't forget to increment KIVY_CONFIG_VERSION !

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -253,7 +253,7 @@ Available configuration tokens
         When enabled, the window will be brought to the front and will keep
         the window above the rest. Only works for the sdl2 window provider.
         ``0`` is disabled, ``1`` is enabled.
-    `show_taskbar_icon`: int, one of ``0`` or ``1``, defaults to ``0``
+    `show_taskbar_icon`: int, one of ``0`` or ``1``, defaults to ``1``
         Determines whether the app's icon will be added to the taskbar. Only
         applicable for the SDL2 window provider.
         ``0`` means the icon will not be shown in the taskbar and ``1`` means

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -75,11 +75,8 @@ cdef class _WindowSDL2Storage:
     def die(self):
         raise RuntimeError(<bytes> SDL_GetError())
 
-    def setup_window(self, x, y, width, height, borderless, fullscreen, resizable, show_taskbar_icon, state, gl_backend):
+    def setup_window(self, x, y, width, height, borderless, fullscreen, resizable, state, gl_backend):
         self.win_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI
-
-        if not show_taskbar_icon:
-            self.win_flags |= SDL_WINDOW_SKIP_TASKBAR
 
         if resizable:
             self.win_flags |= SDL_WINDOW_RESIZABLE
@@ -106,6 +103,10 @@ cdef class _WindowSDL2Storage:
             self.win_flags |= SDL_WINDOW_MINIMIZED
         elif state == 'hidden':
             self.win_flags |= SDL_WINDOW_HIDDEN
+
+        show_taskbar_icon = Config.getboolean('graphics', 'show_taskbar_icon')
+        if not show_taskbar_icon:
+            self.win_flags |= SDL_WINDOW_SKIP_TASKBAR
 
         SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, b'0')
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -75,9 +75,11 @@ cdef class _WindowSDL2Storage:
     def die(self):
         raise RuntimeError(<bytes> SDL_GetError())
 
-    def setup_window(self, x, y, width, height, borderless, fullscreen,
-                     resizable, state, gl_backend):
+    def setup_window(self, x, y, width, height, borderless, fullscreen, resizable, show_taskbar_icon, state, gl_backend):
         self.win_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI
+
+        if not show_taskbar_icon:
+            self.win_flags |= SDL_WINDOW_SKIP_TASKBAR
 
         if resizable:
             self.win_flags |= SDL_WINDOW_RESIZABLE

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -311,15 +311,11 @@ class WindowSDL(WindowBase):
             # setup window
             w, h = self.system_size
             resizable = Config.getboolean('graphics', 'resizable')
-            show_taskbar_icon = Config.getboolean(
-                'graphics',
-                'show_taskbar_icon'
-            )
             state = (Config.get('graphics', 'window_state')
                      if self._is_desktop else None)
             self.system_size = self._win.setup_window(
                 pos[0], pos[1], w, h, self.borderless,
-                self.fullscreen, resizable, show_taskbar_icon, state,
+                self.fullscreen, resizable, state,
                 self.get_gl_backend_name())
 
             # We don't have a density or dpi yet set, so let's ask for an update

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -311,11 +311,12 @@ class WindowSDL(WindowBase):
             # setup window
             w, h = self.system_size
             resizable = Config.getboolean('graphics', 'resizable')
+            show_taskbar_icon = Config.getboolean('graphics', 'show_taskbar_icon')
             state = (Config.get('graphics', 'window_state')
                      if self._is_desktop else None)
             self.system_size = self._win.setup_window(
                 pos[0], pos[1], w, h, self.borderless,
-                self.fullscreen, resizable, state,
+                self.fullscreen, resizable, show_taskbar_icon, state,
                 self.get_gl_backend_name())
 
             # We don't have a density or dpi yet set, so let's ask for an update

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -311,7 +311,10 @@ class WindowSDL(WindowBase):
             # setup window
             w, h = self.system_size
             resizable = Config.getboolean('graphics', 'resizable')
-            show_taskbar_icon = Config.getboolean('graphics', 'show_taskbar_icon')
+            show_taskbar_icon = Config.getboolean(
+                'graphics',
+                'show_taskbar_icon'
+            )
             state = (Config.get('graphics', 'window_state')
                      if self._is_desktop else None)
             self.system_size = self._win.setup_window(

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -256,6 +256,7 @@ cdef extern from "SDL.h":
         SDL_WINDOW_FOREIGN = 0x00000800         #            /**< window not created by SDL */
         SDL_WINDOW_FULLSCREEN_DESKTOP
         SDL_WINDOW_ALLOW_HIGHDPI
+        SDL_WINDOW_SKIP_TASKBAR = 0x00010000    #,   /**< window should not be added to the taskbar */
 
     ctypedef enum SDL_HitTestResult:
         SDL_HITTEST_NORMAL


### PR DESCRIPTION
This PR introduces the possibility to hide the taskbar application icon.

Options:
- `0` → The icon will be hidden in the taskbar.
- `1` → default - The icon will be shown on the taskbar.

<br>

Test code:

```python
from kivy.config import Config
Config.set("graphics", "show_taskbar_icon", 0)

from kivy.app import App
from kivy.uix.button import Button


class TestApp(App):

    def build(self):
        return Button(text="Hello World")

if __name__ == "__main__":
    TestApp().run()
```


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
