### PR TITLE
Added property for mouse draggable tab scrollbar to TabbedPanel

### DIFF
--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -703,7 +703,7 @@ class TabbedPanel(GridLayout):
         tab_layout = self._tab_layout
         tab_layout.clear_widgets()
         scrl_v = ScrollView(size_hint=(None, 1), always_overscroll=False,
-                            bar_width=self.bar_width, 
+                            bar_width=self.bar_width,
                             scroll_type=self.scroll_type)
         tabs = self._tab_strip
         parent = tabs.parent

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -372,6 +372,8 @@ class TabbedPanel(GridLayout):
     '''Width of the horizontal scroll bar. The width is interpreted
     as a height for the horizontal bar.
 
+    .. versionadded:: 2.2.0
+
     :attr:`bar_width` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 2.
     '''
@@ -381,6 +383,8 @@ class TabbedPanel(GridLayout):
 
     '''Sets the type of scrolling to use for the content of the scrollview.
     Available options are: ['content'], ['bars'], ['bars', 'content'].
+
+    .. versionadded:: 2.2.0
 
     :attr:`scroll_type` is an :class:`~kivy.properties.OptionProperty` and
     defaults to ['content'].

--- a/kivy/uix/tabbedpanel.py
+++ b/kivy/uix/tabbedpanel.py
@@ -368,6 +368,24 @@ class TabbedPanel(GridLayout):
     defaults to 100.
     '''
 
+    bar_width = NumericProperty('2dp')
+    '''Width of the horizontal scroll bar. The width is interpreted
+    as a height for the horizontal bar.
+
+    :attr:`bar_width` is a :class:`~kivy.properties.NumericProperty` and
+    defaults to 2.
+    '''
+
+    scroll_type = OptionProperty(['content'], options=(['content'], ['bars'],
+                                 ['bars', 'content'], ['content', 'bars']))
+
+    '''Sets the type of scrolling to use for the content of the scrollview.
+    Available options are: ['content'], ['bars'], ['bars', 'content'].
+
+    :attr:`scroll_type` is an :class:`~kivy.properties.OptionProperty` and
+    defaults to ['content'].
+    '''
+
     do_default_tab = BooleanProperty(True)
     '''Specifies whether a default_tab head is provided.
 
@@ -684,7 +702,9 @@ class TabbedPanel(GridLayout):
         tab_pos = self.tab_pos
         tab_layout = self._tab_layout
         tab_layout.clear_widgets()
-        scrl_v = ScrollView(size_hint=(None, 1), always_overscroll=False)
+        scrl_v = ScrollView(size_hint=(None, 1), always_overscroll=False,
+                            bar_width=self.bar_width, 
+                            scroll_type=self.scroll_type)
         tabs = self._tab_strip
         parent = tabs.parent
         if parent:


### PR DESCRIPTION
Added `bar_width` and `scroll_type` properties for ScrollView to enable mouse control of tab scrollbars.

Example:
```Python
tp = TabbedPanel(bar_width='10dp', scroll_type=['content', 'bars'])
```

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
