### PR TITLE
Fix memory issue on iOS 16.2 for AVMetadataObject (during QRCode scan)

### DIFF
--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -99,7 +99,7 @@ didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
 
 - (id)init {
     [super init];
-    metadata = NULL;
+    metadata = new CameraMetadata();
     newMetadata = 0;
     return self;
 }
@@ -107,17 +107,24 @@ didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
 - (void)captureOutput:(AVCaptureOutput *)captureOutput
 didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
 fromConnection:(AVCaptureConnection *)connection{
-    for (AVMetadataObject *object in metadataObjects) {
-        if ([object.type isEqualToString:AVMetadataObjectTypeQRCode]){
-            AVMetadataMachineReadableCodeObject *codeObject = (AVMetadataMachineReadableCodeObject *)object;
-            if (metadata == NULL)
-            {
-                metadata = new CameraMetadata();
-            }
+    for (AVMetadataObject *metadataResult in metadataObjects) {
+        if ([metadataResult.type isEqualToString:AVMetadataObjectTypeQRCode]){
+            AVMetadataMachineReadableCodeObject *codeObject = (AVMetadataMachineReadableCodeObject *)metadataResult;
             NSString *stringValue = codeObject.stringValue ? codeObject.stringValue : @"Unable to decode";
-            metadata->type = (char *)"AVMetadataMachineReadableCodeObject";
-            metadata->data = (char *)[stringValue UTF8String];
             NSLog(@"Code: %@", stringValue);
+
+            if (metadata->type != NULL){
+                free(metadata->type);
+            }
+            if (metadata->data != NULL){
+                free(metadata->data);
+            }
+            metadata->type = (char *)malloc(sizeof(char) * (strlen([metadataResult.type UTF8String]) + 1));
+            metadata->data = (char *)malloc(sizeof(char) * (strlen([stringValue UTF8String]) + 1));
+
+            strcpy(metadata->type, [metadataResult.type UTF8String]);
+            strcpy(metadata->data, [stringValue UTF8String]);
+
             newMetadata = 1;
         }
     }


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Prior to iOS 16.2, the `(NSArray<__kindof AVMetadataObject *> *)metadataObjects`  were kept in memory, likely until another scan was performed and it was "safe" to store the pointer.

From iOS 16.2 and onward that seems to not happen anymore, so we should copy the content instead.