### PR TITLE
Detect High DPI on Linux Desktop

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -266,6 +266,13 @@ cdef class _WindowSDL2Storage:
         SDL_GetWindowSize(self.win, &w, &h)
         return w, h
 
+
+    def _get_display_dpi(self):
+        cdef int display_index = SDL_GetWindowDisplayIndex(self.win)
+        cdef float horizontal_dpi = 0.
+        SDL_GetDisplayDPI(display_index, NULL, &horizontal_dpi, NULL)
+        return horizontal_dpi
+
     def _set_cursor_state(self, value):
         SDL_ShowCursor(value)
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -403,7 +403,24 @@ class WindowSDL(WindowBase):
         else:
             self._density = self._win._get_gl_size()[0] / self._size[0]
             if self._is_desktop:
-                self.dpi = self._density * 96.
+                # If the SDL window allows high DPI mode,
+                # then the window size and renderer size may be different.
+                # https://wiki.libsdl.org/SDL2/SDL_GetWindowSize
+                if self._density != 1.0:
+                    dpi = self._density * 96.
+                else:
+                    # Try to get the display DPI from SDL. This works in SDL2 on
+                    # the X11 SDL2 backend, given that the X11 display
+                    # is correctly configured.
+                    display_dpi = self._win._get_display_dpi()
+                    if display_dpi > 0.0:
+                        dpi = display_dpi
+
+                # Change window DPI if it has changed.
+                # This will call reset_metrics under the hood,
+                # so only do it once and if it has changed.
+                if self.dpi != dpi:
+                    self.dpi = dpi
 
     def close(self):
         self._win.teardown_window()

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -552,6 +552,7 @@ cdef extern from "SDL.h":
     cdef SDL_GLContext SDL_GL_CreateContext(SDL_Window* window)
     cdef int SDL_GetNumVideoDisplays()
     cdef int SDL_GetNumDisplayModes(int displayIndex)
+    cdef int SDL_GetDisplayDPI(int displayIndex, float * ddpi, float * hdpi, float * vdpi);
     cdef int SDL_GetDisplayMode(int displayIndex, int index, SDL_DisplayMode * mode)
     cdef SDL_bool SDL_HasIntersection(SDL_Rect * A, SDL_Rect * B) nogil
     cdef SDL_bool SDL_IntersectRect(SDL_Rect * A, SDL_Rect * B, SDL_Rect * result) nogil

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -259,7 +259,7 @@ class MetricsBase(EventDispatcher):
         elif platform == 'ios':
             import ios
             value = ios.get_scale()
-        elif platform in ('macosx', 'win'):
+        elif platform in ('linux', 'macosx', 'win'):
             value = self.dpi / 96.
 
         sync_pixel_scale(density=value)

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -415,19 +415,19 @@ def test_numeric_string_with_units_check(self, set_name):
 
     a.set(wid, '55dp')
     density = Metrics.density
-    self.assertEqual(a.get(wid), 55 * density)
+    self.assertAlmostEqual(a.get(wid), 55 * density, delta=1E-2)
     self.assertEqual(a.get_format(wid), 'dp')
 
     a.set(wid, u'55dp')
-    self.assertEqual(a.get(wid), 55 * density)
+    self.assertAlmostEqual(a.get(wid), 55 * density, delta=1E-2)
     self.assertEqual(a.get_format(wid), 'dp')
 
     a.set(wid, '99in')
-    self.assertEqual(a.get(wid), 9504.0 * density)
+    self.assertAlmostEqual(a.get(wid), 9504.0 * density, delta=1E-2)
     self.assertEqual(a.get_format(wid), 'in')
 
     a.set(wid, u'99in')
-    self.assertEqual(a.get(wid), 9504.0 * density)
+    self.assertAlmostEqual(a.get(wid), 9504.0 * density, delta=1E-2)
     self.assertEqual(a.get_format(wid), 'in')
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.


# Before patch on Linux with high DPI
Scaling is not working unless setting the DPI and density manually using the environment variables `KIVY_DPI` and `KIVY_METRICS_DENSITY`.
![image](https://user-images.githubusercontent.com/5873750/221440994-d1a04357-1c32-497c-8667-e3c41e56b838.png)

# After patch on Linux with high DPI
DPI is correctly set to the same as X11 is configured to.
![image](https://user-images.githubusercontent.com/5873750/221441034-47408b0d-fecc-4f40-8fed-c7047e1bdc91.png)


## Implementation
The DPI can be found using this SDL function [SDL_GetDisplayDPI](https://wiki.libsdl.org/SDL2/SDL_GetDisplayDPI). 

The warning suggests using another method, which is the one already used in `kivy/core/window/window_sdl2.py`
This other method I think only really works for macOS and IOS with retina displays.

So, if we are on a desktop and this method fails, then try to get the DPI using the SDL function and if that does not work we use the default of 96. Which will yield a density of 1.0 when density is calculated on Linux (with 74b866d9e53859d832519840637d28a42e82d429) as well as the other desktop OSes.