### PR TITLE
Use correct Path for Kivy Home Dir

### DIFF
--- a/doc/sources/guide/config.rst
+++ b/doc/sources/guide/config.rst
@@ -14,15 +14,29 @@ environment variable `KIVY_HOME`::
 
     <KIVY_HOME>/config.ini
 
-On desktop, this defaults to::
+On Windows, this defaults to::
 
-    <HOME_DIRECTORY>/.kivy/config.ini
+    %APPDATA%/kivy/config.ini
 
 Therefore, if your user is named "tito", the file will be here:
 
-- Windows: ``C:\Users\tito\.kivy\config.ini``
-- macOS: ``/Users/tito/.kivy/config.ini``
-- Linux: ``/home/tito/.kivy/config.ini``
+    ``C:\Users\tito\AppData\Roaming\kivy\config.ini``
+
+On macOS, this defaults to::
+
+    <HOME_DIRECTORY>/Library/'Application Support/kivy/config.ini
+
+Therefore, if your user is named "tito", the file will be here:
+
+    ``/Users/tito/Library/'Application Support/kivy/config.ini``
+
+On Linux and BSD, this defaults to::
+
+    $XDG_DATA_HOME/kivy
+
+Therefore, if your user is named "tito", the file will be here:
+
+    ``/home/tito/.local/share/kivy``
 
 On Android, this defaults to::
 

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -352,11 +352,23 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         kivy_home_dir = expanduser(environ['KIVY_HOME'])
     else:
         user_home_dir = expanduser('~')
-        if platform == 'android':
+        if platform == 'win':
+            kivy_home_dir = join(environ['APPDATA'], 'kivy')
+        elif platform == 'macosx':
+            kivy_home_dir = join(user_home_dir, 'Library', 'Application Support', 'kivy')
+        elif platform == 'linux':
+            if 'XDG_DATA_HOME' in environ:
+                kivy_home_dir = join(environ['XDG_DATA_HOME'], 'kivy')
+            else:
+                kivy_home_dir = join(user_home_dir, '.local', 'share', 'kivy')
+        elif platform == 'android':
             user_home_dir = environ['ANDROID_APP_PATH']
+            kivy_home_dir = join(user_home_dir, '.kivy')
         elif platform == 'ios':
             user_home_dir = join(expanduser('~'), 'Documents')
-        kivy_home_dir = join(user_home_dir, '.kivy')
+            kivy_home_dir = join(user_home_dir, '.kivy')
+        else:
+            kivy_home_dir = join(user_home_dir, '.kivy')
 
     kivy_config_fn = join(kivy_home_dir, 'config.ini')
     kivy_usermodules_dir = join(kivy_home_dir, 'mods')


### PR DESCRIPTION
At the moment, Kivy saves all of it's data under `~/.kivy`, but this is wrong. Each Operating System has it's own Location to save such files. This PR make Kivy respect the Standard for each OS.

This is especially important for Linux, if you run a Kivy App in a Sandboxed Environment (e.g. Flatpak or Snap) which expects the Apps to save it's Data in a custom Directory (e.g. Flat Flatpak it's `~/.var/<appid>`) and restrict access to Home.

For macOS I#m not 100% sure, if I got the right Location, because I never used it, but this is the Location I found that are used by other Programs as well.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
