### PR TITLE
Dependencies build tool: exit immediately on fail and allows to debug easier

### DIFF
--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e -x
 
 # manylinux SDL2
 MANYLINUX__SDL2__VERSION="2.24.2"
@@ -21,7 +22,7 @@ MANYLINUX__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/downloa
 MANYLINUX__SDL2_TTF__FOLDER="SDL2_ttf-2.20.1"
 
 # Clean the dependencies folder
-rm -r kivy-dependencies
+rm -rf kivy-dependencies
 
 # Create the dependencies folder
 mkdir kivy-dependencies

--- a/tools/build_macos_dependencies.sh
+++ b/tools/build_macos_dependencies.sh
@@ -1,3 +1,5 @@
+set -e -x
+
 # macOS SDL2
 MACOS__SDL2__VERSION="2.24.2"
 MACOS__SDL2__URL="https://github.com/libsdl-org/SDL/releases/download/release-$MACOS__SDL2__VERSION/SDL2-$MACOS__SDL2__VERSION.tar.gz"
@@ -19,7 +21,7 @@ MACOS__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/re
 MACOS__SDL2_TTF__FOLDER="SDL2_ttf-2.20.1"
 
 # Clean the dependencies folder
-rm -r kivy-dependencies
+rm -rf kivy-dependencies
 
 # Create the dependencies folder
 mkdir kivy-dependencies


### PR DESCRIPTION

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


As reported by @akshayaurora on Discord, the dependencies build tool does not exit immediately on fail, and the user may not notice if something went wrong during the build.