### PR TITLE
Added API preference to VideoCapture

### DIFF
--- a/kivy/core/camera/camera_opencv.py
+++ b/kivy/core/camera/camera_opencv.py
@@ -106,7 +106,7 @@ class CameraOpenCV(CameraBase):
 
         elif self.opencvMajorVersion in (2, 3, 4):
             # create the device
-            self._device = cv2.VideoCapture(self._index)
+            self._device = cv2.VideoCapture(self._index, cv2.CAP_DSHOW)
             # Set preferred resolution
             self._device.set(PROPERTY_WIDTH,
                              self.resolution[0])


### PR DESCRIPTION
Added a preferred capture API backend to the cv2 VideoCapture function call to greatly reduce lag when creating a kivy camera object in Windows.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
