### PR TITLE
`Label`: allow different values of left, top, right and bottom for `padding`.

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -721,10 +721,11 @@ class LabelBase(object):
         valign = options['valign']
 
         y = padding_top = options['padding'][1]  # pos in the texture
+        padding_bottom = options['padding'][3]
         if valign == 'bottom':
             y = size[1] - ih + padding_top
         elif valign == 'middle' or valign == 'center':
-            y = int((size[1] - ih) / 2 + padding_top)
+            y = int((size[1] - ih) / 2 + (padding_top + padding_bottom) / 2)
         self._render_begin()
         self.render_lines(lines, options, self._render_text, y, size)
 

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -302,7 +302,7 @@ class LabelBase(object):
         for padding_option in ('padding_x', 'padding_y'):
             if kwargs_get(padding_option):
                 Logger.warning(
-                    f"The use of the {padding_option} parameter is "
+                    f"LabelBase: The use of the {padding_option} parameter is "
                     "deprecated, and will be removed in future versions. Use "
                     "padding instead."
                 )

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -640,9 +640,10 @@ class LabelBase(object):
     def render_lines(self, lines, options, render_text, y, size):
         get_extents = self.get_cached_extents()
         uw, uh = options['text_size']
-        xpad = options['padding'][0]
+        padding_left = options['padding'][0]
+        padding_right = options['padding'][2]
         if uw is not None:
-            uww = uw - 2 * xpad  # real width of just text
+            uww = uw - padding_left - padding_right  # real width of just text
         w = size[0]
         sw = options['space_width']
         halign = options['halign']
@@ -659,14 +660,15 @@ class LabelBase(object):
                 line = last_word.text
                 if not cur_base_dir:
                     cur_base_dir = find_base_dir(line)
-            x = xpad
+            x = padding_left
             if halign == 'auto':
                 if cur_base_dir and 'rtl' in cur_base_dir:
-                    x = max(0, int(w - lw - xpad))  # right-align RTL text
+                    # right-align RTL text
+                    x = max(0, int(w - lw - padding_right))
             elif halign == 'center':
                 x = int((w - lw) / 2.)
             elif halign == 'right':
-                x = max(0, int(w - lw - xpad))
+                x = max(0, int(w - lw - padding_right))
 
             # right left justify
             # divide left over space between `spaces`
@@ -718,12 +720,11 @@ class LabelBase(object):
         size = self.size
         valign = options['valign']
 
-        y = ypad = options['padding'][1]  # pos in the texture
+        y = padding_top = options['padding'][1]  # pos in the texture
         if valign == 'bottom':
-            y = size[1] - ih + ypad
+            y = size[1] - ih + padding_top
         elif valign == 'middle' or valign == 'center':
-            y = int((size[1] - ih) / 2 + ypad)
-
+            y = int((size[1] - ih) / 2 + padding_top)
         self._render_begin()
         self.render_lines(lines, options, self._render_text, y, size)
 

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -669,7 +669,7 @@ class LabelBase(object):
                 x = min(
                     int(w - lw),
                     max(
-                        padding_left,
+                        int(padding_left),
                         int((w - lw + padding_left - padding_right) / 2.0)
                     )
                 )
@@ -727,12 +727,14 @@ class LabelBase(object):
         size = self.size
         valign = options['valign']
 
-        y = padding_top = options['padding'][1]  # pos in the texture
-        padding_bottom = options['padding'][3]
+        padding_top = options['padding'][1]
         if valign == 'bottom':
-            y = size[1] - ih + padding_top
-        elif valign == 'middle' or valign == 'center':
-            y = int((size[1] - ih) / 2 + (padding_top + padding_bottom) / 2)
+            y = int(size[1] - ih + padding_top)
+        elif valign == 'top':
+            y = int(padding_top)
+        elif valign in ('middle', 'center'):
+            y = int((size[1] - ih + 2 * padding_top) / 2)
+
         self._render_begin()
         self.render_lines(lines, options, self._render_text, y, size)
 

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -131,9 +131,11 @@ class LabelBase(object):
         `text_size`: tuple, defaults to (None, None)
             Add constraint to render the text (inside a bounding box).
             If no size is given, the label size will be set to the text size.
-        `padding`: list, defaults to [0, 0, 0, 0].
+        `padding`: int|float or list|tuple, defaults to [0, 0, 0, 0].
             Padding of the text in the format [padding_left, padding_top,
-            padding_right, padding_bottom]
+            padding_right, padding_bottom].
+            ``padding`` should be int|float or a list|tuple with 1, 2 or 4
+            elements.
         `padding_x`: float, defaults to 0.0
             Left/right padding
         `padding_y`: float, defaults to 0.0
@@ -189,7 +191,8 @@ class LabelBase(object):
         instead.
 
     .. versionchanged:: 2.2.0
-        `padding` is now a list and defaults to [0, 0, 0, 0].
+        `padding` is now a list and defaults to [0, 0, 0, 0]. `padding` accepts
+        int|float or a list|tuple with 1, 2 or 4 elements.
 
     .. versionchanged:: 1.10.1
         `font_context`, `font_family`, `font_features`, `base_direction`
@@ -321,9 +324,9 @@ class LabelBase(object):
         self.texture = None
         self.is_shortened = False
         self.resolve_font_name()
-        self._update_padding()
+        self._migrate_deprecated_padding_xy()
 
-    def _update_padding(self):
+    def _migrate_deprecated_padding_xy(self):
         options = self.options
         self.options['padding'] = list(self.options['padding'])
         if options['padding_x']:

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -666,7 +666,14 @@ class LabelBase(object):
                     # right-align RTL text
                     x = max(0, int(w - lw - padding_right))
             elif halign == 'center':
-                x = int((w - lw) / 2.)
+                x = min(
+                    int(w - lw),
+                    max(
+                        padding_left,
+                        int((w - lw + padding_left - padding_right) / 2.0)
+                    )
+                )
+
             elif halign == 'right':
                 x = max(0, int(w - lw - padding_right))
 

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -1047,7 +1047,6 @@ Text = Label = core_select_lib('text', label_libs)
 
 if 'KIVY_DOC' not in os.environ:
     if not Label:
-        from kivy.logger import Logger
         import sys
         Logger.critical('App: Unable to get a Text provider, abort.')
         sys.exit(1)

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -131,6 +131,8 @@ class LabelBase(object):
             Add constraint to render the text (inside a bounding box).
             If no size is given, the label size will be set to the text size.
         `padding`: list, defaults to [0, 0, 0, 0].
+            Padding of the text in the format [padding_left, padding_top,
+            padding_right, padding_bottom]
         `padding_x`: float, defaults to 0.0
             Left/right padding
         `padding_y`: float, defaults to 0.0

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -466,7 +466,13 @@ class MarkupLabel(MarkupLabelBase):
             lw, lh = layout_line.w, layout_line.h
             x = padding_left
             if halign == 'center':
-                x = int((w - lw) / 2.)
+                x = min(
+                    int(w - lw),
+                    max(
+                        int(padding_left),
+                        int((w - lw + padding_left - padding_right) / 2.0)
+                    )
+                )
             elif halign == 'right' or auto_halign_r:
                 x = max(0, int(w - lw - padding_right))
             layout_line.x = x

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -165,7 +165,7 @@ class MarkupLabel(MarkupLabelBase):
         # flattened later when shortening and broken up lines if broken
         # mid-word will have space mid-word when lines are joined
         uw_temp = None if shorten else uw
-        xpad = options['padding_x']
+        xpad = options['padding'][0]
         uhh = (None if uh is not None and options['valign'] != 'top' or
                options['shorten'] else uh)
         options['strip'] = options['strip'] or options['halign'] == 'justify'
@@ -453,7 +453,7 @@ class MarkupLabel(MarkupLabelBase):
         return int(w), int(h)
 
     def render_lines(self, lines, options, render_text, y, size):
-        xpad = options['padding_x']
+        xpad = options['padding'][0]
         w = size[0]
         halign = options['halign']
         refs = self._refs
@@ -669,12 +669,18 @@ class MarkupLabel(MarkupLabelBase):
         if uw is None:
             return w, h, lines
         old_opts = copy(self.options)
-        uw = max(0, int(uw - old_opts['padding_x'] * 2 - margin))
+        uw = max(
+            0,
+            int(uw - old_opts["padding"][0] - old_opts["padding"][2] - margin),
+        )
         chr = type(self.text)
         ssize = textwidth(' ')
         c = old_opts['split_str']
         line_height = old_opts['line_height']
-        xpad, ypad = old_opts['padding_x'], old_opts['padding_y']
+        xpad, ypad = (
+            old_opts["padding"][0] + old_opts["padding"][2],
+            old_opts["padding"][1] + old_opts["padding"][3],
+        )
         dir = old_opts['shorten_from'][0]
 
         # flatten lines into single line

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -165,7 +165,7 @@ class MarkupLabel(MarkupLabelBase):
         # flattened later when shortening and broken up lines if broken
         # mid-word will have space mid-word when lines are joined
         uw_temp = None if shorten else uw
-        xpad = options['padding'][0]
+        xpad = options['padding'][0] + options['padding'][2]
         uhh = (None if uh is not None and options['valign'] != 'top' or
                options['shorten'] else uh)
         options['strip'] = options['strip'] or options['halign'] == 'justify'
@@ -338,7 +338,7 @@ class MarkupLabel(MarkupLabelBase):
             # XXX: update refs to justified pos
             # when justify, each line should've been stripped already
             split = partial(re.split, re.compile('( +)'))
-            uww = uw - 2 * xpad
+            uww = uw - xpad
             chr = type(self.text)
             space = chr(' ')
             empty = chr('')
@@ -453,7 +453,7 @@ class MarkupLabel(MarkupLabelBase):
         return int(w), int(h)
 
     def render_lines(self, lines, options, render_text, y, size):
-        xpad = options['padding'][0]
+        padding_right = options['padding'][2]
         w = size[0]
         halign = options['halign']
         refs = self._refs
@@ -463,11 +463,11 @@ class MarkupLabel(MarkupLabelBase):
 
         for layout_line in lines:  # for plain label each line has only one str
             lw, lh = layout_line.w, layout_line.h
-            x = xpad
+            x = padding_right
             if halign == 'center':
                 x = int((w - lw) / 2.)
             elif halign == 'right' or auto_halign_r:
-                x = max(0, int(w - lw - xpad))
+                x = max(0, int(w - lw - padding_right))
             layout_line.x = x
             layout_line.y = y
             psp = pph = 0
@@ -702,8 +702,8 @@ class MarkupLabel(MarkupLabelBase):
             lh = max([word.lh for word in line] + [0]) * line_height
             self.is_shortened = False
             return (
-                lw + 2 * xpad,
-                lh + 2 * ypad,
+                lw + xpad,
+                lh + ypad,
                 [LayoutLine(0, 0, lw, lh, 1, 0, line)]
             )
 
@@ -720,8 +720,8 @@ class MarkupLabel(MarkupLabelBase):
             s = textwidth('..')
             if s[0] <= uw:
                 return (
-                    s[0] + 2 * xpad,
-                    s[1] * line_height + 2 * ypad,
+                    s[0] + xpad,
+                    s[1] * line_height + ypad,
                     [LayoutLine(
                         0, 0, s[0], s[1], 1, 0,
                         [LayoutWord(old_opts, s[0], s[1], '..')])]
@@ -730,8 +730,8 @@ class MarkupLabel(MarkupLabelBase):
             else:
                 s = textwidth('.')
                 return (
-                    s[0] + 2 * xpad,
-                    s[1] * line_height + 2 * ypad,
+                    s[0] + xpad,
+                    s[1] * line_height + ypad,
                     [LayoutLine(
                         0, 0, s[0], s[1], 1, 0,
                         [LayoutWord(old_opts, s[0], s[1], '.')])]
@@ -773,8 +773,8 @@ class MarkupLabel(MarkupLabelBase):
                 self.options = old_opts
                 self.is_shortened = True
                 return (
-                    lw + 2 * xpad,
-                    lh + 2 * ypad,
+                    lw + xpad,
+                    lh + ypad,
                     [LayoutLine(0, 0, lw, lh, 1, 0, line1)]
                 )
 
@@ -836,8 +836,8 @@ class MarkupLabel(MarkupLabelBase):
                 self.options = old_opts
                 self.is_shortened = True
                 return (
-                    lw + 2 * xpad,
-                    lh + 2 * ypad,
+                    lw + xpad,
+                    lh + ypad,
                     [LayoutLine(0, 0, lw, lh, 1, 0, line1)]
                 )
 
@@ -879,7 +879,7 @@ class MarkupLabel(MarkupLabelBase):
         if uw < lw:
             self.is_shortened = True
         return (
-            lw + 2 * xpad,
-            lh + 2 * ypad,
+            lw + xpad,
+            lh + ypad,
             [LayoutLine(0, 0, lw, lh, 1, 0, line1)]
         )

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -453,6 +453,7 @@ class MarkupLabel(MarkupLabelBase):
         return int(w), int(h)
 
     def render_lines(self, lines, options, render_text, y, size):
+        padding_left = options['padding'][0]
         padding_right = options['padding'][2]
         w = size[0]
         halign = options['halign']
@@ -463,7 +464,7 @@ class MarkupLabel(MarkupLabelBase):
 
         for layout_line in lines:  # for plain label each line has only one str
             lw, lh = layout_line.w, layout_line.h
-            x = padding_right
+            x = padding_left
             if halign == 'center':
                 x = int((w - lw) / 2.)
             elif halign == 'right' or auto_halign_r:

--- a/kivy/core/text/text_layout.pyx
+++ b/kivy/core/text/text_layout.pyx
@@ -118,7 +118,7 @@ cdef inline LayoutLine add_line(object text, int lw, int lh, LayoutLine line,
             add_h = max(lh, line.h)
         # if we're appending to existing line don't add height twice
         h[0] = h[0] + add_h - old_lh
-        w[0] = max(w[0], line.w + 2 * xpad)
+        w[0] = max(w[0], line.w + xpad)
         if strip:
             final_strip(line)
         if pos == -1:
@@ -214,7 +214,7 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
         else:
             add_h = _line.h
 
-        w = max(w, _line.w + 2 * xpad)
+        w = max(w, _line.w + xpad)
         h += add_h - old_lh
 
     # now do the remaining lines
@@ -244,7 +244,7 @@ cdef inline layout_text_unrestricted(object text, list lines, int w, int h,
             break
 
         pos += 1
-        w = max(w, int(lw + 2 * xpad))
+        w = max(w, int(lw + xpad))
         h += add_h
         if lw:
             _line = LayoutLine(0, 0, lw, lhh, 1, 0, [LayoutWord(options, lw,
@@ -386,7 +386,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     '''
 
     cdef int uw, uh,  _do_last_line, lwe, lhe, ends_line, is_last_line
-    cdef int xpad = options['padding_x'], ypad = options['padding_y']
+    cdef int xpad = options['padding'][0] + options['padding'][2], ypad = options['padding'][1] + options['padding'][3]
     cdef int max_lines = int(options.get('max_lines', 0))
     cdef float line_height = options['line_height']
     cdef int strip = options['strip'] or options['halign'] == 'justify'
@@ -402,7 +402,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
     uh = text_size[1] if text_size[1] is not None else -1
 
     if not h:
-        h = ypad * 2
+        h = ypad
 
     if uw == -1:  # no width specified
         return layout_text_unrestricted(text, lines, w, h, uh, options,
@@ -411,7 +411,7 @@ def layout_text(object text, list lines, tuple size, tuple text_size,
 
     new_lines = text.split('\n')
     n = <int>len(new_lines)
-    uw = max(0, uw - xpad * 2)  # actual w, h allowed for rendering
+    uw = max(0, uw - xpad)  # actual w, h allowed for rendering
     _, bare_h = get_extents('')
     if dwn:
         pos = -1  # don't use pos when going down b/c we append at end of lines

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -285,8 +285,8 @@ from kivy.uix.widget import Widget
 from kivy.core.text import Label as CoreLabel, DEFAULT_FONT
 from kivy.core.text.markup import MarkupLabel as CoreMarkupLabel
 from kivy.properties import StringProperty, OptionProperty, \
-    NumericProperty, BooleanProperty, ReferenceListProperty, \
-    ListProperty, ObjectProperty, DictProperty, ColorProperty
+    NumericProperty, BooleanProperty, ListProperty, \
+    ObjectProperty, DictProperty, ColorProperty, VariableListProperty
 from kivy.utils import get_hex_from_color
 
 
@@ -304,8 +304,8 @@ class Label(Widget):
     _font_properties = ('text', 'font_size', 'font_name', 'font_script_name',
                         'font_direction', 'bold', 'italic',
                         'underline', 'strikethrough', 'font_family', 'color',
-                        'disabled_color', 'halign', 'valign', 'padding_x',
-                        'padding_y', 'outline_width', 'disabled_outline_color',
+                        'disabled_color', 'halign', 'valign', 'padding',
+                        'outline_width', 'disabled_outline_color',
                         'outline_color', 'text_size', 'shorten', 'mipmap',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
                         'split_str', 'ellipsis_options', 'unicode_errors',
@@ -732,7 +732,7 @@ class Label(Widget):
     defaults to False.
     '''
 
-    padding_x = NumericProperty(0)
+    padding_x = NumericProperty(0, deprecated=True)
     '''Horizontal padding of the text inside the widget box.
 
     :attr:`padding_x` is a :class:`~kivy.properties.NumericProperty` and
@@ -741,9 +741,12 @@ class Label(Widget):
     .. versionchanged:: 1.9.0
         `padding_x` has been fixed to work as expected.
         In the past, the text was padded by the negative of its values.
+
+    .. deprecated:: 2.2.0
+        Please use :attr:`padding` instead.
     '''
 
-    padding_y = NumericProperty(0)
+    padding_y = NumericProperty(0, deprecated=True)
     '''Vertical padding of the text inside the widget box.
 
     :attr:`padding_y` is a :class:`~kivy.properties.NumericProperty` and
@@ -752,13 +755,23 @@ class Label(Widget):
     .. versionchanged:: 1.9.0
         `padding_y` has been fixed to work as expected.
         In the past, the text was padded by the negative of its values.
+
+    .. deprecated:: 2.2.0
+        Please use :attr:`padding` instead.
     '''
 
-    padding = ReferenceListProperty(padding_x, padding_y)
-    '''Padding of the text in the format (padding_x, padding_y)
+    padding = VariableListProperty([0, 0, 0, 0], lenght=4)
+    '''Padding of the text in the format [padding_left, padding_top,
+    padding_right, padding_bottom]
 
-    :attr:`padding` is a :class:`~kivy.properties.ReferenceListProperty` of
-    (:attr:`padding_x`, :attr:`padding_y`) properties.
+    ``padding`` also accepts a two argument form [padding_horizontal,
+    padding_vertical] and a one argument form [padding].
+
+    .. versionchanged:: 2.2.0
+        Replaced ReferenceListProperty with VariableListProperty.
+
+    :attr:`padding` is a :class:`~kivy.properties.VariableListProperty` and
+    defaults to [0, 0, 0, 0].
     '''
 
     halign = OptionProperty('auto', options=['left', 'center', 'right',

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -304,7 +304,8 @@ class Label(Widget):
     _font_properties = ('text', 'font_size', 'font_name', 'font_script_name',
                         'font_direction', 'bold', 'italic',
                         'underline', 'strikethrough', 'font_family', 'color',
-                        'disabled_color', 'halign', 'valign', 'padding',
+                        'disabled_color', 'halign', 'valign',
+                        'padding', 'padding_x', 'padding_y',
                         'outline_width', 'disabled_outline_color',
                         'outline_color', 'text_size', 'shorten', 'mipmap',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
@@ -373,8 +374,17 @@ class Label(Widget):
                 self._label.options['outline_color'] = (
                     self.disabled_outline_color if value else
                     self.outline_color)
+
+            # Compatibility with deprecated properties.
+            # Must be removed along with padding_x and padding_y
+            elif name == 'padding_x':
+                self._label.options['padding'][::2] = [value] * 2
+            elif name == 'padding_y':
+                self._label.options['padding'][1::2] = [value] * 2
+
             else:
                 self._label.options[name] = value
+
         self._trigger_texture()
 
     def texture_update(self, *largs):

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -304,8 +304,7 @@ class Label(Widget):
     _font_properties = ('text', 'font_size', 'font_name', 'font_script_name',
                         'font_direction', 'bold', 'italic',
                         'underline', 'strikethrough', 'font_family', 'color',
-                        'disabled_color', 'halign', 'valign',
-                        'padding', 'padding_x', 'padding_y',
+                        'disabled_color', 'halign', 'valign', 'padding',
                         'outline_width', 'disabled_outline_color',
                         'outline_color', 'text_size', 'shorten', 'mipmap',
                         'line_height', 'max_lines', 'strip', 'shorten_from',
@@ -322,6 +321,11 @@ class Label(Widget):
         d = Label._font_properties
         fbind = self.fbind
         update = self._trigger_texture_update
+
+        # NOTE: Compatibility code due to deprecated properties.
+        fbind('padding_x', update, 'padding_x')
+        fbind('padding_y', update, 'padding_y')
+
         fbind('disabled', update, 'disabled')
         for x in d:
             fbind(x, update, x)
@@ -375,7 +379,7 @@ class Label(Widget):
                     self.disabled_outline_color if value else
                     self.outline_color)
 
-            # Compatibility with deprecated properties.
+            # NOTE: Compatibility code due to deprecated properties
             # Must be removed along with padding_x and padding_y
             elif name == 'padding_x':
                 self._label.options['padding'][::2] = [value] * 2


### PR DESCRIPTION
Previously, `padding `only accepted 2 values: `[padding_horizontal, padding_vertical]`, now it has the same behavior as `padding` in `BoxLayout`/`GridLayout`:

- `[10]` → `[10, 10, 10, 10]`
- `[10, 20]` → `[10, 20, 10, 20]`
- `[10, 20, 30, 40]` → `[10, 20, 30, 40]`


Test code:
```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.floatlayout import FloatLayout


class UI(FloatLayout):
    pass


Builder.load_string(
    """
<UI>:
    padding_left: 0
    padding_top: 0
    padding_right: 0
    padding_bottom: 0
    Label:
        text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
        size_hint: None, None
        center: root.center
        size: 300, 300

        text_size: self.size
        # size: self.texture_size

        # markup: True

        # base_direction: "rtl"

        halign: 'center'
        valign: 'center'

        padding: root.padding_left, root.padding_top, root.padding_right, root.padding_bottom

        canvas:
            Color:
                rgba: 0.2, 0.2, 0.8, 0.5
            Rectangle:
                pos: self.pos
                size: self.size

            Color:
                rgba: 1, 0, 0, 0.5
            Rectangle:
                pos: self.pos
                size: root.padding_left, self.height

            Rectangle:
                pos: self.x, self.top - root.padding_top
                size: self.width, root.padding_top

            Rectangle:
                pos: self.right - root.padding_right, self.y
                size: root.padding_right, self.height

            Rectangle:
                pos: self.pos
                size: self.width, root.padding_bottom

    BoxLayout:
        size_hint_y: 0.4
        orientation: "vertical"

        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 400
            step: 1
            on_value:
                root.padding_left = self.value
        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 400
            step: 1
            on_value:
                root.padding_top = self.value
        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 400
            step: 1
            on_value:
                root.padding_right = self.value
        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 400
            step: 1
            on_value:
                root.padding_bottom = self.value

"""
)


class Testapp(App):

    def build(self):
        return UI()


Testapp().run()
```

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
