### PR TITLE
`Image`: add `fit_mode` feature

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -119,13 +119,25 @@
         PopMatrix
 
 <Image,AsyncImage>:
+    canvas.before:
+        StencilPush
+        Rectangle:
+            pos: self.pos
+            size: self.size
+        StencilUse
     canvas:
         Color:
             rgba: self.color
         Rectangle:
-            texture: self._adjusted_texture
+            texture: self.texture
             size: self.norm_image_size
             pos: self.center_x - self.norm_image_size[0] / 2., self.center_y - self.norm_image_size[1] / 2.
+    canvas.after:
+        StencilUnUse
+        Rectangle:
+            pos: self.pos
+            size: self.size
+        StencilPop
 
 <EffectWidget>:
     canvas.before:

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -123,7 +123,7 @@
         Color:
             rgba: self.color
         Rectangle:
-            texture: self.texture
+            texture: self._adjusted_texture
             size: self.norm_image_size
             pos: self.center_x - self.norm_image_size[0] / 2., self.center_y - self.norm_image_size[1] / 2.
 

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -177,7 +177,9 @@ class Image(Widget):
     defaults to True.
     '''
 
-    fill_mode = OptionProperty('none', options=['none', 'stretch', 'fit', 'fill'])
+    fill_mode = OptionProperty(
+        "none", options=["none", "stretch", "fit", "fill"]
+    )
     '''If the image size is smaller than the widget size, determines how the
     image should be stretched to fill the widget box.
 
@@ -234,7 +236,7 @@ class Image(Widget):
     internal cache. The cache will simply ignore any calls trying to
     append the core image.
 
-    .. versionadded:: 1.6.00
+    .. versionadded:: 1.6.0
 
     :attr:`nocache` is a :class:`~kivy.properties.BooleanProperty` and defaults
     to False.

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -185,9 +185,9 @@ class Image(Widget):
 
     - ``"none"``: the image will not be stretched.
 
-    - ``"stretch"``: the image is stretched to fill the widget, regardless of
-    its aspect ratio or dimensions. This can lead to distortion of the image if
-    it has a different aspect ratio than the widget.
+    - ``"stretch"``: the image is stretched to fill the widget, **regardless of
+    its aspect ratio or dimensions**. This can lead to distortion of the image
+    if it has a different aspect ratio than the widget.
 
     - ``"fit"``: the image will be maximized to fit in the widget box,
     **maintaining its aspect ratio**. This can result in blank areas on the

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -253,12 +253,19 @@ class Image(Widget):
     '''
 
     def get_norm_image_size(self):
-        if not self.texture or self.fit_mode == "cover":
+        if not self.texture:
             return list(self.size)
 
         ratio = self.image_ratio
         w, h = self.size
         tw, th = self.texture.size
+
+        if self.fit_mode == "cover":
+            widget_ratio = w / max(1, h)
+            if widget_ratio > ratio:
+                return [w, (w * th) / tw]
+            else:
+                return [(h * tw) / th, h]
 
         # ensure that the width is always maximized to the container width
         # NOTE: self.allow_stretch and self.keep_ratio conditions should be
@@ -303,38 +310,6 @@ class Image(Widget):
     :attr:`norm_image_size` is an :class:`~kivy.properties.AliasProperty` and
     is read-only.
     '''
-
-    def _get_adjusted_texture(self):
-        if not self.texture:
-            return None
-
-        if self.fit_mode == "cover":
-            texture = self.texture
-            image_ratio = self.image_ratio
-            widget_ratio = self.size[0] / self.size[1]
-
-            crop_width, crop_height = (
-                texture_width,
-                texture_height,
-            ) = texture.size
-
-            if widget_ratio > image_ratio:
-                crop_height = texture_width / widget_ratio
-            else:
-                crop_width = texture_height * widget_ratio
-
-            crop_x = (texture_width - crop_width) / 2
-            crop_y = (texture_height - crop_height) / 2
-
-            return texture.get_region(crop_x, crop_y, crop_width, crop_height)
-        else:
-            return self.texture
-
-    _adjusted_texture = AliasProperty(
-        _get_adjusted_texture,
-        bind=('texture', 'size', 'image_ratio', 'fit_mode'),
-        cache=True,
-    )
 
     def __init__(self, **kwargs):
         self._coreimage = None

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -153,7 +153,7 @@ class Image(Widget):
     .. versionadded:: 1.0.7
 
     .. deprecated:: 2.2.0
-        :attr:`allow_stretch` have been deprecated. Please use `fill_mode`
+        :attr:`allow_stretch` have been deprecated. Please use `fit_mode`
         instead.
 
     :attr:`allow_stretch` is a :class:`~kivy.properties.BooleanProperty` and
@@ -170,36 +170,46 @@ class Image(Widget):
     .. versionadded:: 1.0.8
 
     .. deprecated:: 2.2.0
-        :attr:`keep_ratio` have been deprecated. Please use `fill_mode`
+        :attr:`keep_ratio` have been deprecated. Please use `fit_mode`
         instead.
 
     :attr:`keep_ratio` is a :class:`~kivy.properties.BooleanProperty` and
     defaults to True.
     '''
 
-    fill_mode = OptionProperty(
-        "none", options=["none", "stretch", "fit", "fill"]
+    fit_mode = OptionProperty(
+        "scale-down", options=["scale-down", "fill", "contain", "cover"]
     )
-    '''If the image size is smaller than the widget size, determines how the
-    image should be stretched to fill the widget box.
+    '''If the size of the image is smaller than the size of the widget,
+    determine how the image should be resized to fit inside the widget box.
 
     Available options:
 
-    - ``"none"``: the image will not be stretched.
+    - ``"scale-down"``: the image will be scaled down to fit inside the widget
+    box, **maintaining its aspect ratio and without stretching**. If the size
+    of the image is smaller than the widget, it will be displayed at its
+    original size. If the image has a different aspect ratio than the widget,
+    there will be blank areas on the widget box.
 
-    - ``"stretch"``: the image is stretched to fill the widget, **regardless of
-    its aspect ratio or dimensions**. This can lead to distortion of the image
-    if it has a different aspect ratio than the widget.
+    - ``"fill"``: the image is stretched to fill the widget, **regardless of
+    its aspect ratio or dimensions**. If the image has a different aspect ratio
+    than the widget, this option can lead to distortion of the image.
 
-    - ``"fit"``: the image will be maximized to fit in the widget box,
-    **maintaining its aspect ratio**. This can result in blank areas on the
-    widget if the image has a different aspect ratio than the widget.
+    - ``"contain"``: the image is resized to fit inside the widget box,
+    **maintaining its aspect ratio**. If the image size is larger than the
+    widget size, the behavior will be similar to ``"scale-down"``. However, if
+    the size of the image size is smaller than the widget size, unlike
+    ``"scale-down``, the image will be resized to fit inside the widget.
+    If the image has a different aspect ratio than the widget, there will be
+    blank areas on the widget box.
 
-    - ``fill``: the image will be stretched horizontally or vertically to
-    fill the widget box, **maintaining its aspect ratio**.
+    - ``"cover"``: the image will be stretched horizontally or vertically to
+    fill the widget box, **maintaining its aspect ratio**. If the image has a
+    different aspect ratio than the widget, then the image will be clipped to
+    fit.
 
-    :attr:`fill_mode` is a :class:`~kivy.properties.OptionProperty` and
-    defaults to ``"none"``.
+    :attr:`fit_mode` is a :class:`~kivy.properties.OptionProperty` and
+    defaults to ``"scale-down"``.
     '''
 
     keep_data = BooleanProperty(False)
@@ -243,7 +253,7 @@ class Image(Widget):
     '''
 
     def get_norm_image_size(self):
-        if not self.texture or self.fill_mode == "fill":
+        if not self.texture or self.fit_mode == "cover":
             return list(self.size)
 
         ratio = self.image_ratio
@@ -253,8 +263,8 @@ class Image(Widget):
         # ensure that the width is always maximized to the container width
         # NOTE: self.allow_stretch and self.keep_ratio conditions should be
         # removed along with the deprecated properties in the future
-        if self.fill_mode in ("stretch", "fit") or self.allow_stretch:
-            if self.fill_mode == "stretch" or not self.keep_ratio:
+        if self.fit_mode in ("fill", "contain") or self.allow_stretch:
+            if self.fit_mode == "fill" or not self.keep_ratio:
                 return [w, h]
             iw = w
         else:
@@ -266,7 +276,7 @@ class Image(Widget):
         if ih > h:
             # NOTE: self.allow_stretch condition should be removed along with
             # the deprecated property in the future
-            if self.fill_mode == "fit" or self.allow_stretch:
+            if self.fit_mode == "contain" or self.allow_stretch:
                 ih = h
             else:
                 ih = min(h, th)
@@ -281,7 +291,7 @@ class Image(Widget):
             'allow_stretch',
             'image_ratio',
             'keep_ratio',
-            'fill_mode',
+            'fit_mode',
         ),
         cache=True,
     )
@@ -298,7 +308,7 @@ class Image(Widget):
         if not self.texture:
             return None
 
-        if self.fill_mode == "fill":
+        if self.fit_mode == "cover":
             texture = self.texture
             image_ratio = self.image_ratio
             widget_ratio = self.size[0] / self.size[1]
@@ -322,7 +332,7 @@ class Image(Widget):
 
     _adjusted_texture = AliasProperty(
         _get_adjusted_texture,
-        bind=('texture', 'size', 'image_ratio', 'fill_mode'),
+        bind=('texture', 'size', 'image_ratio', 'fit_mode'),
         cache=True,
     )
 

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -306,9 +306,6 @@ class Image(Widget):
                 texture_height,
             ) = texture.size
 
-            crop_width = texture_width
-            crop_height = texture_height
-
             if widget_ratio > image_ratio:
                 crop_height = texture_width / widget_ratio
             else:


### PR DESCRIPTION
This PR adds the `fit_mode` feature, as a replacement for `allow_stretch` and `keep_ratio`.

The previous behaviors using `allow_stretch` and `keep_ratio` will be present in `fit_mode`, plus a new mode is being introduced: `"cover"`. The `"cover"` mode will fill the widget box with the image regardless of the size and aspect ratio of both, keeping the aspect ratio of the image.

The available options will be
    
- ``"scale-down"``: the image will be scaled down to fit inside the widget box, **maintaining its aspect ratio and without stretching**. If the size of the image is smaller than the widget, it will be displayed at its original size. If the image has a different aspect ratio than the widget, there will be blank areas on the widget box.

- ``"fill"``: the image is stretched to fill the widget, **regardless of its aspect ratio or dimensions**. If the image has a different aspect ratio than the widget, this option can lead to distortion of the image.

- ``"contain"``: the image is resized to fit inside the widget box, **maintaining its aspect ratio**. If the image size is larger than the widget size, the behavior will be similar to ``"scale-down"``. However, if the size of the image size is smaller than the widget size, unlike ``"scale-down``, the image will be resized to fit inside the widget. If the image has a different aspect ratio than the widget, there will be blank areas on the widget box.

- ``"cover"``: the image will be stretched horizontally or vertically to fill the widget box, **maintaining its aspect ratio**. If the image has a different aspect ratio than the widget, then the image will be clipped to fit.


**Demo**:

https://user-images.githubusercontent.com/73297572/226389904-02e783b4-7705-47bd-bea8-a75d6eb75976.mp4


<br>

**image_test.png (250x250px)**:

![image_test](https://user-images.githubusercontent.com/73297572/225336153-28621ea5-f19f-4aad-80ba-a30292abd2ee.png)

**Code for testing** (It is recommended to test with images with different aspect ratios):
```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.floatlayout import FloatLayout


class UI(FloatLayout):
    pass


Builder.load_string(
    """
<UI>:
    Image:
        id: img
        source: "image_test.png"
        size_hint: None, None
        pos_hint: {"center": (0.5, 0.6)}
        mipmap: True
        canvas.after:
            Color:
                rgba: 1, 0, 0, 0.5
            Rectangle:
                pos: self.pos
                size: self.size

    BoxLayout:
        size_hint_y: 0.4
        orientation: "vertical"

        Label:
            text: f"fit_mode = {img.fit_mode} \\nwidth = {img.width} | height = {img.height}"
            outline_width: 1
            font_size: dp(18)

        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 3
            step: 1
            on_value:
                img.fit_mode = ("scale-down", "fill", "contain", "cover")[int(self.value)]
        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 1000
            step: 1
            on_value:
                img.width = self.value
        Slider:
            size_hint_y: None
            height: 50
            min: 0
            max: 1000
            step: 1
            on_value:
                img.height = self.value

"""
)


class Testapp(App):

    def build(self):
        return UI()


Testapp().run()
```


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
