### PR TITLE
Make VideoFFPy work with RTSP streams.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ kivy/deps/*
 kivy.deps*
 kivy/version.py
 results.png
+kivy-dependencies
 
 MANIFEST
 

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -255,7 +255,7 @@ class VideoFFPy(VideoBase):
                 wait_for_wakeup(0.005)
                 continue
 
-            if src_pix_fmt == 'yuv420p':
+            if src_pix_fmt == b'yuv420p':
                 self._out_fmt = 'yuv420p'
                 ffplayer.set_output_pix_fmt(self._out_fmt)
             break

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -117,7 +117,10 @@ class VideoFFPy(VideoBase):
 
     @property
     def _is_stream(self):
-        # XXX: tested with RTSP streams only right now
+        # This is only used when building ff_opts, to prevent starting
+        # player paused and can probably be removed as soon as the 'eof'
+        # receiving issue is solved.
+        # See https://github.com/matham/ffpyplayer/issues/142
         return self.filename.startswith('rtsp://')
 
     def __del__(self):

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -255,7 +255,9 @@ class VideoFFPy(VideoBase):
                 wait_for_wakeup(0.005)
                 continue
 
-            if src_pix_fmt == b'yuv420p':
+            # ffpyplayer reports src_pix_fmt as bytes. this may or may not
+            # change in future, so we check for both bytes and str
+            if src_pix_fmt in (b'yuv420p', 'yuv420p'):
                 self._out_fmt = 'yuv420p'
                 ffplayer.set_output_pix_fmt(self._out_fmt)
             break
@@ -387,7 +389,7 @@ class VideoFFPy(VideoBase):
         # if stream and we start paused, we sometimes receive eof after a
         # few frames, depending on the stream producer.
         # XXX: This probably needs to be figured out in ffpyplayer, using
-        #      ffplay directly works.?
+        #      ffplay directly works.
         ff_opts = {
             'paused': not self._is_stream,
             'out_fmt': self._out_fmt,

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -264,23 +264,6 @@ class VideoFFPy(VideoBase):
             ffplayer.close_player()
             return
 
-        # wait until loaded or failed, shouldn't take long, but just to make
-        # sure metadata is available.
-        while not self._ffplayer_need_quit:
-            if self._is_stream:
-                # check if src_pix_fmt instead of src_vid_size, which is (0, 0)
-                # at least with rtsp streams
-                if ffplayer.get_metadata()['src_pix_fmt'] != '':
-                    break
-            else:
-                if ffplayer.get_metadata()['src_vid_size'] != (0, 0):
-                    break
-            wait_for_wakeup(0.005)
-
-        if self._ffplayer_need_quit:
-            ffplayer.close_player()
-            return
-
         self._ffplayer = ffplayer
         self._finish_setup()
         # now, we'll be in internal paused state and loop will wait until

--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -339,8 +339,6 @@ class VideoFFPy(VideoBase):
         ffplayer.close_player()
 
     def seek(self, percent, precise=True):
-        if self._is_stream:
-            raise RuntimeError('Cannot seek streams')
         # still save seek while thread is setting up
         self._seek_queue.append((percent, precise,))
         self._wakeup_thread()
@@ -386,8 +384,10 @@ class VideoFFPy(VideoBase):
         self.load()
         self._out_fmt = 'rgba'
         # if no stream, it starts internally paused, but unpauses itself
-        # XXX: if stream and we start paused, we receive eof after a few frames
-        #      why does this happen?
+        # if stream and we start paused, we sometimes receive eof after a
+        # few frames, depending on the stream producer.
+        # XXX: This probably needs to be figured out in ffpyplayer, using
+        #      ffplay directly works.?
         ff_opts = {
             'paused': not self._is_stream,
             'out_fmt': self._out_fmt,


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Recently i'm working on displaying RTSP streams in kivy. The ffpyplayer implementation actually supports streams, but causes some problems in the VideoFFPy implementation.

This PR is a proof of concept. I'd really like to solve video streaming in kivy core, any feedback whether i'm on the right track is appreciated @tito @matham @misl6 @tshirtman