### PR TITLE
Bump Windows dependencies via `kivy_deps` packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ requires = [
     "setuptools", "wheel",
     "cython>=0.24,<=0.29.32,!=0.27,!=0.27.2",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"',
+    'kivy_deps.sdl2_dev~=0.6.0; sys_platform == "win32"',
     'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
     'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2~=0.5.0; sys_platform == "win32"',
+    'kivy_deps.sdl2~=0.6.0; sys_platform == "win32"',
     'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,8 @@ install_requires =
     Kivy-Garden>=0.1.4
     docutils
     pygments
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
+    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.sdl2~=0.6.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
@@ -41,7 +41,7 @@ dev =
     sphinxcontrib-nwdiag
     funcparserlib==1.0.0a0
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
-    kivy_deps.sdl2_dev~=0.5.0; sys_platform == "win32"
+    kivy_deps.sdl2_dev~=0.6.0; sys_platform == "win32"
     kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"
     flake8
     pre-commit
@@ -51,8 +51,8 @@ base =
     requests
     docutils
     pygments
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
+    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.sdl2~=0.6.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
 media =
@@ -63,8 +63,8 @@ full =
     docutils
     pygments
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
+    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.sdl2~=0.6.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
     pypiwin32; sys_platform == "win32"
@@ -72,9 +72,9 @@ gstreamer =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     # don't use 0.4.0 because it was deleted
 angle =
-    kivy_deps.angle~=0.3.2; sys_platform == "win32"
+    kivy_deps.angle~=0.3.3; sys_platform == "win32"
 sdl2 =
-    kivy_deps.sdl2~=0.5.0; sys_platform == "win32"
+    kivy_deps.sdl2~=0.6.0; sys_platform == "win32"
 glew =
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Bump dependencies versions for Windows (managed via `kivy_deps.*` packages), as required by the Kivy Release Plan (2.2.0).

See: https://github.com/kivy/kivy/issues/8167