### PR TITLE
Revert "Detect High DPI on Linux Desktop"

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -266,13 +266,6 @@ cdef class _WindowSDL2Storage:
         SDL_GetWindowSize(self.win, &w, &h)
         return w, h
 
-
-    def _get_display_dpi(self):
-        cdef int display_index = SDL_GetWindowDisplayIndex(self.win)
-        cdef float horizontal_dpi = 0.
-        SDL_GetDisplayDPI(display_index, NULL, &horizontal_dpi, NULL)
-        return horizontal_dpi
-
     def _set_cursor_state(self, value):
         SDL_ShowCursor(value)
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -403,24 +403,7 @@ class WindowSDL(WindowBase):
         else:
             self._density = self._win._get_gl_size()[0] / self._size[0]
             if self._is_desktop:
-                # If the SDL window allows high DPI mode,
-                # then the window size and renderer size may be different.
-                # https://wiki.libsdl.org/SDL2/SDL_GetWindowSize
-                if self._density != 1.0:
-                    dpi = self._density * 96.
-                else:
-                    # Try to get the display DPI from SDL. This works in SDL2 on
-                    # the X11 SDL2 backend, given that the X11 display
-                    # is correctly configured.
-                    display_dpi = self._win._get_display_dpi()
-                    if display_dpi > 0.0:
-                        dpi = display_dpi
-
-                # Change window DPI if it has changed.
-                # This will call reset_metrics under the hood,
-                # so only do it once and if it has changed.
-                if self.dpi != dpi:
-                    self.dpi = dpi
+                self.dpi = self._density * 96.
 
     def close(self):
         self._win.teardown_window()

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -552,7 +552,6 @@ cdef extern from "SDL.h":
     cdef SDL_GLContext SDL_GL_CreateContext(SDL_Window* window)
     cdef int SDL_GetNumVideoDisplays()
     cdef int SDL_GetNumDisplayModes(int displayIndex)
-    cdef int SDL_GetDisplayDPI(int displayIndex, float * ddpi, float * hdpi, float * vdpi);
     cdef int SDL_GetDisplayMode(int displayIndex, int index, SDL_DisplayMode * mode)
     cdef SDL_bool SDL_HasIntersection(SDL_Rect * A, SDL_Rect * B) nogil
     cdef SDL_bool SDL_IntersectRect(SDL_Rect * A, SDL_Rect * B, SDL_Rect * result) nogil

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -259,7 +259,7 @@ class MetricsBase(EventDispatcher):
         elif platform == 'ios':
             import ios
             value = ios.get_scale()
-        elif platform in ('linux', 'macosx', 'win'):
+        elif platform in ('macosx', 'win'):
             value = self.dpi / 96.
 
         sync_pixel_scale(density=value)

--- a/kivy/tests/test_properties.py
+++ b/kivy/tests/test_properties.py
@@ -415,19 +415,19 @@ def test_numeric_string_with_units_check(self, set_name):
 
     a.set(wid, '55dp')
     density = Metrics.density
-    self.assertAlmostEqual(a.get(wid), 55 * density, delta=1E-2)
+    self.assertEqual(a.get(wid), 55 * density)
     self.assertEqual(a.get_format(wid), 'dp')
 
     a.set(wid, u'55dp')
-    self.assertAlmostEqual(a.get(wid), 55 * density, delta=1E-2)
+    self.assertEqual(a.get(wid), 55 * density)
     self.assertEqual(a.get_format(wid), 'dp')
 
     a.set(wid, '99in')
-    self.assertAlmostEqual(a.get(wid), 9504.0 * density, delta=1E-2)
+    self.assertEqual(a.get(wid), 9504.0 * density)
     self.assertEqual(a.get_format(wid), 'in')
 
     a.set(wid, u'99in')
-    self.assertAlmostEqual(a.get(wid), 9504.0 * density, delta=1E-2)
+    self.assertEqual(a.get(wid), 9504.0 * density)
     self.assertEqual(a.get_format(wid), 'in')
 
 


### PR DESCRIPTION
Reverts kivy/kivy#8147

Previous way of using size difference between Window.size and Windows.get_DrwableSize is the correct way as outlined by SDL2 Documentation too.

The reason on why currently on Wayland window reports both to be the same cause apparently we are not properly using Wayland window provider.