### PR TITLE
XCode 14.3 fails to build SDL if `MACOSX_DEPLOYMENT_TARGET` < `10.13`

### DIFF
--- a/tools/build_macos_dependencies.sh
+++ b/tools/build_macos_dependencies.sh
@@ -56,27 +56,28 @@ pushd kivy-dependencies/build
 
 echo "-- Build SDL2 (Universal)"
 pushd $MACOS__SDL2__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO -project Xcode/SDL/SDL.xcodeproj -target Framework -configuration Release
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
+        -project Xcode/SDL/SDL.xcodeproj -target Framework -configuration Release
 cp -r Xcode/SDL/build/Release/SDL2.framework ../../dist/Frameworks
 popd
 
 echo "-- Build SDL2_mixer (Universal)"
 pushd $MACOS__SDL2_MIXER__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO \
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
         -project Xcode/SDL_mixer.xcodeproj -target Framework -configuration Release
 cp -r Xcode/build/Release/SDL2_mixer.framework ../../dist/Frameworks
 popd
 
 echo "-- Build SDL2_image (Universal)"
 pushd $MACOS__SDL2_IMAGE__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO \
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
         -project Xcode/SDL_image.xcodeproj -target Framework -configuration Release
 cp -r Xcode/build/Release/SDL2_image.framework ../../dist/Frameworks
 popd
 
 echo "-- Build SDL2_ttf (Universal)"
 pushd $MACOS__SDL2_TTF__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO \
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
         -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release
 cp -r Xcode/build/Release/SDL2_ttf.framework ../../dist/Frameworks
 popd


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Thank you Apple!

The new minimum supported `MACOSX_DEPLOYMENT_TARGET` on XCode 14.3 is `10.13`, anything built with `MACOSX_DEPLOYMENT_TARGET<=10.13` will fail with: https://developer.apple.com/forums/thread/725300

Ref:
https://github.com/libsdl-org/SDL/issues/7563
https://github.com/libsdl-org/SDL_image/issues/355
