### PR TITLE
remove obvious comment

### DIFF
--- a/kivy/animation.py
+++ b/kivy/animation.py
@@ -312,7 +312,6 @@ class Animation(EventDispatcher):
                 original_value = original_value.copy()
             p[key] = (original_value, value)
 
-        # install clock
         self._clock_install()
 
     def _clock_install(self):


### PR DESCRIPTION
This PR removes an obvious comment (i.e. comment that restates what the code does in an obvious manner). The code itself is understandable that the clock is installed.