### PR TITLE
shorten long comment

### DIFF
--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -86,12 +86,8 @@ class Cache(object):
         if getattr(obj, '_nocache', False):
             return
         if key is None:
-            # This check is added because of the case when key is None and
-            # one of purge methods gets called. Then loop in purge method will
-            # call Cache.remove with key None which then clears entire
-            # category from Cache making next iteration of loop to raise a
-            # KeyError because next key will not exist.
-            # See: https://github.com/kivy/kivy/pull/6950
+            # This check is added due to the issue
+            # described in https://github.com/kivy/kivy/pull/6950
             raise ValueError('"None" cannot be used as key in Cache')
         try:
             cat = Cache._categories[category]


### PR DESCRIPTION
This PR shortens the comment that gives too much information (i.e. an overly verbose comment). Additional details are removed as the comment already includes a link to the described issue.