### PR TITLE
Migrate `allow_stretch` and `keep_ratio` in widgets/examples by corresponding `fit_mode`

### DIFF
--- a/examples/kv/app_video.kv
+++ b/examples/kv/app_video.kv
@@ -7,7 +7,7 @@ BoxLayout:
     Video:
         id: myvideo
         source: '../widgets/cityCC0.mpg'
-        allow_stretch: True
+        fit_mode: "contain"
         on_eos: self.play = True; print('woot we are looping!')
 
     BoxLayout:

--- a/examples/widgets/colorpicker.py
+++ b/examples/widgets/colorpicker.py
@@ -90,7 +90,7 @@ Builder.load_string('''
         Image:
             color: app.color_selector.color
             source: '../demo/touchtracer/particle.png'
-            allow_stretch: True
+            fit_mode: "contain"
             size: self.parent.size
             pos: self.parent.pos
     Button:

--- a/examples/widgets/effectwidget3_advanced.py
+++ b/examples/widgets/effectwidget3_advanced.py
@@ -55,8 +55,7 @@ TouchWidget:
         text: 'Some text!'
     Image:
         source: 'data/logo/kivy-icon-512.png'
-        allow_stretch: True
-        keep_ratio: False
+        fit_mode: "fill"
 ''')
 
 

--- a/examples/widgets/sequenced_images/uix/custom_button.py
+++ b/examples/widgets/sequenced_images/uix/custom_button.py
@@ -11,8 +11,7 @@ from kivy.properties import StringProperty, OptionProperty, \
 class AnimatedButton(Label):
 
     state = OptionProperty('normal', options=('normal', 'down'))
-    allow_stretch = BooleanProperty(True)
-    keep_ratio = BooleanProperty(False)
+    fit_mode = StringProperty("fill")
     border = ObjectProperty(None)
     anim_delay = ObjectProperty(None)
     background_normal = StringProperty(
@@ -31,8 +30,7 @@ class AnimatedButton(Label):
         # Image to display depending on state
         self.img = Image(
             source=self.background_normal,
-            allow_stretch=self.allow_stretch,
-            keep_ratio=self.keep_ratio,
+            fit_mode=self.fit_mode,
             mipmap=True)
 
         # reset animation if anim_delay is changed

--- a/examples/widgets/tabbed_panel_showcase.py
+++ b/examples/widgets/tabbed_panel_showcase.py
@@ -236,8 +236,7 @@ Builder.load_string('''
                 source: 'sequenced_images/data/images/info.png'\
                     if my_header.state == 'normal' else 'cityCC0.png'
                 size: my_header.size
-                allow_stretch: True
-                keep_ratio: False
+                fit_mode: "fill"
 ''')
 
 

--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -72,8 +72,7 @@
         pos: (root.value_pos[0] - root.cursor_width / 2, root.center_y - root.cursor_height / 2) if root.orientation == 'horizontal' else (root.center_x - root.cursor_width / 2, root.value_pos[1] - root.cursor_height / 2)
         size: root.cursor_size
         source: root.cursor_disabled_image if root.disabled else root.cursor_image
-        allow_stretch: True
-        keep_ratio: False
+        fit_mode: "fill"
 
 <ProgressBar>:
     canvas:
@@ -98,7 +97,7 @@
     Image:
         pos: root.pos
         size: root.size
-        allow_stretch: True
+        fit_mode: "contain"
         source: 'atlas://data/images/defaulttheme/splitter_grip' + root.horizontal
 
 <Scatter>:
@@ -187,7 +186,7 @@
 
 <Selector>
     color: 148. / 255, 208 / 255., 230 / 255., 1
-    allow_stretch: True
+    fit_mode: "contain"
 
 <TextInput>:
     canvas.before:
@@ -616,7 +615,7 @@
     color: self.color[:3] + [0 if (root.icon and not root.inside_group) else 1]
 
     Image:
-        allow_stretch: True
+        fit_mode: "contain"
         opacity: 1 if (root.icon and not root.inside_group) else 0
         source: root.icon
         mipmap: root.mipmap
@@ -667,7 +666,7 @@
                     id: prev_icon_image
                     source: root.previous_image
                     opacity: 1 if root.with_previous else 0
-                    allow_stretch: True
+                    fit_mode: "contain"
                     size_hint_x: None
                     temp_width: root.previous_image_width or dp(prev_icon_image.texture_size[0])
                     temp_height: root.previous_image_height or dp(prev_icon_image.texture_size[1])
@@ -679,7 +678,7 @@
                 ActionPreviousImage:
                     id: app_icon_image
                     source: root.app_icon
-                    allow_stretch: True
+                    fit_mode: "contain"
                     size_hint_x: None
                     temp_width: root.app_icon_width or dp(app_icon_image.texture_size[0])
                     temp_height: root.app_icon_height or dp(app_icon_image.texture_size[1])
@@ -1098,21 +1097,21 @@
             video: root
             width: '44dp'
             source: root.image_stop
-            allow_stretch: True
+            fit_mode: "contain"
 
         VideoPlayerPlayPause:
             size_hint_x: None
             video: root
             width: '44dp'
             source: root.image_pause if root.state == 'play' else root.image_play
-            allow_stretch: True
+            fit_mode: "contain"
 
         VideoPlayerVolume:
             video: root
             size_hint_x: None
             width: '44dp'
             source: root.image_volumehigh if root.volume > 0.8 else (root.image_volumemedium if root.volume > 0.4 else (root.image_volumelow if root.volume > 0 else root.image_volumemuted))
-            allow_stretch: True
+            fit_mode: "contain"
 
         Widget:
             size_hint_x: None

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -381,7 +381,7 @@ class Bubble(BoxLayout):
 
         self._arrow_image = Image(
             source=self.arrow_image,
-            fit_mode="scale-down"
+            fit_mode="scale-down",
             color=self.arrow_color
         )
         self._arrow_image.width = self._arrow_image.texture_size[0]

--- a/kivy/uix/bubble.py
+++ b/kivy/uix/bubble.py
@@ -381,7 +381,7 @@ class Bubble(BoxLayout):
 
         self._arrow_image = Image(
             source=self.arrow_image,
-            allow_stretch=False,
+            fit_mode="scale-down"
             color=self.arrow_color
         )
         self._arrow_image.width = self._arrow_image.texture_size[0]

--- a/kivy/uix/carousel.py
+++ b/kivy/uix/carousel.py
@@ -24,7 +24,7 @@ Example::
             carousel = Carousel(direction='right')
             for i in range(10):
                 src = "http://placehold.it/480x270.png&text=slide-%d&.png" % i
-                image = AsyncImage(source=src, allow_stretch=True)
+                image = AsyncImage(source=src, fit_mode="contain")
                 carousel.add_widget(image)
             return carousel
 
@@ -688,7 +688,7 @@ if __name__ == '__main__':
                                 loop=True)
             for i in range(4):
                 src = "http://placehold.it/480x270.png&text=slide-%d&.png" % i
-                image = Factory.AsyncImage(source=src, allow_stretch=True)
+                image = Factory.AsyncImage(source=src, fit_mode="contain")
                 carousel.add_widget(image)
             return carousel
 

--- a/kivy/uix/rst.py
+++ b/kivy/uix/rst.py
@@ -393,7 +393,7 @@ Builder.load_string('''
     font_size: sp(self.document.base_font_size / 2.0)
 
 <RstVideoPlayer>:
-    options: {'allow_stretch': True}
+    options: {'fit_mode': 'contain'}
     canvas.before:
         Color:
             rgba: (1, 1, 1, 1)

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -53,7 +53,7 @@ You can allow stretching by passing custom options to a
 :class:`VideoPlayer` instance::
 
     player = VideoPlayer(source='myvideo.avi', state='play',
-        options={'allow_stretch': True})
+        options={'fit_mode': 'contain'})
 
 End-of-stream behavior
 ----------------------


### PR DESCRIPTION
Because of #8169 , `allow_stretch` and `keep_ratio` are now deprecated. This PR replaces these properties with the corresponding `fit_mode` in the widgets and examples.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
