### PR TITLE
Migrate from `autotools` to `cmake` for SDL2 linux dependencies

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -9,7 +9,7 @@ RUN [ "cross-build-start" ]
 # Install dependencies.
 RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple" && \
-    install_kivy_test_run_apt_deps && \
+    install_ubuntu_build_deps && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install xorg libxrender-dev && \
     install_python && \
     install_kivy_test_run_pip_deps'

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -23,15 +23,6 @@ generate_sdist() {
   python3 -m pip uninstall cython -y
 }
 
-install_kivy_test_run_apt_deps() {
-  sudo apt-get update
-  sudo apt-get -y install libunwind-dev
-  sudo apt-get -y install libgstreamer1.0-dev gstreamer1.0-alsa gstreamer1.0-plugins-base gstreamer1.0-plugins-good
-  sudo apt-get -y install libsmpeg-dev libswscale-dev libavformat-dev libavcodec-dev libjpeg-dev libtiff5-dev libx11-dev libmtdev-dev
-  sudo apt-get -y install build-essential libgl1-mesa-dev libgles2-mesa-dev
-  sudo apt-get -y install xvfb pulseaudio xsel
-}
-
 install_python() {
   sudo apt-get -y install python3 python3-dev python3-setuptools
 }
@@ -161,9 +152,31 @@ upload_docs_to_server() {
   fi
 }
 
-install_build_deps() {
+install_manylinux_build_deps() {
+  # These are basically copy-pasted from the SDL dependencies
+  # (it contains both build tools and libraries development packages)
+  # See: https://wiki.libsdl.org/SDL2/README/linux
   yum install -y epel-release;
-  yum -y install autoconf automake cmake gcc gcc-c++ git make pkgconfig zlib-devel portmidi portmidi-devel xorg-x11-server-devel mesa-libEGL-devel mtdev-devel mesa-libEGL freetype freetype-devel openjpeg openjpeg-devel libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel dbus-devel dbus ibus-devel ibus libsamplerate-devel libsamplerate libudev-devel libmodplug-devel libmodplug libvorbis-devel libvorbis flac-devel flac libjpeg-turbo-devel libjpeg-turbo wget;
+  yum -y install autoconf automake cmake gcc gcc-c++ git make pkgconfig \
+            ninja-build alsa-lib-devel pulseaudio-libs-devel \
+            libX11-devel libXext-devel libXrandr-devel libXcursor-devel libXfixes-devel \
+            libXi-devel libXScrnSaver-devel dbus-devel ibus-devel fcitx-devel \
+            systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel \
+            mesa-libEGL-devel wayland-devel wayland-protocols-devel \
+            libdrm-devel mesa-libgbm-devel libsamplerate-devel
+}
+
+install_ubuntu_build_deps() {
+  # These are basically copy-pasted from the SDL dependencies
+  # (it contains both build tools and libraries development packages)
+  # See: https://wiki.libsdl.org/SDL2/README/linux
+  sudo apt-get update
+  sudo apt-get -y install build-essential git make autoconf automake libtool \
+          pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev \
+          libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev \
+          libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
+          libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+          libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
 }
 
 generate_armv7l_wheels() {

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -37,13 +37,13 @@ jobs:
 
   manylinux_wheel_create:
     env:
-      CIBW_ENVIRONMENT_LINUX: "KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies"
+      CIBW_ENVIRONMENT_LINUX: "KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies LD_LIBRARY_PATH=$(pwd)/kivy-dependencies/dist/lib:$(pwd)/kivy-dependencies/dist/lib64"
       CIBW_BUILD_VERBOSITY_LINUX: 3
       CIBW_BUILD:  ${{ matrix.cibw_build }}
       CIBW_ARCHS: ${{ matrix.cibw_archs }}
       CIBW_BEFORE_ALL_LINUX: >
         source .ci/ubuntu_ci.sh &&
-        install_build_deps
+        install_manylinux_build_deps
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -73,7 +73,8 @@ jobs:
       if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
       run: |
         docker run --rm -v `pwd`:/root:rw --workdir=/root \
-           quay.io/pypa/manylinux2014_${{ matrix.cibw_archs }} bash -ec './tools/build_linux_dependencies.sh'
+           quay.io/pypa/manylinux2014_${{ matrix.cibw_archs }} \
+           bash -ec 'source .ci/ubuntu_ci.sh && install_manylinux_build_deps && ./tools/build_linux_dependencies.sh'
     - name: Generate version metadata
       run: |
         source .ci/ubuntu_ci.sh
@@ -197,7 +198,7 @@ jobs:
       - name: Install dependencies
         run: |
           source .ci/ubuntu_ci.sh
-          install_kivy_test_run_apt_deps
+          install_ubuntu_build_deps
           ./tools/build_linux_dependencies.sh
           install_kivy_test_wheel_run_pip_deps
       - name: Setup env

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
-        install_kivy_test_run_apt_deps
+        install_ubuntu_build_deps
         ./tools/build_linux_dependencies.sh
         install_kivy_test_run_pip_deps
     - name: Setup env
@@ -76,7 +76,7 @@ jobs:
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
-        install_kivy_test_run_apt_deps
+        install_ubuntu_build_deps
         ./tools/build_linux_dependencies.sh
         install_kivy_test_run_pip_deps
     - name: Setup env

--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -17,24 +17,19 @@ main :ref:`pip installation guide<installation-canonical>`, specific to Linux.
 Installing Python
 ^^^^^^^^^^^^^^^^^
 
-Python and python-pip, git and build tools are required to build Kivy and its dependencies.
-If you do not have these installed, please install them before continuing:
+Python and pip are already installed on most Linux distributions. If you don't have Python installed, you can
+install it using your distribution's package manager.
 
 Ubuntu
 ~~~~~~
 
 Using apt::
 
+    sudo apt-get update
+
     sudo apt-get install -y \
         python3-pip \
-        build-essential \
-        autoconf \
-        libtool \
-        libxext-dev \
-        curl \
-        git \
-        python3 \
-        python3-dev \
+        python3
 
 Fedora
 ~~~~~~
@@ -69,19 +64,15 @@ Ubuntu
 
 Using apt::
 
-    # Install necessary system packages
-    sudo apt-get install -y \
-        libportmidi-dev \
-        libswscale-dev \
-        libavformat-dev \
-        libavcodec-dev \
-        zlib1g-dev
+    sudo apt-get update
 
-    # Install gstreamer for audio, video (optional)
-    sudo apt-get install -y \
-        libgstreamer1.0 \
-        gstreamer1.0-plugins-base \
-        gstreamer1.0-plugins-good
+    # Install build tools, and dependencies to perform a full build (including SDL2 dependencies)
+    sudo apt-get -y install python3-dev build-essential git make autoconf automake libtool \
+          pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev \
+          libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev \
+          libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
+          libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+          libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
 
 
 Fedora
@@ -89,9 +80,17 @@ Fedora
 
 Using dnf::
 
-    # Install necessary system packages
-    sudo dnf install -y ffmpeg-libs portmidi-devel libavdevice libavc1394-devel zlibrary-devel ccache \
-    mesa-libGL mesa-libGL-devel
+    sudo dnf install epel-release
+
+    # Install build tools, and dependencies to perform a full build (including SDL2 dependencies)
+    yum -y install autoconf automake cmake gcc gcc-c++ git make pkgconfig \
+            ninja-build alsa-lib-devel pulseaudio-libs-devel \
+            libX11-devel libXext-devel libXrandr-devel libXcursor-devel libXfixes-devel \
+            libXi-devel libXScrnSaver-devel dbus-devel ibus-devel fcitx-devel \
+            systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel \
+            mesa-libEGL-devel wayland-devel wayland-protocols-devel \
+            libdrm-devel mesa-libgbm-devel libsamplerate-devel
+
     # Install xclip in case you run a kivy app using your computer, and the app requires a CutBuffer provider:
     sudo dnf install -y xclip
 

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,13 @@ def pkgconfig(*packages, **kw):
 
     if KIVY_DEPS_ROOT and platform != 'win32':
         lenviron = environ.copy()
-        lenviron["PKG_CONFIG_PATH"] = "{}:{}".format(
+        lenviron["PKG_CONFIG_PATH"] = "{}:{}:{}".format(
             environ.get("PKG_CONFIG_PATH", ""),
             join(
                 KIVY_DEPS_ROOT, "dist", "lib", "pkgconfig"
+            ),
+            join(
+                KIVY_DEPS_ROOT, "dist", "lib64", "pkgconfig"
             ),
         )
 
@@ -710,6 +713,7 @@ def determine_sdl2():
         default_sdl2_path = os.pathsep.join(
             [
                 join(KIVY_DEPS_ROOT, "dist", "lib"),
+                join(KIVY_DEPS_ROOT, "dist", "lib64"),
                 join(KIVY_DEPS_ROOT, "dist", "include", "SDL2"),
             ]
         )

--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -50,68 +50,60 @@ popd
 # Create distribution folder
 echo "Creating distribution folder..."
 mkdir kivy-dependencies/dist
-DIST_FOLDER="$(pwd)/kivy-dependencies/dist"
 
 # Build the dependencies
 pushd kivy-dependencies/build
 
-
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DIST_FOLDER/lib;
-
 echo "-- Build SDL2"
 pushd $MANYLINUX__SDL2__FOLDER
-./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"  --enable-alsa-shared=no  --enable-jack-shared=no  --enable-pulseaudio-shared=no  --enable-esd-shared=no  --enable-arts-shared=no  --enable-nas-shared=no  --enable-sndio-shared=no  --enable-fusionsound-shared=no  --enable-libsamplerate-shared=no  --enable-wayland-shared=no --enable-x11-shared=no --enable-directfb-shared=no --enable-kmsdrm-shared=no;
-make;
-make install;
-make distclean;
+  cmake -S . -B build \
+          -DCMAKE_INSTALL_PREFIX=../../dist \
+          -DCMAKE_BUILD_TYPE=Release \
+          -GNinja
+  cmake --build build/ --config Release --verbose --parallel
+  cmake --install build/ --config Release
 popd
 
 echo "-- Build SDL2_mixer"
 pushd $MANYLINUX__SDL2_MIXER__FOLDER
   ./external/download.sh;
-  echo "-- Build SDL2_mixer - libmodplug"
-  pushd external/libmodplug
-    autoreconf -i;
-    PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin";
-    PATH="$DIST_FOLDER/bin:$PATH" make;
-    make install;
-  popd
-  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-music-mod-modplug-shared=no --enable-music-mod-mikmod-shared=no --enable-music-midi-fluidsynth-shared=no --enable-music-ogg-shared=no --enable-music-flac-shared=no --enable-music-mp3-mpg123-shared=no LDFLAGS=-Wl,-rpath="$ORIGIN";
-  PATH="$DIST_FOLDER/bin:$PATH" make;
-  make install;
-  make distclean;
+  cmake -B build -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DSDL2MIXER_MOD_MODPLUG=ON \
+          -DSDL2MIXER_MOD_MODPLUG_SHARED=OFF \
+          -DCMAKE_INSTALL_PREFIX=../../dist \
+          -DSDL2MIXER_VENDORED=ON \
+          -GNinja
+  cmake --build build/ --config Release --parallel --verbose
+  cmake --install build/ --config Release
 popd
 
 echo "-- Build SDL2_image"
 pushd $MANYLINUX__SDL2_IMAGE__FOLDER
   ./external/download.sh;
-  echo "-- Build SDL2_image - libwebp"
-  pushd external/libwebp
-    autoreconf -i;
-    PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"
-    PATH="$DIST_FOLDER/bin:$PATH" make;
-    make install;
-  popd
-  echo "-- Build SDL2_image - libtiff"
-  pushd external/libtiff
-    autoreconf -i;
-    PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin"
-    PATH="$DIST_FOLDER/bin:$PATH" make;
-    make install;
-  popd
-  autoreconf -i
-  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin" --enable-png-shared=no --enable-jpg-shared=no --enable-tif-shared=no --enable-webp-shared=no LDFLAGS=-Wl,-rpath="$ORIGIN";
-  PATH="$DIST_FOLDER/bin:$PATH" make;
-  make install;
-  make distclean;
+  cmake -B build -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DSDL2IMAGE_TIF=ON \
+          -DSDL2IMAGE_WEBP=ON \
+          -DSDL2IMAGE_TIF_SHARED=OFF \
+          -DSDL2IMAGE_WEBP_SHARED=OFF \
+          -DCMAKE_INSTALL_PREFIX=../../dist \
+          -DSDL2IMAGE_VENDORED=ON -GNinja
+  cmake --build build/ --config Release --parallel --verbose
+  cmake --install build/ --config Release
 popd
 
 echo "-- Build SDL2_ttf"
 pushd $MANYLINUX__SDL2_TTF__FOLDER
-  PATH="$DIST_FOLDER/bin:$PATH" PKG_CONFIG_PATH="$DIST_FOLDER/lib/pkgconfig" ./configure --prefix="$DIST_FOLDER" --bindir="$DIST_FOLDER/bin";
-  PATH="$DIST_FOLDER/bin:$PATH" make;
-  make install;
-  make distclean;
+  cmake -B build-cmake \
+          -DBUILD_SHARED_LIBS=ON \
+          -DSDL2TTF_HARFBUZZ=ON \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=../../dist \
+          -DSDL2TTF_VENDORED=ON -GNinja
+  cmake --build build-cmake --config Release --verbose
+  cmake --install build-cmake/ --config Release --verbose
 popd
 
 popd


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

`SDL2` "migrated" to `cmake` for their builds, and the migration also makes it easier for us to build `SDL2` (and its components such us `SDL_image`) with all the needed sub-dependencies (like `webp`).

Also, during cross-builds for RPi (via https://github.com/kivy/kivy/pull/7852), we found out that the `autoreconf` call is breaking the build.
With `cmake`, that call is not needed anymore, and therefore, the build for RPi is also not failing anymore.

I've performed a few tests of the produced artifacts on a `Ubuntu 22.04.2 LTS (x86_64)`, and everything looks good.

TODO:

- [ ] Perform more tests with pre-built artifacts (https://github.com/kivy/kivy/actions/runs/4681667158)
    - [x] Ubuntu 22.04.2 LTS (x86_64)
    - [x] Fedora Linux 37 Workstation Edition (x86_64) - Clean install
- [x] Update the docs