### PR TITLE
Improved KV-lang parser error info when indentation is invalid 

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -753,6 +753,8 @@ class Parser(object):
                     if current_propobject is None:
                         current_propobject = ParserRuleProperty(
                             self, ln, current_property, content)
+                        if not current_property:
+                            raise ParserException(self, ln, "Invalid declaration")
                         if current_property[:3] == 'on_':
                             current_object.handlers.append(current_propobject)
                         else:

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -756,7 +756,8 @@ class Parser(object):
                         current_propobject = ParserRuleProperty(
                             self, ln, current_property, content)
                         if not current_property:
-                            raise ParserException(self, ln, "Invalid indentation.")
+                            raise ParserException(self, ln,
+                                                  "Invalid indentation")
                         if current_property[:3] == 'on_':
                             current_object.handlers.append(current_propobject)
                         else:

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -695,6 +695,8 @@ class Parser(object):
                             self, ln, 'clear previous, `-`, not allowed here')
                     _objects, _lines = self.parse_level(
                         level + 1, lines[i:], spaces)
+                    if current_object is None:
+                        raise ParserException(self, ln, 'Invalid indentation')
                     current_object.children = _objects
                     lines = _lines
                     i = 0
@@ -754,7 +756,7 @@ class Parser(object):
                         current_propobject = ParserRuleProperty(
                             self, ln, current_property, content)
                         if not current_property:
-                            raise ParserException(self, ln, "Invalid declaration")
+                            raise ParserException(self, ln, "Invalid indentation.")
                         if current_property[:3] == 'on_':
                             current_object.handlers.append(current_propobject)
                         else:

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -72,6 +72,32 @@ class LangTestCase(unittest.TestCase):
         Factory.register('TLangClass3', cls=TLangClass3)
         return Builder
 
+    def test_invalid_indentation(self):
+        Builder = self.import_builder()
+        from kivy.lang import ParserException
+        kv_code = dedent('''\
+            BoxLayout:
+                orientation: 'vertical'
+                    Button:
+        ''')
+
+        try:
+            Builder.load_string(kv_code)
+            self.fail('Invalid indentation.')
+        except ParserException:
+            pass
+
+    def test_invalid_indentation2(self):
+        Builder = self.import_builder()
+        from kivy.lang import ParserException
+        kv_code = '''   BoxLayout:'''
+
+        try:
+            Builder.load_string(kv_code)
+            self.fail('Invalid indentation.')
+        except ParserException as e:
+            pass
+
     def test_loading_failed_1(self):
         # invalid indent
         Builder = self.import_builder()


### PR DESCRIPTION
If you write something like this:
```yml
BoxLayout:
    orientation: 'vertical'
        Button:
```
You will get this error:
```
  File "/.venv/lib/python3.10/site-packages/kivy/lang/parser.py", line 756, in parse_level
    if current_property[:3] == "on_":
TypeError: 'NoneType' object is not subscriptable
```
Because `current_property` is None, and on [line 756](https://github.com/kivy/kivy/blob/master/kivy/lang/parser.py#L756) we try to subscript it. But this error is not informative and does not allow the developer to know where the error comes from. In this case we should show in which line there is a invalid declaration,  by raising a `ParserException`.

After the changes, this is the result:
```
kivy.lang.parser.ParserException: Parser: File "main.kv", line 3:
...
    1: BoxLayout:
    2:     orientation: 'vertical'
>>  3:        Button:
    4:
    5:
...
Invalid declaration
```
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
