### PR TITLE
Fix dropped motion events in mtdev provider.

### DIFF
--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -283,7 +283,7 @@ else:
 
             invert_x = int(bool(drs('invert_x', 0)))
             invert_y = int(bool(drs('invert_y', 0)))
-            Logger.info('MTD: <%s> axes inversion: X is %d, Y is %d' %
+            Logger.info('MTD: <%s> axes invertion: X is %d, Y is %d' %
                         (_fn, invert_x, invert_y))
 
             rotation = drs('rotation', 0)
@@ -333,11 +333,25 @@ else:
                                         range_min_position_x,
                                         range_max_position_x)
                         assign_coord(point, val, invert_x, 'xy')
+                        # some constellation not reports MTDEV_CODE_TRACKING_ID
+                        # -1 which is used to dispatch changes, thus we call
+                        # process here to ensure we not miss move events.
+                        _changes.add(_slot)
+                        process([l_points[x] for x in _changes])
+                        _changes.clear()
+                        continue
                     elif ev_code == MTDEV_CODE_POSITION_Y:
                         val = 1. - normalize(ev_value,
                                              range_min_position_y,
                                              range_max_position_y)
                         assign_coord(point, val, invert_y, 'yx')
+                        # some constellation not reports MTDEV_CODE_TRACKING_ID
+                        # -1 which is used to dispatch changes, thus we call
+                        # process here to ensure we not miss move events.
+                        _changes.add(_slot)
+                        process([l_points[x] for x in _changes])
+                        _changes.clear()
+                        continue
                     elif ev_code == MTDEV_CODE_PRESSURE:
                         point['pressure'] = normalize(ev_value,
                                                       range_min_pressure,

--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -97,7 +97,7 @@ else:
         MTDEV_CODE_TOUCH_MAJOR, MTDEV_CODE_TOUCH_MINOR, \
         MTDEV_CODE_TRACKING_ID, MTDEV_ABS_POSITION_X, \
         MTDEV_ABS_POSITION_Y, MTDEV_ABS_TOUCH_MINOR, \
-        MTDEV_ABS_TOUCH_MAJOR
+        MTDEV_ABS_TOUCH_MAJOR, MTDEV_TYPE_EV_SYN
     from kivy.input.provider import MotionEventProvider
     from kivy.input.factory import MotionEventFactory
     from kivy.logger import Logger
@@ -191,6 +191,7 @@ else:
             touches_sent = []
             point = {}
             l_points = {}
+            changes = set()
 
             def assign_coord(point, value, invert, coords):
                 cx, cy = coords
@@ -206,6 +207,7 @@ else:
                     point[cy] = 1. - value
 
             def process(points):
+                changes.clear()
                 for args in points:
                     # this can happen if we have a touch going on already at
                     # the start of the app
@@ -249,7 +251,6 @@ else:
                     return
                 else:
                     raise
-            _changes = set()
 
             # prepare some vars to get limit of some component
             ab = _device.get_abs(MTDEV_ABS_POSITION_X)
@@ -328,30 +329,21 @@ else:
                     point = l_points[_slot]
                     ev_value = data.value
                     ev_code = data.code
-                    if ev_code == MTDEV_CODE_POSITION_X:
+                    if ev_code == MTDEV_CODE_TRACKING_ID:
+                        if ev_value == -1:
+                            point['delete'] = True
+                        else:
+                            point['id'] = ev_value
+                    elif ev_code == MTDEV_CODE_POSITION_X:
                         val = normalize(ev_value,
                                         range_min_position_x,
                                         range_max_position_x)
                         assign_coord(point, val, invert_x, 'xy')
-                        # some constellation not reports MTDEV_CODE_TRACKING_ID
-                        # -1 which is used to dispatch changes, thus we call
-                        # process here to ensure we not miss move events.
-                        _changes.add(_slot)
-                        process([l_points[x] for x in _changes])
-                        _changes.clear()
-                        continue
                     elif ev_code == MTDEV_CODE_POSITION_Y:
                         val = 1. - normalize(ev_value,
                                              range_min_position_y,
                                              range_max_position_y)
                         assign_coord(point, val, invert_y, 'yx')
-                        # some constellation not reports MTDEV_CODE_TRACKING_ID
-                        # -1 which is used to dispatch changes, thus we call
-                        # process here to ensure we not miss move events.
-                        _changes.add(_slot)
-                        process([l_points[x] for x in _changes])
-                        _changes.clear()
-                        continue
                     elif ev_code == MTDEV_CODE_PRESSURE:
                         point['pressure'] = normalize(ev_value,
                                                       range_min_pressure,
@@ -364,26 +356,17 @@ else:
                         point['size_h'] = normalize(ev_value,
                                                     range_min_minor,
                                                     range_max_minor)
-                    elif ev_code == MTDEV_CODE_TRACKING_ID:
-                        if ev_value == -1:
-                            point['delete'] = True
-                            # force process of changes here, as the slot can be
-                            # reused.
-                            _changes.add(_slot)
-                            process([l_points[x] for x in _changes])
-                            _changes.clear()
-                            continue
-                        else:
-                            point['id'] = ev_value
+                    elif ev_code == MTDEV_TYPE_EV_SYN and changes:
+                        process([l_points[x] for x in changes])
+                        continue
                     else:
                         # unrecognized command, ignore.
                         continue
-                    _changes.add(_slot)
+                    changes.add(_slot)
 
                 # push all changes
-                if _changes:
-                    process([l_points[x] for x in _changes])
-                    _changes.clear()
+                if changes:
+                    process([l_points[x] for x in changes])
 
         def update(self, dispatch_fn):
             # dispatch all event from threads

--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -283,7 +283,7 @@ else:
 
             invert_x = int(bool(drs('invert_x', 0)))
             invert_y = int(bool(drs('invert_y', 0)))
-            Logger.info('MTD: <%s> axes invertion: X is %d, Y is %d' %
+            Logger.info('MTD: <%s> axes inversion: X is %d, Y is %d' %
                         (_fn, invert_x, invert_y))
 
             rotation = drs('rotation', 0)


### PR DESCRIPTION
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

with a current setup on a 6.1.0 linux kernel and a multi touch display i encountered motion events getting dropped.

The mtdev input provider processes values if MTDEV_CODE_TRACKING_ID event is received and it's value denotes an unused slot. However, this not happens in my case, so i added processing on position changes as well to ensure on_touch_move events get fired properly.

Actually i have not tried with another kernel, so i have no idea if there are changes in libmtdev or if the multitouch display i use not follows standards with sending data.

Also i have not digged in detail into the mtdev docs (https://docs.kernel.org/6.1/input/multi-touch-protocol.html) nor did i studied the input provider implementation in depth, maybe there's a better place to fix this issue.