### PR TITLE
Added client certificate authentication to UrlRequest.py

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -120,6 +120,9 @@ class UrlRequestBase(Thread):
 
         Parameters `on_finish` added.
         Parameters `auth` added.
+    
+    .. versionchanged:: 2.3.0
+
         Parameters `cert_file` added.
         Parameters `key_file` added.
         Parameters `key_password` added.


### PR DESCRIPTION
Hello,

This pull request is for adding client certificate authentication to UrlRequest.py.
The client certificate can be used for authentication with the API server where certificate verification takes place.
As per protocol, server and client certificates must be signed by the same CA.

Added parameters to UrlRequest:
- cert_file : the client certificate
- key_file : the key of the client certificate
- key_password : the password of the key if any. It could be also a function that results the password as text

Example:

        req = UrlRequest(webservices_url,
                on_success=self.req_made,
                on_error=self.req_error,
                on_failure=self.req_error,
                debug=True,
                ca_file=ca_file,
                verify=False,
                cert_file=cert_file,
                key_file=key_file,
                key_password=key_password,
                req_body=params,
                req_headers=headers)




Thank you so much to everybody!


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
