### PR TITLE
`Generate-sdist` needs `packaging` as a dependency [build wheel win]

### DIFF
--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -24,7 +24,7 @@ function Update-version-metadata {
 }
 
 function Generate-sdist {
-    python -m pip install cython
+    python -m pip install cython packaging
     python setup.py sdist --formats=gztar
     python setup.py bdist_wheel --build_examples --universal
     python -m pip uninstall cython -y


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

The nightly builds for `windows` wheels started to fail, as `packaging` is a required dependency, and has been removed from `windows-latest` images.