### PR TITLE
Perform RPi builds on `balenalib/raspberrypi3-*` images and skip `DISPMANX` API usage if can't be used [build wheel armv7l]

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -1,5 +1,7 @@
-ARG image=balenalib/armv7hf-debian:buster
+ARG image=balenalib/raspberrypi3-debian-python:3.7-buster
 FROM $image
+
+ENV KIVY_CROSS_PLATFORM=rpi
 
 COPY . /kivy
 WORKDIR /kivy
@@ -10,9 +12,17 @@ RUN [ "cross-build-start" ]
 RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple" && \
     install_ubuntu_build_deps && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg wget libxrender-dev && \
-    install_python && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg wget libxrender-dev lsb-release libraspberrypi-dev raspberrypi-kernel-headers && \
     install_kivy_test_run_pip_deps'
+
+# If we're on Debian buster, we need to install cmake from backports as the cmake version
+# in buster is too old to build sdl2
+RUN /bin/bash -c 'if [ "$(lsb_release -cs)" = "buster" ]; then \
+        echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list; \
+        apt-get update; \
+        apt-get -y install -t buster-backports cmake; \
+    fi'
+
 
 # Install patchelf (needed during delocation)
 RUN /bin/bash -c 'wget https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-armv7l.tar.gz'
@@ -22,22 +32,22 @@ RUN /bin/bash -c 'rm patchelf-0.17.2-armv7l.tar.gz'
 # Install auditwheel for delocation
 RUN /bin/bash -c 'pip install auditwheel'
 
-# Download the Raspberry Pi firmware, so Raspberry Pi 1-3 can use the 'egl_rpi' window provider.
-ARG KIVY_CROSS_PLATFORM=""
-ARG KIVY_CROSS_SYSROOT=""
-RUN if [ "$KIVY_CROSS_PLATFORM" = "rpi" ]; then \
-        apt-get -y install git; \
-        git clone --depth=1 https://github.com/raspberrypi/firmware "$KIVY_CROSS_SYSROOT"; \
-        ln -s "$KIVY_CROSS_SYSROOT"/opt/vc "$KIVY_CROSS_SYSROOT"/usr; \
-    fi
 
 # Build the dependencies (sdl)
 RUN ./tools/build_linux_dependencies.sh
 
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" KIVY_CROSS_SYSROOT="$KIVY_CROSS_SYSROOT" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
-# Delocate the wheel
-RUN /bin/bash -c 'auditwheel repair /kivy-wheel/Kivy-*.whl -w /kivy-delocated-wheel --plat manylinux_2_31_armv7l --no-update-tags --exclude libbrcmGLESv2.so --exclude libbcm_host.so --exclude libbrcmEGL.so'
+# Delocate the wheel.
+# if we're on buster, platform is manylinux_2_28_armv7l, if bullseye, manylinux_2_31_armv7l, otherwise let's just try manylinux2014_armv7l
+RUN /bin/bash -c 'if [ "$(lsb_release -cs)" = "buster" ]; then \
+        MANYLINUX_PLATFORM=manylinux_2_28_armv7l; \
+    elif [ "$(lsb_release -cs)" = "bullseye" ]; then \
+        MANYLINUX_PLATFORM=manylinux_2_31_armv7l; \
+    else \
+        MANYLINUX_PLATFORM=manylinux2014_armv7l; \
+    fi; \
+    auditwheel repair /kivy-wheel/Kivy-*.whl -w /kivy-delocated-wheel --plat "$MANYLINUX_PLATFORM" --no-update-tags --exclude libbrcmGLESv2.so --exclude libbcm_host.so --exclude libbrcmEGL.so'
 
 RUN [ "cross-build-end" ]

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -23,9 +23,6 @@ generate_sdist() {
   python3 -m pip uninstall cython -y
 }
 
-install_python() {
-  sudo apt-get -y install python3 python3-dev python3-setuptools
-}
 
 install_kivy_test_run_pip_deps() {
   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
@@ -179,11 +176,11 @@ install_ubuntu_build_deps() {
           libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
 }
 
-generate_armv7l_wheels() {
+generate_rpi_wheels() {
   image=$1
 
   mkdir dist
-  docker build -f .ci/Dockerfile.armv7l -t kivy/kivy-armv7l --build-arg image="$image" --build-arg KIVY_CROSS_PLATFORM="$2" --build-arg KIVY_CROSS_SYSROOT="$3" .
+  docker build -f .ci/Dockerfile.armv7l -t kivy/kivy-armv7l --build-arg image="$image" .
   docker cp "$(docker create kivy/kivy-armv7l)":/kivy-delocated-wheel .
   cp kivy-delocated-wheel/Kivy-* dist/
 

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -9,8 +9,6 @@ on:
 
 env:
   SERVER_IP: '159.203.106.198'
-  KIVY_CROSS_PLATFORM: 'rpi'
-  KIVY_CROSS_SYSROOT: '/rpi-firmware'
 
 jobs:
   raspberrypi:
@@ -18,7 +16,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        docker_images: ['balenalib/armv7hf-python:3.7-bullseye', 'balenalib/armv7hf-python:3.9-bullseye']
+        docker_images: ['balenalib/raspberrypi3-debian-python:3.7-buster', 'balenalib/raspberrypi3-debian-python:3.9-bullseye']
     steps:
     - uses: actions/checkout@v3
     - name: Generate version metadata
@@ -28,7 +26,7 @@ jobs:
     - name: Make ${{ matrix.docker_images }} wheel
       run: |
         source .ci/ubuntu_ci.sh
-        generate_armv7l_wheels ${{ matrix.docker_images }} "$KIVY_CROSS_PLATFORM" "$KIVY_CROSS_SYSROOT"
+        generate_rpi_wheels ${{ matrix.docker_images }}
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
       run: |


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

- The previous artifacts for RPi on `buster-3.7` were not working due to an incompatibility on `GCLIB`.
- The previous artifacts for RPi on `bullseye-3.9` were not working due to missing features (during the build we were manually downloading raspberry-specific libs and headers which are not available on `bullseye-3.9`)

Now, cross-builds are performed on `balenalib/raspberrypi3-debian-python:3.7-buster` and `balenalib/raspberrypi3-debian-python:3.9-bullseye`. That allows us to have almost the same environment which is available on a real RPi with Raspbian.

Additionally, since `DISPMANX` is not available on `Raspbian Bullseye`, we should check if it's usable, even if we're on an RPi. For this reason, on `setup.py` a new helper method `check_c_source_compiles` has been added.

As `DISPMANX` is not available on `Raspbian Bullseye`, `vidcore_lite` support is missing on the `cp39` artifact. In the future (`2.3.0` ?), we will need to add support for `DRM` instead.

⚠️ I performed the tests over a VNC session on a Raspberry Pi 3 without a display attached. For that reason, I needed to circumvent an issue manually (`Can't create window since it couldn't find matching GLX visual`).
Would be nice to test the artifacts on an RPi which is attached to a display, before the final `2.2.0` release.