### PR TITLE
Sphinx `7.0.0` is incompatible, use `<=6.2.1` for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ dev =
     pytest-timeout
     pytest-benchmark
     pyinstaller
-    sphinx
+    sphinx<=6.2.1
     sphinxcontrib-blockdiag
     sphinxcontrib-seqdiag
     sphinxcontrib-actdiag


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

The newly released (29 March) Sphinx `7.x` is incompatible with our template:
```
 /home/runner/work/kivy/kivy/kivy/__init__.py
An error happened in rendering the page api-index.
Reason: UndefinedError("'style' is undefined")
Auto-generation finished
```

Since we're in feature freeze, and we do not like surprises, I've just set `<=6.2.1` for now.

Related issue: https://github.com/kivy/kivy/issues/8230