### PR TITLE
Fix errors when simulating (arm) on a Native M1 Mac (Design for Iphone/Ipad)

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -381,44 +381,47 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     Logger.setLevel(level=level)
 
     # Can be overridden in command line
-    if ('KIVY_UNITTEST' not in environ and
-            'KIVY_PACKAGING' not in environ and
-            environ.get('KIVY_NO_ARGS', "false") not in ('true', '1', 'yes')):
-        # save sys argv, otherwise, gstreamer use it and display help..
-        sys_argv = sys.argv
-        sys.argv = sys.argv[:1]
+    try:
+        if ('KIVY_UNITTEST' not in environ and
+                'KIVY_PACKAGING' not in environ and
+                environ.get('KIVY_NO_ARGS', "false") not in ('true', '1', 'yes')):
+            # save sys argv, otherwise, gstreamer use it and display help..
+            sys_argv = sys.argv
+            sys.argv = sys.argv[:1]
 
-        try:
-            opts, args = getopt(sys_argv[1:], 'hp:fkawFem:sr:dc:', [
-                'help', 'fullscreen', 'windowed', 'fps', 'event',
-                'module=', 'save', 'fake-fullscreen', 'auto-fullscreen',
-                'multiprocessing-fork', 'display=', 'size=', 'rotate=',
-                'config=', 'debug', 'dpi='])
+            try:
+                opts, args = getopt(sys_argv[1:], 'hp:fkawFem:sr:dc:', [
+                    'help', 'fullscreen', 'windowed', 'fps', 'event',
+                    'module=', 'save', 'fake-fullscreen', 'auto-fullscreen',
+                    'multiprocessing-fork', 'display=', 'size=', 'rotate=',
+                    'config=', 'debug', 'dpi='])
 
-        except GetoptError as err:
-            Logger.error('Core: %s' % str(err))
-            kivy_usage()
-            sys.exit(2)
+            except GetoptError as err:
+                Logger.error('Core: %s' % str(err))
+                kivy_usage()
+                sys.exit(2)
 
-        mp_fork = None
-        try:
-            for opt, arg in opts:
-                if opt == '--multiprocessing-fork':
-                    mp_fork = True
-                    break
-        except:
-            pass
+            mp_fork = None
+            try:
+                for opt, arg in opts:
+                    if opt == '--multiprocessing-fork':
+                        mp_fork = True
+                        break
+            except:
+                pass
 
-        # set argv to the non-read args
-        sys.argv = sys_argv[0:1] + args
-        if mp_fork is not None:
-            # Needs to be first opt for support_freeze to work
-            sys.argv.insert(1, '--multiprocessing-fork')
+            # set argv to the non-read args
+            sys.argv = sys_argv[0:1] + args
+            if mp_fork is not None:
+                # Needs to be first opt for support_freeze to work
+                sys.argv.insert(1, '--multiprocessing-fork')
 
-    else:
+        else:
+            opts = []
+            args = []
+    except:
         opts = []
         args = []
-
     need_save = False
     for opt, arg in opts:
         if opt in ('-h', '--help'):


### PR DESCRIPTION
Fix errors when simulating on a Native M1 Mac (Design for Iphone/Ipad):

`TypeError: unsupported operand type(s) for %: 'NoneType' and 'str' Application quit abnormally!`

With a native M1 Mac, we can run builds directly in My Mac (Design for Iphone/Ipad) simulator much faster compared to the iPhone simulator. We no longer need to build an Intel version in the production of recipes using the --arch=arm64 flag.
Xcode build setting:
-Architechtures: arm64
-Excluded Architechtures: x86_64
