### PR TITLE
Refactoring: garden importer imp upgrade to importlib

### DIFF
--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -136,8 +136,8 @@ For example::
 
 __path__ = 'kivy.garden'
 
+import importlib.util
 import sys
-import imp
 from os.path import dirname, join, realpath, exists, abspath
 from kivy import kivy_home_dir
 from kivy.utils import platform
@@ -160,7 +160,7 @@ if platform == "ios":
     garden_app_dir = join(dirname(main_py_file), 'libs', 'garden')
 
 
-class GardenImporter(object):
+class GardenImporter:
 
     def find_module(self, fullname, path):
         if path == 'kivy.garden':
@@ -180,10 +180,13 @@ class GardenImporter(object):
                 return self._load_module(fullname, moddir)
 
     def _load_module(self, fullname, moddir):
-        mod = imp.load_module(fullname, None, moddir,
-                              ('', '', imp.PKG_DIRECTORY))
+        spec = importlib.util.spec_from_file_location(fullname, moddir)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
         return mod
 
 
 # insert the garden importer as ultimate importer
 sys.meta_path.append(GardenImporter())
+
+

--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -188,5 +188,3 @@ class GardenImporter:
 
 # insert the garden importer as ultimate importer
 sys.meta_path.append(GardenImporter())
-
-


### PR DESCRIPTION
Adressing  #8225 
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

. Replaced imp import with importlib.util:
-The original code used imp.load_module to load the modules. In the updated code, I replaced it with importlib.util.spec_from_file_location and importlib.util.module_from_spec to achieve the same functionality.

. Updated imports:
-Added import importlib.util to import the spec_from_file_location and module_from_spec functions
-Removed the import imp statement since it is no longer needed.

.Modified _load_module method:
-Replaced imp.load_module with importlib.util.module_from_spec to create the module object.
-Used spec.loader.exec_module(mod) to execute the module code.
