### PR TITLE
Increase timeout of `httpbin` tests to reduce risk of failures on CI runs

### DIFF
--- a/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
+++ b/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
@@ -98,7 +98,7 @@ def test_auth_header(kivy_clock):
         req_headers=head,
         debug=True
     )
-    wait_request_is_finished(kivy_clock, req)
+    wait_request_is_finished(kivy_clock, req, timeout=60)
 
     if req.error and req.error.errno == 11001:
         pytest.skip('Cannot connect to get address')
@@ -120,7 +120,7 @@ def test_auth_auto(kivy_clock):
         on_redirect=obj._on_redirect,
         debug=True
     )
-    wait_request_is_finished(kivy_clock, req)
+    wait_request_is_finished(kivy_clock, req, timeout=60)
 
     if req.error and req.error.errno == 11001:
         pytest.skip('Cannot connect to get address')
@@ -146,7 +146,7 @@ def test_ca_file(kivy_clock, scheme):
         ca_file=certifi.where(),
         debug=True
     )
-    wait_request_is_finished(kivy_clock, req)
+    wait_request_is_finished(kivy_clock, req, timeout=60)
 
     if req.error and req.error.errno == 11001:
         pytest.skip('Cannot connect to get address')


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

`httpbin.org` is becoming increasingly slow, and our CI runs are badly affected.
I'm **NOT** a fan of increasing timeouts to handle failures, but that seems the easiest workaround.

Unfortunately running a `httpbin` service via `docker` does not work well for us, as we also perform `https://` tests.

An alternative would be hosting a `httpbin` service on our server e.g. at `https://httpbin.kivy.org`, but that will likely increase the traffic (from non-kivy CI) on our server. (Also, would be something else to maintain 😀)

