### PR TITLE
Allow `Scale` and `Translate` to take `x`, `y` and `z` as `kwargs`. Removes deprecated `Scale().scale` property.

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -901,13 +901,17 @@ cdef class Translate(Transform):
     '''
     def __init__(self, *args, **kwargs):
         cdef double x, y, z
-        Transform.__init__(self, **kwargs)
+        x, y, z = 0, 0, 0
         if len(args) == 3:
             x, y, z = args
-            self.set_translate(x, y, z)
         elif len(args) == 2:
             x, y = args
-            self.set_translate(x, y, 0)
+        x = kwargs.pop("x", x)
+        y = kwargs.pop("y", y)
+        z = kwargs.pop("z", z)
+
+        Transform.__init__(self, **kwargs)
+        self.set_translate(x, y, z)
 
     cdef set_translate(self, double x, double y, double z):
         self.matrix = Matrix().translate(x, y, z)
@@ -964,5 +968,3 @@ cdef class Translate(Transform):
     @xyz.setter
     def xyz(self, c):
         self.set_translate(c[0], c[1], c[2])
-
-

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -767,6 +767,19 @@ cdef class Scale(Transform):
     '''
     def __init__(self, *args, **kwargs):
         cdef double x, y, z
+
+        x, y, z = 1.0, 1.0, 1.0
+        if len(args) == 1:
+            s = args[0]
+            x, y, z = s, s, s
+        if len(args) == 2:
+            x, y = args
+        elif len(args) == 3:
+            x, y, z = args
+        x = kwargs.pop("x", x)
+        y = kwargs.pop("y", y)
+        z = kwargs.pop("z", z)
+
         Transform.__init__(self, **kwargs)
         self._origin = (0, 0, 0)
 
@@ -779,14 +792,7 @@ cdef class Scale(Transform):
             else:
                 raise Exception('invalid number of components in origin')
 
-        if len(args) == 1:
-            s = args[0]
-            self.set_scale(s, s, s)
-        elif len(args) == 3:
-            x, y, z = args
-            self.set_scale(x, y, z)
-        else:
-            self.set_scale(1.0, 1.0, 1.0)
+        self.set_scale(x, y, z)
 
     cdef set_scale(self, double x, double y, double z):
         cdef double ox, oy, oz

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -764,6 +764,9 @@ cdef class Scale(Transform):
     .. deprecated:: 1.6.0
         Deprecated single scale property in favor of x, y, z, xyz axis
         independent scaled factors.
+
+    .. versionchanged:: 2.3.0
+        Allowed kwargs to be used to supply x, y and z.
     '''
     def __init__(self, *args, **kwargs):
         cdef double x, y, z
@@ -904,6 +907,9 @@ cdef class Translate(Transform):
 
         Translate(x, y)         # translate in just the two axes
         Translate(x, y, z)      # translate in all three axes
+
+    .. versionchanged:: 2.3.0
+        Allowed kwargs to be used to supply x, y and z.
     '''
     def __init__(self, *args, **kwargs):
         cdef double x, y, z

--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -756,28 +756,19 @@ cdef class Rotate(Transform):
 cdef class Scale(Transform):
     '''Instruction to create a non uniform scale transformation.
 
-    Create using one or three arguments::
+    Create using three arguments::
 
-       Scale(s)         # scale all three axes the same
        Scale(x, y, z)   # scale the axes independently
-
-    .. deprecated:: 1.6.0
-        Deprecated single scale property in favor of x, y, z, xyz axis
-        independent scaled factors.
 
     .. versionchanged:: 2.3.0
         Allowed kwargs to be used to supply x, y and z.
+        Removed depreciated Scale(s) in favour of Scale(x, y, z).
     '''
     def __init__(self, *args, **kwargs):
         cdef double x, y, z
 
         x, y, z = 1.0, 1.0, 1.0
-        if len(args) == 1:
-            s = args[0]
-            x, y, z = s, s, s
-        if len(args) == 2:
-            x, y = args
-        elif len(args) == 3:
+        if len(args) == 3:
             x, y, z = args
         x = kwargs.pop("x", x)
         y = kwargs.pop("y", y)
@@ -808,28 +799,6 @@ cdef class Scale(Transform):
         matrix = matrix.multiply(Matrix().scale(x, y, z))
         matrix = matrix.multiply(Matrix().translate(-ox, -oy, -oz))
         self.matrix = matrix
-
-    @property
-    def scale(self):
-        '''Property for getting/setting the scale.
-
-        .. deprecated:: 1.6.0
-            Deprecated in favor of per axis scale properties x,y,z, xyz, etc.
-        '''
-        if self._x == self._y == self._z:
-            Logger.warning("scale property is deprecated, use xyz, x, " +\
-                "y, z, etc properties to get scale factor based on axis.")
-            return self._x
-        else:
-            raise Exception("trying to access deprecated property" +\
-                " 'scale' on Scale instruction with non uniform scaling!")
-
-
-    @scale.setter
-    def scale(self, s):
-        Logger.warning("scale property is deprecated, use xyz, x, " +\
-            "y, z, etc properties to get scale factor based on axis.")
-        self.set_scale(s,s,s)
 
     @property
     def x(self):

--- a/kivy/tests/test_animations.py
+++ b/kivy/tests/test_animations.py
@@ -160,7 +160,7 @@ class TestAnimation:
         from kivy.graphics import Scale
         from kivy.animation import Animation
         a = Animation(x=100, d=1)
-        instruction = Scale(3)
+        instruction = Scale(3, 3, 3)
         a.start(instruction)
         assert a.animated_properties == {'x': 100, }
         assert instruction.x == pytest.approx(3)

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -455,10 +455,6 @@ class TransformationsTestCase(GraphicUnitTest):
 
     def check_transform_works(self, transform_type):
         # Normal args
-        transform = transform_type(0, 1)
-        self.assertEquals(transform.x, 0)
-        self.assertEquals(transform.y, 1)
-
         transform = transform_type(0, 1, 2)
         self.assertEquals(transform.x, 0)
         self.assertEquals(transform.y, 1)

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -472,7 +472,7 @@ class TransformationsTestCase(GraphicUnitTest):
         transform = transform_type(x=0, y=1, z=2)
         self.assertEquals(transform.x, 0)
         self.assertEquals(transform.y, 1)
-        self.assertEquals(transform.z, 1)
+        self.assertEquals(transform.z, 2)
 
     def test_translate_normal_arg_creation(self):
         from kivy.graphics import Translate

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -456,19 +456,19 @@ class TransformationsTestCase(GraphicUnitTest):
     def check_transform_works(self, transform_type):
         # Normal args
         transform = transform_type(0, 1, 2)
-        self.assertEquals(transform.x, 0)
-        self.assertEquals(transform.y, 1)
-        self.assertEquals(transform.z, 2)
+        self.assertEqual(transform.x, 0)
+        self.assertEqual(transform.y, 1)
+        self.assertEqual(transform.z, 2)
 
         # Key word args
         transform = transform_type(x=0, y=1)
-        self.assertEquals(transform.x, 0)
-        self.assertEquals(transform.y, 1)
+        self.assertEqual(transform.x, 0)
+        self.assertEqual(transform.y, 1)
 
         transform = transform_type(x=0, y=1, z=2)
-        self.assertEquals(transform.x, 0)
-        self.assertEquals(transform.y, 1)
-        self.assertEquals(transform.z, 2)
+        self.assertEqual(transform.x, 0)
+        self.assertEqual(transform.y, 1)
+        self.assertEqual(transform.z, 2)
 
     def test_translate_creation(self):
         from kivy.graphics import Translate

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -470,11 +470,11 @@ class TransformationsTestCase(GraphicUnitTest):
         self.assertEquals(transform.y, 1)
         self.assertEquals(transform.z, 2)
 
-    def test_translate_normal_arg_creation(self):
+    def test_translate_creation(self):
         from kivy.graphics import Translate
         self.check_transform_works(Translate)
 
-    def test_scale_normal_arg_creation(self):
+    def test_scale_creation(self):
         from kivy.graphics import Scale
         self.check_transform_works(Scale)
 

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -453,6 +453,35 @@ class TransformationsTestCase(GraphicUnitTest):
         mat = LoadIdentity()
         self.assertTrue(mat.stack)
 
+    def check_transform_works(self, transform_type):
+        # Normal args
+        transform = transform_type(0, 1)
+        self.assertEquals(transform.x, 0)
+        self.assertEquals(transform.y, 1)
+
+        transform = transform_type(0, 1, 2)
+        self.assertEquals(transform.x, 0)
+        self.assertEquals(transform.y, 1)
+        self.assertEquals(transform.z, 2)
+
+        # Key word args
+        transform = transform_type(x=0, y=1)
+        self.assertEquals(transform.x, 0)
+        self.assertEquals(transform.y, 1)
+
+        transform = transform_type(x=0, y=1, z=2)
+        self.assertEquals(transform.x, 0)
+        self.assertEquals(transform.y, 1)
+        self.assertEquals(transform.z, 1)
+
+    def test_translate_normal_arg_creation(self):
+        from kivy.graphics import Translate
+        self.check_transform_works(Translate)
+
+    def test_scale_normal_arg_creation(self):
+        from kivy.graphics import Scale
+        self.check_transform_works(Scale)
+
 
 class CallbackInstructionTest(GraphicUnitTest):
 


### PR DESCRIPTION
Added support to create scale and translate instructions with kwargs like this
```
Translate(x=0, y=1, z=2)
Translate(0, 1)  # Original method still works

Scale(x=2, y=1, z=23)  # Scale also works
Scale(1, 2, 3)  # But the original for this also works.
```
Unit tests were also added for both methods of creation.

P.S. If your want to know why I can't just use normal args: I have a system where I load designs from a JSON file which stores the type of instruction and kwargs (like pos and size), and it doesn't work with normal args.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
