### PR TITLE
Fix `SmoothLine` rendering issues

### DIFF
--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -1481,19 +1481,37 @@ cdef class SmoothLine(Line):
         return 0
 
     # FIXME: Some artifacts can be observed, depending on the line width,
-    # overdraw_width and radius.
+    # overdraw_width and radius. This occurs due to the way the vertices are
+    # built. It is not noticeable when the alpha value of the color of the
+    # active context is equal to 1. One solution would be to avoid overlapping
+    # vertices.
     cdef void build_smooth(self):
         cdef:
             list p = self.points
+            int close = self._close
             double width = max(0, (self._width - 1.))
             double owidth = width + self._owidth
             vertex_t *vertices = NULL
             unsigned short *indices = NULL
             unsigned short *tindices = NULL
+            double min_angle_threshold, angle_diff
             double ax, ay, bx = 0., by = 0., rx = 0., ry = 0., last_angle = 0., angle, av_angle
             double cos1, sin1, cos2, sin2, ocos1, ocos2, osin1, osin2
             long index, icount, iv, ii, max_vindex, count
             unsigned short i0, i1, i2, i3, i4, i5, i6, i7, vindex, vcount
+
+
+        # Points that are very close (with a distance less than 0.1) will
+        # be discarded. This increases the reliability of line rendering.
+        p = self._remove_close_points(p)
+
+        # If it is just a line segment, there will be no support to close the line.
+        if len(p) <= 4:
+            close = False
+
+        # A new point needs to meet a minimum distance threshold before being added.
+        if close and not (abs(p[-2] - p[0]) < 0.1 and abs(p[-1] - p[1]) < 0.1):
+            p = p + p[:2]
 
         iv = vindex = 0
         count = <long>int(len(p) / 2.)
@@ -1503,8 +1521,6 @@ cdef class SmoothLine(Line):
 
         vcount = <unsigned short>(count * 4)
         icount = (count - 1) * 18
-        if self._close and self._close_mode == 'straight-line':
-            icount += 18
 
         vertices = <vertex_t *>malloc(vcount * sizeof(vertex_t))
         if vertices == NULL:
@@ -1515,9 +1531,9 @@ cdef class SmoothLine(Line):
             free(vertices)
             raise MemoryError("indices")
 
-        if self._close and self._close_mode == 'straight-line':
-            ax = p[-2]
-            ay = p[-1]
+        if close and self._close_mode == 'straight-line':
+            ax = p[-4]
+            ay = p[-3]
             bx = p[0]
             by = p[1]
             rx = bx - ax
@@ -1528,16 +1544,27 @@ cdef class SmoothLine(Line):
         for index in range(0, max_index, 2):
             ax = p[index]
             ay = p[index + 1]
+
             if index < max_index - 2:
                 bx = p[index + 2]
                 by = p[index + 3]
                 rx = bx - ax
                 ry = by - ay
                 angle = atan2(ry, rx)
+
+            elif close and index == max_index - 2:
+                ax = p[0]
+                ay = p[1]
+                bx = p[2]
+                by = p[3]
+                rx = bx - ax
+                ry = by - ay
+                angle = atan2(ry, rx)
+
             else:
                 angle = last_angle
 
-            if index == 0 and (not self._close or self._close_mode != 'straight-line'):
+            if index == 0 and (not close or self._close_mode != 'straight-line'):
                 av_angle = angle
                 ad_angle = pi
             else:
@@ -1549,30 +1576,24 @@ cdef class SmoothLine(Line):
 
             a1 = av_angle - PI2
             a2 = av_angle + PI2
-            '''
-            cos1 = cos(a1) * width
-            sin1 = sin(a1) * width
-            cos2 = cos(a2) * width
-            sin2 = sin(a2) * width
-            ocos1 = cos(a1) * owidth
-            osin1 = sin(a1) * owidth
-            ocos2 = cos(a2) * owidth
-            osin2 = sin(a2) * owidth
-            print('angle diff', ad_angle)
-            '''
-            #l = width
-            #ol = owidth
 
-            if index == 0 or index >= max_index - 2:
+
+            if (index == 0 or index >= max_index - 2) and (not close or self._close_mode != 'straight-line'):
                 l = width
                 ol = owidth
             else:
+                if index == 0:
+                    ox = p[- 4]
+                    oy = p[- 3]
+                else:
+                    ox = p[index - 2]
+                    oy = p[index - 1]
+
                 la1 = last_angle - PI2
                 la2 = angle - PI2
                 ra1 = last_angle + PI2
                 ra2 = angle + PI2
-                ox = p[index - 2]
-                oy = p[index - 1]
+
                 if line_intersection(
                     ox + cos(la1) * width,
                     oy + sin(la1) * width,
@@ -1603,25 +1624,37 @@ cdef class SmoothLine(Line):
 
                 ol = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
 
+
+                angle_diff = self._get_angle_diff(
+                    ox + cos(ra1) * owidth,
+                    oy + sin(ra1) * owidth,
+                    ax + cos(ra1) * owidth,
+                    ay + sin(ra1) * owidth,
+                    ax + cos(ra2) * owidth,
+                    ay + sin(ra2) * owidth,
+                    bx + cos(ra2) * owidth,
+                    by + sin(ra2) * owidth,
+                )
+
+                # 1 degree in radians, determined empirically.
+                min_angle_threshold = 0.017453292519943295
+
+                # If the angle difference is too small it is not safe to use
+                # the calculated values of l or l. Otherwise, l and ol will
+                # have extremely high values, causing the line to become
+                # excessively thick at some intersections (in specific cases).
+                if angle_diff < min_angle_threshold or ad_angle < min_angle_threshold:
+                    l = width
+                    ol = owidth
+
+
             last_angle = angle
 
-            #l = sqrt(width ** 2 * (1. / sin(av_angle)) ** 2)
-            #l = width / tan(av_angle / 2.)
-            #l = width * sqrt(1 + 1 / (av_angle / 2.))
-            #l = 2 * (width * width * sin(av_angle))
-            #l = 2 * (cos(av_angle / 2.) * width)
-            #l = width / abs(cos(PI2 - 1.5 * ad_angle))
             cos1 = cos(a1) * l
             sin1 = sin(a1) * l
             cos2 = cos(a2) * l
             sin2 = sin(a2) * l
 
-            #ol = sqrt(owidth ** 2 * (1. / sin(av_angle)) ** 2)
-            #ol = owidth / tan(av_angle / 2.)
-            #ol = owidth * sqrt(1 + 1 / (av_angle / 2.))
-            #ol = 2 * (owidth * owidth * sin(av_angle))
-            #ol = 2 * (cos(av_angle / 2.) * owidth)
-            #ol = owidth / abs(cos(PI2 - 1.5 * ad_angle))
             ocos1 = cos(a1) * ol
             osin1 = sin(a1) * ol
             ocos2 = cos(a2) * ol
@@ -1680,43 +1713,41 @@ cdef class SmoothLine(Line):
             tindices[17] = vindex + 7
             tindices = tindices + 18
 
-        if self._close and self._close_mode == 'straight-line':
-            vindex = vcount - 4
-            i0 = vindex
-            i1 = vindex + 1
-            i2 = vindex + 2
-            i3 = vindex + 3
-            i4 = 0
-            i5 = 1
-            i6 = 2
-            i7 = 3
-            tindices[0] = i0
-            tindices[1] = i2
-            tindices[2] = i6
-            tindices[3] = i0
-            tindices[4] = i6
-            tindices[5] = i4
-            tindices[6] = i1
-            tindices[7] = i0
-            tindices[8] = i4
-            tindices[9] = i1
-            tindices[10] = i4
-            tindices[11] = i5
-            tindices[12] = i3
-            tindices[13] = i1
-            tindices[14] = i5
-            tindices[15] = i3
-            tindices[16] = i5
-            tindices[17] = i7
-            tindices = tindices + 18
-
         # print('tindices', <long>tindices, <long>indices, (<long>tindices - <long>indices) / sizeof(unsigned short))
-
 
         self.batch.set_data(vertices, <int>vcount, indices, <int>icount)
 
         free(vertices)
         free(indices)
+    
+    cdef list _remove_close_points(self, list p):
+        cdef int index = 0
+        cdef double x1, y1, x2, y2
+
+        while index < len(p) - 2:
+            x1, y1 = p[index], p[index + 1]
+            x2, y2 = p[index + 2], p[index + 3]
+            if abs(x2 - x1) < 0.1 and abs(y2 - y1) < 0.1:
+                del p[index + 2: index + 4]
+            else:
+                index += 2
+        return p
+
+    cdef double _get_angle_diff(self, double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4):
+        cdef list vector_1, vector_2
+
+        vector_1 = [x2 - x1, y2 - y1]
+        vector_2 = [x4 - x3, y4 - y3]
+
+        angle_1 = atan2(vector_1[1], vector_1[0])
+        angle_2 = atan2(vector_2[1], vector_2[0])
+
+        angle_diff = abs(angle_1 - angle_2)
+
+        if angle_diff > pi:
+            angle_diff = 2 * pi - angle_diff
+
+        return angle_diff
 
 
     property overdraw_width:

--- a/kivy/graphics/vertex_instructions_line.pxi
+++ b/kivy/graphics/vertex_instructions_line.pxi
@@ -1494,8 +1494,8 @@ cdef class SmoothLine(Line):
             vertex_t *vertices = NULL
             unsigned short *indices = NULL
             unsigned short *tindices = NULL
-            double min_angle_threshold, angle_diff
-            double ax, ay, bx = 0., by = 0., rx = 0., ry = 0., last_angle = 0., angle, av_angle
+            double min_angle_threshold = 0.017453292519943295  # 1 degree in radians, determined empirically.
+            double ax, ay, bx = 0., by = 0., rx = 0., ry = 0., last_angle = 0., angle, av_angle, ad_angle, angle_diff
             double cos1, sin1, cos2, sin2, ocos1, ocos2, osin1, osin2
             long index, icount, iv, ii, max_vindex, count
             unsigned short i0, i1, i2, i3, i4, i5, i6, i7, vindex, vcount
@@ -1594,36 +1594,6 @@ cdef class SmoothLine(Line):
                 ra1 = last_angle + PI2
                 ra2 = angle + PI2
 
-                if line_intersection(
-                    ox + cos(la1) * width,
-                    oy + sin(la1) * width,
-                    ax + cos(la1) * width,
-                    ay + sin(la1) * width,
-                    ax + cos(la2) * width,
-                    ay + sin(la2) * width,
-                    bx + cos(la2) * width,
-                    by + sin(la2) * width,
-                    &rx, &ry) == 0:
-                    # print('ERROR LINE INTERSECTION 1')
-                    pass
-
-                l = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
-
-                if line_intersection(
-                    ox + cos(ra1) * owidth,
-                    oy + sin(ra1) * owidth,
-                    ax + cos(ra1) * owidth,
-                    ay + sin(ra1) * owidth,
-                    ax + cos(ra2) * owidth,
-                    ay + sin(ra2) * owidth,
-                    bx + cos(ra2) * owidth,
-                    by + sin(ra2) * owidth,
-                    &rx, &ry) == 0:
-                    # print('ERROR LINE INTERSECTION 2')
-                    pass
-
-                ol = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
-
 
                 angle_diff = self._get_angle_diff(
                     ox + cos(ra1) * owidth,
@@ -1636,9 +1606,6 @@ cdef class SmoothLine(Line):
                     by + sin(ra2) * owidth,
                 )
 
-                # 1 degree in radians, determined empirically.
-                min_angle_threshold = 0.017453292519943295
-
                 # If the angle difference is too small it is not safe to use
                 # the calculated values of l or l. Otherwise, l and ol will
                 # have extremely high values, causing the line to become
@@ -1646,6 +1613,36 @@ cdef class SmoothLine(Line):
                 if angle_diff < min_angle_threshold or ad_angle < min_angle_threshold:
                     l = width
                     ol = owidth
+                else:
+                    if line_intersection(
+                        ox + cos(la1) * width,
+                        oy + sin(la1) * width,
+                        ax + cos(la1) * width,
+                        ay + sin(la1) * width,
+                        ax + cos(la2) * width,
+                        ay + sin(la2) * width,
+                        bx + cos(la2) * width,
+                        by + sin(la2) * width,
+                        &rx, &ry) == 0:
+                        # print('ERROR LINE INTERSECTION 1')
+                        pass
+
+                    l = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
+
+                    if line_intersection(
+                        ox + cos(ra1) * owidth,
+                        oy + sin(ra1) * owidth,
+                        ax + cos(ra1) * owidth,
+                        ay + sin(ra1) * owidth,
+                        ax + cos(ra2) * owidth,
+                        ay + sin(ra2) * owidth,
+                        bx + cos(ra2) * owidth,
+                        by + sin(ra2) * owidth,
+                        &rx, &ry) == 0:
+                        # print('ERROR LINE INTERSECTION 2')
+                        pass
+
+                    ol = <float>sqrt((ax - rx) ** 2 + (ay - ry) ** 2)
 
 
             last_angle = angle


### PR DESCRIPTION
This PR fixes several rendering issues with the `SmoothLine` when drawing fixed or freehand shapes (as shown in the demonstration videos below). There is also code included in this PR, with some sets of points for testing. These points had many rendering issues (which are now resolved).

**Some issues and fixes applied:**

- Incorrect width rendering: 
  - When the angle between two line segments was very small, the line width value at the intersection was extrapolated, causing serious line rendering issues. The solution was to use fixed width values when this situation is identified.
  - If the distance between the points was very small, incorrect angle values were calculated. The solution was to remove points that were within a distance of less than 0.1 from each other (I believe it is insignificant to have points with a distance smaller than that - in the context of kivy graphics).

- Line closing: The generated closing line was distorted in several cases. The approach adopted to fix it was to add an extra point and perform the calculations of final and initial angles based on that point.

**In general, these approaches make the rendering of `SmoothLine` significantly more reliable and stable!**


## Line closing
### Before:

![image](https://github.com/kivy/kivy/assets/73297572/7d9e20e5-8936-49d2-960c-717dfa77577a)

### After:

![image](https://github.com/kivy/kivy/assets/73297572/89e0d2f0-fdc4-44b7-bb4e-46e3927e9b86)

## General fixes
### Before:

https://github.com/kivy/kivy/assets/73297572/9d35291e-86c3-4666-9d62-e96402cc3df6


### After:

https://github.com/kivy/kivy/assets/73297572/8a8baba4-0458-41d8-b6cf-97ea08cef2a6


### Test code:

```python
from kivy.lang import Builder
from kivy.uix.floatlayout import FloatLayout
from kivy.app import App

Builder.load_string(
    """
<UI>:
    points: []
    canvas.before:
        Color:
            rgba: 0.9, 0.9, 0.9, 1
        Rectangle:
            size: self.size
            pos: self.pos

        Color:
            rgba: 0, 0, 1, 1
        SmoothLine:
            overdraw_width: 2.5
            width: 1
            # close: 1

            points: root.points
            # points: [234.86195373535156, 400.0, 247.36195373535156, 412.5, 247.3619384765625, 412.5, 259.86195373535156, 400.0, 259.8619384765625, 400.0, 247.3619384765625, 387.5, 247.36195373535156, 387.5, 234.86195373535156, 400.0]
            # points:  [300, 300, 300, 300, 50, 160, 100, 200]
            # points:  [300, 300, 300, 300, 100, 200]
            # points:  [300, 300, 300, 250, 100, 200]
            # points:  [300, 300, 300, 280, 100, 200]
            # points:  [300, 300, 300, 200, 100, 200]
            # points:  [100, 100, 100, 200, 100, 200]
            # points:  [300, 300, 300, 200, 100, 200, 200, 300]
            # points:  [100, 230, 300, 200, 100, 200]
            # points: [150, 30, 200, 100, 300, 300]


    on_touch_move:
        self.points.extend(args[1].pos)

    # on_touch_down:
        # self.points.extend(args[1].pos)

"""
)


class UI(FloatLayout):
    ...


class TestSmoothLine(App):
    def build(self):
        return UI()


TestSmoothLine().run()
```


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
