### PR TITLE
`Image`: Fix stencil instructions leaking to user `canvas.before`/`canvas` instructions

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -118,20 +118,18 @@
         PopMatrix
 
 <Image,AsyncImage>:
-    canvas.before:
+    canvas:
+        Color:
+            rgba: self.color
         StencilPush
         Rectangle:
             pos: self.pos
             size: self.size
         StencilUse
-    canvas:
-        Color:
-            rgba: self.color
         Rectangle:
             texture: self.texture
             size: self.norm_image_size
             pos: self.center_x - self.norm_image_size[0] / 2., self.center_y - self.norm_image_size[1] / 2.
-    canvas.after:
         StencilUnUse
         Rectangle:
             pos: self.pos


### PR DESCRIPTION
The feature introduced in this [PR ](https://github.com/kivy/kivy/pull/8169) leaks stencil instructions to other user `canvas.before`/`canvas` instructions. Therefore, as discussed in Kivy's Discrod #dev channel, the most appropriate approach (taken in this PR) would be to limit the stencil instructions internally, preventing anything else drawn on the layers of the canvas from being clipped.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
