### PR TITLE
Handle edge case when padding is None in _migrate_deprecated_padding_xy

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -328,7 +328,11 @@ class LabelBase(object):
 
     def _migrate_deprecated_padding_xy(self):
         options = self.options
-        self.options['padding'] = list(self.options['padding'])
+        if self.options['padding'] is not None:
+            self.options['padding'] = list(self.options['padding'])
+        else:
+            self.options['padding'] = [0, 0, 0, 0]
+        
         if options['padding_x']:
             self.options['padding'][::2] = [options['padding_x']] * 2
         if options['padding_y']:


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy/issues/8280

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
