### PR TITLE
core-providers (audio): removes deprecated `filename` property

### DIFF
--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -157,15 +157,6 @@ class Sound(EventDispatcher):
         Use :attr:`state` instead.
     '''
 
-    def _get_filename(self):
-        return self.source
-    filename = AliasProperty(
-        _get_filename, None, bind=('source', ), deprecated=True)
-    '''
-    .. deprecated:: 1.3.0
-        Use :attr:`source` instead.
-    '''
-
     __events__ = ('on_play', 'on_stop')
 
     def on_source(self, instance, filename):


### PR DESCRIPTION
#8177 
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [x] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
