### PR TITLE
Rework custom `garden` importer to avoid usage of `imp` module (removed in Python `3.12`)

### DIFF
--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -160,6 +160,7 @@ if platform == "ios":
     main_py_file = __main__.__file__
     garden_app_dir = join(dirname(main_py_file), 'libs', 'garden')
 
+
 class GardenImporter(MetaPathFinder):
 
     def find_spec(self, fullname, path, target=None):
@@ -179,6 +180,7 @@ class GardenImporter(MetaPathFinder):
                 return importlib.util.spec_from_file_location(fullname, moddir)
 
         return None
+
 
 # insert the garden importer as ultimate importer
 sys.meta_path.append(GardenImporter())

--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -136,8 +136,8 @@ For example::
 
 __path__ = 'kivy.garden'
 
+import importlib.util
 import sys
-import imp
 from os.path import dirname, join, realpath, exists, abspath
 from kivy import kivy_home_dir
 from kivy.utils import platform
@@ -160,7 +160,7 @@ if platform == "ios":
     garden_app_dir = join(dirname(main_py_file), 'libs', 'garden')
 
 
-class GardenImporter(object):
+class GardenImporter:
 
     def find_module(self, fullname, path):
         if path == 'kivy.garden':
@@ -180,8 +180,9 @@ class GardenImporter(object):
                 return self._load_module(fullname, moddir)
 
     def _load_module(self, fullname, moddir):
-        mod = imp.load_module(fullname, None, moddir,
-                              ('', '', imp.PKG_DIRECTORY))
+        spec = importlib.util.spec_from_file_location(fullname, moddir)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
         return mod
 
 

--- a/kivy/garden/__init__.py
+++ b/kivy/garden/__init__.py
@@ -137,6 +137,7 @@ For example::
 __path__ = 'kivy.garden'
 
 import importlib.util
+from importlib.abc import MetaPathFinder
 import sys
 from os.path import dirname, join, realpath, exists, abspath
 from kivy import kivy_home_dir
@@ -159,32 +160,25 @@ if platform == "ios":
     main_py_file = __main__.__file__
     garden_app_dir = join(dirname(main_py_file), 'libs', 'garden')
 
+class GardenImporter(MetaPathFinder):
 
-class GardenImporter:
+    def find_spec(self, fullname, path, target=None):
+        if path != "kivy.garden":
+            return None
 
-    def find_module(self, fullname, path):
-        if path == 'kivy.garden':
-            return self
-
-    def load_module(self, fullname):
-        assert fullname.startswith('kivy.garden')
-
-        moddir = join(garden_kivy_dir, fullname.split('.', 2)[-1])
+        moddir = join(
+            garden_kivy_dir, fullname.split(".", 2)[-1], "__init__.py"
+        )
         if exists(moddir):
-            return self._load_module(fullname, moddir)
+            return importlib.util.spec_from_file_location(fullname, moddir)
 
-        modname = fullname.split('.', 1)[-1]
+        modname = fullname.split(".", 1)[-1]
         for directory in (garden_app_dir, garden_system_dir):
-            moddir = join(directory, modname)
+            moddir = join(directory, modname, "__init__.py")
             if exists(moddir):
-                return self._load_module(fullname, moddir)
+                return importlib.util.spec_from_file_location(fullname, moddir)
 
-    def _load_module(self, fullname, moddir):
-        spec = importlib.util.spec_from_file_location(fullname, moddir)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-
+        return None
 
 # insert the garden importer as ultimate importer
 sys.meta_path.append(GardenImporter())

--- a/kivy/tests/test_garden.py
+++ b/kivy/tests/test_garden.py
@@ -3,19 +3,21 @@ from tempfile import TemporaryDirectory
 
 from unittest import mock
 
+
 def test_garden_import_module():
-
     with TemporaryDirectory() as tmpdir:
-        fake_garden_dir = os.path.join(tmpdir, 'garden')
+        fake_garden_dir = os.path.join(tmpdir, "garden")
 
-        with mock.patch('kivy.garden.garden_system_dir', fake_garden_dir):
-
+        with mock.patch("kivy.garden.garden_system_dir", fake_garden_dir):
             # Add a fake garden module to the temporary directory
-            dummy_flower_dir = os.path.join(fake_garden_dir, 'garden.dummyflower')
+            dummy_flower_dir = os.path.join(
+                fake_garden_dir, "garden.dummyflower"
+            )
             os.makedirs(dummy_flower_dir, exist_ok=True)
 
-            with open(os.path.join(dummy_flower_dir, '__init__.py'), 'w') as f:
+            with open(os.path.join(dummy_flower_dir, "__init__.py"), "w") as f:
                 f.write("dummy_var = 1")
 
             from kivy.garden.dummyflower import dummy_var
+
             assert dummy_var == 1

--- a/kivy/tests/test_garden.py
+++ b/kivy/tests/test_garden.py
@@ -1,0 +1,21 @@
+import os
+from tempfile import TemporaryDirectory
+
+from unittest import mock
+
+def test_garden_import_module():
+
+    with TemporaryDirectory() as tmpdir:
+        fake_garden_dir = os.path.join(tmpdir, 'garden')
+
+        with mock.patch('kivy.garden.garden_system_dir', fake_garden_dir):
+
+            # Add a fake garden module to the temporary directory
+            dummy_flower_dir = os.path.join(fake_garden_dir, 'garden.dummyflower')
+            os.makedirs(dummy_flower_dir, exist_ok=True)
+
+            with open(os.path.join(dummy_flower_dir, '__init__.py'), 'w') as f:
+                f.write("dummy_var = 1")
+
+            from kivy.garden.dummyflower import dummy_var
+            assert dummy_var == 1


### PR DESCRIPTION
Adressing https://github.com/kivy/kivy/issues/8225

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

. Replaced imp import with importlib.util:
-The original code used imp.load_module to load the modules. In the updated code, I replaced it with importlib.util.spec_from_file_location and importlib.util.module_from_spec to achieve the same functionality.

. Updated imports:
-Added import importlib.util to import the spec_from_file_location and module_from_spec functions
-Removed the import imp statement since it is no longer needed.

.Modified _load_module method:
-Replaced imp.load_module with importlib.util.module_from_spec to create the module object.
-Used spec.loader.exec_module(mod) to execute the module code.


Edit from @misl6 :

- The approach followed by the original author did not worked, as now in `sys.meta_path` is needed a [importlib.abc.MetaPathFinder](https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder) object.

- The `find_spec` method is mandatory, and should return `None` if no module is found, or a https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec if is found. (https://docs.python.org/3/library/importlib.html#importlib.util.spec_from_file_location takes care of it)

- Added a test that creates a fake legacy `garden` module and tries to import it, in order to check the functionality across multiple python versions.
