### PR TITLE
pin `Pillow` version to `9.5.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ dev =
     pre-commit
     responses
 base =
-    pillow
+    pillow==9.5.0
     requests
     docutils
     pygments
@@ -60,7 +60,7 @@ media =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
 full =
-    pillow
+    pillow==9.5.0
     docutils
     pygments
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Pillow `10.0.0` does not ship wheels for 32 bit Windows, but we still support (and test it).

Additionally, we should pin specific dependencies versions in order to avoid breakages on non-development versions.

~~Later today~~ (After switching to PEP 621 - https://github.com/kivy/kivy/pull/8127), I'm going to configure a dependabot + pin every version of our dependencies to a specific one, so we are alerted, and we will keep our dependencies updated, but without breaking things 😀