### PR TITLE
Linux dependencies: Build `libpng16` for `freetype` so can render colored emoji

### DIFF
--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -21,6 +21,11 @@ MANYLINUX__SDL2_TTF__VERSION="2.20.2"
 MANYLINUX__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/release-$MANYLINUX__SDL2_TTF__VERSION/SDL2_ttf-$MANYLINUX__SDL2_TTF__VERSION.tar.gz"
 MANYLINUX__SDL2_TTF__FOLDER="SDL2_ttf-$MANYLINUX__SDL2_TTF__VERSION"
 
+# manylinux libpng
+MANYLINUX__LIBPNG__VERSION="1.6.40"
+MANYLINUX__LIBPNG__URL="https://downloads.sourceforge.net/project/libpng/libpng16/$MANYLINUX__LIBPNG__VERSION/libpng-$MANYLINUX__LIBPNG__VERSION.tar.gz"
+MANYLINUX__LIBPNG__FOLDER="libpng-$MANYLINUX__LIBPNG__VERSION"
+
 # Clean the dependencies folder
 rm -rf kivy-dependencies
 
@@ -35,6 +40,7 @@ curl -L $MANYLINUX__SDL2__URL -o "${MANYLINUX__SDL2__FOLDER}.tar.gz"
 curl -L $MANYLINUX__SDL2_IMAGE__URL -o "${MANYLINUX__SDL2_IMAGE__FOLDER}.tar.gz"
 curl -L $MANYLINUX__SDL2_MIXER__URL -o "${MANYLINUX__SDL2_MIXER__FOLDER}.tar.gz"
 curl -L $MANYLINUX__SDL2_TTF__URL -o "${MANYLINUX__SDL2_TTF__FOLDER}.tar.gz"
+curl -L $MANYLINUX__LIBPNG__URL -o "${MANYLINUX__LIBPNG__FOLDER}.tar.gz"
 popd
 
 # Extract the dependencies into build folder
@@ -45,6 +51,7 @@ tar -xzf ../download/${MANYLINUX__SDL2__FOLDER}.tar.gz
 tar -xzf ../download/${MANYLINUX__SDL2_IMAGE__FOLDER}.tar.gz
 tar -xzf ../download/${MANYLINUX__SDL2_MIXER__FOLDER}.tar.gz
 tar -xzf ../download/${MANYLINUX__SDL2_TTF__FOLDER}.tar.gz
+tar -xzf ../download/${MANYLINUX__LIBPNG__FOLDER}.tar.gz
 popd
 
 # Create distribution folder
@@ -59,6 +66,19 @@ pushd $MANYLINUX__SDL2__FOLDER
   cmake -S . -B build \
           -DCMAKE_INSTALL_PREFIX=../../dist \
           -DCMAKE_BUILD_TYPE=Release \
+          -GNinja
+  cmake --build build/ --config Release --verbose --parallel
+  cmake --install build/ --config Release
+popd
+
+
+echo "-- Build libpng"
+pushd $MANYLINUX__LIBPNG__FOLDER
+  cmake -S . -B build \
+          -DCMAKE_INSTALL_PREFIX=../../dist \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNG_TESTS=OFF \
+          -DPNG_EXECUTABLES=OFF \
           -GNinja
   cmake --build build/ --config Release --verbose --parallel
   cmake --install build/ --config Release
@@ -105,6 +125,7 @@ pushd $MANYLINUX__SDL2_TTF__FOLDER
   cmake -B build-cmake \
           -DBUILD_SHARED_LIBS=ON \
           -DSDL2TTF_HARFBUZZ=ON \
+          -DFT_DISABLE_PNG=OFF \
           -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=../../dist \


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

`freetype` (a dependency of `SDL_ttf`) should be built with `libpng` support, otherwise colored emoji which make use of PNG (like the default Noto Color Emoji provided on Ubuntu).

FYI: For Noto Color Emoji,  only https://github.com/googlefonts/noto-emoji/blob/main/fonts/NotoColorEmoji_WindowsCompatible.ttf and the `NotoColorEmoji.ttf` available on `/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf` seem to render correctly.

Linked issue (do not close as support on macOS -and likely other platforms- is missing): #7565 

✅ Tested locally
✅ Tested with wheel (`manylinux_x86_64`) artifact on Ubuntu 22.04 LTS with bundled NotoColorEmoji font
✅ Tested with wheel (`linux_armv7l`) artifact on RPi 4 Raspberry OS 32 bit (bullseye) with `NotoColorEmoji_WindowsCompatible.ttf` font (link above)
⚠️ Unfortunately we do not handle (and maybe SDL does not) an error when rendering is not possible, so we can't add a test ATM.

Demo:
```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout


class UI(BoxLayout):
    pass


Builder.load_string(
    """
<UI>:
    Label:
        text: "😀 🎉 📷 👕 🐞"
        font_size: dp(100)
        font_name: "NotoColorEmoji"
"""
)


class Testapp(App):
    def build(self):
        return UI()


Testapp().run()
```

Output:
![Screenshot from 2023-07-15 10-45-02](https://github.com/kivy/kivy/assets/8177736/ed09573d-08e7-4bbb-ab6c-5c49645656f2)

![2023-07-15-111433_1920x1080_scrot](https://github.com/kivy/kivy/assets/8177736/0d0dffc9-b2ed-4d10-8907-238bf1f60a00)
