### PR TITLE
macOS dependencies: Build `libpng16` for `freetype`, so can render colored emoji

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -70,6 +70,12 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         update_version_metadata
+    - name: Install build dependencies
+      run: |
+        source .ci/ubuntu_ci.sh
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        brew install pkg-config cmake ninja
     - name: Build universal Kivy dependencies
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -34,6 +34,12 @@ jobs:
       with:
         path: osx-cache
         key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_ci.sh') }}
+    - name: Install build dependencies
+      run: |
+        source .ci/ubuntu_ci.sh
+        source .ci/osx_ci.sh
+        arm64_set_path_and_python_version ${{ matrix.python }}
+        brew install pkg-config cmake ninja
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -55,10 +55,10 @@ To install Kivy from source, please follow the :ref:`installation guide<kivy-whe
 :ref:`Kivy install step<kivy-source-install>` and then install the additional dependencies
 below before continuing.
 
-**pkg-config** is required to build Kivy from source. If you're using ``brew`` as your
+**pkg-config**, **cmake**, **ninja** are required to build Kivy from source. If you're using ``brew`` as your
 package manager, you can install it with::
 
-    brew install pkg-config
+    brew install pkg-config cmake ninja
 
 Now that you have all the dependencies for kivy, you need to make sure
 you have the command line tools installed::

--- a/tools/build_macos_dependencies.sh
+++ b/tools/build_macos_dependencies.sh
@@ -20,6 +20,11 @@ MACOS__SDL2_TTF__VERSION="2.20.2"
 MACOS__SDL2_TTF__URL="https://github.com/libsdl-org/SDL_ttf/releases/download/release-$MACOS__SDL2_TTF__VERSION/SDL2_ttf-$MACOS__SDL2_TTF__VERSION.tar.gz"
 MACOS__SDL2_TTF__FOLDER="SDL2_ttf-${MACOS__SDL2_TTF__VERSION}"
 
+# macOS libpng
+MACOS__LIBPNG__VERSION="1.6.40"
+MACOS__LIBPNG__URL="https://download.sourceforge.net/libpng/libpng16/${MACOS__LIBPNG__VERSION}/libpng-${MACOS__LIBPNG__VERSION}.tar.gz"
+MACOS__LIBPNG__FOLDER="libpng-${MACOS__LIBPNG__VERSION}"
+
 # Clean the dependencies folder
 rm -rf kivy-dependencies
 
@@ -34,6 +39,7 @@ curl -L $MACOS__SDL2__URL -o "${MACOS__SDL2__FOLDER}.tar.gz"
 curl -L $MACOS__SDL2_IMAGE__URL -o "${MACOS__SDL2_IMAGE__FOLDER}.tar.gz"
 curl -L $MACOS__SDL2_MIXER__URL -o "${MACOS__SDL2_MIXER__FOLDER}.tar.gz"
 curl -L $MACOS__SDL2_TTF__URL -o "${MACOS__SDL2_TTF__FOLDER}.tar.gz"
+curl -L $MACOS__LIBPNG__URL -o "${MACOS__LIBPNG__FOLDER}.tar.gz"
 popd
 
 # Extract the dependencies into build folder
@@ -44,6 +50,7 @@ tar -xzf ../download/${MACOS__SDL2__FOLDER}.tar.gz
 tar -xzf ../download/${MACOS__SDL2_IMAGE__FOLDER}.tar.gz
 tar -xzf ../download/${MACOS__SDL2_MIXER__FOLDER}.tar.gz
 tar -xzf ../download/${MACOS__SDL2_TTF__FOLDER}.tar.gz
+tar -xzf ../download/${MACOS__LIBPNG__FOLDER}.tar.gz
 popd
 
 # Create distribution folder
@@ -51,8 +58,33 @@ echo "Creating distribution folder..."
 mkdir kivy-dependencies/dist
 mkdir kivy-dependencies/dist/Frameworks
 
+LIBPNG_SEARCH_PATH="$(pwd)/kivy-dependencies/dist/Frameworks/png.framework/Headers"
+FRAMEWORK_SEARCH_PATHS="$(pwd)/kivy-dependencies/dist/Frameworks"
+
 # Build the dependencies
 pushd kivy-dependencies/build
+
+# libpng is neeeded by SDL2_ttf to render emojis
+echo "-- Build libpng (Universal)"
+pushd $MACOS__LIBPNG__FOLDER
+  cmake -S . -B build \
+          -DCMAKE_INSTALL_PREFIX=../../dist \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+          -DPNG_TESTS=OFF \
+          -DPNG_EXECUTABLES=OFF \
+          -DPNG_SHARED=OFF \
+          -DPNG_STATIC=OFF \
+          -DPNG_FRAMEWORK=ON \
+          -DCMAKE_C_FLAGS="-DPNG_ARM_NEON_OPT=0" \
+          -GNinja
+  cmake --build build/ --config Release --verbose --parallel
+  cmake --install build/ --config Release
+
+# for some reason, the framework is installed in lib instead of Frameworks
+cp -r ../../dist/lib/png.framework ../../dist/Frameworks
+
+popd
 
 echo "-- Build SDL2 (Universal)"
 pushd $MACOS__SDL2__FOLDER
@@ -78,7 +110,12 @@ popd
 echo "-- Build SDL2_ttf (Universal)"
 pushd $MACOS__SDL2_TTF__FOLDER
 xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
-        -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release
+        -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release \
+        GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_DEFINITIONS) FT_CONFIG_OPTION_USE_PNG=1' \
+        FRAMEWORK_SEARCH_PATHS='$(FRAMEWORK_SEARCH_PATHS) '"$FRAMEWORK_SEARCH_PATHS" \
+        HEADER_SEARCH_PATHS='$(HEADER_SEARCH_PATHS) '"$LIBPNG_SEARCH_PATH" \
+        OTHER_LDFLAGS='$(OTHER_LDFLAGS) -framework png'
+
 cp -r Xcode/build/Release/SDL2_ttf.framework ../../dist/Frameworks
 popd
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

`freetype` (a dependency of `SDL_ttf`) should be built with `libpng` support, otherwise colored emoji which make use of PNG (like the default Noto Color Emoji provided on Ubuntu).

FYI: For Noto Color Emoji,  only https://github.com/googlefonts/noto-emoji/blob/main/fonts/NotoColorEmoji_WindowsCompatible.ttf and the `NotoColorEmoji.ttf` available on `/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf` seem to render correctly.

✅ Tested locally
✅ Tested with wheel artifact
⚠️ Unfortunately we do not handle (and maybe SDL does not) an error when rendering is not possible, so we can't add a test ATM.

Linked issue (do not close as support on Linux -and likely other platforms- is missing): #7565 

Linux one: https://github.com/kivy/kivy/pull/8313

Demo:
```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout


class UI(BoxLayout):
    pass


Builder.load_string(
    """
<UI>:
    Label:
        text: "😀 🎉 📷 👕 🐞"
        font_size: dp(100)
        font_name: "Apple Color Emoji.ttc"
"""
)


class Testapp(App):
    def build(self):
        return UI()


Testapp().run()
```

Output:
![Image 15-07-23 at 10 25](https://github.com/kivy/kivy/assets/8177736/6fb93998-695f-4834-a9c8-544cecfdeca4)

