### PR TITLE
Docs: Fix double word typos

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -297,7 +297,7 @@ well be executed in the order they were scheduled.
 Also, all the scheduling and canceling methods are fully thread safe and
 can be safely used from external threads.
 
-As a a consequence, calling :meth:`CyClockBase.unschedule` with the original
+As a consequence, calling :meth:`CyClockBase.unschedule` with the original
 callback is now significantly slower and highly discouraged. Instead, the
 returned events should be used to cancel. As a tradeoff, all the other methods
 are now significantly faster than before.
@@ -356,7 +356,7 @@ This clock, and all the clocks described after this have an option,
 :attr:`ClockBaseInterruptBehavior.interupt_next_only`. When True, any of the
 behavior new behavior will only apply to the callbacks with a timeout of
 zero. Non-zero timeouts will behave like in the default clock. E.g. for this
-clock when True, only zero timeouts will execute during the the interval.
+clock when True, only zero timeouts will execute during the interval.
 
 In a test using a fps of 30, a callback with a timeout of 0, 0.001, and 0.05,
 resulted in a mean callback delay of 0.00013, 0.00013, and 0.04120 seconds,

--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -118,7 +118,7 @@ class CameraBase(EventDispatcher):
         pass
 
     def _copy_to_gpu(self):
-        '''Copy the the buffer into the texture'''
+        '''Copy the buffer into the texture'''
         if self._texture is None:
             Logger.debug('Camera: copy_to_gpu() failed, _texture is None !')
             return

--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -118,7 +118,7 @@ class CameraBase(EventDispatcher):
         pass
 
     def _copy_to_gpu(self):
-        '''Copy the buffer into the texture'''
+        '''Copy the buffer into the texture.'''
         if self._texture is None:
             Logger.debug('Camera: copy_to_gpu() failed, _texture is None !')
             return

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -486,7 +486,7 @@ class LabelBase(object):
     def shorten(self, text, margin=2):
         ''' Shortens the text to fit into a single line by the width specified
         by :attr:`text_size` [0]. If :attr:`text_size` [0] is None, it returns
-        text text unchanged.
+        text unchanged.
 
         :attr:`split_str` and :attr:`shorten_from` determines how the text is
         shortened.

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -252,7 +252,7 @@ class WindowBase(EventDispatcher):
             Fired when the event loop wants to close the window, or if the
             escape key is pressed and `exit_on_escape` is `True`. If a function
             bound to this event returns `True`, the window will not be closed.
-            If the the event is triggered because of the keyboard escape key,
+            If the event is triggered because of the keyboard escape key,
             the keyword argument `source` is dispatched along with a value of
             `keyboard` to the bound functions.
 
@@ -289,7 +289,7 @@ class WindowBase(EventDispatcher):
             .. versionadded:: 1.10.0
 
         `on_show`:
-            Fired when when the window is shown.
+            Fired when the window is shown.
 
             .. versionadded:: 1.10.0
 
@@ -1919,7 +1919,7 @@ class WindowBase(EventDispatcher):
 
     def on_request_close(self, *largs, **kwargs):
         '''Event called before we close the window. If a bound function returns
-        `True`, the window will not be closed. If the the event is triggered
+        `True`, the window will not be closed. If the event is triggered
         because of the keyboard escape key, the keyword argument `source` is
         dispatched along with a value of `keyboard` to the bound functions.
 

--- a/kivy/input/postproc/tripletap.py
+++ b/kivy/input/postproc/tripletap.py
@@ -37,7 +37,7 @@ class InputPostprocTripleTap(object):
     def find_triple_tap(self, ref):
         '''Find a triple tap touch within *self.touches*.
         The touch must be not be a previous triple tap and the distance
-        must be be within the bounds specified. Additionally, the touch profile
+        must be within the bounds specified. Additionally, the touch profile
         must be the same kind of touch.
         '''
         ref_button = None

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -299,7 +299,7 @@ change to 'Release me!'.
 More precisely, the kivy language parser detects all substrings of the form
 `X.a.b` where `X` is `self` or `root` or `app` or a known id, and `a` and `b`
 are properties: it then adds the appropriate dependencies to cause the
-the constraint to be reevaluated whenever something changes. For example,
+constraint to be reevaluated whenever something changes. For example,
 this works exactly as expected::
 
     <IndexedExample>:

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -83,7 +83,7 @@ definitions and templates::
     <NewWidget@BaseClass>:
         # .. definitions ..
 
-    # Syntax for create a template
+    # Syntax for creating a template
     [TemplateName@BaseClass1,BaseClass2]:
         # .. definitions ..
 

--- a/kivy/support.py
+++ b/kivy/support.py
@@ -152,7 +152,7 @@ def install_twisted_reactor(**kwargs):
     to do some work.
 
     Any arguments or keyword arguments passed to this function will be
-    passed on the the threadedselect reactors interleave function. These
+    passed on the threadedselect reactors interleave function. These
     are the arguments one would usually pass to twisted's reactor.startRunning.
 
     Unlike the default twisted reactor, the installed reactor will not handle

--- a/kivy/uix/image.py
+++ b/kivy/uix/image.py
@@ -212,7 +212,7 @@ class Image(Widget):
     - ``"contain"``: the image is resized to fit inside the widget box,
     **maintaining its aspect ratio**. If the image size is larger than the
     widget size, the behavior will be similar to ``"scale-down"``. However, if
-    the size of the image size is smaller than the widget size, unlike
+    the size of the image is smaller than the widget size, unlike
     ``"scale-down``, the image will be resized to fit inside the widget.
     If the image has a different aspect ratio than the widget, there will be
     blank areas on the widget box.


### PR DESCRIPTION
Fixed a grammar typo in the docs of kivy lang.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
