### PR TITLE
Fix linux dependencies build instructions

### DIFF
--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -74,7 +74,7 @@ subsequent commands outside the virtual environment)::
 Create virtual environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create a new `virtual environment <https://virtualenv.pypa.io/en/latest/>`_
+Create a new `virtual environment <https://docs.python.org/3/library/venv.html>`_
 for your Kivy project. A virtual environment will prevent possible installation conflicts
 with other Python versions and packages. It's optional **but strongly recommended**:
 

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -80,7 +80,7 @@ with other Python versions and packages. It's optional **but strongly recommende
 
 #. Create the virtual environment named ``kivy_venv`` in your current directory::
 
-       python -m virtualenv kivy_venv
+       python -m venv kivy_venv
 
 #. Activate the virtual environment. You will have to do this step from the current directory
    **every time** you start a new terminal. This sets up the environment so the new ``kivy_venv``
@@ -166,7 +166,7 @@ On **macOS**::
 
 On **Linux**::
 
-    curl -O https://raw.githubusercontent.com/kivy/kivy/master/tools/build_linux_dependencies.sh -o build_kivy_deps.sh
+    curl https://raw.githubusercontent.com/kivy/kivy/master/tools/build_linux_dependencies.sh -o build_kivy_deps.sh
 
 Make the script executable::
 


### PR DESCRIPTION
#8305 
change from:
python -m virtualenv kivy_venv
to:
python -m venv kivy_venv

change from:
curl -O https://raw.githubusercontent.com/kivy/kivy/master/tools/build_linux_dependencies.sh -o build_kivy_deps.sh

to:
curl https://raw.githubusercontent.com/kivy/kivy/master/tools/build_linux_dependencies.sh -o build_kivy_deps.sh

change from:
https://virtualenv.pypa.io/en/latest/
to:
https://docs.python.org/3/library/venv.html

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
