### PR TITLE
Add support for `Cython==3.x.x` and increase `cython_min` version

### DIFF
--- a/kivy/core/image/_img_sdl2.pyx
+++ b/kivy/core/image/_img_sdl2.pyx
@@ -14,14 +14,14 @@ cdef struct SDL_RWops:
     int (* close) (SDL_RWops * context)
 
 
-cdef size_t rwops_bytesio_write(SDL_RWops *context, const void *ptr, size_t size, size_t num):
+cdef size_t rwops_bytesio_write(SDL_RWops *context, const void *ptr, size_t size, size_t num) noexcept:
     cdef char *c_string = <char *>ptr
     byteio = <object>context.hidden.unknown.data1
     byteio.write(c_string[:size * num])
     return size * num
 
 
-cdef int rwops_bytesio_close(SDL_RWops *context):
+cdef int rwops_bytesio_close(SDL_RWops *context) noexcept:
     byteio = <object>context.hidden.unknown.data1
     byteio.seek(0)
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -263,7 +263,7 @@ cdef class _WindowSDL2Storage:
         for joy_i in range(SDL_NumJoysticks()):
             SDL_JoystickOpen(joy_i)
 
-        SDL_SetEventFilter(_event_filter, <void *>self)
+        SDL_SetEventFilter(<SDL_EventFilter *>_event_filter, <void *>self)
 
         SDL_EventState(SDL_DROPFILE, SDL_ENABLE)
         SDL_EventState(SDL_DROPTEXT, SDL_ENABLE)
@@ -437,7 +437,7 @@ cdef class _WindowSDL2Storage:
     def set_shape(self, shape, mode, cutoff, color_key):
         cdef SDL_Surface * sdl_shape
 
-        cpdef SDL_WindowShapeMode sdl_window_mode
+        cdef SDL_WindowShapeMode sdl_window_mode
         cdef SDL_WindowShapeParams parameters
         cdef SDL_Color color
         cdef int result
@@ -793,7 +793,7 @@ cdef class _WindowSDL2Storage:
 
     def set_custom_titlebar(self, titlebar_widget):
         SDL_SetWindowBordered(self.win, SDL_FALSE)
-        return SDL_SetWindowHitTest(self.win,custom_titlebar_handler_callback,<void *>titlebar_widget)
+        return SDL_SetWindowHitTest(self.win, <SDL_HitTest>custom_titlebar_handler_callback,<void *>titlebar_widget)
 
     @property
     def window_size(self):

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -225,7 +225,7 @@ cdef class GstPlayer:
         gst_bus_enable_sync_message_emission(self.bus)
         if self.eos_cb or self.message_cb:
             self.hid_message = c_bus_connect_message(
-                    self.bus, _on_gstplayer_message, <void *>self)
+                self.bus, <buscallback_t>_on_gstplayer_message, <void *>self)
 
         # instantiate the playbin
         self.playbin = gst_element_factory_make('playbin', NULL)
@@ -266,7 +266,7 @@ cdef class GstPlayer:
         # the reference of self in the set_sample_callback() method.
         if self.sample_cb:
             self.hid_sample = c_appsink_set_sample_callback(
-                    self.appsink, _on_appsink_sample, <void *>self)
+                    self.appsink, <appcallback_t>_on_appsink_sample, <void *>self)
 
         # get ready!
         with nogil:
@@ -415,4 +415,4 @@ cdef class GstPlayer:
                     &pending_state, <GstClockTime>GST_SECOND)
             if current_state != GST_STATE_PLAYING:
                 c_appsink_pull_preroll(
-                    self.appsink, _on_appsink_sample, <void *>self)
+                    self.appsink, <appcallback_t>_on_appsink_sample, <void *>self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools", "wheel", "packaging",
-    "cython>=0.24,<=0.29.33,!=0.27,!=0.27.2",
+    "cython>=0.29.1,<=3.0.0",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
     'kivy_deps.sdl2_dev~=0.6.0; sys_platform == "win32"',
     'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [kivy]
-cython_min=0.24
-cython_max=0.29.33
-cython_exclude=0.27,0.27.2
+cython_min=0.29.1
+cython_max=3.0.0
+cython_exclude=
 python_versions=3.7 - 3.11
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -597,10 +597,6 @@ class CythonExtension(Extension):
             'language_level': 3,
             'unraisable_tracebacks': True,
         }
-        # XXX with pip, setuptools is imported before distutils, and change
-        # our pyx to c, then, cythonize doesn't happen. So force again our
-        # sources
-        self.sources = args[1]
 
 
 def merge(d1, *args):


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

🟢 Everything has been tested on `Cython==3.0.0` and `Cython==0.29.36` on Apple Silicon (mac)
⚠️ Let's see if there's something else to migrate for other platforms via CI

- `self.sources = args[1]` raises an error with `Cython==3.0.0` as `sources` is a kwarg instead, but that does not seem needed anymore.

- `cpdef` can't be used for variables (and was not needed)

- `Cython==3.0.0` is less permissive with implicit casting

- Increased `cython_max` to `3.0.0` and `cython_min` to `0.29.1` (previous Cython versions are not compatible with any of the currently supported Python versions)