### PR TITLE
Add binding syntax to UrlRequest objects

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -57,10 +57,12 @@ If you want a synchronous request, you can call the wait() method.
 '''
 
 import os
+from abc import abstractmethod, ABC
 from base64 import b64encode
 from collections import deque
 from http.client import HTTPConnection
 from json import loads
+import ssl
 from threading import Event, Thread
 from time import sleep
 from urllib.parse import urlparse, urlunparse
@@ -73,15 +75,11 @@ from kivy.utils import platform
 from kivy.weakmethod import WeakMethod
 
 try:
-    import ssl
-
-    HTTPSConnection = None
     from http.client import HTTPSConnection
 except ImportError:
-    # depending the platform, if openssl support wasn't compiled before python,
-    # this class is not available.
-    pass
-
+    # depending on the platform, if openssl support wasn't compiled before
+    # python, this class is not available.
+    HTTPSConnection = None
 
 # list to save UrlRequest and prevent GC on un-referenced objects
 g_requests = []
@@ -155,7 +153,7 @@ class UrlRequestBase(Thread):
             want to have the maximum download speed, increase the chunk_size
             or don't use ``on_progress``.
         `timeout`: int, defaults to None
-            If set, blocking operations will timeout after this many seconds.
+            If set, blocking operations will time out after this many seconds.
         `method`: str, defaults to 'GET' (or 'POST' if ``body`` is specified)
             The HTTP method to use.
         `decode`: bool, defaults to True
@@ -167,7 +165,7 @@ class UrlRequestBase(Thread):
             If set, the result of the UrlRequest will be written to this path
             instead of in memory.
         `ca_file`: str, defaults to None
-            Indicates a SSL CA certificate file path to validate HTTPS
+            Indicates an SSL CA certificate file path to validate HTTPS
             certificates against
         `verify`: bool, defaults to True
             If False, disables SSL CA certificate verification
@@ -247,26 +245,8 @@ class UrlRequestBase(Thread):
         self.start()
 
     def run(self):
-        q = self._queue.appendleft
-        url = self.url
-        req_body = self.req_body
-        req_headers = self.req_headers or {}
 
-        user_agent = self._user_agent
-        cookies = self._cookies
-
-        if user_agent:
-            req_headers.setdefault('User-Agent', user_agent)
-
-        elif (
-            Config.has_section('network')
-            and 'useragent' in Config.items('network')
-        ):
-            useragent = Config.get('network', 'useragent')
-            req_headers.setdefault('User-Agent', useragent)
-
-        if cookies:
-            req_headers.setdefault("Cookie", cookies)
+        q, req_body, req_headers, url = self.prepare_request_()
 
         try:
             result, resp = self._fetch_url(url, req_body, req_headers, q)
@@ -283,7 +263,7 @@ class UrlRequestBase(Thread):
         # using trigger can result in a missed on_success event
         self._trigger_result()
 
-        # clean ourself when the queue is empty
+        # clean ourselves when the queue is empty
         while len(self._queue):
             sleep(.1)
             self._trigger_result()
@@ -291,6 +271,34 @@ class UrlRequestBase(Thread):
         # ok, authorize the GC to clean us.
         if self in g_requests:
             g_requests.remove(self)
+
+    def prepare_request_(self):
+        '''Prepare headers, cookie, auth, etc.'''
+
+        q = self._queue.appendleft
+        url = self.url
+        req_body = self.req_body
+
+        req_headers = self.req_headers or {}
+        user_agent = self._user_agent
+        cookies = self._cookies
+
+        # set user_agent from init value
+        if user_agent:
+            req_headers.setdefault('User-Agent', user_agent)
+
+        # set user_agent from kivy config value
+        elif (
+                Config.has_section('network')
+                and 'useragent' in Config.items('network')
+        ):
+            useragent = Config.get('network', 'useragent')
+            req_headers.setdefault('User-Agent', useragent)
+
+        if cookies:
+            req_headers.setdefault("Cookie", cookies)
+
+        return q, req_body, req_headers, url
 
     def _fetch_url(self, url, body, headers, q):
         # Parse and fetch the current url
@@ -349,8 +357,8 @@ class UrlRequestBase(Thread):
         return result, resp
 
     def decode_result(self, result, resp):
-        '''Decode the result fetched from url according to his Content-Type.
-        Currently supports only application/json.
+        '''Decode the result fetched from url according to Content-Type.
+        Currently, supports only application/json.
         '''
         # Entry to decode url from the content type.
         # For example, if the content type is a json, it will be automatically
@@ -363,12 +371,61 @@ class UrlRequestBase(Thread):
                     result = result.decode('utf-8')
                 try:
                     return loads(result)
-                except Exception:
+                except Exception as e:
+                    if self._debug:
+                        Logger.debug(
+                            'UrlRequest: {0} failed to decode result'
+                            'with exception {1}.'.format(id(self), e)
+                        )
                     return result
 
         return result
 
+    def _on_status_code(self, data, resp, status_class):
+        '''When the http request was "successful" in the sense that the server
+         returned a response code--the code may indicate an error, but we did
+         successfully get a response.'''
+
+        if status_class in (1, 2):
+            if self._debug:
+                Logger.debug(
+                    'UrlRequest: {0} Download finished with '
+                    '{1} data len'.format(id(self), data)
+                )
+            self._dispatch_callbacks(self.on_success, data)
+
+        elif status_class == 3:
+            if self._debug:
+                Logger.debug('UrlRequest: {} Download '
+                             'redirected'.format(id(self)))
+            self._dispatch_callbacks(self.on_redirect, data)
+
+        elif status_class in (4, 5):
+            if self._debug:
+                Logger.debug(
+                    'UrlRequest: {} Download failed with '
+                    'http error {}'.format(
+                        id(self),
+                        self.get_status_code(resp)
+                    )
+                )
+            self._dispatch_callbacks(self.on_failure, data)
+
+    def _dispatch_callbacks(self, callbacks: list[WeakMethod], *largs, **kwargs):
+        '''Dispatch any callbacks associated with the http response or user
+        driven actions.
+        '''
+
+        if callbacks:
+            for callback in callbacks:
+                func = callback()
+                if func:
+                    func(self, *largs, **kwargs)
+
     def _dispatch_result(self, dt):
+        '''Method called by clock trigger. Checks request progress and
+        dispatches results'''
+
         while True:
             # Read the result pushed on the queue, and dispatch to the client
             try:
@@ -377,104 +434,71 @@ class UrlRequestBase(Thread):
                 return
 
             if resp:
-                # Small workaround in order to prevent the situation mentioned
-                # in the comment below
-                final_cookies = ""
-                parsed_headers = []
-                for key, value in self.get_all_headers(resp):
-                    if key == "Set-Cookie":
-                        final_cookies += "{};".format(value)
-                    else:
-                        parsed_headers.append((key, value))
-                parsed_headers.append(("Set-Cookie", final_cookies[:-1]))
+                self.modify_response_headers(resp)
 
-                # XXX usage of dict can be dangerous if multiple headers
-                # are set even if it's invalid. But it look like it's ok
-                # ?  http://stackoverflow.com/questions/2454494/..
-                # ..urllib2-multiple-set-cookie-headers-in-response
-                self._resp_headers = dict(parsed_headers)
-                self._resp_status = self.get_status_code(resp)
+            # When we reach python 3.11 as the minimum supported version, this
+            # hot mess should be replaced with match statement syntax.
 
+            # server returned a response
             if result == 'success':
+                self._is_finished = True
+                self._result = data
+
                 status_class = self.get_status_code(resp) // 100
 
-                if status_class in (1, 2):
-                    if self._debug:
-                        Logger.debug(
-                            'UrlRequest: {0} Download finished with '
-                            '{1} datalen'.format(id(self), data)
-                        )
-                    self._is_finished = True
-                    self._result = data
-                    if self.on_success:
-                        func = self.on_success()
-                        if func:
-                            func(self, data)
+                self._on_status_code(data, resp, status_class)
 
-                elif status_class == 3:
-                    if self._debug:
-                        Logger.debug('UrlRequest: {} Download '
-                                     'redirected'.format(id(self)))
-                    self._is_finished = True
-                    self._result = data
-                    if self.on_redirect:
-                        func = self.on_redirect()
-                        if func:
-                            func(self, data)
-
-                elif status_class in (4, 5):
-                    if self._debug:
-                        Logger.debug(
-                            'UrlRequest: {} Download failed with '
-                            'http error {}'.format(
-                                id(self),
-                                self.get_status_code(resp)
-                            )
-                        )
-                    self._is_finished = True
-                    self._result = data
-                    if self.on_failure:
-                        func = self.on_failure()
-                        if func:
-                            func(self, data)
-
-            elif result == 'error':
-                if self._debug:
-                    Logger.debug('UrlRequest: {0} Download error '
-                                 '<{1}>'.format(id(self), data))
-                self._is_finished = True
-                self._error = data
-                if self.on_error:
-                    func = self.on_error()
-                    if func:
-                        func(self, data)
-
+            # result is pending
             elif result == 'progress':
                 if self._debug:
                     Logger.debug('UrlRequest: {0} Download progress '
                                  '{1}'.format(id(self), data))
-                if self.on_progress:
-                    func = self.on_progress()
-                    if func:
-                        func(self, data[0], data[1])
+                self._dispatch_callbacks(self.on_progress, data[0], data[1])
 
+            # server did not return a response
+            elif result == 'error':
+                self._is_finished = True
+                self._error = data
+
+                if self._debug:
+                    Logger.debug('UrlRequest: {0} Download error '
+                                 '<{1}>'.format(id(self), data))
+                self._dispatch_callbacks(self.on_error, data)
+
+            # user cancelled the request
             elif result == 'killed':
                 if self._debug:
                     Logger.debug('UrlRequest: Cancelled by user')
-                if self.on_cancel:
-                    func = self.on_cancel()
-                    if func:
-                        func(self)
+                self._dispatch_callbacks(self.on_cancel)
 
+            # this block should never be reached in normal use
             else:
-                assert 0
+                raise ValueError('UrlRequest: {} Unknown result value {}'
+                                 .format((id(self)), result))
 
-            if result != "progress" and self.on_finish:
+            # additional callback when result is finished
+            if result != "progress":
                 if self._debug:
                     Logger.debug('UrlRequest: Request is finished')
-                func = self.on_finish()
-                if func:
-                    func(self)
+                self._dispatch_callbacks(self.on_finish)
+
+    def modify_response_headers(self, resp):
+        ''' XXX usage of dict can be dangerous if multiple headers
+            are set even if it's invalid. But it look like it's ok
+            ?  http://stackoverflow.com/questions/2454494/..
+            ..urllib2-multiple-set-cookie-headers-in-response'''
+
+        final_cookies = ""
+        parsed_headers = []
+        for key, value in self.get_all_headers(resp):
+            if key == "Set-Cookie":
+                final_cookies += "{};".format(value)
+            else:
+                parsed_headers.append((key, value))
+        parsed_headers.append(("Set-Cookie", final_cookies[:-1]))
+
+        self._resp_headers = dict(parsed_headers)
+        self._resp_status = self.get_status_code(resp)
 
     @property
     def is_finished(self):
@@ -546,8 +570,8 @@ class UrlRequestBase(Thread):
 class UrlRequestUrllib(UrlRequestBase):
 
     def get_chunks(
-        self, resp, chunk_size, total_size, report_progress, q,
-        trigger, fd=None
+            self, resp, chunk_size, total_size, report_progress, q,
+            trigger, fd=None
     ):
         bytes_so_far = 0
         result = b''
@@ -666,7 +690,7 @@ class UrlRequestUrllib(UrlRequestBase):
             args['context'] = ctx
 
         if not verify and parse.scheme == 'https' and (
-            hasattr(ssl, 'create_default_context')):
+                hasattr(ssl, 'create_default_context')):
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
@@ -698,8 +722,8 @@ class UrlRequestUrllib(UrlRequestBase):
 class UrlRequestRequests(UrlRequestBase):
 
     def get_chunks(
-        self, resp, chunk_size, total_size, report_progress, q,
-        trigger, fd=None
+            self, resp, chunk_size, total_size, report_progress, q,
+            trigger, fd=None
     ):
         bytes_so_far = 0
         result = b''
@@ -753,9 +777,11 @@ class UrlRequestRequests(UrlRequestBase):
         req = requests
         kwargs = {}
 
-        # get method
+        # determine default method if not set via __init__
         if self._method is None:
             method = 'get' if body is None else 'post'
+
+        # otherwise, use the user provided http method
         else:
             method = self._method.lower()
 
@@ -785,10 +811,10 @@ implementation_map = {
 }
 
 if not os.environ.get("KIVY_DOC_INCLUDE"):
-    prefered_implementation = Config.getdefault(
+    preferred_implementation = Config.getdefault(
         "network", "implementation", "default"
     )
 else:
-    prefered_implementation = "default"
+    preferred_implementation = "default"
 
-UrlRequest = implementation_map.get(prefered_implementation)
+UrlRequest = implementation_map.get(preferred_implementation)

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -85,7 +85,60 @@ except ImportError:
 g_requests = []
 
 
-class UrlRequestBase(Thread):
+class UrlRequestABC:
+    """Grouping of abstract methods that must be defined by implementations.
+    Currently, urllib and requests are supported.
+    """
+
+    @abstractmethod
+    def get_chunks(self, resp, chunk_size, total_size, report_progress, q,
+                   trigger, fd):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_response(self, resp):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_total_size(self, resp):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_content_type(self, resp):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_status_code(self, resp):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_headers(self, resp):
+        raise NotImplementedError
+
+    @abstractmethod
+    def close_connection(self, req):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _parse_url(self, url):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_connection_for_scheme(self, scheme):
+        '''Return the Connection class for a particular scheme.
+        This is an internal function that can be expanded to support custom
+        schemes.
+
+        Actual supported schemes: http, https.
+        '''
+        raise NotImplementedError
+
+    @abstractmethod
+    def call_request(self, body, headers):
+        raise NotImplementedError
+
+
+class UrlRequestBase(Thread, UrlRequestABC, ABC):
     '''A UrlRequest. See module documentation for usage.
 
     .. versionchanged:: 1.5.1

--- a/kivy/tests/test_urlrequest/test_urlrequest_binding.py
+++ b/kivy/tests/test_urlrequest/test_urlrequest_binding.py
@@ -1,0 +1,83 @@
+import os
+
+import pytest
+
+from kivy.network.urlrequest import UrlRequestUrllib as UrlRequest
+from kivy.tests.test_urlrequest.test_urlrequest_urllib import UrlRequestQueue, \
+    wait_request_is_finished, ensure_called_from_thread, check_queue_values
+
+
+@pytest.mark.skipif(os.environ.get('NONETWORK'), reason="No network")
+def test_binding(kivy_clock):
+    obj = UrlRequestQueue([])
+    queue = obj.queue
+    req = UrlRequest(
+        'https://google.com',
+        debug=True,
+        start=False,
+    )
+
+    req.bind(
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+    )
+
+    req.start()
+
+    wait_request_is_finished(kivy_clock, req)
+
+    if req.error and req.error.errno == 11001:
+        pytest.skip('Cannot connect to get address')
+
+    ensure_called_from_thread(queue)
+    check_queue_values(queue)
+
+
+@pytest.mark.skipif(os.environ.get('NONETWORK'), reason="No network")
+def test_multiple_binding(kivy_clock):
+    obj = UrlRequestQueue([])
+    queue = obj.queue
+    req = UrlRequest(
+        'https://google.com',
+        debug=True,
+        start=False,
+    )
+
+    # separate binding
+    req.bind(
+        on_success=obj._on_success,
+        on_redirect=obj._on_redirect,
+    )
+    req.bind(
+        on_success=obj._on_success,
+        on_redirect=obj._on_redirect,
+    )
+
+    # multiple binding
+    req.bind(on_progress=[obj._on_progress, obj._on_progress])
+
+    # check callback lists
+    assert len(getattr(req, 'on_success')) == 2
+    assert len(getattr(req, 'on_redirect')) == 2
+    assert len(getattr(req, 'on_progress')) == 2
+
+    req.start()
+
+    wait_request_is_finished(kivy_clock, req)
+
+    if req.error and req.error.errno == 11001:
+        pytest.skip('Cannot connect to get address')
+
+    ensure_called_from_thread(queue)
+
+    # request may be successful or redirected if source changes. Either way,
+    # assert that we get two queue elements corresponding to callbacks.
+    filtered_len = len([x for x in queue if x[1] in ('success', 'redirect')])
+    assert filtered_len >= 2
+
+    # On progress should be dispatched at least twice per callback. Assert that
+    # we have at least four queue elements, two from each progress callback.
+    filtered_len = len([x for x in queue if x[1] == 'progress'])
+    assert filtered_len >= 4


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
This PR seeks to mimic the normal binding behavior associated with widgets as I'd like to have clean syntax for dynamically updating a variable number of widgets based on the results of a url request. Everywhere else in the library, the answer to that problem is binding to an event, but here you have to set up the callback before creating the request object.

As it stands currently, to get more than one action per callback, we need to define a helper function separately and add it to the UrlRequest object at creation. If I make the same request multiple times over the life cycle of the app, it is easier to first build the a request and then bind to it in a different manner, rather than needing to adjust the creation logic for the request.

Under these proposed changes, The following code snippets are equivalent:

```python
r = UrlRequest(url, on_success=callback)
```

```python
r = UrlRequest(url, start=False)
r.bind(on_success=callback)
r.start()
```

One possible advantage is demonstrated in the following equivalent snippets:

         
```python
def my_on_success_callback_helper(request, response):
  update_app_display(request, response)
  update_app_state(request, response)
        
def my_on_cancel_callback_helper(request, response):
  update_app_state(request)
        
r = UrlRequest(
  url,
  on_success=my_on_success_callback_helper,
  on_cancel=my_on_cancel_callback_helper,
)

```
```python    
r = UrlRequest(url, start=False)
r.bind(on_success=[update_app_display, update_app_state])
r.bind(on_cancel=update_app_state)
r.start()
```

This PR preserves compatibility with code written for the current version. Making binding the default approach would further reduce the complexity at the cost of needing a `UrlRequest.start()` call in code written for prior versions. If there is any compelling use case for equivalent `UrlRequest.unbind` or `UrlRequest.fbind` methods, those would be simple to add.  Additionally, this approach would reduce some initial confusion and frustration with `UrlRequest.wait()` blocking the app. You don't need to wait on events, you just bind to them; when they fire, you get your action. It feels consistent.


Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
