### PR TITLE
Clipboard: fixes blank string being pasted into clipboard when using the default `win32` backend

### DIFF
--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -40,8 +40,6 @@ class ClipboardWindows(ClipboardBase):
         return data
 
     def put(self, text, mimetype='text/plain'):
-        text = text.decode(self._encoding)  # auto converted later
-        text += u'\x00'
 
         SetClipboardData = user32.SetClipboardData
         SetClipboardData.argtypes = [wintypes.UINT, wintypes.HANDLE]
@@ -51,14 +49,22 @@ class ClipboardWindows(ClipboardBase):
         GlobalAlloc.argtypes = [wintypes.UINT, ctypes.c_size_t]
         GlobalAlloc.restype = wintypes.HGLOBAL
 
-        CF_UNICODETEXT = 13
-
         user32.OpenClipboard(user32.GetActiveWindow())
         user32.EmptyClipboard()
-        hCd = GlobalAlloc(0, len(text) * ctypes.sizeof(ctypes.c_wchar))
 
-        # ignore null character for strSource pointer
-        msvcrt.wcscpy_s(c_wchar_p(hCd), len(text), c_wchar_p(text[:-1]))
+        # this allocates memory for the string and returns a handle to it
+        # allocates fixed memory, len + 2 is for the null character
+        # todo: discuss, do we not need to free this memory?
+        GMEM_FIXED = 0x0000
+        hCd = GlobalAlloc(GMEM_FIXED, len(text) + 2)
+
+        # copy the string into the allocated memory
+        msvcrt.wcscpy(c_wchar_p(hCd), text)
+
+        # standard clipboard format for unicode text
+        # noqa: E501 see https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats#constants
+        CF_UNICODETEXT = 13
+        # set the clipboard data, later used by GetClipboardData()
         SetClipboardData(CF_UNICODETEXT, hCd)
         user32.CloseClipboard()
 

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -54,7 +54,8 @@ class ClipboardWindows(ClipboardBase):
 
         # this allocates memory for the string and returns a handle to it
         # allocates fixed memory, len + 2 is for the null character
-        # todo: discuss, do we not need to free this memory?
+        # no need to  call GlobalFree here as SetClipboardData will do for you
+        # see: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata#parameters
         GMEM_FIXED = 0x0000
         hCd = GlobalAlloc(GMEM_FIXED, len(text) + 2)
 

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -55,7 +55,7 @@ class ClipboardWindows(ClipboardBase):
         # this allocates memory for the string and returns a handle to it
         # allocates fixed memory, len + 2 is for the null character
         # no need to  call GlobalFree here as SetClipboardData will do for you
-        # see: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata#parameters
+        # noqa: E501 see: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata#parameters
         GMEM_FIXED = 0x0000
         hCd = GlobalAlloc(GMEM_FIXED, len(text) + 2)
 

--- a/kivy/tests/test_clipboard.py
+++ b/kivy/tests/test_clipboard.py
@@ -1,4 +1,5 @@
 from kivy.tests.common import GraphicUnitTest
+import random
 
 
 class ClipboardTestCase(GraphicUnitTest):
@@ -32,7 +33,7 @@ class ClipboardTestCase(GraphicUnitTest):
             clippy.copy(u"Hello World")
         except:
             self.fail(
-                'Can not get put data to clipboard')
+                'Can not put data to clipboard')
 
     def test_clipboard_copy_paste(self):
         clippy = self._clippy
@@ -40,3 +41,17 @@ class ClipboardTestCase(GraphicUnitTest):
         clippy.copy(txt1)
         ret = clippy.paste()
         self.assertEqual(txt1, ret)
+
+    def test_clipboard_copy_paste_with_emoji(self):
+        clippy = self._clippy
+        emoji_list = [
+            '😀', '😁', '🤣',
+            '😃', '😄', '😅',
+            '😆', '😉', '😊',
+            '😋', '😎', '😍',
+            '😘', '😗', '😎'
+        ]
+        target_string = " kivy ".join(random.choices(emoji_list, k=3))
+        clippy.copy(target_string)
+        ret = clippy.paste()
+        self.assertEqual(target_string, ret)

--- a/kivy/tests/test_clipboard.py
+++ b/kivy/tests/test_clipboard.py
@@ -1,5 +1,4 @@
 from kivy.tests.common import GraphicUnitTest
-import random
 
 
 class ClipboardTestCase(GraphicUnitTest):
@@ -44,14 +43,6 @@ class ClipboardTestCase(GraphicUnitTest):
 
     def test_clipboard_copy_paste_with_emoji(self):
         clippy = self._clippy
-        emoji_list = [
-            '😀', '😁', '🤣',
-            '😃', '😄', '😅',
-            '😆', '😉', '😊',
-            '😋', '😎', '😍',
-            '😘', '😗', '😎'
-        ]
-        target_string = " kivy ".join(random.choices(emoji_list, k=3))
-        clippy.copy(target_string)
-        ret = clippy.paste()
-        self.assertEqual(target_string, ret)
+        test_emoji_str = 'kivy 😀 😁 🤣 😃 😄 😅 😆 😉 😊 😋 😎 😍 😘 😗'
+        clippy.copy(test_emoji_str)
+        self.assertEqual(test_emoji_str, clippy.paste())


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

fixes #8314 