### PR TITLE
Prevent apps from crashing when `sys.stderr` is `None` (pythonw and pyinstaller 5.7)

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -597,7 +597,7 @@ def add_kivy_handlers(logger):
     # Use the custom handler instead of streaming one.
     # Don't output to stderr if it is set to None
     # stderr is set to None by pythonw and pyinstaller 5.7+
-    if (sys.stderr is not None) and ('KIVY_NO_CONSOLELOG' not in os.environ):
+    if sys.stderr and 'KIVY_NO_CONSOLELOG' not in os.environ:
         use_color = is_color_terminal()
         if not use_color:
             # No additional control characters will be inserted inside the

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -595,7 +595,9 @@ def add_kivy_handlers(logger):
         logger.addHandler(file_log_handler)
 
     # Use the custom handler instead of streaming one.
-    if 'KIVY_NO_CONSOLELOG' not in os.environ:
+    # Don't output to stderr if it is set to None
+    # stderr is set to None by pythonw and pyinstaller 5.7+
+    if (sys.stderr is not None) and ('KIVY_NO_CONSOLELOG' not in os.environ):
         use_color = is_color_terminal()
         if not use_color:
             # No additional control characters will be inserted inside the
@@ -613,11 +615,6 @@ def add_kivy_handlers(logger):
 
 KIVY_LOG_MODE = os.environ.get("KIVY_LOG_MODE", "KIVY")
 assert KIVY_LOG_MODE in ("KIVY", "PYTHON", "MIXED"), "Unknown log mode"
-
-# if run from pythonw or pyinstaller v5.7, sys.stderr is None
-# If sys.stderr is None the ConsoleHandler() must not be loaded
-if sys.stderr is None:
-    os.environ['KIVY_NO_CONSOLELOG'] = '1'
 
 if KIVY_LOG_MODE == "KIVY":
     # Add the Kivy handlers to the root logger, so they will be used

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -508,7 +508,9 @@ def test_logger_fix_8345():
     sys.stderr = None
     add_kivy_handlers(Logger)
     sys.stderr = original_sys_stderr  # restore sys.stderr
-    console_handler_found = any(isinstance(handler, ConsoleHandler)
-                                for handler in Logger.handlers)
-    assert not console_handler_found, \
-        "Console handler added, despite sys.stderr being None"
+    console_handler_found = any(
+        isinstance(handler, ConsoleHandler) for handler in Logger.handlers
+    )
+    assert (
+        not console_handler_found
+    ), "Console handler added, despite sys.stderr being None"

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -508,5 +508,7 @@ def test_logger_fix_8345():
     sys.stderr = None
     add_kivy_handlers(Logger)
     sys.stderr = original_sys_stderr  # restore sys.stderr
-    console_handler_found = any(isinstance(handler, ConsoleHandler) for handler in Logger.handlers)
-    assert not console_handler_found, "Console handler added, despite sys.stderr being None"
+    console_handler_found = any(isinstance(handler, ConsoleHandler) \
+                                for handler in Logger.handlers)
+    assert not console_handler_found, \
+        "Console handler added, despite sys.stderr being None"

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -510,5 +510,5 @@ def test_logger_fix_8345():
     sys.stderr = original_sys_stderr  # restore sys.stderr
     console_handler_found = any(isinstance(handler, ConsoleHandler)
                                 for handler in Logger.handlers)
-    assert not console_handler_found, \
-        "Console handler added, despite sys.stderr being None"
+    assert (not console_handler_found,
+            "Console handler added, despite sys.stderr being None")

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -510,5 +510,5 @@ def test_logger_fix_8345():
     sys.stderr = original_sys_stderr  # restore sys.stderr
     console_handler_found = any(isinstance(handler, ConsoleHandler)
                                 for handler in Logger.handlers)
-    assert (not console_handler_found,
-            "Console handler added, despite sys.stderr being None")
+    assert not console_handler_found, \
+        "Console handler added, despite sys.stderr being None"

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -488,3 +488,25 @@ def test_mixed_mode_handlers():
     assert not are_regular_logs_handled()
     assert are_kivy_logger_logs_handled()
     assert not is_stderr_output_handled()
+
+
+@pytest.mark.logmodepython
+@pytest.mark.skipif(
+    LOG_MODE != "PYTHON",
+    reason="Requires KIVY_LOG_MODE==PYTHON to run.",
+)
+def test_logger_fix_8345():
+    """
+    The test checks that the ConsoleHandler is not in the Logger
+    handlers list if stderr is None.  Test sets stderr to None,
+    if the Console handler is found, the test fails.
+    Pythonw and Pyinstaller 5.7+ (with console set to false) set stderr
+    to None.
+    """
+    from kivy.logger import Logger, add_kivy_handlers, ConsoleHandler
+    original_sys_stderr = sys.stderr
+    sys.stderr = None
+    add_kivy_handlers(Logger)
+    sys.stderr = original_sys_stderr  # restore sys.stderr
+    console_handler_found = any(isinstance(handler, ConsoleHandler) for handler in Logger.handlers)
+    assert not console_handler_found, "Console handler added, despite sys.stderr being None"

--- a/kivy/tests/test_logger.py
+++ b/kivy/tests/test_logger.py
@@ -508,7 +508,7 @@ def test_logger_fix_8345():
     sys.stderr = None
     add_kivy_handlers(Logger)
     sys.stderr = original_sys_stderr  # restore sys.stderr
-    console_handler_found = any(isinstance(handler, ConsoleHandler) \
+    console_handler_found = any(isinstance(handler, ConsoleHandler)
                                 for handler in Logger.handlers)
     assert not console_handler_found, \
         "Console handler added, despite sys.stderr being None"


### PR DESCRIPTION
Kivy apps will crash if run from pythonw or if they are built with pyinstaller 5.7.  The reason is that these runtimes set sys.stderr  to None, causing a recursion error in the python logger.  This fix will not load the ConsoleHandler if sys.stderr is None.  This preserves the behavior prior to pyinstaller 5.7, and allows correct operation under pythonw.exe

Edit: Updated comment to reflect the solution.

This will fix this issue: https://github.com/kivy/kivy/issues/8074

Here is a small test I used developing the fix. The design of the logger redirects messages written to stderr to the logfile. That behavior is retained. If this code is executed with pythonw (or is built with pyinstaller 5.7) on a version of kivy without the fix - it will fail to run.

```py
import sys

initial_stderror = sys.stderr  # at startup sys.stderror == None

from kivy.app import App
from kivy.uix.label import Label
from kivy.logger import Logger
from kivy.lang.builder import Builder
import itertools

kv = """
BoxLayout:
    orientation: 'vertical'
    AnchorLayout
        Button:
            size_hint: None, None
            size: dp(200), dp(48)
            text: 'Say Hello'
            on_release: label.say_hello()
    HelloLabel:
        id: label
        size_hint_y: None
        height: dp(48)
        text: 'Nice to meet you'
"""


class HelloLabel(Label):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.hellos = itertools.cycle(['Hello to you!', 'Hey There!', "What's up?"])

    def say_hello(self):
        self.text = next(self.hellos)
        Logger.info(f'{self.text=}')
        # writes to stderr should be logged under pythonw or pyinstaller, but not written to the console
        print('print to stderr', file=sys.stderr)
        sys.stderr.write('write to stderr\n')


class ExampleWithPyinstallerApp(App):
    def build(self):
        return Builder.load_string(kv)

    def on_stop(self):
        Logger.info(f'sys.stderr before kivy loads: {initial_stderror}; sys.stderr at on_stop: {sys.stderr}')


ExampleWithPyinstallerApp().run()
```
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
