### PR TITLE
RecycleDataAdapter: Fixed typo in class docstring

### DIFF
--- a/kivy/uix/recycleview/views.py
+++ b/kivy/uix/recycleview/views.py
@@ -166,7 +166,7 @@ class RecycleDataAdapter(EventDispatcher):
           are typically added to the internal cache.
 
     Typically what happens is that the layout manager lays out the data
-    and then asks for views, using :meth:`set_visible_views,` for some specific
+    and then asks for views, using :meth:`set_visible_views`, for some specific
     data items that it displays.
 
     These views are gotten from the current views, dirty or global cache. Then


### PR DESCRIPTION
The comma should be outside the method declaration in line 169.
The current line 169 is - "and then asks for views, using :meth:`set_visible_views,` for some specific"
After the change, it becomes - "and then asks for views, using :meth:`set_visible_views`, for some specific"
which is syntactically correct.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
