### PR TITLE
Added new conifg value `lazy_window_initialization`

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -405,7 +405,7 @@ from kivy.utils import platform
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 27
+KIVY_CONFIG_VERSION = 28
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -941,6 +941,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 26:
             Config.setdefault("graphics", "show_taskbar_icon", "1")
+
+         elif version == 27:
+            Config.setdefault("graphics", "lazy_window_initialization", "0")
 
         # WARNING: When adding a new version migration here,
         # don't forget to increment KIVY_CONFIG_VERSION !


### PR DESCRIPTION
For removing side-effects during Window initialization, while maintaining backward behaviour compatibility, and also for advanced users who would want to have multiprocessing used with Kivy (without multiple window initialization), we added a config value named `lazy_window_initialization`, which when set would lazily do the window initialization.

Reference https://github.com/kivy/kivy/issues/8340

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
