### PR TITLE
Apply style fixes as suggested by new flake8 version

### DIFF
--- a/examples/demo/showcase/main.py
+++ b/examples/demo/showcase/main.py
@@ -29,8 +29,12 @@ from time import time
 from kivy.app import App
 from os.path import dirname, join
 from kivy.lang import Builder
-from kivy.properties import NumericProperty, StringProperty, BooleanProperty,\
-    ListProperty
+from kivy.properties import (
+    NumericProperty,
+    StringProperty,
+    BooleanProperty,
+    ListProperty,
+)
 from kivy.clock import Clock
 from kivy.animation import Animation
 from kivy.uix.screenmanager import Screen

--- a/kivy/core/gl/__init__.py
+++ b/kivy/core/gl/__init__.py
@@ -27,10 +27,17 @@ if 'KIVY_DOC' not in environ:
     from kivy.logger import Logger
     from kivy.graphics import gl_init_resources
     from kivy.graphics.opengl_utils import gl_get_version
-    from kivy.graphics.opengl import GL_VERSION, GL_VENDOR, GL_RENDERER, \
-        GL_MAX_TEXTURE_IMAGE_UNITS, GL_MAX_TEXTURE_SIZE, \
-        GL_SHADING_LANGUAGE_VERSION,\
-        glGetString, glGetIntegerv, gl_init_symbols
+    from kivy.graphics.opengl import (
+        GL_VERSION,
+        GL_VENDOR,
+        GL_RENDERER,
+        GL_MAX_TEXTURE_IMAGE_UNITS,
+        GL_MAX_TEXTURE_SIZE,
+        GL_SHADING_LANGUAGE_VERSION,
+        glGetString,
+        glGetIntegerv,
+        gl_init_symbols,
+    )
     from kivy.graphics.cgl import cgl_get_initialized_backend_name
     from kivy.utils import platform
 

--- a/kivy/interactive.py
+++ b/kivy/interactive.py
@@ -175,7 +175,7 @@ def safeWait(dt):
 
 
 def unwrap(ob):
-    while type(ob) == SafeMembrane:
+    while isinstance(ob, SafeMembrane):
         ob = ob._ref
     return ob
 

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -12,8 +12,13 @@ from types import CodeType
 from functools import partial
 
 from kivy.factory import Factory
-from kivy.lang.parser import Parser, ParserException, _handlers, global_idmap,\
-    ParserRuleProperty
+from kivy.lang.parser import (
+    Parser,
+    ParserException,
+    _handlers,
+    global_idmap,
+    ParserRuleProperty,
+)
 from kivy.logger import Logger
 from kivy.utils import QueryDict
 from kivy.cache import Cache

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -1060,7 +1060,7 @@ class Settings(BoxLayout):
                 data = json.loads(fd.read())
         else:
             data = json.loads(data)
-        if type(data) != list:
+        if isinstance(data, list):
             raise ValueError('The first element must be a list')
         panel = SettingsPanel(title=title, settings=self, config=config)
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Recently our PEP8 check started to fail due to the following new checks which now raise an error by default.
```
E231 missing whitespace after ','
E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

Makes sense, so instead of silencing them, I applied some changes in order to fulfill flake8 requirements.