### PR TITLE
Avoid multiple values for `noadd` in `VertexInstruction`

### DIFF
--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -289,7 +289,7 @@ cdef class VertexInstruction(Instruction):
     Triangles, Lines, Ellipse and so on.
     '''
     def __init__(self, **kwargs):
-        # avoid multiple values for 'noadd' in BindTexture bellow
+        # avoid multiple values for 'noadd' in BindTexture below
         noadd_value = kwargs.pop('noadd', False)
 
         # Set a BindTexture instruction to bind the texture used for

--- a/kivy/graphics/instructions.pyx
+++ b/kivy/graphics/instructions.pyx
@@ -289,6 +289,9 @@ cdef class VertexInstruction(Instruction):
     Triangles, Lines, Ellipse and so on.
     '''
     def __init__(self, **kwargs):
+        # avoid multiple values for 'noadd' in BindTexture bellow
+        noadd_value = kwargs.pop('noadd', False)
+
         # Set a BindTexture instruction to bind the texture used for
         # this instruction before the actual vertex instruction
         self.texture_binding = BindTexture(noadd=True, **kwargs)
@@ -297,7 +300,7 @@ cdef class VertexInstruction(Instruction):
         if tex_coords:
             self.tex_coords = tex_coords
 
-        Instruction.__init__(self, **kwargs)
+        Instruction.__init__(self, noadd=noadd_value, **kwargs)
         self.flags = GI_VERTEX_DATA & GI_NEEDS_UPDATE
         self.batch = VertexBatch()
 


### PR DESCRIPTION
## Notes:

When adding an `Instruction`, there is a possibility of not adding the `Instruction` automatically through the canvas context manager. Therefore, the only way to add an instruction defined with `noadd = True` is from `canvas.add` or `canvas.insert`.

In some cases, it is not desired for the canvas context manager to automatically add instructions to the children of the canvas (as with `BindTexture`), because the instructions are managed (added in specific orders, or not added) within a specific instruction, as is the case from `VertexInstruction`. However, the code that prevents the `BindTexture` from being added also prevents a `Instruction` as a whole from not being added (because it duplicates the definition of the arguments in the `BindTexture`), which can be seen as a limitation.

This PR isolates the definition of `noadd` in `BindTexture` from the rest of the `VertexInstruction`.


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->


---
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
