### PR TITLE
Bug fixture for window opening while importing Window class

### DIFF
--- a/kivy/base.py
+++ b/kivy/base.py
@@ -133,8 +133,12 @@ class EventLoopBase(EventDispatcher):
     def ensure_window(self):
         '''Ensure that we have a window.
         '''
-        import kivy.core.window  # NOQA
-        if not self.window:
+        if self.window:
+            return
+        from kivy.core.window import Window # NOQA
+        
+        Window.initialize_window_setup()
+        if not Window.initialized or not self.window:
             Logger.critical('App: Unable to get a Window, abort.')
             sys.exit(1)
 

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -405,7 +405,7 @@ from kivy.utils import platform
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 27
+KIVY_CONFIG_VERSION = 28
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -941,6 +941,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 26:
             Config.setdefault("graphics", "show_taskbar_icon", "1")
+
+         elif version == 27:
+            Config.setdefault("graphics", "lazy_window_initialization", "0")
 
         # WARNING: When adding a new version migration here,
         # don't forget to increment KIVY_CONFIG_VERSION !

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -353,7 +353,23 @@ class WindowBase(EventDispatcher):
     '''
 
     __instance = None
-    __initialized = False
+    
+    _initialized = BooleanProperty(False)
+
+     # make some property read-only
+    def _get_initialized(self):
+        return self._initialized
+
+    initialized = AliasProperty(_get_initialized, bind=('_initialized',))
+    '''Read only property to check if the window is initialized and the associated setup
+    like registering the window to eventloop, modules, keyboard and metrics are completed or not.
+
+    .. versionadded:: 2.3.0
+
+    :attr:`initialized` is an :class:`~kivy.properties.AliasProperty`.
+    '''
+
+    
     _fake_fullscreen = False
 
     # private properties
@@ -1005,7 +1021,6 @@ class WindowBase(EventDispatcher):
         if WindowBase.__instance is not None and not force:
             return
 
-        self.initialized = False
         self.event_managers = []
         self.event_managers_dict = defaultdict(list)
         self._is_desktop = Config.getboolean('kivy', 'desktop')
@@ -1095,6 +1110,14 @@ class WindowBase(EventDispatcher):
         self.children = []
         self.parent = self
 
+        lazy = Config.getboolean('graphics', 'lazy_window_initialization')
+
+        if not lazy:
+            self.initialize_window_setup()
+
+    def initialize_window_setup(self):   
+        if self.initialized:
+            return
         # before creating the window
         import kivy.core.gl  # NOQA
 
@@ -1109,13 +1132,13 @@ class WindowBase(EventDispatcher):
         if not hasattr(self, '_context'):
             self._context = get_current_context()
 
-        # because Window is created as soon as imported, if we bound earlier,
+        # because Window might be created as soon as imported, if we bound earlier,
         # metrics would be imported when dp is set during window creation.
         # Instead, don't process dpi changes until everything is set
         self.fbind('dpi', self._reset_metrics_dpi)
 
         # mark as initialized
-        self.initialized = True
+        self._initialized = True
 
     def _reset_metrics_dpi(self, *args):
         from kivy.metrics import Metrics

--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -159,9 +159,7 @@ class GraphicUnitTest(_base):
         Window.bind(on_flip=self.on_window_flip)
 
         # ensure our window is correctly created
-        Window.create_window()
-        Window.register()
-        Window.initialized = True
+        Window.initialize_window_setup()
         Window.close = lambda *s: None
         self.clear_window_and_event_loop()
 

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -122,9 +122,7 @@ async def kivy_app(request, nursery):
     context['Builder'] = BuilderBase.create_from(Builder)
     context.push()
 
-    Window.create_window()
-    Window.register()
-    Window.initialized = True
+    Window.initialize_window_setup()
     Window.canvas.clear()
 
     app = request.param[0]()


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Issues addressed (known to me atleast): 
* #8340 
* #8222 

Changes done:
* Updated `EventLoop.ensure_window` function to work with lazy initialization of the `Window` class
* Converted `_initialized` to `BooleanProperty`, changed initialized to read only `AliasProperty`, added lazy initialization of window
        Removed side-effects during window import, added lazy initialization of window. This would also help advanced users who want to use multiprocessing with Kivy without side-effects. Removed the bug that `Window.initialized` was able to be changed/set by users, which should not be the case. Made `Window.initialized` read-only property.
* Added new conifg value `lazy_window_initialization`
       For removing side-effects during `Window` initialization, while maintaining backward behaviour compatibility, and also for advanced users who would want to have multiprocessing used with Kivy (without multiple window initialization), we added a config value named `lazy_window_initialization`, which when set would lazily do the window initialization.
* Updated the function `setup` to properly work with lazy initialization feature of `Window`
* Updated the fixture `kivy_app` to properly work with lazy initialization feature of `Window`

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
