### PR TITLE
Rename `CaptureDelegate` to `KivyCaptureDelegate` in `AVFoundationCamera` to avoid duplicated symbols

### DIFF
--- a/kivy/core/camera/camera_avfoundation_implem.m
+++ b/kivy/core/camera/camera_avfoundation_implem.m
@@ -63,7 +63,7 @@ public:
 @end
 #endif
 
-@interface CaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+@interface KivyCaptureDelegate : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
 {
     int newFrame;
     CVImageBufferRef  mCurrentImageBuffer;
@@ -175,7 +175,7 @@ private:
     AVCaptureDeviceInput        *mCaptureDeviceInput;
     AVCaptureVideoDataOutput    *mCaptureDecompressedVideoOutput;
     AVCaptureDevice             *mCaptureDevice;
-    CaptureDelegate             *capture;
+    KivyCaptureDelegate             *capture;
     #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     /* AVCaptureMetadataOutput is not available on MacOS */
     AVCaptureMetadataOutput     *mMetadataOutput;
@@ -355,7 +355,7 @@ int Camera::startCaptureDevice() {
     if (started == 1)
         return 1;
 
-    capture = [[CaptureDelegate alloc] init];
+    capture = [[KivyCaptureDelegate alloc] init];
 
     devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 
@@ -637,7 +637,7 @@ bool Camera::setProperty(int property_id, double value) {
 }
 #endif
 
-@implementation CaptureDelegate
+@implementation KivyCaptureDelegate
 
 - (id)init {
     [super init];


### PR DESCRIPTION
kivy-ios camera backend was using same class layout/name as Opencv. Which resulted in duplicated symbols

Class name changed from CaptureDelegate to KivyCaptureDelegate to avoid this issue.