### PR TITLE
Fixes a regression that prevents the setting panel to load

### DIFF
--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -1060,7 +1060,7 @@ class Settings(BoxLayout):
                 data = json.loads(fd.read())
         else:
             data = json.loads(data)
-        if isinstance(data, list):
+        if not isinstance(data, list):
             raise ValueError('The first element must be a list')
         panel = SettingsPanel(title=title, settings=self, config=config)
 


### PR DESCRIPTION
Setting fail to load because they should be a list

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Edit from the maintainer (as the title has been changed):
Regression has been introduced via c7f42752c3519b32015ccb33d9dea3c5ed00d9b3