### PR TITLE
Now Github Actions provides python3 via setup-python also for Apple Silicon Macs

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -20,17 +20,6 @@ download_cache_curl() {
   fi
 }
 
-arm64_set_path_and_python_version(){
-  python_version="$1"
-  if [[ $(/usr/bin/arch) = arm64 ]]; then
-      export PATH=/opt/homebrew/bin:$PATH
-      eval "$(pyenv init --path)"
-      pyenv install $python_version -s
-      pyenv global $python_version
-      export PATH=$(pyenv prefix)/bin:$PATH
-  fi
-}
-
 install_platypus() {
   download_cache_curl "platypus$MACOS__PLATYPUS__VERSION.zip" "osx-cache" "https://github.com/sveinbjornt/Platypus/releases/download/v$MACOS__PLATYPUS__VERSION/platypus$MACOS__PLATYPUS__VERSION.zip"
 

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -56,8 +56,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
-      if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
@@ -72,25 +70,15 @@ jobs:
         update_version_metadata
     - name: Install build dependencies
       run: |
-        source .ci/ubuntu_ci.sh
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         brew install pkg-config cmake ninja
     - name: Build universal Kivy dependencies
       run: |
-        source .ci/ubuntu_ci.sh
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         ./tools/build_macos_dependencies.sh
     - name: Install cibuildwheel
       run: |
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         python -m pip install cibuildwheel==2.11.2
     - name: Build wheels
       run: |
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
         export REPAIR_LIBRARY_PATH=$KIVY_DEPS_ROOT/dist/Frameworks:$KIVY_DEPS_ROOT/dist/Frameworks/SDL2_mixer.framework/Frameworks
         python -m cibuildwheel --output-dir wheelhouse
@@ -147,32 +135,21 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        include:
-          - runs_on: macos-latest
+        runs_on: ['macos-latest', 'apple-silicon-m1']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        exclude:
+          # apple-silicon-m1 does not support older python versions (3.7, 3.8, 3.9)
+          - runs_on: apple-silicon-m1
             python: '3.7'
-          - runs_on: macos-latest
+          - runs_on: apple-silicon-m1
             python: '3.8'
-          - runs_on: macos-latest
+          - runs_on: apple-silicon-m1
             python: '3.9'
-          - runs_on: macos-latest
-            python: '3.10'
-          - runs_on: macos-latest
-            python: '3.11'
-          - runs_on: apple-silicon-m1
-            python: '3.8.13'
-          - runs_on: apple-silicon-m1
-            python: '3.9.7'
-          - runs_on: apple-silicon-m1
-            python: '3.10.1'
-          - runs_on: apple-silicon-m1
-            python: '3.11'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }} on ${{ matrix.runs_on }}
-        # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
-        if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
@@ -183,14 +160,10 @@ jobs:
       - name: Install test dependencies
         run: |
           source .ci/ubuntu_ci.sh
-          source .ci/osx_ci.sh
-          arm64_set_path_and_python_version ${{ matrix.python }}
           install_kivy_test_wheel_run_pip_deps dev
       - name: Install Kivy wheel
         run: |
           source .ci/ubuntu_ci.sh
-          source .ci/osx_ci.sh
-          arm64_set_path_and_python_version ${{ matrix.python }}
           install_kivy_wheel dev
       - uses: actions/download-artifact@v3
         with:
@@ -199,14 +172,10 @@ jobs:
       - name: Install kivy-examples wheel
         run: |
           source .ci/ubuntu_ci.sh
-          source .ci/osx_ci.sh
-          arm64_set_path_and_python_version ${{ matrix.python }}
           install_kivy_examples_wheel dev
       - name: Test Kivy wheel
         run: |
           source .ci/ubuntu_ci.sh
-          source .ci/osx_ci.sh
-          arm64_set_path_and_python_version ${{ matrix.python }}
           test_kivy_install
 
   osx_app_create:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -16,47 +16,28 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        include:
-          - runs_on: macos-latest
-            python: '3.x'
-          - runs_on: apple-silicon-m1
-            python: '3.11'
+        runs_on: ['macos-latest', 'apple-silicon-m1']
+        python: ['3.11'] # Change me to 3.x when support for 3.12 is available
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
-      if: ${{ matrix.runs_on  != 'apple-silicon-m1' }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-    - name: Cache macOS deps downloads
-      uses: actions/cache@v3
-      with:
-        path: osx-cache
-        key: ${{ runner.OS }}-build-${{ hashFiles('.ci/osx_ci.sh') }}
     - name: Install build dependencies
       run: |
-        source .ci/ubuntu_ci.sh
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         brew install pkg-config cmake ninja
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         ./tools/build_macos_dependencies.sh
         install_kivy_test_run_pip_deps
     - name: Install Kivy
       run: |
         source .ci/ubuntu_ci.sh
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
         install_kivy
     - name: Test Kivy
       run: |
         source .ci/ubuntu_ci.sh
-        source .ci/osx_ci.sh
-        arm64_set_path_and_python_version ${{ matrix.python }}
         test_kivy


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Finally, no more apple-silicon specific workarounds! 🎉 (at least on selected Python3 versions, but that's enough)

Similar PRs: https://github.com/kivy/kivy-ios/pull/829, https://github.com/kivy/buildozer/pull/1687, https://github.com/kivy/pyjnius/pull/677
