### PR TITLE
[WIP] Prevent `VideoFFPy` from crashing when `filename` is `None`

### DIFF
--- a/kivy/core/video/video_ffpyplayer.py
+++ b/kivy/core/video/video_ffpyplayer.py
@@ -121,6 +121,8 @@ class VideoFFPy(VideoBase):
         # player paused and can probably be removed as soon as the 'eof'
         # receiving issue is solved.
         # See https://github.com/matham/ffpyplayer/issues/142
+        if self.filename is None:
+            return False
         return self.filename.startswith('rtsp://')
 
     def __del__(self):

--- a/kivy/tests/test_core_video_ffpyplayer.py
+++ b/kivy/tests/test_core_video_ffpyplayer.py
@@ -1,0 +1,14 @@
+from kivy.core.video.video_ffpyplayer import VideoFFPy
+
+
+def test_video_ffpyplayer__is_stream():
+    """Test that the VideoFFPy _is_stream property works as expected."""
+    player = VideoFFPy(filename='test.mp4')
+    assert player._is_stream is False
+
+    player = VideoFFPy(filename='rtsp://test.mp4')
+    assert player._is_stream is True
+
+    # The default, when no filename is given
+    player = VideoFFPy(filename=None)
+    assert player._is_stream is False


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Fixes issue #8390 