### PR TITLE
Introduce `clear_stencil` option in `StencilPush`, to allow disabling stencil clearing and improve GPU performance when using Stencil Instructions

### DIFF
--- a/kivy/graphics/stencil_instructions.pxd
+++ b/kivy/graphics/stencil_instructions.pxd
@@ -5,6 +5,7 @@ cdef void restore_stencil_state(dict state)
 cdef void reset_stencil_state()
 
 cdef class StencilPush(Instruction):
+    cdef int _clear_stencil
     cdef int apply(self) except -1
 
 cdef class StencilPop(Instruction):

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -224,6 +224,18 @@ cdef void stencil_apply_state(dict state, restore_only):
 cdef class StencilPush(Instruction):
     '''Push the stencil stack. See the module documentation for more
     information.
+
+    .. versionadded:: 2.3.0
+        ``clear_stencil`` was added to allow disabling stencil clearing in the
+        ``StencilPush`` phase. This option essentially disables the invocation
+        of the functions ``cgl.glClearStencil(0)`` and ``cgl.glClear(GL_STENCIL_BUFFER_BIT).``
+
+    .. note::
+        It is **highly recommended** to set ``clear_stencil=False`` for improved
+        performance and reduced GPU usage. However, if any side effects (such as
+        artifacts or inaccurate functioning of ``StencilPush``) occur, it is
+        advisable to re-enable the clearing instructions with ``clear_stencil=True.``
+
     '''
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This PR applies the findings obtained from https://github.com/kivy/kivy/pull/8309, where a high GPU utilization was noticed, when using a huge amount of Stencil Instructions.

From the tests, no side effects were noticed (_could this be a potential bug in Kivy? This would mean that Kivy could be "rebuilding" the entire canvas context, even when not necessary, which makes cleaning the stencil unnecessary in all, or almost all the cases?_)

🟢  For comparison purposes, with the tests done in https://github.com/kivy/kivy/pull/8309, the difference in GPU usage went from ~98% (`clear_stencil=True`) to 38% (`clear_stencil =False`).


By default, the option is enabled, but disabling it is recommended unless any side effects are noticed.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
