### PR TITLE
Expose new `clear_stencil` property in `StencilPush`

### DIFF
--- a/kivy/graphics/stencil_instructions.pxd
+++ b/kivy/graphics/stencil_instructions.pxd
@@ -5,7 +5,8 @@ cdef void restore_stencil_state(dict state)
 cdef void reset_stencil_state()
 
 cdef class StencilPush(Instruction):
-    cdef int _clear_stencil
+    cdef bint _clear_stencil
+    cdef bint _check_bool(self, object value)
     cdef int apply(self) except -1
 
 cdef class StencilPop(Instruction):

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -225,17 +225,6 @@ cdef class StencilPush(Instruction):
     '''Push the stencil stack. See the module documentation for more
     information.
 
-    .. versionadded:: 2.3.0
-        ``clear_stencil`` was added to allow disabling stencil clearing in the
-        ``StencilPush`` phase. This option essentially disables the invocation
-        of the functions ``cgl.glClearStencil(0)`` and ``cgl.glClear(GL_STENCIL_BUFFER_BIT).``
-
-    .. note::
-        It is **highly recommended** to set ``clear_stencil=False`` for improved
-        performance and reduced GPU usage. However, if any side effects (such as
-        artifacts or inaccurate functioning of ``StencilPush``) occur, it is
-        advisable to re-enable the clearing instructions with ``clear_stencil=True.``
-
     '''
 
     def __init__(self, **kwargs):
@@ -247,6 +236,33 @@ cdef class StencilPush(Instruction):
         _stencil_state["clear_stencil"] = self._clear_stencil
         stencil_apply_state(_stencil_state, False)
         return 0
+    
+    @property
+    def clear_stencil(self):
+        '''``clear_stencil`` allow to disable stencil clearing in the ``StencilPush``
+        phase. This option essentially disables the invocation of the functions
+        ``cgl.glClearStencil(0)`` and ``cgl.glClear(GL_STENCIL_BUFFER_BIT).``
+
+        If ``True``, the stencil will be cleaned in the ``StencilPush`` phase, if
+        ``False``, it will not be cleaned.
+
+        .. note::
+            It is **highly recommended** to set ``clear_stencil=False`` for improved
+            performance and reduced GPU usage (especially if there are hundreds of
+            instructions). However, if any side effects (such as artifacts or inaccurate
+            behavior of ``StencilPush``) occur, it is advisable to re-enable the clearing
+            instructions with ``clear_stencil=True.``
+
+        .. versionadded:: 2.3.0
+        '''
+        return self._clear_stencil
+    
+    @clear_stencil.setter
+    def clear_stencil(self, value):
+        cdef int clear_stencil = int(value)
+        if clear_stencil != self._clear_stencil:
+            self._clear_stencil = clear_stencil
+            self.flag_data_update()
 
 
 cdef class StencilPop(Instruction):

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -229,7 +229,7 @@ cdef class StencilPush(Instruction):
 
     def __init__(self, **kwargs):
         super(StencilPush, self).__init__(**kwargs)
-        self._clear_stencil = kwargs.get('clear_stencil', True)
+        self._clear_stencil = int(kwargs.get('clear_stencil', True))
 
     cdef int apply(self) except -1:
         _stencil_state["op"] = "push"

--- a/kivy/graphics/stencil_instructions.pyx
+++ b/kivy/graphics/stencil_instructions.pyx
@@ -229,14 +229,21 @@ cdef class StencilPush(Instruction):
 
     def __init__(self, **kwargs):
         super(StencilPush, self).__init__(**kwargs)
-        self._clear_stencil = int(kwargs.get('clear_stencil', True))
+        self._clear_stencil = self._check_bool(kwargs.get('clear_stencil', True))
+
+    cdef bint _check_bool(self, object value):
+        if not isinstance(value, bool):
+            raise TypeError(
+                f"'clear_stencil' accept only boolean values (True or False), got {type(value)}."
+            )
+        return value
 
     cdef int apply(self) except -1:
         _stencil_state["op"] = "push"
         _stencil_state["clear_stencil"] = self._clear_stencil
         stencil_apply_state(_stencil_state, False)
         return 0
-    
+
     @property
     def clear_stencil(self):
         '''``clear_stencil`` allow to disable stencil clearing in the ``StencilPush``
@@ -256,10 +263,10 @@ cdef class StencilPush(Instruction):
         .. versionadded:: 2.3.0
         '''
         return self._clear_stencil
-    
+
     @clear_stencil.setter
     def clear_stencil(self, value):
-        cdef int clear_stencil = int(value)
+        cdef int clear_stencil = self._check_bool(value)
         if clear_stencil != self._clear_stencil:
             self._clear_stencil = clear_stencil
             self.flag_data_update()


### PR DESCRIPTION
`clear_stencil` was introduced [here](https://github.com/kivy/kivy/pull/8405) but could not be modified after instantiation, nor could it be declared in the `kvlang`; this PR exposes this property.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
