### PR TITLE
Install `setuptools` before `sdist` generation, as `setuptools` is not anymore available by default on `3.12`

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -18,7 +18,7 @@ update_version_metadata() {
 }
 
 generate_sdist() {
-  python3 -m pip install cython packaging
+  python3 -m pip install cython packaging setuptools
   python3 setup.py sdist --formats=gztar
   python3 -m pip uninstall cython -y
 }


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


The CI started to fail when the `setup-python` `3.x` python version targeted Python `3.12` as `setuptools`, is not anymore installed by default.

This PR installs `setuptools` before the sdist generation.