### PR TITLE
Add `balenalib/raspberrypi3-debian-python:3.11-bookworm` to rpi builds for newer  RPi OS

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -26,7 +26,11 @@ RUN /bin/bash -c 'if [ "$(lsb_release -cs)" = "buster" ]; then \
 
 # Install patchelf (needed during delocation)
 RUN /bin/bash -c 'wget https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-armv7l.tar.gz'
-RUN /bin/bash -c 'tar -xvf patchelf-0.18.0-armv7l.tar.gz -C /'
+RUN /bin/bash -c 'mkdir patchelf-0.18.0-armv7l'
+RUN /bin/bash -c 'tar -xvf patchelf-0.18.0-armv7l.tar.gz -C ./patchelf-0.18.0-armv7l && \
+    cp patchelf-0.18.0-armv7l/bin/patchelf /usr/local/bin/ && \
+    chmod +x /usr/local/bin/patchelf'
+RUN /bin/bash -c 'rm -rf patchelf-0.18.0-armv7l'
 RUN /bin/bash -c 'rm patchelf-0.18.0-armv7l.tar.gz'
 
 # Install auditwheel for delocation

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -25,13 +25,13 @@ RUN /bin/bash -c 'if [ "$(lsb_release -cs)" = "buster" ]; then \
 
 
 # Install patchelf (needed during delocation)
-RUN /bin/bash -c 'wget https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-armv7l.tar.gz'
-RUN /bin/bash -c 'mkdir patchelf-0.18.0-armv7l'
-RUN /bin/bash -c 'tar -xvf patchelf-0.18.0-armv7l.tar.gz -C ./patchelf-0.18.0-armv7l && \
-    cp patchelf-0.18.0-armv7l/bin/patchelf /usr/local/bin/ && \
+RUN /bin/bash -c 'wget https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-armv7l.tar.gz'
+RUN /bin/bash -c 'mkdir patchelf-0.17.2-armv7l'
+RUN /bin/bash -c 'tar -xvf patchelf-0.17.2-armv7l.tar.gz -C ./patchelf-0.17.2-armv7l && \
+    cp patchelf-0.17.2-armv7l/bin/patchelf /usr/local/bin/ && \
     chmod +x /usr/local/bin/patchelf'
-RUN /bin/bash -c 'rm -rf patchelf-0.18.0-armv7l'
-RUN /bin/bash -c 'rm patchelf-0.18.0-armv7l.tar.gz'
+RUN /bin/bash -c 'rm -rf patchelf-0.17.2-armv7l'
+RUN /bin/bash -c 'rm patchelf-0.17.2-armv7l.tar.gz'
 
 # Install auditwheel for delocation
 RUN /bin/bash -c 'pip install auditwheel'

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -25,9 +25,9 @@ RUN /bin/bash -c 'if [ "$(lsb_release -cs)" = "buster" ]; then \
 
 
 # Install patchelf (needed during delocation)
-RUN /bin/bash -c 'wget https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-armv7l.tar.gz'
-RUN /bin/bash -c 'tar -xvf patchelf-0.17.2-armv7l.tar.gz -C /'
-RUN /bin/bash -c 'rm patchelf-0.17.2-armv7l.tar.gz'
+RUN /bin/bash -c 'wget https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-armv7l.tar.gz'
+RUN /bin/bash -c 'tar -xvf patchelf-0.18.0-armv7l.tar.gz -C /'
+RUN /bin/bash -c 'rm patchelf-0.18.0-armv7l.tar.gz'
 
 # Install auditwheel for delocation
 RUN /bin/bash -c 'pip install auditwheel'

--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -44,13 +44,13 @@ RUN ./tools/build_linux_dependencies.sh
 RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL2=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 # Delocate the wheel.
-# if we're on buster, platform is manylinux_2_28_armv7l, if bullseye, manylinux_2_31_armv7l, otherwise let's just try manylinux2014_armv7l
+# buster: manylinux_2_28_armv7l, bullseye: manylinux_2_31_armv7l, bookworm: manylinux_2_35_armv7l
 RUN /bin/bash -c 'if [ "$(lsb_release -cs)" = "buster" ]; then \
         MANYLINUX_PLATFORM=manylinux_2_28_armv7l; \
     elif [ "$(lsb_release -cs)" = "bullseye" ]; then \
         MANYLINUX_PLATFORM=manylinux_2_31_armv7l; \
-    else \
-        MANYLINUX_PLATFORM=manylinux2014_armv7l; \
+    elif [ "$(lsb_release -cs)" = "bookworm" ]; then \
+        MANYLINUX_PLATFORM=manylinux_2_35_armv7l; \
     fi; \
     auditwheel repair /kivy-wheel/Kivy-*.whl -w /kivy-delocated-wheel --plat "$MANYLINUX_PLATFORM" --no-update-tags --exclude libbrcmGLESv2.so --exclude libbcm_host.so --exclude libbrcmEGL.so'
 

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        docker_images: ['balenalib/raspberrypi3-debian-python:3.7-buster', 'balenalib/raspberrypi3-debian-python:3.9-bullseye']
+        docker_images: ['balenalib/raspberrypi3-debian-python:3.7-buster', 'balenalib/raspberrypi3-debian-python:3.9-bullseye', 'balenalib/raspberrypi3-debian-python:3.11-bookworm']
     steps:
     - uses: actions/checkout@v3
     - name: Generate version metadata

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -54,9 +54,10 @@ If no wheels are available ``pip`` will build the package from sources (i.e. on 
 Alternatively, installing :ref:`from source<kivy-source-install>` is required for newer Python versions not listed
 above or if the wheels do not work or fail to run properly.
 
-On RPi, when using a 32 bit OS, wheels are provided for Python 3.7 (Raspberry Pi OS Buster) and Python 3.9 (Raspberry Pi OS Bullseye),
-via the `PiWheels <https://www.piwheels.org/>`_ project. For other Python versions, on 32 bit OSes, you will need to
-install from source.
+On RPi, when using a 32 bit OS, wheels are provided for Python 3.7 (Raspberry Pi OS Buster), Python 3.9 (Raspberry Pi OS Bullseye)
+and Python 3.11 (Raspberry Pi OS Bookworm) via the `PiWheels <https://www.piwheels.org/>`_ project.
+
+For other Python versions, on 32 bit OSes, you will need to install from source.
 
 
 Setup terminal and pip
@@ -120,6 +121,15 @@ from the kivy-team provided PyPi wheels. Simply do::
 This also installs the minimum dependencies of Kivy. To additionally install Kivy with
 **audio/video** support, install either ``kivy[base,media]`` or ``kivy[full]``.
 See :ref:`Kivy's dependencies<kivy-dependencies>` for the list of selectors.
+
+.. note::
+
+    When using Raspberry Pi OS Lite or similar Linux-based headless systems, it may be necessary to install additional 
+    dependencies to ensure Kivy functions properly.
+
+    For instance, on Raspberry Pi OS Lite, you will be required to install the following dependencies::
+
+        apt-get install libgl1-mesa-glx libgles2-mesa libegl1-mesa libmtdev1
 
 .. _kivy-source-install:
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -18,7 +18,7 @@ Installing Python
 
 Python and python-pip must be installed from the package manager:
 
-Raspberry Pi OS Buster/Bullseye
+Raspberry Pi OS Buster/Bullseye/Bookworm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using apt::
@@ -54,7 +54,7 @@ To install Kivy from source, please follow the :ref:`installation guide<kivy-whe
 :ref:`Kivy install step<kivy-source-install>` and then install the dependencies below
 before continuing.
 
-Raspberry Pi OS Buster/Bullseye
+Raspberry Pi OS Buster/Bullseye/Bookworm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using apt::
@@ -77,11 +77,11 @@ Using apt::
         apt-get -y install -t buster-backports cmake; \
     fi
 
-Cross-Compilation for Raspberry Pi OS Buster/Bullseye (32 bit)
+Cross-Compilation for Raspberry Pi OS Buster/Bullseye/Bookworm (32 bit)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Kivy performs a dockerized cross-compilation for Raspberry Pi OS Buster/Bullseye (32 bit) wheels.
-The base images used for cross-compilation are the `balenalib`_ images for raspberrypi3 (buster and bullseye).
+Kivy performs a dockerized cross-compilation for Raspberry Pi OS Buster/Bullseye/Bookworm (32 bit) wheels.
+The base images used for cross-compilation are the `balenalib`_ images for raspberrypi3 (buster, bullseye and bookworm).
 
 .. _balenalib: https://www.balena.io/docs/reference/base-images/base-images-ref/
 
@@ -100,6 +100,9 @@ To cross-compile the wheels, you need to run the following commands::
 
     # Generate wheels for Raspberry Pi OS Bullseye (32 bit, Python 3.9)
     generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.9-bullseye
+
+    # Generate wheels for Raspberry Pi OS Bookworm (32 bit, Python 3.11)
+    generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.11-bookworm
 
 
 Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

The newer Raspberry Pi OS has been released 2 weeks ago, and a new RPi wheel has been already requested via #8416 .

This PR adds `balenalib/raspberrypi3-debian-python:3.11-bookworm` to our build matrix, so a compatible wheel can be produced.

The docs have been updated accordingly, and a note section has been added for headless environments, where some additional dependencies have to be installed.

(When a new Kivy version gets released, we will also need to send this artifact to piwheels maintainer)

Tested on:
✅  Raspberry Pi 4 + Raspberry Pi OS 5.0 32 bit (Bookworm) - Python 3.11
✅ Raspberry Pi 4 + Raspberry Pi OS 5.0 Lite 32 bit (Bookworm) - Python 3.11