### PR TITLE
Fixes markup `[sup]` followed by `[sub]` doesn't work (issue #8077)

### DIFF
--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -484,12 +484,13 @@ class MarkupLabel(MarkupLabelBase):
                 wh = options['line_height'] * word.lh
                 # calculate sub/super script pos
                 if options['script'] == 'superscript':
-                    script_pos = max(0, psp if psp and (wh<pph) else self.get_descent())
+                    script_pos = max(0, psp if psp and (wh < pph)
+                                     else self.get_descent())
                     psp = script_pos
                     pph = wh
                 elif options['script'] == 'subscript':
                     script_pos = min(lh - wh, ((psp + pph) - wh)
-                                     if pph and (wh<pph) else (lh - wh))
+                                     if pph and (wh < pph) else (lh - wh))
                     pph = wh
                     psp = script_pos
                 else:

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -484,12 +484,12 @@ class MarkupLabel(MarkupLabelBase):
                 wh = options['line_height'] * word.lh
                 # calculate sub/super script pos
                 if options['script'] == 'superscript':
-                    script_pos = max(0, psp if psp else self.get_descent())
+                    script_pos = max(0, psp if psp and (wh<pph) else self.get_descent())
                     psp = script_pos
                     pph = wh
                 elif options['script'] == 'subscript':
                     script_pos = min(lh - wh, ((psp + pph) - wh)
-                                     if pph else (lh - wh))
+                                     if pph and (wh<pph) else (lh - wh))
                     pph = wh
                     psp = script_pos
                 else:


### PR DESCRIPTION
Made changes to `markup.py` to fix #8077

Fix was to add a condition `wh < pph` to the logic used to calculate `script_pos` for sub-/superscript in `render_lines` method.  This means the "if condition" is only evaluated when nested, otherwise the "else condition" is evaluated and used in the calculation.

Tested with the following file, which builds on the test script in the original issue report:
[Issue8077_test.zip](https://github.com/kivy/kivy/files/13257789/Issue8077_test.zip)

Output display, showing multiple variations of sub and sup, including nested conditions:
<img width="161" alt="image" src="https://github.com/kivy/kivy/assets/123660683/0240111c-cdfb-4f88-a895-f0b6d732191c">

Please let me know if there are any other tests I should run (I did not see anything in the documentation), additional changes that need to be make, or if I should make the pull request against a different branch.
 
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
