### PR TITLE
Make Code Of Conduct, Readme and setup.py consistent with other docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,7 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+In the interest of fostering an open and welcoming environment, the Kivy team
+have committed to a Code of Conduct.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
-
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at kivy-users@googlegroups.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+Full details are available in the latest 
+[Contribution Guidelines](https://kivy.org/doc/master/contribute.html).

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Kivy
 
 <img align="right" height="256" src="https://raw.githubusercontent.com/kivy/kivy/master/kivy/data/logo/kivy-icon-256.png"/>
 
-[Kivy](http://kivy.org) is an open-source Python framework for developing 
-GUI apps that work cross-platform, including desktop, mobile and embedded 
-platforms.
+[Kivy](https://kivy.org) is an open-source [Python](https://www.python.org/)
+framework for developing GUI apps that work cross-platform, including desktop, 
+mobile and embedded platforms.
 
 The aim is to allow for quick and easy interaction design and rapid prototyping
 whilst making your code reusable and deployable: Innovative user interfaces made
 easy.
 
-Kivy is written in Python and [Cython](http://cython.org/), supports various input devices and
+Kivy is written in Python and [Cython](https://cython.org/), supports various input devices and
 has an extensive (and extensible) widget library. With the
-same codebase, you can target Windows, OSX, Linux, Android, iOS and Raspberry
-Pi. All Kivy widgets are built with multitouch support.
+same codebase, you can target Windows, macOS, Linux (including Raspberry Pi OS),
+Android and iOS. All Kivy widgets are built with multitouch support.
 
 Kivy is MIT licensed, actively developed by a great community and is supported
 by many projects managed by the [Kivy Organization](https://kivy.org/#organization).
@@ -106,18 +106,17 @@ Licenses
   and is licensed under the terms of the
   [LGPLv2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1).
 
-## Financial Contributors
+## Contributors
 
-This project exists thanks to all the people who donate. [[Donate](.github/CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute.
+[[Become a contributor](https://kivy.org/doc/master/contribute.html)]
 <a href="https://github.com/kivy/kivy/graphs/contributors"><img src="https://opencollective.com/kivy/contributors.svg?width=890&button=false" /></a>
-
 
 ## Backers
 
 Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/kivy#backer)]
 
 <a href="https://opencollective.com/kivy#backers" target="_blank"><img src="https://opencollective.com/kivy/backers.svg?width=890"></a>
-
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -133,3 +133,25 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 <a href="https://opencollective.com/kivy/sponsor/7/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/7/avatar.svg"></a>
 <a href="https://opencollective.com/kivy/sponsor/8/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/kivy/sponsor/9/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/9/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/10/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/10/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/11/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/11/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/12/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/12/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/13/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/13/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/14/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/14/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/15/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/15/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/16/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/16/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/17/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/17/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/18/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/18/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/19/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/19/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/20/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/20/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/21/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/21/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/22/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/22/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/23/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/23/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/24/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/24/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/25/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/25/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/26/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/26/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/27/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/27/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/28/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/28/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/29/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/29/avatar.svg"></a>
+<a href="https://opencollective.com/kivy/sponsor/30/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/30/avatar.svg"></a>
+

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The aim is to allow for quick and easy interaction design and rapid prototyping
 whilst making your code reusable and deployable: Innovative user interfaces made
 easy.
 
-Kivy is written in Python and [Cython](https://cython.org/), supports various input devices and
-has an extensive (and extensible) widget library. With the
+Kivy is written in Python and [Cython](https://cython.org/) and is built on
+[OpenGL ES 2.0](https://www.khronos.org/opengles/). It supports various input 
+devices and has an extensive (and extensible) widget library. With the
 same codebase, you can target Windows, macOS, Linux (including Raspberry Pi OS),
 Android and iOS. All Kivy widgets are built with multitouch support.
 

--- a/README.md
+++ b/README.md
@@ -3,29 +3,34 @@ Kivy
 
 <img align="right" height="256" src="https://raw.githubusercontent.com/kivy/kivy/master/kivy/data/logo/kivy-icon-256.png"/>
 
-Innovative user interfaces made easy.
+[Kivy](http://kivy.org) is an open-source Python framework for developing 
+GUI apps that work cross-platform, including desktop, mobile and embedded 
+platforms.
 
-Kivy is an open source, cross-platform [Python](https://www.python.org)
-framework for the development of applications that make use of innovative,
-multi-touch user interfaces.
 The aim is to allow for quick and easy interaction design and rapid prototyping
-whilst making your code reusable and deployable.
+whilst making your code reusable and deployable: Innovative user interfaces made
+easy.
 
-Kivy is written in Python and [Cython](http://cython.org/), based on OpenGL ES
-2, supports various input devices and has an extensive widget library. With the
-same codebase, you can target Windows, macOS, Linux, Android and iOS. All Kivy
-widgets are built with multitouch support.
+Kivy is written in Python and [Cython](http://cython.org/), supports various input devices and
+has an extensive (and extensible) widget library. With the
+same codebase, you can target Windows, OSX, Linux, Android, iOS and Raspberry
+Pi. All Kivy widgets are built with multitouch support.
 
 Kivy is MIT licensed, actively developed by a great community and is supported
 by many projects managed by the [Kivy Organization](https://kivy.org/#organization).
 
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
-[![Coverage Status](https://coveralls.io/repos/kivy/kivy/badge.svg?branch=master)](https://coveralls.io/r/kivy/kivy?branch=master)
+![PyPI - Version](https://img.shields.io/pypi/v/kivy)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/kivy)
+
 [![Windows Unittests Status](https://github.com/kivy/kivy/workflows/Windows%20Unittests/badge.svg)](https://github.com/kivy/kivy/actions?query=workflow%3A%22Windows+Unittests%22)
 [![Ubuntu Unittests Status](https://github.com/kivy/kivy/workflows/Ubuntu%20Unittests/badge.svg)](https://github.com/kivy/kivy/actions?query=workflow%3A%22Ubuntu+Unittests%22)
 [![OSX Unittests Status](https://github.com/kivy/kivy/workflows/OSX%20Unittests/badge.svg)](https://github.com/kivy/kivy/actions?query=workflow%3A%22OSX+Unittests%22)
+[![Coverage Status](https://coveralls.io/repos/kivy/kivy/badge.svg?branch=master)](https://coveralls.io/r/kivy/kivy?branch=master)
+
 [![Windows wheels Status](https://github.com/kivy/kivy/workflows/Windows%20wheels/badge.svg)](https://github.com/kivy/kivy/actions?query=workflow%3A%22Windows+wheels%22)
 [![Manylinux wheels Status](https://github.com/kivy/kivy/workflows/Manylinux%20wheels/badge.svg)](https://github.com/kivy/kivy/actions?query=workflow%3A%22Manylinux+wheels%22)
 [![Raspberry Pi wheels Status](https://github.com/kivy/kivy/workflows/RPi%20wheels/badge.svg)](https://github.com/kivy/kivy/actions?query=workflow%3A%22RPi+wheels%22)
@@ -43,33 +48,29 @@ Kivy ships with many examples which can be found in the `examples` folder.
 Support
 -------
 
-If you need help, please feel free to seek assistance through our support channels:
+Are you having trouble using the Kivy framework, or any of its related projects?
+Is there an error you don’t understand? Are you trying to figure out how to use 
+it? We have volunteers who can help!
 
-- Join the [Kivy Users Google Group](https://groups.google.com/group/kivy-users).
-- Ask questions using [discussions](https://github.com/orgs/kivy/discussions/new?category=q-a) on github
-- Use support-channels on our official [Discord](https://chat.kivy.org) server.
-
+The best channels to contact us for support are listed in the latest 
+[Contact Us](https://kivy.org/doc/master/contact.html) section in the 
+documentation.
 
 Contributing
 ------------
 
 We love pull requests and discussing novel ideas. Check out our
-[contribution guide](https://kivy.org/docs/contribute.html) and
+[latest contribution guide](https://kivy.org/doc/master/contribute.html) and
 feel free to improve Kivy.
 
-The following mailing list and Discord channel are used exclusively for
-discussions about developing the Kivy framework and its sister projects:
+It gives details of the best places online to discuss the development with the
+core developers and other enthusiasts.
 
-* Dev Group : https://groups.google.com/group/kivy-dev
-* Email     : kivy-dev@googlegroups.com
+Sibling projects
+----------------
 
-Discord channel:
-
-* Server     : https://chat.kivy.org
-* Channel    : #dev
-
-Sister projects
----------------
+The Kivy team manager a number of additional projects that support the Kivy 
+eco-system.
 
 - [Buildozer](https://github.com/kivy/buildozer): generic Python packager
   for Android and iOS.
@@ -105,9 +106,9 @@ Licenses
   and is licensed under the terms of the
   [LGPLv2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1).
 
-## Contributors
+## Financial Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
+This project exists thanks to all the people who donate. [[Donate](.github/CONTRIBUTING.md)].
 <a href="https://github.com/kivy/kivy/graphs/contributors"><img src="https://opencollective.com/kivy/contributors.svg?width=890&button=false" /></a>
 
 
@@ -132,5 +133,3 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 <a href="https://opencollective.com/kivy/sponsor/7/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/7/avatar.svg"></a>
 <a href="https://opencollective.com/kivy/sponsor/8/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/kivy/sponsor/9/website" target="_blank"><img src="https://opencollective.com/kivy/sponsor/9/avatar.svg"></a>
-
-

--- a/setup.py
+++ b/setup.py
@@ -1158,8 +1158,9 @@ if not build_examples:
         },
         license='MIT',
         description=(
-            'A software library for rapid development of '
-            'hardware-accelerated multitouch applications.'),
+            'An open-source Python framework for developing '
+            'GUI apps that work cross-platform, including '
+            'desktop, mobile and embedded platforms.'),
         long_description=get_description(),
         long_description_content_type='text/markdown',
         ext_modules=ext_modules,


### PR DESCRIPTION
These documents duplicate information stored elsewhere. Bring them up-to-date:

* Change CODE_OF_CONDUCT.md to to point to Contribution Guidelines.

* Make Kivy tag line in README consistent with FAQ and Discussions.

* Change README to point to Contact us and Contributions pages.

* Also, add a few more useful badges, and tidy them up.

* Make setup.py/PyPI description consistent with new README.

* Minor copy-edits. Mention Raspberry Pi. Gender-neutral language, Stop mentioning OpenGL ES 2.

Note: Some links are to MASTER documents, not STABLE, where they are not linked to releases and may change faster than that.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
