### PR TITLE
Deprecate `kivy.utils.interpolate` and improve related docs

### DIFF
--- a/kivy/tests/test_utils.py
+++ b/kivy/tests/test_utils.py
@@ -5,10 +5,7 @@ utils tests
 
 import os
 import unittest
-try:
-    from unittest.mock import patch   # python 3.x
-except:
-    from mock import patch   # python 2.x
+from unittest.mock import patch
 
 from kivy.utils import (boundary, escape_markup, format_bytes_to_human,
         is_color_transparent, SafeList, get_random_color, get_hex_from_color,

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -331,6 +331,7 @@ def deprecated(func=None, msg=''):
         return func(*args, **kwargs)
     return new_func
 
+
 @deprecated
 def interpolate(value_from, value_to, step=10):
     '''Interpolate between two values, by providing the
@@ -351,7 +352,6 @@ def interpolate(value_from, value_to, step=10):
         return out
     else:
         return value_from + (value_to - value_from) / float(step)
-
 
 
 class SafeList(list):
@@ -393,7 +393,8 @@ class QueryDict(dict):
         try:
             return self.__getitem__(attr)
         except KeyError:
-            return super(QueryDict, self).__getattr__(attr)
+            raise AttributeError("%r object has no attribute %r" % (
+                self.__class__.__name__self, attr))
 
     def __setattr__(self, attr, value):
         self.__setitem__(attr, value)

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -18,7 +18,8 @@ __all__ = ('intersection', 'difference', 'strtotuple',
            'is_color_transparent', 'hex_colormap', 'colormap', 'boundary',
            'deprecated', 'SafeList',
            'interpolate', 'QueryDict',
-           'platform', 'escape_markup', 'reify', 'rgba', 'pi_version')
+           'platform', 'escape_markup', 'reify', 'rgba', 'pi_version',
+           'format_bytes_to_human')
 
 from os import environ, path
 from sys import platform as _sys_platform

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -41,29 +41,6 @@ def difference(set1, set2):
     return [s for s in set1 if s not in set2]
 
 
-def interpolate(value_from, value_to, step=10):
-    '''Interpolate between two values. This can be useful for smoothing some
-    transitions. For example::
-
-        # instead of setting directly
-        self.pos = pos
-
-        # use interpolate, and you'll have a nicer transition
-        self.pos = interpolate(self.pos, new_pos)
-
-    .. warning::
-        These interpolations work only on lists/tuples/doubles with the same
-        dimensions. No test is done to check the dimensions are the same.
-    '''
-    if type(value_from) in (list, tuple):
-        out = []
-        for x, y in zip(value_from, value_to):
-            out.append(interpolate(x, y, step))
-        return out
-    else:
-        return value_from + (value_to - value_from) / float(step)
-
-
 def strtotuple(s):
     '''Convert a tuple string into a tuple
     with some security checks. Designed to be used
@@ -352,6 +329,28 @@ def deprecated(func=None, msg=''):
                 Logger.warning(func.__doc__)
         return func(*args, **kwargs)
     return new_func
+
+@deprecated
+def interpolate(value_from, value_to, step=10):
+    '''Interpolate between two values, by providing the
+    reciprocal of the proportion between two points.
+
+    .. deprecated:: 2.3.0
+        For animations, consider using the
+        `AnimationTransition.linear()` for a similar purpose.
+
+    .. warning::
+        These interpolations work only on lists/tuples/doubles with the same
+        dimensions. No test is done to check the dimensions are the same.
+    '''
+    if type(value_from) in (list, tuple):
+        out = []
+        for x, y in zip(value_from, value_to):
+            out.append(interpolate(x, y, step))
+        return out
+    else:
+        return value_from + (value_to - value_from) / float(step)
+
 
 
 class SafeList(list):


### PR DESCRIPTION
1) #2788 discusses in detail why `interpolate()` and should be deprecated. This PR deprecates it.
2) `QueryDict` handled missing attributes wrongly. Corrected.
3) `convert_bytes_to_human` was arbitrarily left out of `__all__`. Added in.
4) Some Python 2 imports remained. Cleaned those out.


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
