### PR TITLE
Rectifying event consumption in `on_touch_down`

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -583,8 +583,13 @@ class Widget(WidgetBase):
             If False, the event will continue to be dispatched to the rest
             of the widget tree.
         '''
-        if self.disabled and self.collide_point(*touch.pos):
-            return True
+        if not self.collide_point(*touch.pos):
+            return
+        if self.disabled:
+            if self.opacity == 0:
+                return
+            else:
+                return True
         for child in self.children[:]:
             if child.dispatch('on_touch_down', touch):
                 return True


### PR DESCRIPTION
This commit tries to rectify the assumption that a disabled widget having a touch collision should consume the event. This shall only be true if the widget is visible and disabled and not when the widget is disabled and not visible at all. This helps in a lot of scenarios where due to design constraints and animations, one widget might come on top of another while being hidden completely. As Kivy doesn't have equivalent feature of `pointer-events` or `z-index`, so we shouldn't consume the event if the widget is hidden.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
