### PR TITLE
`SetClipboardData` requires a memory object allocated with `GMEM_MOVEABLE` (and locks)

### DIFF
--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -73,7 +73,7 @@ class ClipboardWindows(ClipboardBase):
 
         # The wsclen function returns the number of
         # wide characters in a string (not including the null character)
-        text_len = msvcrt.wcslen(text)
+        text_len = msvcrt.wcslen(text) + 1
 
         # According to the docs regarding SetClipboardDatam, if the hMem
         # parameter identifies a memory object, the object must have
@@ -82,13 +82,18 @@ class ClipboardWindows(ClipboardBase):
         # The size of the memory object is the number of wide characters in
         # the string plus one for the terminating null character
         hCd = GlobalAlloc(
-            GMEM_MOVEABLE, ctypes.sizeof(ctypes.c_wchar) * (text_len + 1)
+            GMEM_MOVEABLE, ctypes.sizeof(ctypes.c_wchar) * text_len
         )
 
         # Since the memory object is allocated with GMEM_MOVEABLE, should be
         # locked to get the actual pointer to the data.
         hCd_locked = GlobalLock(hCd)
-        msvcrt.wcscpy(c_wchar_p(hCd_locked), text)
+        # msvcrt.wcscpy(c_wchar_p(hCd_locked), text)
+        ctypes.memmove(
+            c_wchar_p(hCd_locked),
+            c_wchar_p(text),
+            ctypes.sizeof(ctypes.c_wchar) * text_len,
+        )
         GlobalUnlock(hCd)
 
         # Finally, set the clipboard data (and then close the clipboard)

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -32,6 +32,10 @@ GMEM_MOVEABLE = 0x0002
 
 class ClipboardWindows(ClipboardBase):
 
+    def _copy(self, data):
+        self._ensure_clipboard()
+        self.put(data, self._clip_mime_type)
+
     def get(self, mimetype='text/plain'):
         GetClipboardData = user32.GetClipboardData
         GetClipboardData.argtypes = [wintypes.UINT]

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -92,7 +92,6 @@ class ClipboardWindows(ClipboardBase):
         # Since the memory object is allocated with GMEM_MOVEABLE, should be
         # locked to get the actual pointer to the data.
         hCd_locked = GlobalLock(hCd)
-        # msvcrt.wcscpy(c_wchar_p(hCd_locked), text)
         ctypes.memmove(
             c_wchar_p(hCd_locked),
             c_wchar_p(text),

--- a/kivy/core/clipboard/clipboard_winctypes.py
+++ b/kivy/core/clipboard/clipboard_winctypes.py
@@ -18,6 +18,17 @@ msvcrt = ctypes.cdll.msvcrt
 c_char_p = ctypes.c_char_p
 c_wchar_p = ctypes.c_wchar_p
 
+GlobalLock = kernel32.GlobalLock
+GlobalLock.argtypes = [wintypes.HGLOBAL]
+GlobalLock.restype = wintypes.LPVOID
+
+GlobalUnlock = kernel32.GlobalUnlock
+GlobalUnlock.argtypes = [wintypes.HGLOBAL]
+GlobalUnlock.restype = wintypes.BOOL
+
+CF_UNICODETEXT = 13
+GMEM_MOVEABLE = 0x0002
+
 
 class ClipboardWindows(ClipboardBase):
 
@@ -27,20 +38,28 @@ class ClipboardWindows(ClipboardBase):
         GetClipboardData.restype = wintypes.HANDLE
 
         user32.OpenClipboard(user32.GetActiveWindow())
-        # Standard Clipboard Format "1" is "CF_TEXT"
-        pcontents = GetClipboardData(13)
+
+        # GetClipboardData returns a HANDLE to the clipboard data
+        # which is a memory object containing the data
+        # See: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getclipboarddata  # noqa: E501
+        pcontents = GetClipboardData(CF_UNICODETEXT)
 
         # if someone pastes a FILE, the content is None for SCF 13
         # and the clipboard is locked if not closed properly
         if not pcontents:
             user32.CloseClipboard()
             return ''
-        data = c_wchar_p(pcontents).value.encode(self._encoding)
+
+        # The handle returned by GetClipboardData is a memory object
+        # and needs to be locked to get the actual pointer to the data
+        pcontents_locked = GlobalLock(pcontents)
+        data = c_wchar_p(pcontents_locked).value
+        GlobalUnlock(pcontents)
+
         user32.CloseClipboard()
         return data
 
-    def put(self, text, mimetype='text/plain'):
-
+    def put(self, text, mimetype="text/plain"):
         SetClipboardData = user32.SetClipboardData
         SetClipboardData.argtypes = [wintypes.UINT, wintypes.HANDLE]
         SetClipboardData.restype = wintypes.HANDLE
@@ -52,20 +71,27 @@ class ClipboardWindows(ClipboardBase):
         user32.OpenClipboard(user32.GetActiveWindow())
         user32.EmptyClipboard()
 
-        # this allocates memory for the string and returns a handle to it
-        # allocates fixed memory, len + 2 is for the null character
-        # no need to  call GlobalFree here as SetClipboardData will do for you
-        # noqa: E501 see: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata#parameters
-        GMEM_FIXED = 0x0000
-        hCd = GlobalAlloc(GMEM_FIXED, len(text) + 2)
+        # The wsclen function returns the number of
+        # wide characters in a string (not including the null character)
+        text_len = msvcrt.wcslen(text)
 
-        # copy the string into the allocated memory
-        msvcrt.wcscpy(c_wchar_p(hCd), text)
+        # According to the docs regarding SetClipboardDatam, if the hMem
+        # parameter identifies a memory object, the object must have
+        # been allocated using the GMEM_MOVEABLE flag.
+        # See: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata  # noqa: E501
+        # The size of the memory object is the number of wide characters in
+        # the string plus one for the terminating null character
+        hCd = GlobalAlloc(
+            GMEM_MOVEABLE, ctypes.sizeof(ctypes.c_wchar) * (text_len + 1)
+        )
 
-        # standard clipboard format for unicode text
-        # noqa: E501 see https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats#constants
-        CF_UNICODETEXT = 13
-        # set the clipboard data, later used by GetClipboardData()
+        # Since the memory object is allocated with GMEM_MOVEABLE, should be
+        # locked to get the actual pointer to the data.
+        hCd_locked = GlobalLock(hCd)
+        msvcrt.wcscpy(c_wchar_p(hCd_locked), text)
+        GlobalUnlock(hCd)
+
+        # Finally, set the clipboard data (and then close the clipboard)
         SetClipboardData(CF_UNICODETEXT, hCd)
         user32.CloseClipboard()
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


As per [Microsoft Docs regarding SetClipboardData](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata), if the hMem parameter (the handle) identifies a memory object (and that applies to our implementation), the object must have been allocated using the function with the `GMEM_MOVEABLE` flag.

Additionally, the handles returned by `GetClipboardData`, and the handle we create via `GlobalAlloc`, should be locked before getting accessed, to have the actual pointer of the data.

This fixes #8458 (and makes the CI happy)