### PR TITLE
ColorWheel/ColorPicker Clean up. Fixes #6585

### DIFF
--- a/kivy/tests/test_uix_colorpicker.py
+++ b/kivy/tests/test_uix_colorpicker.py
@@ -1,0 +1,77 @@
+"""
+Color Wheel and Color Picker Tests
+==================================
+"""
+
+from kivy.tests.common import GraphicUnitTest, UTMotionEvent
+from kivy.uix.colorpicker import ColorWheel, ColorPicker
+
+
+class ColorWheelTest(GraphicUnitTest):
+    def test_render(self):
+        color_wheel = ColorWheel()
+        self.render(color_wheel)
+
+    def test_clicks(self):
+        color_wheel = ColorWheel()
+
+        # ColorPicker has a stated default colour (opaque white).
+        # ColorWheel has a different default Color (transparent black).
+        self.assertEqual(color_wheel.color, [0, 0, 0, 0])
+
+        # Click on corner of widget
+        pos = (color_wheel.pos[0], color_wheel.pos[1])
+        touch = UTMotionEvent(
+            "unittest",
+            1,
+            {
+                "x": pos[0],
+                "y": pos[1],
+            },
+        )
+        touch.grab_current = color_wheel
+        touch.pos = pos
+
+        color_wheel.on_touch_down(touch)
+        color_wheel.on_touch_up(touch)
+
+        # Too far from the center. No effect.
+        self.assertEqual(color_wheel.color, [0, 0, 0, 0])
+
+        pos = (
+            color_wheel.pos[0] + color_wheel.size[0] / 2,
+            color_wheel.pos[1] + color_wheel.size[1] / 4,
+        )
+        # Click in middle, half-the-radius up.
+        touch = UTMotionEvent(
+            "unittest",
+            1,
+            {"x": pos[0], "y": pos[1]},
+        )
+        touch.grab_current = color_wheel
+        touch.pos = pos
+
+        color_wheel.on_touch_down(touch)
+        color_wheel.on_touch_up(touch)
+
+        self.assertEqual(color_wheel.color, [0.75, 0.5, 1, 1])
+
+
+class ColorPickerTest(GraphicUnitTest):
+    def test_render(self):
+        color_picker = ColorPicker()
+        self.render(color_picker)
+
+    def test_set_colour(self):
+        color_picker = ColorPicker()
+        # ColorPicker has a stated default colour (opaque white).
+        # ColorWheel has a different default Color (transparent black).
+        self.assertEqual(color_picker.color, [1, 1, 1, 1])
+
+        # Set without alpha
+        color_picker.set_color((0.5, 0.6, 0.7))
+        self.assertEqual(color_picker.color, [0.5, 0.6, 0.7, 1])
+
+        # Set with alpha
+        color_picker.set_color((0.5, 0.6, 0.7, 0.8))
+        self.assertEqual(color_picker.color, [0.5, 0.6, 0.7, 0.8])


### PR DESCRIPTION
ColorWheel/ColorPicker had a number of issues addressed:

* Major changes:
  * `ColorWheel._hsv` was unused (and was an "attractive nuisance" for developers - see #6585).
     * Removed.
  * `ColorWheel` had attributes not defined in `__init__()`
     * Defined them.
  * `init_wheel()` had unused parameter (perhaps it was intended to be scheduled as a Clock event, but never was?)
     * Removed parameter.
  * `init_wheel()` was public, but doesn't need to be called by clients (and was an "attractive nuisance" for developers - see #6585).
     * Made private by adding underscore prefix.
  * `_init_wheel()` was misleading about its role, as it is may be called often.
     * Renamed to `_reset_canvas()`
  * Add basic unit-tests for Color Picker and Color Wheel.
     * Before,  `colorpicker.py` had 0% coverage! This is a long, long way from a complete set of unit-tests of each of the features of these Widgets. It now has 60% statement coverage, which is way too low, but 20% above the project average. It is enough to catch #6585 regressing.
  * ColorWheel: only Red had a stated default value in the documentation. This is important, because ColorPicker and ColorWheel differ over default values.
     * Added default values to default values to documentation

I considered whether to add back `init_wheel(dt)`, mark it deprecated and have it do nothing but `pass`, but the whole API is marked experimental, so I didn't feel the need.

* Trivial changes due to IDE style-checks complaining
  * Unnecessary parenthesis around tuples
      * Removed.
  * comparison expression could be simplified
     *  Simplified
  * Type-check was complaining about `max(0, float(text))`, which seems perfectly fine to me.
     * Changed it to max(0.0, float(text)), which shut up the type-checker, but also removed the need for several more calls to float().
  * Import order wasn't pep8 compliant
     * Sorted imports

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
