### PR TITLE
🐛 Fix #4951: Better handling of `do_backspace`, `do_undo` and `paste``

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2086,6 +2086,8 @@ class TextInput(FocusBehavior, Widget):
         self._ensure_clipboard()
         data = Clipboard.paste()
         self.delete_selection()
+        if not self.multiline:
+            data = data.replace('\n', ' ')
         self.insert_text(data)
 
     def _update_cutbuffer(self, *args):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -936,6 +936,7 @@ class TextInput(FocusBehavior, Widget):
                 substring = x_item['undo_command'][2:][0]
                 self.insert_text(substring, True)
             self._redo.append(x_item)
+            self.scroll_x = self.get_max_scroll_x()
         except IndexError:
             # reached at top of undo list
             pass
@@ -995,6 +996,7 @@ class TextInput(FocusBehavior, Widget):
             cursor_index,
             cursor_index - 1,
             substring, from_undo, mode)
+        self.scroll_x = self.get_max_scroll_x()
 
     def _set_unredo_bkspc(self, ol_index, new_index, substring, from_undo,
                           mode):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1420,6 +1420,16 @@ class TextInput(FocusBehavior, Widget):
 
         return cursor_x, cursor_y
 
+    def get_max_scroll_x(self):
+        '''
+        Return how many pixels it needs to scroll to the right
+        to reveal the remaining content of a text that extends
+        beyond the visible width of a TextInput
+        '''
+        minimum_width = self._get_row_width(0) + self.padding[0] + self.padding[2]
+        max_scroll_x = max(0, minimum_width - self.width)
+        return max_scroll_x
+
     #
     # Selection control
     #


### PR DESCRIPTION
This PR solves these `TextInput` issues:

1) `TextInput.scroll_x` was never updated after pressing `backspace` or `ctrl+z`, so any text before the cursor would be eventually unreadable.

```python
from kivy.app import runTouchApp
from kivy.lang import Builder

runTouchApp(Builder.load_string("""
FloatLayout:
    TextInput:
        size_hint: None, None



        size: 100, 30
        pos_hint: {'center_x': .5, 'center_y': .5}
        multiline: False
"""))
```

Before:

https://github.com/kivy/kivy/assets/23220309/fce51282-1ce0-4941-8434-356776339e95

Now:

https://github.com/kivy/kivy/assets/23220309/68617de9-60dd-46c1-af17-63df248c22b2

2) The `paste` function does not respect `multiline=False` currently. If you paste a multiline text in a `multiline=False` TextInput, it will still break lines, which should not be allowed. I propose to replace `'\n'` by whitespaces, so all lines will be joined in a single line. It means the user still can paste a multiline text, but all lines will be shown in a single line.

Before:

https://github.com/kivy/kivy/assets/23220309/49735a14-f14f-40cf-8da9-9bd68e3adc71

After:

https://github.com/kivy/kivy/assets/23220309/0b247a51-bc0d-41c4-b449-e0108bfa5c0e


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
