### PR TITLE
Bump `kivy_deps.angle` version to `~=0.4.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     Kivy-Garden>=0.1.4
     docutils
     pygments
-    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.angle~=0.4.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
@@ -52,7 +52,7 @@ base =
     requests
     docutils
     pygments
-    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.angle~=0.4.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
@@ -64,7 +64,7 @@ full =
     docutils
     pygments
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.angle~=0.4.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
@@ -73,7 +73,7 @@ gstreamer =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     # don't use 0.4.0 because it was deleted
 angle =
-    kivy_deps.angle~=0.3.3; sys_platform == "win32"
+    kivy_deps.angle~=0.4.0; sys_platform == "win32"
 sdl2 =
     kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
 glew =


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


See `kivy-sdk-packager` linked PR: https://github.com/kivy/kivy-sdk-packager/pull/99

`kivy_deps.angle~=0.4.0` offers support for Python `3.12`, and now tracks an updated `angle` branch, form one of the latest `chromium` stable releases.