### PR TITLE
Pillow: use get_bbox when get_size is not available. Allows latest versions of pillow to work along with older ones.

### DIFF
--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -34,11 +34,16 @@ class LabelPIL(LabelBase):
 
     def get_extents(self, text):
         font = self._select_font()
-        w, h = font.getsize(text)
+        try:
+            w, h = font.getsize(text)
+        except AttributeError:
+            left, top, right, bottom = font.getbbox(text)
+            w = right - left
+            h = bottom
         return w, h
 
     def get_cached_extents(self):
-        return self._select_font().getsize
+        return self.get_extents
 
     def _render_begin(self):
         # create a surface, context, font...


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
