### PR TITLE
Restrict the Pillow version to `>=9.5.0,<11`

### DIFF
--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -86,7 +86,7 @@ function Install-kivy-test-run-pip-deps {
 }
 
 function Install-kivy {
-    python -m pip install -e .[dev,full]
+    python -m pip install --prefer-binary -e .[dev,full]
 }
 
 function Install-kivy-wheel {

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -86,7 +86,7 @@ function Install-kivy-test-run-pip-deps {
 }
 
 function Install-kivy {
-    python -m pip install --prefer-binary -e .[dev,full]
+    python -m pip install --only-binary Pillow -e .[dev,full]
 }
 
 function Install-kivy-wheel {

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -124,6 +124,20 @@ See :ref:`Kivy's dependencies<kivy-dependencies>` for the list of selectors.
 
 .. note::
 
+    The ``Pillow`` library is a dependency of both ``kivy[base]`` and ``kivy[full]``.
+
+    For Windows 32-bit users, please note that the latest releases of `Pillow` are 
+    not available as binary distributions on PyPI. However, Kivy also supports ``Pillow==9.5.0``, 
+    which have a binary distribution for all supported Python versions, even on Windows 32-bit.
+
+    If you are on Windows 32-bit and prefer not to build Pillow from source, 
+    you can use the ``--only-binary Pillow`` flag with the following command to instruct pip 
+    to install the binary distribution of Pillow, albeit not the latest version::
+
+        python -m pip install --only-binary Pillow "kivy[base]"
+
+.. note::
+
     When using Raspberry Pi OS Lite or similar Linux-based headless systems, it may be necessary to install additional 
     dependencies to ensure Kivy functions properly.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ dev =
     pre-commit
     responses
 base =
-    pillow==9.5.0
+    pillow>=9.5.0,<11
     requests
     docutils
     pygments
@@ -60,7 +60,7 @@ media =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
 full =
-    pillow==9.5.0
+    pillow>=9.5.0,<11
     docutils
     pygments
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

- Leaving the `Pillow` version unpinned would open the risk of an incompatible version in the future, which may break the experience for our users.
- `9.x.x` series has been included, as we need to support `9.5.0` for `win32`.
- Documented ``--only-binary Pillow`` in installation docs, for Windows 32 bit users.