### PR TITLE
Filechooser widgets handle system files without logging errors

### DIFF
--- a/kivy/tests/test_filechooser.py
+++ b/kivy/tests/test_filechooser.py
@@ -1,11 +1,47 @@
+import logging
+from os import environ
+from os.path import expanduser, exists
+from sys import version_info
+import unittest
+
 from kivy.tests.common import GraphicUnitTest
+from kivy.uix.filechooser import FileChooserListView, FileChooserIconView
 
 
 class FileChooserTestCase(GraphicUnitTest):
-
     def test_filechooserlistview(self):
-        from kivy.uix.filechooser import FileChooserListView
-        from os.path import expanduser
         r = self.render
-        wid = FileChooserListView(path=expanduser('~'))
-        r(wid, 2)
+        widget = FileChooserListView(path=expanduser("~"))
+        r(widget, 2)
+
+    def test_filechoosericonview(self):
+        r = self.render
+        widget = FileChooserIconView(path=expanduser("~"), show_hidden=True)
+        r(widget, 2)
+
+    @unittest.skipIf(
+        ("SystemDrive" not in environ) or
+        (not exists(environ["SystemDrive"] + "\\pagefile.sys")),
+        "Only runs on Windows with example system file present",
+    )
+    @unittest.skipIf(
+        version_info < (3, 10), "assertNoLogs requires in Python 3.10"
+    )
+    def test_filechooser_files_in_use_5873(self):
+        # Per Kivy Issue #5873, initially viewing C:\ on Windows would
+        # crash.
+        # Later versions, it merely logged warnings.
+        # The cause was hidden system files which could not be interrogated to
+        # find out if they were hidden, because they were in use by the system.
+
+        # This variant always worked, because there was no call to is_hidden.
+        with self.assertNoLogs(logging.getLogger("kivy"), logging.WARNING):
+            widget = FileChooserListView(
+                path=environ["SystemDrive"] + "/", show_hidden=True
+            )
+            self.render(widget, 1)
+
+        # This used to fail, because the call to is_hidden logged errors.
+        with self.assertNoLogs(logging.getLogger("kivy"), logging.WARNING):
+            widget = FileChooserListView(path=environ["SystemDrive"] + "/")
+            self.render(widget, 1)


### PR DESCRIPTION
* Added failing test before implementing fix.
* Added super-basic iconview test, because the code is never exercised.
* Refactor is_hidden so it doesn't fail: Use built-in `os.stat` instead of win32file's `GetFileAttributesExW()` because it handles (in use) system files.
^ Fixes #5873
* Sort imports according to PEP8.
* Stop (conditionally) importing win32file.
* Add support for macOS's UF_Hidden attributes.
* Confirm new tests are now passing.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
