### PR TITLE
New feature: Add `limit_render_to_text_bbox` to `Label` to limit text rendering to the text bounding box, improving `Label` alignments.

### DIFF
--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -186,16 +186,16 @@ class LabelBase(object):
         `text_language`: str, defaults to None (user locale)
             RFC-3066 format language tag as a string (Pango only)
         `limit_render_to_text_bbox`: bool, defaults to False. PIL only.
-            If set to ``True``, this parameter indicates that rendering should be
-            limited to the bounding box of the text, excluding any additional
-            white spaces designated for ascent and descent.
+            If set to ``True``, this parameter indicates that rendering should
+            be limited to the bounding box of the text, excluding any
+            additional white spaces designated for ascent and descent.
             By limiting the rendering to the bounding box of the text, it
             ensures a more precise alignment with surrounding elements when
             utilizing properties such as `valign`, `y`, `pos`, `pos_hint`, etc.
 
     .. versionadded:: 2.3.0
-        `limit_render_to_text_bbox` was added to allow to limit text rendering to
-        the text bounding box (PIL only).
+        `limit_render_to_text_bbox` was added to allow to limit text rendering
+        to the text bounding box (PIL only).
 
     .. deprecated:: 2.2.0
         `padding_x` and `padding_y` have been deprecated. Please use `padding`

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -185,6 +185,17 @@ class LabelBase(object):
             or `'weak_rtl'` (Pango only)
         `text_language`: str, defaults to None (user locale)
             RFC-3066 format language tag as a string (Pango only)
+        `limit_render_to_text_bbox`: bool, defaults to False. PIL only.
+            If set to ``True``, this parameter indicates that rendering should be
+            limited to the bounding box of the text, excluding any additional
+            white spaces designated for ascent and descent.
+            By limiting the rendering to the bounding box of the text, it
+            ensures a more precise alignment with surrounding elements when
+            utilizing properties such as `valign`, `y`, `pos`, `pos_hint`, etc.
+
+    .. versionadded:: 2.3.0
+        `limit_render_to_text_bbox` was added to allow to limit text rendering to
+        the text bounding box (PIL only).
 
     .. deprecated:: 2.2.0
         `padding_x` and `padding_y` have been deprecated. Please use `padding`
@@ -249,6 +260,7 @@ class LabelBase(object):
         outline_width=None, outline_color=None, font_context=None,
         font_features=None, base_direction=None, font_direction='ltr',
         font_script_name='Latin', text_language=None,
+        limit_render_to_text_bbox=False,
         **kwargs):
 
         # Include system fonts_dir in resource paths.
@@ -273,7 +285,8 @@ class LabelBase(object):
                    'base_direction': base_direction,
                    'font_direction': font_direction,
                    'font_script_name': font_script_name,
-                   'text_language': text_language}
+                   'text_language': text_language,
+                   'limit_render_to_text_bbox': limit_render_to_text_bbox}
 
         kwargs_get = kwargs.get
         options['color'] = color or (1, 1, 1, 1)

--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -37,8 +37,11 @@ class LabelPIL(LabelBase):
         left, top, right, bottom = font.getbbox(text)
         ascent, descent = font.getmetrics()
 
+        if self.options['limit_render_to_text_bbox']:
+            h = bottom - top
+        else:
+            h = ascent + descent
         w = right - left
-        h = ascent + descent
 
         return w, h
 
@@ -52,6 +55,14 @@ class LabelPIL(LabelBase):
 
     def _render_text(self, text, x, y):
         color = tuple([int(c * 255) for c in self.options['color']])
+
+        # Adjust x and y position to avoid text cutoff
+        if self.options['limit_render_to_text_bbox']:
+            font = self._select_font()
+            bbox = font.getbbox(text)
+            x -= bbox[0]
+            y -= bbox[1]
+
         self._pil_draw.text((int(x), int(y)),
                             text, font=self._select_font(), fill=color)
 

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -311,7 +311,8 @@ class Label(Widget):
                         'split_str', 'ellipsis_options', 'unicode_errors',
                         'markup', 'font_hinting', 'font_kerning',
                         'font_blended', 'font_context', 'font_features',
-                        'base_direction', 'text_language')
+                        'base_direction', 'text_language',
+                        'limit_render_to_text_bbox')
 
     def __init__(self, **kwargs):
         self._trigger_texture = Clock.create_trigger(self.texture_update, -1)
@@ -1176,4 +1177,20 @@ class Label(Widget):
 
     :attr:`font_blended` is a :class:`~kivy.properties.BooleanProperty` and
     defaults to True.
+    '''
+
+    limit_render_to_text_bbox = BooleanProperty(False)
+    '''If set to ``True``, this parameter indicates that rendering should be
+    limited to the bounding box of the text, excluding any additional white
+    spaces designated for ascent and descent.
+    
+    By limiting the rendering to the bounding box of the text, it ensures a
+    more precise alignment with surrounding elements when utilizing properties
+    such as `valign`, `y`, `pos`, `pos_hint`, etc.
+
+    .. note::
+        This feature requires the PIL text provider.
+
+    :attr:`limit_render_to_text_bbox` is a
+    :class:`~kivy.properties.BooleanProperty` and defaults to False.
     '''

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -1183,7 +1183,7 @@ class Label(Widget):
     '''If set to ``True``, this parameter indicates that rendering should be
     limited to the bounding box of the text, excluding any additional white
     spaces designated for ascent and descent.
-    
+
     By limiting the rendering to the bounding box of the text, it ensures a
     more precise alignment with surrounding elements when utilizing properties
     such as `valign`, `y`, `pos`, `pos_hint`, etc.


### PR DESCRIPTION
This PR adds the `limit_render_to_text_bbox` property to the `Label` to limit the texture rendering to the text bounding box, allowing better control over positioning, and enabling more precise alignment of the Label in relation to other UI elements.

Currently there is no way adjust the label alignment properly, leading to imprecise results that are extremely difficult for the user to work around.

At the moment, support has been added only to the `PIL` text provider. But I believe that this feature should be expanded to other text providers in the future.

This PR is based on:
- https://github.com/kivy/kivy/pull/8511


### Demo:

https://github.com/kivy/kivy/assets/73297572/9cceb576-5881-4414-9b44-16ecae60568f







### Test code:

Note: Use "d" and "f" to change fonts.

```python
import os
os.environ['KIVY_TEXT'] = 'pil'

from kivy.lang import Builder
from kivy.app import App
from kivy.base import EventLoop


class MainApp(App):
    
    root_widget = Builder.load_string(r'''

FloatLayout
    BoxLayout:
        size_hint_y: None
        height: dp(100)
        orientation: "vertical"
        pos_hint: {"top": 1}
        TextInput:
            id: ti
            text: "a"
        ToggleButton:
            text: "limit_render_to_text_bbox"
            on_state:
                label_widget.limit_render_to_text_bbox = not self.state == "normal"

    FloatLayout:
        size_hint: 0.8, 0.5
        pos_hint: {"center_x": 0.5, "center_y": 0.5}
        canvas.before:
            Color:
                rgba: (0.5, 0.5, 0.5, 1)
            Rectangle:
                pos: self.pos
                size: self.size
            
            Color:
                rgba: (1, 0, 0, 1)
            Line:
                points: self.x, self.center_y, self.right, self.center_y
        
            
        Label:
            id: label_widget
            opacity: .5
            # text: (self.font_name.split('/')[-1], self.font_name)[0]
            text: ti.text
            font_size: sp(300)
            size_hint: None, None
            size: self.texture_size
            pos_hint: {"center_x": 0.5, "y": 0}
            limit_render_to_text_bbox: False

            canvas.before:
                Color:
                    rgba: (0, 0, 1, 1)
                Rectangle:
                    pos: self.pos
                    size: self.size
                                        
        BoxLayout:
            pos_hint: {"center_x": 0.5}
            size_hint_y: 0.25

            CheckBox:
                group: "pos"
                on_active:
                    label_widget.pos_hint = {"center_x": 0.5, "top": 1}
            CheckBox:
                group: "pos"
                on_active:
                    label_widget.pos_hint = {"center_x": 0.5, "center_y": 0.5}
            
            CheckBox:
                group: "pos"
                active: True
                active: True
                on_active:
                    label_widget.pos_hint = {"center_x": 0.5, "y": 0}

''')

    def build(self):
        EventLoop.window.bind(on_keyboard=self._hook_keyboard)
        return self.root_widget

    def _hook_keyboard(self, window, key, keycode, text, modifiers):
        # print('keyboard ays :', key, keycode, text, modifiers )

        if text == 'd':
            self.root.ids.label_widget.font_name = get_next_font(self.root.ids.label_widget.font_name, 'left')
        if text == 'f':
            self.root.ids.label_widget.font_name = get_next_font(self.root.ids.label_widget.font_name, 'right')


def get_font_list():
    import pathlib

    def get_fonts(fonts_path):
        '''Get a list of all the fonts available on this system.
        '''

        if not fonts_path: return []
        font_list = []
        for fdir in fonts_path:
            font_list += pathlib.Path(fdir).rglob('*.ttf')
        
        nflist = []
        for i, x in enumerate(font_list):
            if not str(x).split('/')[-1].startswith('._'):
                nflist.append(str(x))
        
        return sorted([*set(nflist)])
    
    from os.path import join, dirname, abspath
    from kivy.core.text import Label as CoreLabel

    return get_fonts(fonts_path = \
        [abspath(join(dirname(__file__), '..', 'data', 'fonts'))] +\
        CoreLabel.get_system_fonts_dir()
        )

font_list = get_font_list()

def get_next_font(pfont_name, l_r):
    try:
        idx = font_list.index(pfont_name)
    except ValueError:
        return font_list[0]

    try:
        font_name = str(font_list[idx +\
                                (-1 if l_r == 'left' else 1)])
    except IndexError:
        font_name = font_list[0]
    return font_name


if __name__ == '__main__':
    MainApp().run()
```

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
