### PR TITLE
`PIL` text provider: Ensure consistent text height to prevent text from bouncing when typing

### DIFF
--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -34,12 +34,12 @@ class LabelPIL(LabelBase):
 
     def get_extents(self, text):
         font = self._select_font()
-        try:
-            w, h = font.getsize(text)
-        except AttributeError:
-            left, top, right, bottom = font.getbbox(text)
-            w = right - left
-            h = bottom
+        left, top, right, bottom = font.getbbox(text)
+        ascent, descent = font.getmetrics()
+        
+        w = right - left
+        h = ascent + descent
+
         return w, h
 
     def get_cached_extents(self):

--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -36,7 +36,7 @@ class LabelPIL(LabelBase):
         font = self._select_font()
         left, top, right, bottom = font.getbbox(text)
         ascent, descent = font.getmetrics()
-        
+
         w = right - left
         h = ascent + descent
 


### PR DESCRIPTION
When using the `PIL` text provider to render text, the height of the text will be computed incorrectly. When typing text, for example, the text will be "jumping/bouncing". The code in this PR gets the actual height of the font, in order to get a consistent height for the text, and prevent this type of behavior from occurring.

### Before:

https://github.com/kivy/kivy/assets/73297572/fff1e1fb-3204-403d-a2ca-d10d9f4e8bf5




### After:

https://github.com/kivy/kivy/assets/73297572/fdab7f56-f941-457f-9e0c-88a8b9272f56

### Test code:

Note: Use "d" and "f" to change fonts.


```python
import os
os.environ['KIVY_TEXT'] = 'pil'


from kivy.core.window import Window
from kivy.app import App, Builder
from kivy.base import EventLoop

Window.clearcolor = (1, 1, 1, 1)


class TestApp(App):

    
    def build(self):
        EventLoop.window.bind(on_keyboard=self._hook_keyboard)

        return Builder.load_string(r"""

BoxLayout:
    TextInput:
        id: ti
        foreground_color: (0, 0, 0, 1)
        cursor_width: dp(2)
        font_size: dp(50)
        
    Label:
        id: label_widget
        text: ti.text
        color: (0, 0, 0, 1)
        font_size: dp(50)
        text_size: self.width ,None
        size_hint_y: None
        height: self.texture_size[1]
        pos_hint: {"center_x": 0.5,"center_y": 0.5}
        markup: True

        canvas.before:
            Color:
                rgba: (0, 0, 1, 0.5)
            Rectangle:
                pos: self.pos
                size: self.size

""")
    

    def _hook_keyboard(self, window, key, keycode, text, modifiers):
        if text == 'd':
            self.root.ids.ti.font_name = self.root.ids.label_widget.font_name = get_next_font(self.root.ids.label_widget.font_name, 'left')
        if text == 'f':
            self.root.ids.ti.font_name = self.root.ids.label_widget.font_name = get_next_font(self.root.ids.label_widget.font_name, 'right')

def get_font_list():
    import pathlib

    def get_fonts(fonts_path):
        '''Get a list of all the fonts available on this system.
        '''

        if not fonts_path: return []
        font_list = []
        for fdir in fonts_path:
            font_list += pathlib.Path(fdir).rglob('*.ttf')
        
        nflist = []
        for i, x in enumerate(font_list):
            if not str(x).split('/')[-1].startswith('._'):
                nflist.append(str(x))
        
        return sorted([*set(nflist)])
    
    from os.path import join, dirname, abspath
    from kivy.core.text import Label as CoreLabel

    return get_fonts(fonts_path = \
        [abspath(join(dirname(__file__), '..', 'data', 'fonts'))] +\
        CoreLabel.get_system_fonts_dir()
        )

font_list = get_font_list()

def get_next_font(pfont_name, l_r):
    try:
        idx = font_list.index(pfont_name)
    except ValueError:
        return font_list[0]

    try:
        font_name = str(font_list[idx +\
                                (-1 if l_r == 'left' else 1)])
    except IndexError:
        font_name = font_list[0]
    return font_name

if __name__ == "__main__":
    TestApp().run()
```


This PR also removes the deprecated `FreeTypeFont.getsize()`. `FreeTypeFont.getsize()` is deprecated since version [9.2.0](https://pillow.readthedocs.io/en/stable/releasenotes/9.2.0.html)




Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
