### PR TITLE
Make sure build dependencies are installed for Kivy.app, and use default python version provided by `create-osx-bundle.sh`

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -36,14 +36,13 @@ install_platypus() {
 }
 
 generate_osx_app_bundle() {
-  py_version="$1"
   app_ver=$(PYTHONPATH=. KIVY_NO_CONSOLELOG=1 python3 -c 'import kivy; print(kivy.__version__)')
 
   cd ../
   git clone https://github.com/kivy/kivy-sdk-packager.git
   cd kivy-sdk-packager/osx
 
-  ./create-osx-bundle.sh -k ../../kivy -p "$py_version" -v "$app_ver"
+  ./create-osx-bundle.sh -k ../../kivy -v "$app_ver"
 }
 
 generate_osx_app_dmg_from_bundle() {

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -209,9 +209,8 @@ jobs:
           install_kivy_test_run_pip_deps dev
       - name: Make app bundle
         run: |
-          py_version=$(python3 -c "import platform; print(platform.python_version())")
           source .ci/osx_ci.sh
-          generate_osx_app_bundle "$py_version"
+          generate_osx_app_bundle
       - name: Create dmg from bundle
         run: |
           source .ci/osx_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -198,6 +198,9 @@ jobs:
         run: |
           source .ci/ubuntu_ci.sh
           update_version_metadata
+      - name: Install build dependencies
+        run: |
+          brew install pkg-config cmake ninja
       - name: Install dependencies
         run: |
           source .ci/ubuntu_ci.sh


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

- Build app script from `kivy/kivy-sdk-packager` now requires a few more deps, and some of them are not already installed in Github Actions macOS image (like `ninja`).
- Use default Python version provided by `create-osx-bundle.sh`