### PR TITLE
Request `--only-binary` for Pillow on Windows when testing wheels

### DIFF
--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -102,7 +102,7 @@ function Install-kivy-wheel {
     $kivy_fname=(ls $root/dist/Kivy-*$version*$bitness*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
     $kivy_examples_fname=(ls $root/dist/Kivy_examples-*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
     echo "kivy_fname = $kivy_fname, kivy_examples_fname = $kivy_examples_fname"
-    python -m pip install "$root/dist/$kivy_fname[full,dev]" "$root/dist/$kivy_examples_fname"
+    python -m pip install --only-binary Pillow "$root/dist/$kivy_fname[full,dev]" "$root/dist/$kivy_examples_fname"
 }
 
 function Install-kivy-sdist {


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

As documented [here](https://kivy.org/doc/master/gettingstarted/installation.html#pre-compiled-wheels) `--only-binary Pillow` is needed on Windows to instruct `pip` to install only binary distributions of Pillow, even if a new one (in the support matrix) is available.

The same change has been applied to non-wheel testing [here](https://github.com/kivy/kivy/blob/9576cf756f804fead102a64ef32c940a488e7ed4/.ci/windows_ci.ps1#L89)
