### PR TITLE
Fix text attributes not changing after the settings panel is opened

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -880,6 +880,7 @@
         font_size: '15sp'
 
 <SettingTitle>:
+    text: self.title
     text_size: self.width - 32, None
     size_hint_y: None
     height: max(dp(20), self.texture_size[1] + dp(20))

--- a/kivy/uix/settings.py
+++ b/kivy/uix/settings.py
@@ -672,7 +672,7 @@ class SettingTitle(Label):
     '''A simple title label, used to organize the settings in sections.
     '''
 
-    title = Label.text
+    title = StringProperty()
 
     panel = ObjectProperty(None)
 


### PR DESCRIPTION
If the settings panel is opened text attributes will no longer get updated.  See issues: #8519, #8079, #8047, #7895, 

Below is a test case.  In version 2.2.1 of kivy, if the setting panel is opened the on screen count will stop, and will not resume.  The Clock callback continues.

```python
from kivy.app import App
from kivy.lang import Builder
from kivy.clock import Clock
from kivy.properties import NumericProperty, BooleanProperty

kv = """
BoxLayout:
    BoxLayout:
        orientation: 'vertical'
        Label:
            id: label
            text: str(app.count)
            font_size: 60
        BoxLayout:
            size_hint_y: None
            height: dp(48)
            Button:
                text: 'Open Settings'
                on_release: app.open()
                disabled: app.settings_open
    BoxLayout:
        id: box
"""


class CheckSettings(App):
    count = NumericProperty(0)
    settings_open = BooleanProperty(False)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)

    def build(self):
        return Builder.load_string(kv)

    def display_settings(self, settings):
        self.root.ids.box.add_widget(settings)
        self.settings_open = True
        return True

    def close_settings(self, *args):
        self.root.ids.box.clear_widgets()
        self.settings_open = False

    def on_start(self):
        Clock.schedule_interval(self._count, 1)

    def _count(self, _):
        self.count += 1
        print(f'Count: {self.count}')

    def open(self):
        self.open_settings()   # added to use as a breakpoint


CheckSettings().run()
```

The issue: In settings.py the class SettingTitle was erroneously redefining Label.text.


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
