### PR TITLE
`PIL` text provider: Do not render text if font size is `< 1`

### DIFF
--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -19,6 +19,9 @@ class LabelPIL(LabelBase):
     _cache = {}
 
     def _select_font(self):
+        if self.options['font_size'] < 1:
+            return None
+
         fontsize = int(self.options['font_size'])
         fontname = self.options['font_name_r']
         try:
@@ -34,6 +37,9 @@ class LabelPIL(LabelBase):
 
     def get_extents(self, text):
         font = self._select_font()
+        if not font:
+            return 0, 0
+        
         left, top, right, bottom = font.getbbox(text)
         ascent, descent = font.getmetrics()
 
@@ -54,17 +60,19 @@ class LabelPIL(LabelBase):
         self._pil_draw = ImageDraw.Draw(self._pil_im)
 
     def _render_text(self, text, x, y):
+        font = self._select_font()
+        if not font:
+            return
+
         color = tuple([int(c * 255) for c in self.options['color']])
 
         # Adjust x and y position to avoid text cutoff
         if self.options['limit_render_to_text_bbox']:
-            font = self._select_font()
             bbox = font.getbbox(text)
             x -= bbox[0]
             y -= bbox[1]
 
-        self._pil_draw.text((int(x), int(y)),
-                            text, font=self._select_font(), fill=color)
+        self._pil_draw.text((int(x), int(y)), text, font=font, fill=color)
 
     def _render_end(self):
         data = ImageData(self._size[0], self._size[1],

--- a/kivy/core/text/text_pil.py
+++ b/kivy/core/text/text_pil.py
@@ -39,7 +39,7 @@ class LabelPIL(LabelBase):
         font = self._select_font()
         if not font:
             return 0, 0
-        
+
         left, top, right, bottom = font.getbbox(text)
         ascent, descent = font.getmetrics()
 


### PR DESCRIPTION
Resolves #8538 

`PIL` does not support, nor does it handle attempts to render text with font size values less than 1, resulting in various errors being raised.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
