### PR TITLE
Bump to `2.3.0rc3`

### DIFF
--- a/kivy/_version.py
+++ b/kivy/_version.py
@@ -10,7 +10,7 @@ __version__ = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 if not RELEASE:
     # if it's a rcx release, it's not proceeded by a period. If it is a
     # devx release, it must start with a period
-    __version__ += 'rc2'
+    __version__ += 'rc3'
 
 
 _kivy_git_hash = ''


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

RC3 will be the final release candidate, `2.3.0` release is scheduled on 2023-01-04 or 2023-01-05