### PR TITLE
Fix typo and mistake at FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -281,7 +281,7 @@ latest available version and retry.
 #### I get an "ImportError: No module named _event". How come?
 
   If you use Kivy from our development version, you must compile it before
-using it. Check :ref:`installation guide<installation-canonical>` for more information.
+using it. Check [installation guide](https://kivy.org/doc/stable/gettingstarted/installation.html) for more information.
 
 ## Android Questions
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -281,9 +281,7 @@ latest available version and retry.
 #### I get an "ImportError: No module named _event". How come?
 
   If you use Kivy from our development version, you must compile it before
-using it. In the kivy directory, run
-
-      python setup.py build_ext --inplace
+using it. Check :ref:`installation guide<installation-canonical>` for more information.
 
 ## Android Questions
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -278,12 +278,12 @@ execution.
 latest available version and retry.
 
 
-#### I get an "ImportError: No module named event". How come?
+#### I get an "ImportError: No module named _event". How come?
 
   If you use Kivy from our development version, you must compile it before
 using it. In the kivy directory, run
 
-      make force
+      python setup.py build_ext --inplace
 
 ## Android Questions
 


### PR DESCRIPTION
> `#### I get an "ImportError: No module named event". How come?`

The `event` module is a simple python module, while `_event` is a cython module which we cannot import if it has not been compiled. [Helpful link.](https://groups.google.com/g/kivy-users/c/kaJTLAvuqJ8)

~> `make force`~

~To build a Python extension, we need to run `setup.py` script, not the `make` command.~

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
