### PR TITLE
Add example for `Smooth*` graphics instructions

### DIFF
--- a/examples/canvas/antialiasing.py
+++ b/examples/canvas/antialiasing.py
@@ -1,0 +1,73 @@
+from kivy.app import App
+from kivy.lang import Builder
+
+kv = '''
+GridLayout:
+    rows: 6
+    columns: 2
+    spacing: [2]
+    Label:
+        height: '50sp'
+        size_hint_y: None
+        font_size: '25sp'
+        text: "Standard"
+    Label:
+        height: '50sp'
+        size_hint_y: None
+        font_size: '25sp'
+        text: "Antialiased"
+    Widget:
+        canvas:
+            Color:
+                rgb: 1.0, 0.0, 0.0
+            RoundedRectangle:
+                pos: self.pos
+                size: self.size
+                segments: 50
+                radius: [(200, 200), (100, 50), (250, 250),(100, 250),]
+    Widget:
+        canvas:
+            SmoothRoundedRectangle:
+                pos: self.pos
+                size: self.size
+                segments: 50
+                radius: [(200, 200), (100, 50), (250, 250),(100, 250),]
+    Widget:
+        canvas:
+            Color:
+                rgb: 0.0, 1.0, 0.0
+            Triangle:
+                points: [self.x, self.y + self.height, self.x + self.width, \
+                            self.y + self.height / 2, self.x + 150, self.y]
+    Widget:
+        canvas:
+            SmoothTriangle:
+                points: [self.x, self.y + self.height, self.x + self.width, \
+                            self.y + self.height / 2, self.x + 150, self.y]
+    Widget:
+        canvas:
+            Color:
+                rgb: 0.0, 0.0, 1.0
+            Ellipse:
+                pos: self.pos
+                size: self.size
+                angle_start: 20
+                angle_end: 300
+    Widget:
+        canvas:
+            SmoothEllipse:
+                pos: self.pos
+                size: self.size
+                angle_start: 20
+                angle_end: 300
+'''
+
+
+class AntialiasDemoApp(App):
+
+    def build(self):
+        return Builder.load_string(kv)
+
+
+if __name__ == '__main__':
+    AntialiasDemoApp().run()

--- a/examples/canvas/antialiasing.py
+++ b/examples/canvas/antialiasing.py
@@ -1,3 +1,14 @@
+'''
+Antialisiang Example
+====================
+
+Kivy 2.3.0 introduced several vertex instrustions with with antialisiang:
+SmoothRectangle, SmoothEllipse, SmoothRoundedRectangle, SmoothQuad and
+SmoothTriangle. This demo script shows the difference between 'standard'
+(non-antialiased) and antialiased graphics.
+
+'''
+
 from kivy.app import App
 from kivy.lang import Builder
 

--- a/examples/canvas/antialiasing.py
+++ b/examples/canvas/antialiasing.py
@@ -1,8 +1,8 @@
 '''
-Antialisiang Example
+Antialiasing Example
 ====================
 
-Kivy 2.3.0 introduced several vertex instrustions with with antialisiang:
+Kivy 2.3.0 introduced several vertex instructions with with antialiasing:
 SmoothRectangle, SmoothEllipse, SmoothRoundedRectangle, SmoothQuad and
 SmoothTriangle. This demo script shows the difference between 'standard'
 (non-antialiased) and antialiased graphics.

--- a/examples/canvas/antialiasing.py
+++ b/examples/canvas/antialiasing.py
@@ -2,7 +2,7 @@
 Antialiasing Example
 ====================
 
-Kivy 2.3.0 introduced several vertex instructions with with antialiasing:
+Kivy 2.3.0 introduced several vertex instructions with antialiasing:
 SmoothRectangle, SmoothEllipse, SmoothRoundedRectangle, SmoothQuad and
 SmoothTriangle. This demo script shows the difference between 'standard'
 (non-antialiased) and antialiased graphics.


### PR DESCRIPTION
PR #8309 added a new graphics section with antialiasing ( @DexerBR, thank you). But there are no examples. I created one small demo script.

![image](https://github.com/kivy/kivy/assets/130763512/f618f0ac-16db-49ba-b755-06fefeeccfa9)

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
