### PR TITLE
POC: Initial tests regarding Skia

### DIFF
--- a/kivy/core/text/text_skia.pyx
+++ b/kivy/core/text/text_skia.pyx
@@ -1,0 +1,19 @@
+cdef extern from "text_skia_implem.cpp":
+    cppclass SkiaOpenGLRenderer:
+        SkiaOpenGLRenderer(unsigned int buffer_id, unsigned int tex_width, unsigned int tex_height)
+        void render_text(const char* text)
+
+
+cdef class TextSkia:
+    cdef SkiaOpenGLRenderer* _renderer
+
+    def __init__(self, buffer_id, tex_width, tex_height):
+        print("Setup a new SkiaOpenGLRenderer with fbo buffer id: ", buffer_id)
+        self._renderer = new SkiaOpenGLRenderer(buffer_id, tex_width, tex_height)
+
+    def render(self, text, font_size, font_name, fg_color):
+        self._renderer.render_text(text)
+
+
+
+        

--- a/kivy/core/text/text_skia_implem.cpp
+++ b/kivy/core/text/text_skia_implem.cpp
@@ -1,0 +1,185 @@
+#include "text_skia_implem.h"
+
+using namespace skia::textlayout;
+
+SkiaOpenGLRenderer::SkiaOpenGLRenderer(unsigned int buffer_id, unsigned int tex_width, unsigned int tex_height)
+{
+
+    /*
+    FBO ALTERNATIVE.
+
+    fboInfo.fFBOID = buffer_id;
+    fboInfo.fFormat = GR_GL_RGBA8;
+    */
+
+    texInfo.fTarget = GL_TEXTURE_2D;
+    texInfo.fID = buffer_id;
+    texInfo.fFormat = GR_GL_RGBA8;
+
+    this->tex_width = tex_width;
+    this->tex_height = tex_height;
+
+    printf("SkiaOpenGLRenderer: Creating OpenGL context\n");
+
+    // Create an interface to the OpenGL context
+    auto interface = GrGLMakeNativeInterface();
+    context = GrDirectContexts::MakeGL(interface).release();
+
+    printf("SkiaOpenGLRenderer: Have OpenGL context\n");
+
+    printf("SkiaOpenGLRenderer: Everything set up, and ready to render\n");
+
+    // A little test to see if we can render something, just to make sure everything is working
+    // this->renderHelloWorld();
+}
+
+void SkiaOpenGLRenderer::reset_context()
+{
+    // context->resetContext(kRenderTarget_GrGLBackendState | kMisc_GrGLBackendState);
+    context->resetContext(kTextureBinding_GrGLBackendState | kMisc_GrGLBackendState);
+}
+
+sk_sp<SkSurface> SkiaOpenGLRenderer::get_surface()
+{
+    /*
+    FBO ALTERNATIVE.
+
+    sk_sp<SkColorSpace> colorSpace = SkColorSpace::MakeSRGB();
+
+    GrGLint sampleCnt;
+    glGetIntegerv(GL_SAMPLES, &sampleCnt);
+    GrGLint stencil;
+    glGetIntegerv(GL_STENCIL_BITS, &stencil);
+
+    auto backend_render_target = GrBackendRenderTargets::MakeGL(this->tex_width, this->tex_height, sampleCnt, stencil, fboInfo);
+
+    return SkSurfaces::WrapBackendRenderTarget(
+        context, backend_render_target, kBottomLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, colorSpace, nullptr);
+    */
+
+    auto backend_texture = GrBackendTextures::MakeGL(this->tex_width, this->tex_height, GrMipMapped::kNo, texInfo);
+
+    return SkSurfaces::WrapBackendTexture(
+        context, backend_texture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, nullptr, nullptr, nullptr);
+
+}
+
+void SkiaOpenGLRenderer::render_text(std::string text)
+{
+    this->reset_context();
+
+    sk_sp<SkSurface> surface = this->get_surface();
+
+    if (surface) 
+    {
+        SkCanvas *canvas = surface->getCanvas();
+        canvas->clear(SK_ColorWHITE);
+
+        SkPaint fg_color = SkPaint();
+        fg_color.setColor(SK_ColorBLACK);
+        fg_color.setAntiAlias(true);
+
+        TextStyle text_default_style;
+        text_default_style.setForegroundColor(fg_color);
+        text_default_style.setFontSize(40.0f);
+        text_default_style.setFontFamilies({SkString("Roboto")});
+
+        ParagraphStyle paragraph_style;
+        paragraph_style.setTextStyle(text_default_style);
+        paragraph_style.setTextAlign(TextAlign::kJustify);
+
+        auto font_collection = sk_make_sp<FontCollection>();
+        font_collection.get()->setDefaultFontManager(SkFontMgr::RefDefault());
+
+        auto builder = ParagraphBuilderImpl::make(paragraph_style, font_collection);
+        builder->addText(text.c_str(), text.length());
+        builder->pop();
+
+        auto paragraph = builder->Build();
+
+        paragraph.get()->layout(this->tex_width);
+        paragraph.get()->paint(canvas, 0, 0);
+
+        // Flush the canvas
+        if (auto dContext = GrAsDirectContext(canvas->recordingContext()))
+        {
+            dContext->flushAndSubmit();
+        }
+
+    }
+}
+
+void SkiaOpenGLRenderer::renderHelloWorld()
+{
+    this->reset_context();
+
+    sk_sp<SkSurface> surface = this->get_surface();
+
+    if (surface)
+    {
+        // Get the SkCanvas from the SkSurface
+        SkCanvas *canvas = surface->getCanvas();
+
+        // Clear the canvas
+        canvas->clear(SK_ColorWHITE);
+
+        canvas->drawColor(SK_ColorWHITE);
+
+        // Draw a red circle
+        SkPaint painta;
+        painta.setAntiAlias(true);
+        painta.setColor(SK_ColorRED);
+        canvas->drawCircle(500, 500, 400, painta);
+
+        // Draw a rectangle with half transparency
+        SkPaint paintb;
+        paintb.setAntiAlias(true);
+        paintb.setColor(SK_ColorBLUE);
+        paintb.setAlpha(128);
+        SkRect rect = SkRect::MakeXYWH(50, 50, 400, 900);
+        canvas->drawRect(rect, paintb);
+
+        SkPaint paint;
+        paint.setAntiAlias(true);
+        paint.setColor(SK_ColorBLACK);
+
+        SkPaint black;
+        black.setColor(SK_ColorBLACK);
+
+        TextStyle defaultStyle;
+        // defaultStyle.setBackgroundColor(black);
+        defaultStyle.setForegroundColor(paint);
+        defaultStyle.setFontSize(40.0f);
+        defaultStyle.setFontFamilies({SkString("Roboto")});
+
+        ParagraphStyle paragraphStyle;
+        paragraphStyle.setTextStyle(defaultStyle);
+        paragraphStyle.setTextAlign(TextAlign::kJustify);
+
+        auto font_collection = sk_make_sp<FontCollection>();
+        font_collection.get()->setDefaultFontManager(SkFontMgr::RefDefault());
+
+        auto builder = ParagraphBuilderImpl::make(paragraphStyle, font_collection);
+        std::string name = "Lorem 🎉 ipsum dolor sit amet, consectetur 🥰 adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.\n\n\n";
+        builder->addText(name.c_str(), name.length());
+        // mix arabic and english
+        std::string arabic_name = "تشاو موند Hellow world Hello World!";
+        builder->addText(arabic_name.c_str(), arabic_name.length());
+        builder->pop();
+
+        auto para = builder->Build();
+
+        para.get()->layout(400);
+
+        // auto rect = SkRect();che
+
+        para.get()->paint(canvas, 50, 50);
+
+        // Flush the canvas
+        if (auto dContext = GrAsDirectContext(canvas->recordingContext()))
+        {
+            dContext->flushAndSubmit();
+        }
+        printf("Rendered Hello, World!\n");
+    }
+}

--- a/kivy/core/text/text_skia_implem.h
+++ b/kivy/core/text/text_skia_implem.h
@@ -1,0 +1,43 @@
+#include "include/ports/SkFontMgr_mac_ct.h"
+#include "include/core/SkCanvas.h"
+#include "include/core/SkSurface.h"
+#include "include/core/SkTextBlob.h"
+#include "include/gpu/GrBackendSurface.h"
+#include "include/gpu/gl/GrGLInterface.h"
+#include "include/gpu/GrDirectContext.h"
+#include "include/gpu/ganesh/gl/GrGLDirectContext.h"
+#include "include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "modules/skparagraph/include/Paragraph.h"
+#include "modules/skparagraph/src/ParagraphBuilderImpl.h"
+#include "modules/skparagraph/src/ParagraphImpl.h"
+#include "include/core/SkColorSpace.h"
+#include "include/gpu/gl/GrGLTypes.h"
+#include "modules/skparagraph/include/TextStyle.h"
+#include "src/gpu/ganesh/gl/GrGLDefines.h"
+
+
+
+#include <OpenGL/gl.h>
+
+
+
+class SkiaOpenGLRenderer
+{
+public:
+    SkiaOpenGLRenderer(unsigned int buffer_id, unsigned int tex_width, unsigned int tex_height);
+    ~SkiaOpenGLRenderer();
+    void render_text(std::string text);
+    void renderHelloWorld();
+
+private:
+    unsigned int tex_width;
+    unsigned int tex_height;
+    GrDirectContext *context;
+    GrBackendTexture backendTexture;
+    // GrGLFramebufferInfo fboInfo; // FBO ALTERNATIVE
+    GrGLTextureInfo texInfo;
+
+    void reset_context();
+    sk_sp<SkSurface> get_surface();
+};

--- a/setup.py
+++ b/setup.py
@@ -884,6 +884,15 @@ graphics_dependencies = {
         'cgl.pxd', 'texture.pxd', 'vertex_instructions_line.pxi'],
     'vertex_instructions_line.pxi': ['stencil_instructions.pxd']}
 
+skia_flags = {
+    'include_dirs': ["/Users/mirko/Documents/projects/skia"],
+    'libraries': ['skia', 'skparagraph', 'skshaper', 'skunicode'],
+    'library_dirs': [os.path.join(KIVY_DEPS_ROOT, 'dist', 'lib', 'skia')],
+    'extra_link_args': ['-framework', 'CoreText', '-Wl,-rpath,' + os.path.join(KIVY_DEPS_ROOT, 'dist', 'lib', 'skia')],
+    'language': 'c++',
+    'extra_compile_args': ['-std=c++17', '-stdlib=libc++'],
+}
+
 sources = {
     '_event.pyx': merge(base_flags, {'depends': ['properties.pxd']}),
     '_clock.pyx': {},
@@ -915,6 +924,7 @@ sources = {
     'graphics/cgl_backend/cgl_sdl2.pyx': merge(base_flags, gl_flags_base),
     'graphics/cgl_backend/cgl_debug.pyx': merge(base_flags, gl_flags_base),
     'core/text/text_layout.pyx': base_flags,
+    'core/text/text_skia.pyx': merge(base_flags, skia_flags),
     'core/window/window_info.pyx': base_flags,
     'graphics/tesselator.pyx': merge(base_flags, {
         'include_dirs': ['kivy/lib/libtess2/Include'],


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Skia is a popular 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.

As an example, it serves as the graphics engine for Google Chrome and many other products.

Even if the first tests solely focused on the `SkParagraph` feature, that will simplify and fix a ton of long-standing issues regarding text rendering (RTL, font fallback, BiDi, proper alignment, ...) if merged in Kivy, Skia could also be an opportunity to introduce other nice features (like a Lottie player, via `SKottie`).

In simple words: From the first tests, Skia is what we were waiting for. A long restructuring and renaming for 3.0.0 series will be needed, and that's the proper time to introduce Skia in our codebase.

With Skia we can easily render into an OpenGL texture and OpenGL FBO (and looks ANGLE is supported for https://github.com/kivy/kivy/pull/8534).

This code is absolutely not intended to be merged as-is, but it's more like an handover to bi0noid, so I can focus on other things. (being an admin, Roadmap, ... etc).


**IMPORTANT:**
- Needs Skia dynamic libraries to be built externally, and in the correct folder (check setup.py). I will work on a tool similar to https://github.com/kivy/angle-builder to automagically handle all the builds. (The macOS one, have a visibility issue, that will be reported to Skia team).


Sketchy example code:
```python
from kivy.app import App
from kivy.uix.widget import Widget
from kivy.clock import Clock

from kivy.graphics.texture import Texture
from kivy.graphics import Rectangle

from kivy.properties import StringProperty, ObjectProperty

from kivy.core.text.text_skia import TextSkia


class SkiaTextWidget(Widget):
    text = StringProperty("")
    tex = ObjectProperty(None)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self._prepare_texture()

    def on_text(self, *args):
        self._skia_render()

    def on_size(self, *args):
        self._prepare_texture()

    def _prepare_texture(self):
        print("recreating texture, size:", self.size)
        self.tex = Texture.create(size=self.size, colorfmt="rgba")
        self.tex.flip_vertical()
        self.tex.bind()

        self._skia_render()

    def _skia_render(self, tex=None):
        self.skia_text_render = TextSkia(
            self.tex.id, self.tex.size[0], self.tex.size[1]
        )
        self.skia_text_render.render(self.text, 0, "font_name", "fg_color")

        self.canvas.clear()
        with self.canvas:
            Rectangle(size=self.tex.size, texture=self.tex)


class NewTextLayoutApp(App):
    def build(self):
        self.skia_text_wid = SkiaTextWidget()

        self.lorem_ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue."
        self.mix_lorem_ipsum_and_emoji = "Lorem 🎉 ipsum 🌏 dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec 🎉 consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue."

        Clock.schedule_interval(self._update_skia_text, 1)

        return self.skia_text_wid

    def _update_skia_text(self, dt):
        if self.skia_text_wid.text == self.lorem_ipsum:
            self.skia_text_wid.text = self.mix_lorem_ipsum_and_emoji
        else:
            self.skia_text_wid.text = self.lorem_ipsum


if __name__ == "__main__":
    NewTextLayoutApp().run()
```


Current output:

https://github.com/kivy/kivy/assets/8177736/2bf6cffc-b492-4067-9e50-3ad6e59856b6


