### PR TITLE
Issue #8563: PageLayout on_touch_down out of range

### DIFF
--- a/kivy/uix/pagelayout.py
+++ b/kivy/uix/pagelayout.py
@@ -135,6 +135,9 @@ class PageLayout(Layout):
         ):
             return
 
+       if self.page >= len(self.children):
+              self.page = len(self.children) - 1
+
         page = self.children[-self.page - 1]
         if self.x <= touch.x < page.x:
             touch.ud['page'] = 'previous'


### PR DESCRIPTION
See issue: https://github.com/kivy/kivy/issues/8563 


 PageLayout on_touch_down doesn't check for length of self.children.
Can get IndexError: list index out of range. #8563

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

