### PR TITLE
Add link to CC-BY-3.0 license for icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Licenses
   [here](https://github.com/dejavu-fonts/dejavu-fonts/blob/master/LICENSE).
 - The current UI design has been adapted from Moblintouch theme's SVGs
   and is licensed under the terms of the
-  [LGPLv2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1).
+  [LGPLv2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1) and
+  [CC-BY-SA-3.0](https://creativecommons.org/licenses/by-sa/3.0/).
 
 
 ## Code of Conduct


### PR DESCRIPTION
License in original source files http://archive.ubuntu.com/ubuntu/pool/universe/m/moblin-icon-theme/moblin-icon-theme_0.10.0.orig.tar.gz

See https://github.com/kivy/kivy/issues/4903 for discussion

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [-] Applied the `api-deprecation` or `api-break` label.
* [-] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [-] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
