### PR TITLE
Remove Python `3.7` from supported matrix and set minimum supported version to `3.8`

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -1,4 +1,4 @@
-ARG image=balenalib/raspberrypi3-debian-python:3.7-buster
+ARG image=balenalib/raspberrypi3-debian-python:3.9-bullseye
 FROM $image
 
 ENV KIVY_CROSS_PLATFORM=rpi

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -136,7 +136,7 @@ jobs:
     needs: [manylinux_wheel_create, kivy_examples_create]
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
     env:
       DISPLAY: ':99.0'
     steps:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -136,11 +136,9 @@ jobs:
     strategy:
       matrix:
         runs_on: ['macos-latest', 'apple-silicon-m1']
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
-          # apple-silicon-m1 does not support older python versions (3.7, 3.8, 3.9)
-          - runs_on: apple-silicon-m1
-            python: '3.7'
+          # apple-silicon-m1 does not support older python versions (3.8, 3.9)
           - runs_on: apple-silicon-m1
             python: '3.8'
           - runs_on: apple-silicon-m1

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        docker_images: ['balenalib/raspberrypi3-debian-python:3.7-buster', 'balenalib/raspberrypi3-debian-python:3.9-bullseye', 'balenalib/raspberrypi3-debian-python:3.11-bookworm']
+        docker_images: ['balenalib/raspberrypi3-debian-python:3.9-bullseye', 'balenalib/raspberrypi3-debian-python:3.11-bookworm']
     steps:
     - uses: actions/checkout@v3
     - name: Generate version metadata

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64', 'x86']
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: ['x64', 'x86']
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel win]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel win]')
     steps:
@@ -107,7 +107,7 @@ jobs:
     needs: windows_wheels_create
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
         arch: [ 'x64', 'x86' ]
     steps:
       - uses: actions/checkout@v3

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -54,7 +54,7 @@ If no wheels are available ``pip`` will build the package from sources (i.e. on 
 Alternatively, installing :ref:`from source<kivy-source-install>` is required for newer Python versions not listed
 above or if the wheels do not work or fail to run properly.
 
-On RPi, when using a 32 bit OS, wheels are provided for Python 3.7 (Raspberry Pi OS Buster), Python 3.9 (Raspberry Pi OS Bullseye)
+On RPi, when using a 32 bit OS, wheels are provided for Python 3.9 (Raspberry Pi OS Bullseye)
 and Python 3.11 (Raspberry Pi OS Bookworm) via the `PiWheels <https://www.piwheels.org/>`_ project.
 
 For other Python versions, on 32 bit OSes, you will need to install from source.
@@ -126,19 +126,19 @@ See :ref:`Kivy's dependencies<kivy-dependencies>` for the list of selectors.
 
     The ``Pillow`` library is a dependency of both ``kivy[base]`` and ``kivy[full]``.
 
-    For Windows 32-bit users, please note that the latest releases of `Pillow` are 
-    not available as binary distributions on PyPI. However, Kivy also supports ``Pillow==9.5.0``, 
+    For Windows 32-bit users, please note that the latest releases of `Pillow` are
+    not available as binary distributions on PyPI. However, Kivy also supports ``Pillow==9.5.0``,
     which have a binary distribution for all supported Python versions, even on Windows 32-bit.
 
-    If you are on Windows 32-bit and prefer not to build Pillow from source, 
-    you can use the ``--only-binary Pillow`` flag with the following command to instruct pip 
+    If you are on Windows 32-bit and prefer not to build Pillow from source,
+    you can use the ``--only-binary Pillow`` flag with the following command to instruct pip
     to install the binary distribution of Pillow, albeit not the latest version::
 
         python -m pip install --only-binary Pillow "kivy[base]"
 
 .. note::
 
-    When using Raspberry Pi OS Lite or similar Linux-based headless systems, it may be necessary to install additional 
+    When using Raspberry Pi OS Lite or similar Linux-based headless systems, it may be necessary to install additional
     dependencies to ensure Kivy functions properly.
 
     For instance, on Raspberry Pi OS Lite, you will be required to install the following dependencies::
@@ -169,7 +169,7 @@ First install the additional system dependencies listed for each platform:
     offer support for this.**
 
     Instead, we recommend installing the SDL dependencies from source. This is the same process
-    our CI uses to build the wheels. The SDL dependencies are built from source and installed into a 
+    our CI uses to build the wheels. The SDL dependencies are built from source and installed into a
     specific directory.
 
 With all the build tools installed, you can now install the SDL dependencies from source for SDL support

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -95,9 +95,6 @@ To cross-compile the wheels, you need to run the following commands::
 
     source .ci/ubuntu_ci.sh
 
-    # Generate wheels for Raspberry Pi OS Buster (32 bit, Python 3.7)
-    generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.7-buster
-
     # Generate wheels for Raspberry Pi OS Bullseye (32 bit, Python 3.9)
     generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.9-bullseye
 
@@ -105,7 +102,7 @@ To cross-compile the wheels, you need to run the following commands::
     generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.11-bookworm
 
 
-Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that 
+Kivy determines automatically the sub-packages to build based on the environment it is compiled within. By default, the `egl_rpi` renderer that
 uses the (now deprecated but still useful) DISPMANX API is only compiled when running on a Raspberry Pi with Raspberry Pi OS Buster (32 bit), as it is the only
 platform that still  supports it.
 
@@ -119,8 +116,8 @@ If you followed the previous steps, or you're using the pre-built wheels, the he
 On supported platforms (RPi 1-3 with Raspberry Pi OS Buster), the `egl_rpi` window provider is used by default. This window provider uses the
 (deprecated, will be removed in future) DISPMANX API to create a headless GL context.
 
-On other platforms (e.g RPi 4 or 64 bit OS), the `sdl2` window provider is used by default. If during the build process for the `sdl2` 
-dependencies the `kmsdrm` headers and libraries are found, the `kmsdrm` backend is enabled. This backend allows to create a headless 
+On other platforms (e.g RPi 4 or 64 bit OS), the `sdl2` window provider is used by default. If during the build process for the `sdl2`
+dependencies the `kmsdrm` headers and libraries are found, the `kmsdrm` backend is enabled. This backend allows to create a headless
 GL context using the KMS/DRM API.
 
 Hardware acceleration

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cython_min=0.29.1
 cython_max=3.0.0
 cython_exclude=
-python_versions=3.7 - 3.12
+python_versions=3.8 - 3.12
 
 [coverage:run]
 parallel = True
@@ -14,7 +14,7 @@ plugins =
 concurrency = thread, multiprocessing
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     Kivy-Garden>=0.1.4
     docutils

--- a/setup.py
+++ b/setup.py
@@ -1198,7 +1198,6 @@ if not build_examples:
             'Operating System :: Microsoft :: Windows',
             'Operating System :: POSIX :: BSD :: FreeBSD',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Python 3.7 version has reached its EOL ,This fixes the issue #8567 . Python version 3.7 has been removed.
- builds for 3.7 has been removed
- CI/CD tests has been removed for 3.7
- Python version 3.8 has been set as minimum version required.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
