### PR TITLE
[Audio]: Add 'on_eos' event

### DIFF
--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -100,7 +100,10 @@ class Sound(EventDispatcher):
         `on_stop`: None
             Fired when the sound is stopped.
         `on_eos`: None
-            Fired when EOS is hit.
+            Fired when EOS is hit. Available only with 
+            `ffpyplayer` and `gstplayer` backends.
+
+            .. versionadded:: 3.0.0
     '''
 
     source = StringProperty(None)
@@ -147,7 +150,7 @@ class Sound(EventDispatcher):
     :attr:`loop` is a :class:`~kivy.properties.BooleanProperty` and defaults to
     False.'''
 
-    __events__ = ('on_play', 'on_stop')
+    __events__ = ('on_play', 'on_stop', 'on_eos')
 
     def on_source(self, instance, filename):
         self.unload()

--- a/kivy/core/audio/__init__.py
+++ b/kivy/core/audio/__init__.py
@@ -99,6 +99,8 @@ class Sound(EventDispatcher):
             Fired when the sound is played.
         `on_stop`: None
             Fired when the sound is stopped.
+        `on_eos`: None
+            Fired when EOS is hit.
     '''
 
     source = StringProperty(None)
@@ -201,6 +203,8 @@ class Sound(EventDispatcher):
     def on_stop(self):
         pass
 
+    def on_eos(self):
+        pass
 
 # Little trick here, don't activate gstreamer on window
 # seem to have lot of crackle or something...

--- a/kivy/core/audio/audio_ffpyplayer.py
+++ b/kivy/core/audio/audio_ffpyplayer.py
@@ -180,6 +180,7 @@ class SoundFFPy(Sound):
             self.stop()
         else:
             self.seek(0.)
+        self.dispatch('on_eos')
 
 
 SoundLoader.register(SoundFFPy)

--- a/kivy/core/audio/audio_gstplayer.py
+++ b/kivy/core/audio/audio_gstplayer.py
@@ -53,6 +53,7 @@ class SoundGstplayer(Sound):
             self.player.play()
         else:
             self.stop()
+        self.dispatch('on_eos')
 
     def load(self):
         self.unload()


### PR DESCRIPTION
Good evening!

I want to add `on_eos` event to Kivy audio system. It works the same way as in the [video](https://kivy.org/doc/stable/api-kivy.core.video.html), but is only available with `ffpyplayer` and `gstplayer` providers.

Related issue: [#2156](https://github.com/kivy/kivy/issues/2156).

P.S.: Could someone please advise me on how the tests for this PR should look? Or is it not necessary to write them for this case?

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
