### PR TITLE
Remove Windows 32-bit support (tests, builds, docs)

### DIFF
--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -86,7 +86,7 @@ function Install-kivy-test-run-pip-deps {
 }
 
 function Install-kivy {
-    python -m pip install --only-binary Pillow -e .[dev,full]
+    python -m pip install -e .[dev,full]
 }
 
 function Install-kivy-wheel {
@@ -102,7 +102,7 @@ function Install-kivy-wheel {
     $kivy_fname=(ls $root/dist/Kivy-*$version*$bitness*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
     $kivy_examples_fname=(ls $root/dist/Kivy_examples-*.whl | Sort-Object -property @{Expression={$_.name.tostring().Length}} | Select-Object -First 1).name
     echo "kivy_fname = $kivy_fname, kivy_examples_fname = $kivy_examples_fname"
-    python -m pip install --only-binary Pillow "$root/dist/$kivy_fname[full,dev]" "$root/dist/$kivy_examples_fname"
+    python -m pip install "$root/dist/$kivy_fname[full,dev]" "$root/dist/$kivy_examples_fname"
 }
 
 function Install-kivy-sdist {

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
-        arch: ['x64', 'x86']
+        arch: ['x64']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }} on ${{ matrix.arch }}

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
-        arch: ['x64', 'x86']
+        arch: ['x64']
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel win]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel win]')
     steps:
     - uses: actions/checkout@v3
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
-        arch: [ 'x64', 'x86' ]
+        arch: [ 'x64' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }} on ${{ matrix.arch }}

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -124,20 +124,6 @@ See :ref:`Kivy's dependencies<kivy-dependencies>` for the list of selectors.
 
 .. note::
 
-    The ``Pillow`` library is a dependency of both ``kivy[base]`` and ``kivy[full]``.
-
-    For Windows 32-bit users, please note that the latest releases of `Pillow` are
-    not available as binary distributions on PyPI. However, Kivy also supports ``Pillow==9.5.0``,
-    which have a binary distribution for all supported Python versions, even on Windows 32-bit.
-
-    If you are on Windows 32-bit and prefer not to build Pillow from source,
-    you can use the ``--only-binary Pillow`` flag with the following command to instruct pip
-    to install the binary distribution of Pillow, albeit not the latest version::
-
-        python -m pip install --only-binary Pillow "kivy[base]"
-
-.. note::
-
     When using Raspberry Pi OS Lite or similar Linux-based headless systems, it may be necessary to install additional
     dependencies to ensure Kivy functions properly.
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Fixes: #8568 

This PR removes:
- Windows 32-bit from tests and build matrix.
- Windows 32-bit dependency docs
- `--no-binary Pillow` flag during install (needed for Windows 32 bit)

#### Why did you left `arch: [ 'x64' ]` even if just one arch is available?
Hopefully, soon we will be able to build / test on **Windows ARM64**
