### PR TITLE
Fix flaky pyinstaller video widget test

### DIFF
--- a/kivy/tests/pyinstaller/video_widget/project/__init__.py
+++ b/kivy/tests/pyinstaller/video_widget/project/__init__.py
@@ -17,7 +17,7 @@ class VideoApp(App):
 
         self.player.fbind('position', self.check_position)
         Clock.schedule_once(self.start_player, 0)
-        Clock.schedule_interval(self.stop_player, 5)
+        Clock.schedule_interval(self.stop_player, 1)
         return player
 
     def start_player(self, *args):
@@ -29,7 +29,7 @@ class VideoApp(App):
             self.stop_player()
 
     def stop_player(self, *args):
-        if time.perf_counter() - self.start_t > 10:
+        if time.perf_counter() - self.start_t > 20:
             assert self.player.duration > 0
             assert self.player.position > 0
             self.stop()

--- a/kivy/tests/pyinstaller/video_widget/project/__init__.py
+++ b/kivy/tests/pyinstaller/video_widget/project/__init__.py
@@ -17,7 +17,7 @@ class VideoApp(App):
 
         self.player.fbind('position', self.check_position)
         Clock.schedule_once(self.start_player, 0)
-        Clock.schedule_interval(self.stop_player, 1)
+        Clock.schedule_interval(self.stop_player, 5)
         return player
 
     def start_player(self, *args):


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

With `pytest>8`, the test execution order has changed, and now `pyinstaller` tests are executed first.
Since the first time that starts Kivy takes "some more time" to start, this leads to a failure, as the VideoWidget test is sorta linked to the execution time.

... This is a temp fix to avoid failures, as GStreamer will likely be removed from Kivy.