### PR TITLE
Allow using `c++` mode for Cython files on Android and iOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1104,7 +1104,7 @@ def get_extensions_from_sources(sources):
                     continue
 
                 distutils_settings_key, _, distutils_settings_value = [
-                    s.strip() for s in line[len("distutils:") :].partition("=")
+                    s.strip() for s in line[len("distutils:"):].partition("=")
                 ]
                 if distutils_settings_key == "language":
                     return _to_extension(distutils_settings_value)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

For a long time, we assumed that the Cythonized file resulted in a file with `.c` extension.

When a Cython file is set to use `c++` language mode (either from the `language` flag or via `# distutils: language = c++` in the source code, when Cythonized file have a `.cpp` extension (and that currently breaks the build phase on Android an iOS)

This PR has been extrapolated from #8534, but the feature will be used from multiple implementations during the development of **Kivy 3.0.0**.

