### PR TITLE
ImageIO provider: Retrieve supported image sources file extensions during runtime

### DIFF
--- a/kivy/core/image/img_imageio_implem.h
+++ b/kivy/core/image/img_imageio_implem.h
@@ -1,0 +1,23 @@
+#include <Foundation/Foundation.h>
+#include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+class KivyImageIOProviderSupportedExtensionList {
+    public:
+        KivyImageIOProviderSupportedExtensionList();
+        ~KivyImageIOProviderSupportedExtensionList();
+        void add(NSString* extension);
+        char* get(int index);
+        int count();
+        void clear();
+    private:
+        NSMutableArray* extensions;
+};
+
+class KivyImageIOProvider {
+    public:
+        KivyImageIOProvider();
+        ~KivyImageIOProvider();
+        KivyImageIOProviderSupportedExtensionList* supported_source_image_extensions;
+    private:
+        void load_supported_source_extensions();
+};

--- a/kivy/core/image/img_imageio_implem.mm
+++ b/kivy/core/image/img_imageio_implem.mm
@@ -63,7 +63,7 @@ void KivyImageIOProvider::load_supported_source_extensions()
         CFStringRef uti = (CFStringRef)CFArrayGetValueAtIndex(type_identifiers, i);
         NSArray *uti_extensions;
 
-        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *))
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *))
         {
             UTType *uttype = [UTType typeWithIdentifier:(NSString *)uti];
             uti_extensions = uttype.tags[@"public.filename-extension"];

--- a/kivy/core/image/img_imageio_implem.mm
+++ b/kivy/core/image/img_imageio_implem.mm
@@ -1,0 +1,84 @@
+#include "img_imageio_implem.h"
+
+/*
+* KivyImageIOProviderSupportedExtensionList
+*/
+
+KivyImageIOProviderSupportedExtensionList::KivyImageIOProviderSupportedExtensionList()
+{
+    this->extensions = [[NSMutableArray alloc] init];
+}
+
+KivyImageIOProviderSupportedExtensionList::~KivyImageIOProviderSupportedExtensionList()
+{
+}
+
+void KivyImageIOProviderSupportedExtensionList::add(NSString *extension)
+{
+    if (![this->extensions containsObject:extension])
+    {
+        [this->extensions addObject:extension];
+    }
+}
+
+int KivyImageIOProviderSupportedExtensionList::count()
+{
+    return [this->extensions count];
+}
+
+char *KivyImageIOProviderSupportedExtensionList::get(int index)
+{
+    NSString *extension = [this->extensions objectAtIndex:index];
+    return (char *)[extension UTF8String];
+}
+
+void KivyImageIOProviderSupportedExtensionList::clear()
+{
+    [this->extensions removeAllObjects];
+}
+
+/*
+* KivyImageIOProvider
+*/
+
+KivyImageIOProvider::KivyImageIOProvider()
+{
+    this->supported_source_image_extensions = new KivyImageIOProviderSupportedExtensionList();
+    this->load_supported_source_extensions();
+}
+
+KivyImageIOProvider::~KivyImageIOProvider()
+{
+    delete this->supported_source_image_extensions;
+}
+
+void KivyImageIOProvider::load_supported_source_extensions()
+{
+    this->supported_source_image_extensions->clear();
+
+    CFArrayRef type_identifiers = CGImageSourceCopyTypeIdentifiers();
+
+    for (CFIndex i = 0; i < CFArrayGetCount(type_identifiers); i++)
+    {
+        CFStringRef uti = (CFStringRef)CFArrayGetValueAtIndex(type_identifiers, i);
+        NSArray *uti_extensions;
+
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *))
+        {
+            UTType *uttype = [UTType typeWithIdentifier:(NSString *)uti];
+            uti_extensions = uttype.tags[@"public.filename-extension"];
+        }
+        else
+        {
+            // UTTypeCopyAllTagsWithClass is deprecated, we're leaving this here
+            // for compatibility with older versions of macOS and iOS
+            uti_extensions = CFBridgingRelease(
+                UTTypeCopyAllTagsWithClass(uti, kUTTagClassFilenameExtension));
+        }
+
+        for (NSString *extension in uti_extensions)
+        {
+            this->supported_source_image_extensions->add(extension);
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -974,6 +974,7 @@ if platform in ('darwin', 'ios'):
     else:
         osx_flags = {'extra_link_args': [
             '-framework', 'ApplicationServices']}
+    osx_flags['extra_compile_args'] = ['-ObjC++']
     sources['core/image/img_imageio.pyx'] = merge(
         base_flags, osx_flags)
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Our list of supported file types on the `ImageIO` provider is outdated, and not correct.
Apple platforms provide a way to retrieve the supported file extensions during runtime, as support may vary on different platforms and OS versions.

This implementation, even if may seem quite over-complicated for the current task will help in the future to enhance / clean up the current implementation.

As a reference, the returned list on macOS 14.3.1 is:
```
['jpeg', 'jpg', 'jpe', 'png', 'gif', 'tif', 'dng', 'dxo', 'cr2', 'cr3', 'mos', 'fff', '3fr', 'nef', 'nrw', 'pef', 'srw', 'srf', 'sr2', 'arw', 'erf', 'dcr', 'tiff', 'jp2', 'jpf', 'jpx', 'j2k', 'j2c', 'astc', 'ktx', 'avci', 'jxl', 'avif', 'heic', 'heics', 'heif', 'hif', 'crw', 'raf', 'raw', 'rw2', 'rwl', 'mrw', 'orf', 'iiq', 'ico', 'bmp', 'dib', 'icns', 'psd', 'tga', 'exr', 'webp', 'sgi', 'pic', 'hdr', 'pbm', 'pgm', 'ppm', 'pfm', 'mpo', 'pvr', 'dds', 'pict', 'pct']
```

FYI: In the future, when running via ANGLE (see #8534 ), `ImageIO` provider will be more important than ever, as `sdl2_image` will be unusable due to incompatibility.