### PR TITLE
Prevents kivy.uix.video.Video warning of "Image: Error loading ..."

### DIFF
--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -161,6 +161,7 @@ class Video(Image):
 
     def __init__(self, **kwargs):
         self._video = None
+        self.source = kwargs.pop('source')
         super(Video, self).__init__(**kwargs)
         self.fbind('source', self._trigger_video_load)
 


### PR DESCRIPTION
### Teaser
Let's have happy Video / Videoplayer widgets by default

### Relevant Knowledge
https://github.com/kivy/kivy/issues/4535

### Feedback Request
Maybe popping more arguments from `kwargs` since `Image` would not need e.g. `state`, `volume`


### Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a Component: xxx label.
* [ ] Applied the api-deprecation or api-break label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
