### PR TITLE
ImageIO Provider: Include `CoreServices` header (fixes iOS build)

### DIFF
--- a/kivy/core/image/img_imageio_implem.h
+++ b/kivy/core/image/img_imageio_implem.h
@@ -1,3 +1,4 @@
+#include <CoreServices/CoreServices.h>
 #include <Foundation/Foundation.h>
 #include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

In #8623 the `CoreServices` framework header has been omitted, and that is preventing to build Kivy on iOS.


