### PR TITLE
Add `Window.unrotated_size`, simplify, clean-up and fix `Window.size` and `Window._density` logic.

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -401,7 +401,9 @@ class WindowSDL(WindowBase):
             except AttributeError:
                 pass
         else:
-            self._density = self._win._get_gl_size()[0] / self._size[0]
+            self._density = (
+                self._win.window_pixel_size[0] / self._win.window_size[0]
+            )
             if self._is_desktop:
                 self.dpi = self._density * 96.
 

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -134,7 +134,7 @@ class MouseMotionEvent(MotionEvent):
 
             # use same logic as WindowBase.on_motion() so we get correct
             # coordinates when _density != 1
-            w, h = win._get_effective_size()
+            w, h = win.unrotated_size
 
             self.scale_for_screen(w, h, rotation=win.rotation)
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -656,7 +656,7 @@ cdef extern from "SDL.h":
     cdef void SDL_SetTextInputRect(SDL_Rect *rect)
     cdef SDL_bool SDL_HasScreenKeyboardSupport()
     cdef SDL_bool SDL_IsScreenKeyboardShown(SDL_Window *window)
-    cdef void SDL_GL_GetDrawableSize(SDL_Window *window, int *w, int *h)
+    cdef void SDL_GetWindowSizeInPixels(SDL_Window *window, int *w, int *h)
     cdef int SDL_SetWindowHitTest(SDL_Window *window, SDL_HitTest callback, void *callback_data)
     # Sound audio formats
     Uint16 AUDIO_U8     #0x0008  /**< Unsigned 8-bit samples */

--- a/kivy/tests/test_window_base.py
+++ b/kivy/tests/test_window_base.py
@@ -21,6 +21,74 @@ class WindowBaseTest(GraphicUnitTest):
             win.system_size = old_system_size
 
 
+class WindowRotationTest(GraphicUnitTest):
+
+    def test_rotation_sizes(self):
+        win = self.Window
+        win.system_size = 320, 240
+
+        for rotation in (0, 90, 180, 270):
+            win.rotation = rotation
+
+            # Comparison should be performed with unrotated size
+            # as it also takes into account the window density
+            w, h = win.unrotated_size
+            if rotation in (90, 270):
+                w, h = h, w
+
+            assert win.size == (w, h)
+
+
+class WindowUnrotatedSizeTest(GraphicUnitTest):
+
+    def test_unrotated_size(self):
+        win = self.Window
+        win.system_size = 320, 240
+
+        # This is automatically set by the window provider, but we can
+        # force it manually for this specific test
+        win._density = 3.0
+
+        assert win.unrotated_size == (960, 720)
+
+
+class WindowSizeTest(GraphicUnitTest):
+
+    def test_window_size_property(self):
+        win = self.Window
+
+        # Test that setting the size property to 100, 100
+        # sets the system_size to 100, 100 when the window is not rotated
+        # and the density is 1.0
+        win.rotation = 0
+        win._density = 1.0
+        win.size = 100, 100
+        assert win.system_size == [100, 100]
+
+        # Test that setting the size property to 100, 50 sets the system_size
+        # to 50, 100 when the window is rotated 90 degrees and the density is
+        # 1.0
+        win.rotation = 90
+        win._density = 1.0
+        win.size = 100, 50
+        assert win.system_size == [50, 100]
+
+        # Test that setting the size property to 200, 100 sets the system_size
+        # to 100, 50 when the window is unrotated and the density is 2.0
+        win.rotation = 0
+        win._density = 2.0
+        win.size = 200, 100
+        assert win.system_size == [100, 50]
+
+        # Test that setting the size property to 100, 200 sets the system_size
+        # to 100, 50 when the window is rotated 90 degrees and the density is
+        # 2.0
+        win.rotation = 90
+        win._density = 2.0
+        win.size = 100, 200
+        assert win.system_size == [100, 50]
+
+
 class WindowOpacityTest(GraphicUnitTest):
 
     def setUp(self):


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

- Avoid usage of `SDL_GL_GetDrawableSize` which is a strict requirement for https://github.com/kivy/kivy/pull/8534:
   - Instead we're using `SDL_GetWindowSizeInPixels` (https://wiki.libsdl.org/SDL2/SDL_GetWindowSizeInPixels) which is a more generic version, and is also `SDL3` ready, as `SDL_GL_GetDrawableSize` will be removed.
 
 - Avoid DRY issues for `_get_width` and `_get_height`, now the generic code from `_get_size` is used instead.
 
 - Avoid usage for `_get_gl_size()` in `WindowBase`, as this is a SDL2 specific feature. `_get_gl_size()` has been moved to `window_pixel_size` property, which is still SDL2-specific but is not used outside of the `SDL2` implementation.
 
 -  `resize_display_mode` method for SDL2 implementation was left abandoned, and not used by the API, but it actually makes sense when a resize is requested when in fullscreen mode, this has been reworked and is now called by the `resize_window` method, when needed.
 
 - `_get_effective_size` has been removed, and `Window.unrotated_size` public property has been added (and achieves the same result, while fixing issues)
 
 - Fixes an issue that prevented to correctly rotate a window on screens with density > 1.0
 
 - Fixes issue #8140:
     - Setting `Window.size=100,100`, when `_density=1.0`, sets the `system_size` to the same value.
     - Setting `Window.size=100,100`, when `_density=2.0`, sets the `system_size` to `50,50`
  
  No `versionchanged` has been applied to `Window.size` as `Window.size` was already meant to work as now better explained in docs.