### PR TITLE
Typo: "kiby" instead of "kivy" in global variable in _text_pango.pyx

### DIFF
--- a/kivy/core/text/_text_pango.pyx
+++ b/kivy/core/text/_text_pango.pyx
@@ -722,7 +722,7 @@ def kpango_font_context_create(font_context, fontfile=None):
 
 def kpango_font_context_add_font(font_context, fontfile):
     global kivy_font_context_cache
-    global kiby_fontfamily_cache
+    global kivy_fontfamily_cache
     cdef bytes fctx = _byte_option(font_context)
     cdef bytes font_name_r = _byte_option(fontfile)
     if not fctx:


### PR DESCRIPTION
This is just a typo fix for the line `global kiby_fontfamily_cache`, the kiby instead of kivy being the typo. I don't use Pango myself and it seems a little odd that this typo is in the code when it looks like it might break something? Someone may want to have a look into this.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
