### PR TITLE
Typo: Docs grammar issue in loader.py (been/be)

### DIFF
--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -145,7 +145,7 @@ class LoaderBase(object):
 
     The default value is 2 for giving a smooth user experience. You could
     increase the number of workers, then all the images will be loaded faster,
-    but the user will not been able to use the application while loading.
+    but the user will not be able to use the application while loading.
     Prior to 1.6.0, the default number was 20, and loading many full-hd images
     was completely blocking the application.
 


### PR DESCRIPTION
Fixed a typo, been/be in this segment for the docs:
```
    The default value is 2 for giving a smooth user experience. You could
    increase the number of workers, then all the images will be loaded faster,
    but the user will not be(en) able to use the application while loading.
    Prior to 1.6.0, the default number was 20, and loading many full-hd images
    was completely blocking the application.
```
The block also seems a little unclear to me, though that may simply because I lack the technical background of what's going on.
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
