### PR TITLE
Expose a `native_handle` property on `WindowBase`

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -990,6 +990,26 @@ class WindowBase(EventDispatcher):
     to `1.0`.
     '''
 
+    def _get_native_handle(self):
+        return self._get_window_native_handle()
+
+    def _get_window_native_handle(self):
+        Logger.warning('Window: Native handle is not implemented in the '
+                       'current window provider')
+
+    native_handle = AliasProperty(_get_native_handle, None)
+    '''Read only property to get the native handle of the window.
+
+    .. note::
+        The value is platform-specific and is mostly meant to be passed to
+        other libraries. This feature is currently only supported on Windows
+        and Linux platforms.
+
+    .. versionadded:: 3.0.0
+
+    :attr:`native_handle` is an :class:`~kivy.properties.AliasProperty`.
+    '''
+
     @property
     def __self__(self):
         return self

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -507,6 +507,16 @@ cdef class _WindowSDL2Storage:
                 windows_info.hdc = wm_info.info.win.hdc
                 return windows_info
 
+    def get_native_handle(self):
+        window_info = self.get_window_info()
+
+        IF USE_WAYLAND:
+            if isinstance(window_info, WindowInfoWayland):
+                return window_info.surface
+
+        if window_info is not None:
+            return window_info.window
+
     # Transparent Window background
     def is_window_shaped(self):
         return SDL_IsShapedWindow(self.win)

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -512,17 +512,17 @@ cdef class _WindowSDL2Storage:
         window_info = self.get_window_info()
 
         if setupconfig.USE_X11:
-            from kivy.core.window.window_info import WindowInfoX11
+            from .window_info import WindowInfoX11
             if isinstance(window_info, WindowInfoX11):
                 return window_info.window
 
         if setupconfig.USE_WAYLAND:
-            from kivy.core.window.window_info import WindowInfoWayland
+            from .window_info import WindowInfoWayland
             if isinstance(window_info, WindowInfoWayland):
                 return window_info.surface
 
         if platform == "win":
-            from kivy.core.window.window_info import WindowInfoWindows
+            from .window_info import WindowInfoWindows
             if isinstance(window_info, WindowInfoWindows):
                 return window_info.window
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -8,6 +8,7 @@ from os import environ
 from kivy.config import Config
 from kivy.logger import Logger
 from kivy import platform
+from kivy import setupconfig
 from kivy.graphics.cgl cimport *
 from kivy.graphics.egl_backend.egl_angle cimport EGLANGLE
 
@@ -510,12 +511,20 @@ cdef class _WindowSDL2Storage:
     def get_native_handle(self):
         window_info = self.get_window_info()
 
-        IF USE_WAYLAND:
+        if setupconfig.USE_X11:
+            from kivy.core.window.window_info import WindowInfoX11
+            if isinstance(window_info, WindowInfoX11):
+                return window_info.window
+
+        if setupconfig.USE_WAYLAND:
+            from kivy.core.window.window_info import WindowInfoWayland
             if isinstance(window_info, WindowInfoWayland):
                 return window_info.surface
 
-        if window_info is not None:
-            return window_info.window
+        if platform == "win":
+            from kivy.core.window.window_info import WindowInfoWindows
+            if isinstance(window_info, WindowInfoWindows):
+                return window_info.window
 
     # Transparent Window background
     def is_window_shaped(self):

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -343,7 +343,7 @@ class WindowSDL(WindowBase):
                         # make windows dispatch,
                         # WM_NCCALCSIZE explicitly
                         ctypes.windll.user32.SetWindowPos(
-                            self._win.get_window_info().window,
+                            self.native_handle,
                             win32con.HWND_TOP,
                             *self._win.get_window_pos(),
                             *self.system_size,
@@ -490,6 +490,9 @@ class WindowSDL(WindowBase):
     def _set_window_opacity(self, opacity):
         if self.opacity != opacity:
             return self._win.set_window_opacity(opacity)
+
+    def _get_window_native_handle(self):
+        return self._win.get_native_handle()
 
     # Transparent Window background
     def _is_shaped(self):

--- a/kivy/core/window/window_x11.pyx
+++ b/kivy/core/window/window_x11.pyx
@@ -225,6 +225,9 @@ class WindowX11(WindowBase):
         window_info.window = x11_get_window()
         return window_info
 
+    def _get_window_native_handle(self):
+        return self.get_window_info().window
+
     def mainloop(self):
         if x11_idle() == 0 and not self.dispatch('on_request_close'):
             EventLoop.quit = True

--- a/kivy/tests/test_window_base.py
+++ b/kivy/tests/test_window_base.py
@@ -1,5 +1,6 @@
 from itertools import product
 
+from kivy import setupconfig
 from kivy.tests import GraphicUnitTest
 from kivy.logger import LoggerHistory
 
@@ -126,3 +127,19 @@ class WindowOpacityTest(GraphicUnitTest):
         if self.check_opacity_support():
             self.Window.opacity = -1.5
             self.assertEqual(self.Window.opacity, 0.0)
+
+
+class WindowNativeHandleTest(GraphicUnitTest):
+
+    def test_native_handle_non_zero(self):
+        win = self.Window
+        native_handle = win.native_handle
+
+        if setupconfig.USE_X11:
+            self.assertNotEqual(native_handle, 0)
+
+        if setupconfig.USE_WAYLAND:
+            self.assertNotEqual(native_handle, 0)
+
+        if setupconfig.PLATFORM == 'win32':
+            self.assertNotEqual(native_handle, 0)


### PR DESCRIPTION
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

Closes #8597 

Retrieving a pointer to the `NSWindow` will also be required for AccessKit integration, but the native code is not present at the moment.