### PR TITLE
Keep (or move) mandatory dependencies only in `install_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ install_requires =
     Kivy-Garden>=0.1.4
     docutils
     pygments
+    requests
+    filetype
     kivy_deps.angle~=0.4.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
@@ -49,28 +51,13 @@ dev =
     responses
 base =
     pillow>=9.5.0,<11
-    requests
-    filetype
-    docutils
-    pygments
-    kivy_deps.angle~=0.4.0; sys_platform == "win32"
-    kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
-    pypiwin32; sys_platform == "win32"
 media =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
 full =
     pillow>=9.5.0,<11
-    docutils
-    pygments
-    filetype
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    kivy_deps.angle~=0.4.0; sys_platform == "win32"
-    kivy_deps.sdl2~=0.7.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
-    pypiwin32; sys_platform == "win32"
 gstreamer =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     # don't use 0.4.0 because it was deleted


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

This is a small chunk taken from of #8655, to follow an incremental approach.

Mandatory dependencies should stay in `install_requires`, and nowhere else.

The previous approach (by using the `base` selector) created confusion, and mandatory dependencies (`requests`, `filetype`) has not been added to `install_requires`. On the other hand, dependencies marked as mandatory, have also been added to extras selectors (have no impact, but that lead to maintaining a long list of deps).

Therefore, if a user (or our CI which started failing), installs kivy via `pip install kivy[dev]`, will not get essential dependencies to correctly run Kivy.

This gives our users a bad experience, as is counter-intuitive and prone to errors.

The long-term solution (as proposed in #8655) is to completely remove the `base` selector, and reduce the mandatory requirements to the bare minimum.

Added `[build wheel]` to check "wheel tests" to pass:
- `manylinux` and `windows` are expected to pass
- `macOS` is not expected to pass due to another (completely different issue)
