### PR TITLE
`Label`: Prevent overwriting `disabled_color` attribute when `color` is updated

### DIFF
--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -379,6 +379,10 @@ class Label(Widget):
                 self._label.options['outline_color'] = (
                     self.disabled_outline_color if value else
                     self.outline_color)
+            elif self.disabled and name in ('color', 'outline_color'):
+                # When disabled, color or outline_color changes should not get
+                # assigned or trigger updates.
+                return
 
             # NOTE: Compatibility code due to deprecated properties
             # Must be removed along with padding_x and padding_y


### PR DESCRIPTION
Ensure that when setting rules for color and disabled_color, refrain from overwriting color attributes if the label is disabled, allowing the label to be drawn using the disabled_color value.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
