### PR TITLE
Fix issue with `CompoundSelectionBehavior` silently ignoring `ValueError` in `on_selected_nodes` event

### DIFF
--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -682,8 +682,7 @@ class CompoundSelectionBehavior(object):
             This method must be called by the derived widget using super if it
             is overwritten.
         '''
-        try:
+        if node in self.selected_nodes:
             self.selected_nodes.remove(node)
             return True
-        except ValueError:
-            return False
+        return False


### PR DESCRIPTION
See issue: #8672

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
