### PR TITLE
add more orientation options to BoxLayout

### DIFF
--- a/kivy/tests/test_uix_boxlayout.py
+++ b/kivy/tests/test_uix_boxlayout.py
@@ -6,6 +6,7 @@ Order matter.
 On the screen, most of example must have the red->blue->green order.
 '''
 
+import pytest
 from kivy.tests.common import GraphicUnitTest
 
 
@@ -92,3 +93,127 @@ class UIXBoxLayoutTestcase(GraphicUnitTest):
         layout.add_widget(b(0, 1, 0))
         layout.add_widget(b(0, 0, 1))
         r(layout)
+
+
+class Test_internal_property:
+    @pytest.mark.parametrize(
+        "ori, expect", [
+            ('horizontal', True, ),
+            ('lr', True, ),
+            ('rl', True, ),
+            ('vertical', False, ),
+            ('tb', False, ),
+            ('bt', False, ),
+        ]
+    )
+    def test_is_horizontal(self, ori, expect):
+        from kivy.uix.boxlayout import BoxLayout
+        box = BoxLayout(orientation=ori)
+        assert box._is_horizontal is expect
+
+    @pytest.mark.parametrize(
+        "ori, expect", [
+            ('horizontal', True, ),
+            ('lr', True, ),
+            ('rl', False, ),
+            ('vertical', False, ),
+            ('tb', False, ),
+            ('bt', True, ),
+        ]
+    )
+    def test_is_forward_direction(self, ori, expect):
+        from kivy.uix.boxlayout import BoxLayout
+        box = BoxLayout(orientation=ori)
+        assert box._is_forward_direction is expect
+
+
+class Test_children_pos:
+    @classmethod
+    def gen_size(cls, is_horizontal):
+        '''
+        >>> list(gen_size(True))
+        [(100, 100), (200, 100), (300, 100), ...]
+        >>> list(gen_size(False))
+        [(100, 100), (100, 200), (100, 300), ...]
+        '''
+        w = h = 100
+        if is_horizontal:
+            w_incr, h_incr = 100, 0
+        else:
+            w_incr, h_incr = 0, 100
+        while True:
+            yield (w, h, )
+            w += w_incr
+            h += h_incr
+
+    @classmethod
+    def compute_layout(cls, *, ori, n_children):
+        from kivy.uix.label import Label
+        from kivy.uix.boxlayout import BoxLayout
+        box = BoxLayout(orientation=ori, pos=(0, 0, ), size=(400, 400, ))
+        size_iter = cls.gen_size(box._is_horizontal)
+        for i, size in zip(range(n_children), size_iter):
+            # Set the position of the children to a value other than the
+            # default (0, 0) to ensure that the result is not affected by the
+            # default position.
+            box.add_widget(Label(
+                text=str(i), size_hint=(None, None), size=size, pos=(8, 8)))
+        box.do_layout()
+        return {int(c.text): tuple(c.pos) for c in box.children}
+
+    # |
+    # |---|
+    # | 0 |
+    # |---|---
+    def test_1x1(self):
+        from kivy.uix.boxlayout import BoxLayout
+        for ori in BoxLayout.orientation.options:
+            assert {0: (0, 0), } == self.compute_layout(n_children=1, ori=ori)
+
+    # |
+    # |---|-----|-------|
+    # | 0 |  1  |   2   |
+    # |---|-----|-------|---
+    @pytest.mark.parametrize('ori', ['horizontal', 'lr', ])
+    def test_3x1_lr(self, ori):
+        assert {0: (0, 0), 1: (100, 0), 2: (300, 0), } == \
+            self.compute_layout(n_children=3, ori=ori)
+
+    # |
+    # |-------|-----|---|
+    # |   2   |  1  | 0 |
+    # |-------|-----|---|---
+    def test_3x1_rl(self):
+        assert {2: (0, 0), 1: (300, 0), 0: (500, 0), } == \
+            self.compute_layout(n_children=3, ori='rl')
+
+    # |
+    # |---|
+    # | 0 |
+    # |---|
+    # |   |
+    # | 1 |
+    # |---|
+    # |   |
+    # | 2 |
+    # |   |
+    # |---|---
+    @pytest.mark.parametrize('ori', ['vertical', 'tb', ])
+    def test_1x3_tb(self, ori):
+        assert {2: (0, 0), 1: (0, 300), 0: (0, 500), } == \
+            self.compute_layout(n_children=3, ori=ori)
+
+    # |
+    # |---|
+    # |   |
+    # | 2 |
+    # |   |
+    # |---|
+    # |   |
+    # | 1 |
+    # |---|
+    # | 0 |
+    # |---|---
+    def test_1x3_bt(self):
+        assert {0: (0, 0), 1: (0, 100), 2: (0, 300), } == \
+            self.compute_layout(n_children=3, ori='bt')

--- a/kivy/tests/test_uix_recycleboxlayout.py
+++ b/kivy/tests/test_uix_recycleboxlayout.py
@@ -1,0 +1,237 @@
+import itertools
+import pytest
+
+
+class Test_children_pos_when_all_the_data_is_visible:
+    @classmethod
+    def gen_size(cls, is_horizontal):
+        '''
+        >>> list(gen_size(True))
+        [(100, 100), (200, 100), (300, 100), ...]
+        >>> list(gen_size(False))
+        [(100, 100), (100, 200), (100, 300), ...]
+        '''
+        w = h = 100
+        if is_horizontal:
+            w_incr, h_incr = 100, 0
+        else:
+            w_incr, h_incr = 0, 100
+        while True:
+            yield (w, h, )
+            w += w_incr
+            h += h_incr
+
+    @classmethod
+    def compute_layout(cls, *, ori, n_data, clock):
+        '''Returns {view-index: pos, view-index: pos, ...}'''
+        from textwrap import dedent
+        from kivy.lang import Builder
+
+        # Use Kvlang because RecycleView cannot be constructed from python
+        rv = Builder.load_string(dedent(f'''
+            RecycleView:
+                viewclass: 'Widget'
+                size: 1000, 1000
+                RecycleBoxLayout:
+                    id: layout
+                    orientation: '{ori}'
+                    default_size_hint: None, None
+            '''))
+        size_iter = cls.gen_size(rv.ids.layout._is_horizontal)
+        rv.data = [
+            {'width': w, 'height': h, }
+            for w, h in itertools.islice(size_iter, n_data)
+        ]
+        clock.tick()
+        clock.tick()
+        layout = rv.ids.layout
+        return {
+            layout.get_view_index_at(c.center): tuple(c.pos)
+            for c in layout.children
+        }
+
+    # |
+    # |---|
+    # | 0 |
+    # |---|---
+    def test_1x1(self, kivy_clock):
+        from kivy.uix.recycleboxlayout import RecycleBoxLayout
+        for ori in RecycleBoxLayout.orientation.options:
+            assert {0: (0, 0), } == self.compute_layout(
+                n_data=1, ori=ori, clock=kivy_clock)
+
+    # |
+    # |---|-----|-------|
+    # | 0 |  1  |   2   |
+    # |---|-----|-------|---
+    @pytest.mark.parametrize('ori', ['horizontal', 'lr', ])
+    def test_3x1_lr(self, kivy_clock, ori):
+        assert {0: (0, 0), 1: (100, 0), 2: (300, 0), } == \
+            self.compute_layout(n_data=3, ori=ori, clock=kivy_clock)
+
+    # |
+    # |-------|-----|---|
+    # |   2   |  1  | 0 |
+    # |-------|-----|---|---
+    def test_3x1_rl(self, kivy_clock):
+        assert {0: (500, 0), 1: (300, 0), 2: (0, 0), } == \
+            self.compute_layout(n_data=3, ori='rl', clock=kivy_clock)
+
+    # |
+    # |---|
+    # | 0 |
+    # |---|
+    # |   |
+    # | 1 |
+    # |---|
+    # |   |
+    # | 2 |
+    # |   |
+    # |---|---
+    @pytest.mark.parametrize('ori', ['vertical', 'tb', ])
+    def test_1x3_tb(self, kivy_clock, ori):
+        assert {0: (0, 500), 1: (0, 300), 2: (0, 0), } == \
+            self.compute_layout(n_data=3, ori=ori, clock=kivy_clock)
+
+    # |
+    # |---|
+    # |   |
+    # | 2 |
+    # |   |
+    # |---|
+    # |   |
+    # | 1 |
+    # |---|
+    # | 0 |
+    # |---|---
+    def test_1x3_bt(self, kivy_clock):
+        assert {0: (0, 0), 1: (0, 100), 2: (0, 300), } == \
+            self.compute_layout(n_data=3, ori='bt', clock=kivy_clock)
+
+
+class Test_children_pos_when_only_a_part_of_the_data_is_visible:
+    def compute_layout(self, *, ori, n_data, scroll_to, clock):
+        '''Returns {view-index: pos, view-index: pos, ...}'''
+        from textwrap import dedent
+        from kivy.lang import Builder
+
+        # Use Kvlang because RecycleView cannot be constructed from python
+        rv = Builder.load_string(dedent(f'''
+            RecycleView:
+                viewclass: 'Widget'
+                size: 100, 100
+                data: ({{}} for __ in range({n_data}))
+                RecycleBoxLayout:
+                    id: layout
+                    orientation: '{ori}'
+                    default_size_hint: None, None
+                    default_size: 100, 100
+                    size_hint: None, None
+                    size: 400, 400
+            '''))
+        clock.tick()
+        layout = rv.ids.layout
+        x, y = scroll_to
+        scrollable_width = layout.width - rv.width
+        if scrollable_width:  # avoids ZeroDivisionError
+            rv.scroll_x = x / scrollable_width
+        scrollable_height = layout.height - rv.height
+        if scrollable_height:  # avoids ZeroDivisionError
+            rv.scroll_y = y / scrollable_height
+        clock.tick()
+        return {
+            layout.get_view_index_at(c.center): tuple(c.pos)
+            for c in layout.children
+        }
+
+    # |
+    # |---|---|---|---|
+    # |   | 1 | 2 |   |
+    # |---|---|---|---|---
+    @pytest.mark.parametrize('ori', ['horizontal', 'lr', ])
+    def test_4x1_lr(self, kivy_clock, ori):
+        assert {1: (100, 0), 2: (200, 0), } == self.compute_layout(
+            n_data=4, ori=ori, scroll_to=(150, 0), clock=kivy_clock)
+
+    # |
+    # |---|---|---|---|
+    # |   | 2 | 1 |   |
+    # |---|---|---|---|---
+    def test_4x1_rl(self, kivy_clock):
+        assert {1: (200, 0), 2: (100, 0), } == self.compute_layout(
+            n_data=4, ori='rl', scroll_to=(150, 0), clock=kivy_clock)
+
+    # |
+    # |---|
+    # |   |
+    # |---|
+    # | 1 |
+    # |---|
+    # | 2 |
+    # |---|
+    # |   |
+    # |---|---
+    @pytest.mark.parametrize('ori', ['vertical', 'tb', ])
+    def test_1x4_tb(self, kivy_clock, ori):
+        assert {1: (0, 200), 2: (0, 100), } == self.compute_layout(
+            n_data=4, ori=ori, scroll_to=(0, 150), clock=kivy_clock)
+
+    # |
+    # |---|
+    # |   |
+    # |---|
+    # | 2 |
+    # |---|
+    # | 1 |
+    # |---|
+    # |   |
+    # |---|---
+    def test_1x4_bt(self, kivy_clock):
+        assert {1: (0, 100), 2: (0, 200), } == self.compute_layout(
+            n_data=4, ori='bt', scroll_to=(0, 150), clock=kivy_clock)
+
+
+class Test_spacing:
+    def compute_layout(self, *, ori, n_data, clock):
+        '''Returns {view-index: pos, view-index: pos, ...}'''
+        from textwrap import dedent
+        from kivy.lang import Builder
+
+        # Use Kvlang because RecycleView cannot be constructed from python
+        rv = Builder.load_string(dedent(f'''
+            RecycleView:
+                viewclass: 'Widget'
+                size: 1000, 1000
+                data: ({{}} for __ in range({n_data}))
+                RecycleBoxLayout:
+                    id: layout
+                    orientation: '{ori}'
+                    spacing: 10
+                    default_size_hint: None, None
+                    default_size: 100, 100
+            '''))
+        clock.tick()
+        clock.tick()
+        layout = rv.ids.layout
+        return {
+            layout.get_view_index_at(c.center): tuple(c.pos)
+            for c in layout.children
+        }
+
+    @pytest.mark.parametrize('ori', ['horizontal', 'lr', ])
+    def test_3x1_lr(self, kivy_clock, ori):
+        assert {0: (0, 0), 1: (110, 0), 2: (220, 0), } == self.compute_layout(
+            n_data=3, ori=ori, clock=kivy_clock)
+
+    def test_3x1_rl(self, kivy_clock):
+        assert {2: (0, 0), 1: (110, 0), 0: (220, 0), } == self.compute_layout(
+            n_data=3, ori='rl', clock=kivy_clock)
+
+    @pytest.mark.parametrize('ori', ['vertical', 'tb', ])
+    def test_1x3_tb(self, kivy_clock, ori):
+        assert {0: (0, 220), 1: (0, 110), 2: (0, 0), } == self.compute_layout(
+            n_data=3, ori=ori, clock=kivy_clock)
+
+    def test_1x3_bt(self, kivy_clock):
+        assert {0: (0, 0), 1: (0, 110), 2: (0, 220), } == self.compute_layout(
+            n_data=3, ori='bt', clock=kivy_clock)

--- a/kivy/uix/recycleboxlayout.py
+++ b/kivy/uix/recycleboxlayout.py
@@ -110,12 +110,12 @@ class RecycleBoxLayout(RecycleLayout, BoxLayout):
             return
 
         view_opts = self.view_opts
-        n = len(view_opts)
+        n_data = len(view_opts)
         for i, x, y, w, h in self._iterate_layout(
                 [(opt['size'], opt['size_hint'], opt['pos_hint'],
                   opt['size_hint_min'], opt['size_hint_max']) for
                  opt in reversed(view_opts)]):
-            opt = view_opts[n - i - 1]
+            opt = view_opts[n_data - i - 1]
             shw, shh = opt['size_hint']
             opt['pos'] = x, y
             wo, ho = opt['size']
@@ -134,12 +134,10 @@ class RecycleBoxLayout(RecycleLayout, BoxLayout):
         self._rv_positions = tuple(islice(
             accumulate(chain(
                 (offset, ),
-                (opt['size'][dim] + spacing for opt in islice(
-                    view_opts if is_forward else reversed(view_opts),
-                    None, n - 1,
-                )),
+                (opt['size'][dim] + spacing for opt in (
+                    view_opts if is_forward else reversed(view_opts))),
             )),
-            1, None,
+            1, n_data,
         ))
 
     def get_view_index_at(self, pos):


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

This PR adds new orientation options (`right-to-left` and `bottom-to-top`) to the BoxLayout.

```python
class BoxLayout:
    orientation = OptionProperty('horizontal', options=('lr', 'rl', 'tb', 'bt',
        'horizontal', 'vertical'))
```

## Potential API break

This might break the API because of the existing code like this:

```python
if boxlayout.orientation == 'horizontal':
    ...
else:
    ...
```

The else-clause part of the code above always assumes that the boxlayout lays out its children from top to bottom, but after this PR is merged, it can lay them out in any of the following directions: top-to-bottom, bottom-to-top, or right-to-left.

## Alternative Idea I was suggested

> "Or by introducing a reverse orientation boolean attribute for BoxLayout"  -- EBabz at Discord

This might be an option but consider other layouts:

```python
class StackLayout:
    orientation = OptionProperty('lr-tb', options=(
        'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt', 'bt-lr', 'rl-bt',
        'bt-rl'))

class GridLayout:
    orientation = OptionProperty('lr-tb', options=(
        'lr-tb', 'tb-lr', 'rl-tb', 'tb-rl', 'lr-bt', 'bt-lr', 'rl-bt',
        'bt-rl'))
```

Using a boolean property may not be a good choice for maintaining consistency.