### PR TITLE
Bump macOS ANGLE version to `chromium-6367_rev1`

### DIFF
--- a/tools/build_macos_dependencies.sh
+++ b/tools/build_macos_dependencies.sh
@@ -28,7 +28,7 @@ MACOS__LIBPNG__VERSION="1.6.40"
 MACOS__LIBPNG__URL="https://download.sourceforge.net/libpng/libpng16/${MACOS__LIBPNG__VERSION}/libpng-${MACOS__LIBPNG__VERSION}.tar.gz"
 MACOS__LIBPNG__FOLDER="libpng-${MACOS__LIBPNG__VERSION}"
 
-MACOS__ANGLE__VERSION="chromium-6261_rev1"
+MACOS__ANGLE__VERSION="chromium-6367_rev1"
 MACOS__ANGLE_URL="https://github.com/kivy/angle-builder/releases/download/${MACOS__ANGLE__VERSION}/angle-macos-universal.tar.gz"
 MACOS__ANGLE__FOLDER="angle-macos-universal"
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


See: https://github.com/kivy/angle-builder/pull/12