### PR TITLE
Fix `xsel` import when clipboard is empty, and add timeout failsafe

### DIFF
--- a/kivy/core/clipboard/clipboard_xsel.py
+++ b/kivy/core/clipboard/clipboard_xsel.py
@@ -13,7 +13,7 @@ if platform != 'linux':
 
 try:
     import subprocess
-    p = subprocess.Popen(['xsel'], stdout=subprocess.PIPE)
+    p = subprocess.Popen(['xsel', '--version'], stdout=subprocess.PIPE)
     p.communicate(timeout=1)
 except:
     raise

--- a/kivy/core/clipboard/clipboard_xsel.py
+++ b/kivy/core/clipboard/clipboard_xsel.py
@@ -14,7 +14,7 @@ if platform != 'linux':
 try:
     import subprocess
     p = subprocess.Popen(['xsel'], stdout=subprocess.PIPE)
-    p.communicate()
+    p.communicate(timeout=1)
 except:
     raise
 

--- a/kivy/core/clipboard/clipboard_xsel.py
+++ b/kivy/core/clipboard/clipboard_xsel.py
@@ -11,12 +11,9 @@ from kivy.core.clipboard._clipboard_ext import ClipboardExternalBase
 if platform != 'linux':
     raise SystemError('unsupported platform for xsel clipboard')
 
-try:
-    import subprocess
-    p = subprocess.Popen(['xsel', '--version'], stdout=subprocess.PIPE)
-    p.communicate(timeout=1)
-except:
-    raise
+import subprocess
+p = subprocess.Popen(['xsel', '--version'], stdout=subprocess.PIPE)
+p.communicate(timeout=1)
 
 
 class ClipboardXsel(ClipboardExternalBase):


### PR DESCRIPTION
My Kivy installation was hanging on import, and it turned out to be because `xsel` wasn't sending anything through its pipe -- because the selection was empty. It looked like `xsel` only got called to make sure it was *there*, so I added a `--version` argument, which will return something with 0 exit code if `xsel` is available.

I also added a timeout to the subprocess, because it seems bad that kivy just hangs when the subprocess does. If `xsel` is broken, Kivy should just use another clipboard provider, rather than locking up.

I removed the bare `except` because it did nothing.