### PR TITLE
Update `cibuildwheel` pinned version to `2.17.0`

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -81,7 +81,7 @@ jobs:
         update_version_metadata
     - name: Install cibuildwheel
       run: |
-        python -m pip install cibuildwheel==2.16.2
+        python -m pip install cibuildwheel==2.17.0
     - name: Make wheels
       run: |
         python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -76,7 +76,7 @@ jobs:
         ./tools/build_macos_dependencies.sh
     - name: Install cibuildwheel
       run: |
-        python -m pip install cibuildwheel==2.16.2
+        python -m pip install cibuildwheel==2.17.0
     - name: Build wheels
       run: |
         export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Just a version bump to be sure upcoming changes regarding build dependencies version management works as expected for wheels.