### PR TITLE
Pin build-time requirements versions, renovatebot will take care of the updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = [
-    "setuptools", "wheel", "packaging",
+    "setuptools~=69.2.0",
+    "wheel~=0.43.0",
+    "packaging~=24.0",
     "cython>=0.29.1,<=3.0.0",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
     'kivy_deps.sdl2_dev~=0.7.0; sys_platform == "win32"',


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

In past we left dependencies (both build-time and run-time) dependencies unpinned.

That led to CI/CD pipeline breakages (Like https://github.com/kivy/kivy/actions/runs/8765819880/job/24057222737) and users finding out something was not working as expected with newer (and untested) versions of a dependency.

By starting out with built-time dependencies, the idea is to migrate to pinned dependencies, and leave renovatebot (#8688) try out new versions and open PRs for us.