### PR TITLE
`mock` gl backend egl context should not be managed by `sdl`

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -168,7 +168,7 @@ cdef class _WindowSDL2Storage:
 
     def setup_window(self, x, y, width, height, borderless, fullscreen, resizable, state, gl_backend):
         self.gl_backend_name = gl_backend
-        self.sdl_manages_egl_context = gl_backend != "angle"
+        self.sdl_manages_egl_context = gl_backend not in ("mock", "angle")
 
         self.win_flags  = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

`mock` gl backend should be treated as `angle`, as `sdl` should not manage the `egl` context.

Previously did not failed as `sdl` have been built with OpenGL support, but since the introduction of the `ANGLE` EGL provider `sdl` is being built without OpenGL support enabled.

During wheel tests, performed with `KIVY_GL_BACKEND=mock`, the pipeline is failing as sdl is trying to create a window with `OpenGL` support, even if we opted out.