### PR TITLE
Remove unused `sphinxcontrib-*diag` dependencies (and `funcparserlib`)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -35,16 +35,6 @@ Install Sphinx
   Get pip (https://pypi.python.org/pypi/pip). You'll use it to install the dependencies.
 
   To install pip, run ``python setup.py install`` in the pip directory. Now run:
-    
-
-  ``pip install sphinxcontrib-blockdiag sphinxcontrib-seqdiag``
-  
-
-  ``pip install sphinxcontrib-actdiag sphinxcontrib-nwdiag``
-    
-
-  Or just use the provided *doc-requirements.txt*:
-    
 
   ``pip install -r doc-requirements.txt``
   

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,5 +1,2 @@
 # Frozen Sphinx requirements for easier pip installation
-sphinxcontrib-actdiag
-sphinxcontrib-blockdiag
-sphinxcontrib-nwdiag
-sphinxcontrib-seqdiag
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,12 +37,7 @@ dev =
     pytest-benchmark
     pyinstaller
     sphinx<=6.2.1
-    sphinxcontrib-blockdiag
-    sphinxcontrib-seqdiag
-    sphinxcontrib-actdiag
-    sphinxcontrib-nwdiag
     sphinxcontrib-jquery
-    funcparserlib==1.0.0a0
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
     kivy_deps.sdl2_dev~=0.7.0; sys_platform == "win32"
     kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

PR #8695 warned us about an outdated pinned dependency (`funcparserlib`), however as explained in https://github.com/kivy/kivy/issues/8465 `funcparserlib` has been pinned to a known working version for a docs-generation-related dependency.

After some research, I've found out that all the following docs-generation related dependencies are installed even if the features they offer are completely unused at the moment.

Specifically:

- `sphinxcontrib-actdiag` (which requires the pinned `funcparserlib`) allows the usage of `actdiag` blocks in docs, but no usage has been find out in the current code.
- `sphinxcontrib-blockdiag` allows the usage of `blockdiag ` blocks in docs, but no usage has been find out in the current code.
- `sphinxcontrib-nwdiag` allows the usage of `blockdiag ` blocks in docs, but no usage has been find out in the current code.
- `hinxcontrib-seqdiag` allows the usage of `block seqdiag iag ` blocks in docs, but no usage has been find out in the current code.


This PR removes all these dependencies from requirements, allowing us to also remove the pinned `funcparserlib`.

While making changes, I've noticed that the docs generation guide looks outdated. Will update it on a separate PR.