### PR TITLE
Make proper changes for `action/upload-artifact@v4` (wheels)

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Upload wheels as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: manylinux_wheels
+        name: manylinux_wheels-${{ matrix.cibw_archs }}
         path: ./wheelhouse/*.whl
 
   manylinux_wheel_upload:
@@ -99,7 +99,8 @@ jobs:
         python-version: 3.x
     - uses: actions/download-artifact@v4
       with:
-        name: manylinux_wheels
+        pattern: manylinux_wheels-*
+        merge-multiple: true
         path: dist
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
@@ -143,7 +144,8 @@ jobs:
         python-version: ${{ matrix.python }}
     - uses: actions/download-artifact@v4
       with:
-        name: manylinux_wheels
+        pattern: manylinux_wheels-*
+        merge-multiple: true
         path: dist
     - name: Setup env
       run: |

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: github.event_name == 'pull_request'
       with:
-        name: armv7l_wheels
+        name: armv7l_wheels-${{ matrix.docker_images }}
         path: dist
     - name: Upload to GitHub Release
       uses: softprops/action-gh-release@v2.0.4

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -16,17 +16,17 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        docker_images: ['balenalib/raspberrypi3-debian-python:3.9-bullseye', 'balenalib/raspberrypi3-debian-python:3.11-bookworm']
+        image_version: ['3.9-bullseye', '3.11-bookworm']
     steps:
     - uses: actions/checkout@v4
     - name: Generate version metadata
       run: |
         source .ci/ubuntu_ci.sh
         update_version_metadata
-    - name: Make ${{ matrix.docker_images }} wheel
+    - name: Make ${{ matrix.image_version }} wheel
       run: |
         source .ci/ubuntu_ci.sh
-        generate_rpi_wheels ${{ matrix.docker_images }}
+        generate_rpi_wheels balenalib/raspberrypi3-debian-python:${{ matrix.image_version }}
     - name: Rename wheels
       if: github.event.ref_type != 'tag'
       run: |
@@ -43,7 +43,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: github.event_name == 'pull_request'
       with:
-        name: armv7l_wheels-${{ matrix.docker_images }}
+        name: armv7l_wheels-${{ matrix.image_version }}
         path: dist
     - name: Upload to GitHub Release
       uses: softprops/action-gh-release@v2.0.4

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -114,8 +114,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
-          pattern: windows_wheels-*-*
-          merge-multiple: true
+          name: windows_wheels-${{ matrix.python }}-${{ matrix.arch }}
           path: dist
       - name: Install Kivy Wheel
         run: |
@@ -147,6 +146,9 @@ jobs:
           python-version: 3.x
       - uses: actions/download-artifact@v4
         with:
+          # Only one windows_wheels-*-* artifact contains the sdist
+          # However, all artifacts are downloaded ATM, to avoid using
+          # a specific name.
           pattern: windows_wheels-*-*
           merge-multiple: true
           path: dist

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Upload wheels as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: windows_wheels
+        name: windows_wheels-${{ matrix.python }}-${{ matrix.arch }}
         path: dist
 
   windows_wheel_upload:
@@ -65,7 +65,8 @@ jobs:
           python-version: 3.x
       - uses: actions/download-artifact@v4
         with:
-          name: windows_wheels
+          pattern: windows_wheels-*-*
+          merge-multiple: true
           path: dist
       - name: Fix wheel names
         if: github.event.ref_type != 'tag'
@@ -113,7 +114,8 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
-          name: windows_wheels
+          pattern: windows_wheels-*-*
+          merge-multiple: true
           path: dist
       - name: Install Kivy Wheel
         run: |
@@ -145,7 +147,8 @@ jobs:
           python-version: 3.x
       - uses: actions/download-artifact@v4
         with:
-          name: windows_wheels
+          pattern: windows_wheels-*-*
+          merge-multiple: true
           path: dist
       - name: Install Kivy sdist
         env:

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -114,7 +114,11 @@ jobs:
           architecture: ${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
-          name: windows_wheels-${{ matrix.python }}-${{ matrix.arch }}
+          # Only one windows_wheels-*-* artifact contains the kivy-examples
+          # However, all artifacts are downloaded ATM, to avoid using
+          # a specific name.
+          pattern: windows_wheels-*-*
+          merge-multiple: true
           path: dist
       - name: Install Kivy Wheel
         run: |


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Moving from `action/upload-artifacts@v3` (which will be deprecated soon) to `action/upload-artifacts@v4` requires some changes to the logic and artifacts names.

Previously, was possible to call `upload-artifacts`  multiple times with the same `name`, to store different files under the same artifact, as the artifact was mutable.

Now, the artifact is not mutable, and a different name is required, so a migration [as explained here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) has been performed.

Some other minor changes have been made (images name in armv7_wheels) to better fit with the required logic for `upload-artifacts`.