### PR TITLE
Sunset `apple-silicon-m1` self-hosted runner, as now is supported by Github Hosted runners via `macos-latest` tag. Use `macos-13` for runs on Intel macs

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -131,14 +131,10 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: ['macos-latest', 'apple-silicon-m1']
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: ['macos-latest', 'macos-13']
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          # apple-silicon-m1 does not support older python versions (3.8, 3.9)
-          - runs_on: apple-silicon-m1
-            python: '3.8'
-          - runs_on: apple-silicon-m1
-            python: '3.9'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: ['macos-latest', 'apple-silicon-m1']
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: ['macos-latest', 'macos-13']
         python: ['3.x']
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

The time has come, as being announced in https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image , `macos-latest` on `kivy/kivy` repo is already targeting `macos-14`, which is an Apple Silicon runner.

Therefore, our self-hosted `apple-silicon-m1` runner, after ~1.5 years of service will start the sunset phase.

However, now comes an additional issue: "How can we make sure to properly test things for Intel Macs?".

As ATM https://github.com/orgs/community/discussions/116568, is still unanswered, targeting `macos-13` for testing on an Intel runner looks like the best (free of charge) choice.
I guess the long-time alternative is `macos-latest-large`, which is a `macos-14` image that runs on Intel Macs, but is quite pricey for us.

What will be the future of `apple-silicon-m1` runner hardware?
- iOS Simulators?
- Android Emulators?

