### PR TITLE
Use a `.ci/cicd-requirements.txt` file to handle CI/CD only dependencies

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,0 +1,5 @@
+cibuildwheel~=2.17.0
+build~=1.2.1
+coveralls~=4.0.0
+twine~=5.0.0
+flake8~=7.0.0

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -17,11 +17,6 @@ update_version_metadata() {
   fi
 }
 
-generate_sdist() {
-  python3 -m pip install build~=1.2.1
-  python3 -m build --sdist .
-}
-
 prepare_env_for_unittest() {
   /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background \
     --exec /usr/bin/Xvfb -- :99 -screen 0 1280x720x24 -ac +extension GLX
@@ -30,12 +25,6 @@ prepare_env_for_unittest() {
 install_kivy() {
   options=${1:-full,dev}
   python3 -m pip install -e "$(pwd)[$options]"
-}
-
-
-create_kivy_examples_wheel() {
-  python3 -m pip install build~=1.2.1
-  KIVY_BUILD_EXAMPLES=1 python3 -m build --wheel .
 }
 
 install_kivy_examples_wheel() {
@@ -89,16 +78,6 @@ test_kivy_install() {
 
 EOF
   KIVY_TEST_AUDIO=0 KIVY_NO_ARGS=1 python3 -m pytest --maxfail=10 --timeout=300 .
-}
-
-upload_coveralls() {
-  python3 -m pip install -U coveralls
-  python3 -m coveralls
-}
-
-validate_pep8() {
-  python3 -m pip install flake8
-  make style
 }
 
 generate_docs() {
@@ -211,9 +190,4 @@ upload_file_to_server() {
 
   echo -e "Host $ip\n\tStrictHostKeyChecking no\n" >>~/.ssh/config
   rsync -avh -e "ssh -p 2458" --include="*/" --include="$file_pat" --exclude="*" "$file_path/" "root@$ip:/web/downloads/ci/$server_path"
-}
-
-upload_artifacts_to_pypi() {
-  python3 -m pip install twine
-  twine upload dist/*
 }

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -135,8 +135,3 @@ function Test-kivy-installed {
     echo "[run]`nplugins = kivy.tools.coverage`n" > .coveragerc
     raise-only-error -Func {python -m pytest --timeout=400 .}
 }
-
-function Upload-artifacts-to-pypi {
-  python -m pip install twine
-  twine upload dist/*
-}

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -21,10 +21,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Install CI/CD Python requirements
+        run: |
+          python -m pip install -r .ci/cicd-requirements.txt
       - name: Create wheel
         run: |
-          source .ci/ubuntu_ci.sh
-          create_kivy_examples_wheel
+          KIVY_BUILD_EXAMPLES=1 python3 -m build --wheel .
       - name: Upload kivy-examples wheel as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -57,6 +59,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install CI/CD Python requirements
+      run: |
+        python -m pip install -r .ci/cicd-requirements.txt
     - name: Set up QEMU
       if: ${{ matrix.cibw_archs == 'aarch64' }}
       uses: docker/setup-qemu-action@v3
@@ -75,9 +80,9 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         update_version_metadata
-    - name: Install cibuildwheel
+    - name: Install CI/CD Python requirements
       run: |
-        python -m pip install cibuildwheel==2.17.0
+        python -m pip install -r .ci/cicd-requirements.txt
     - name: Make wheels
       run: |
         python -m cibuildwheel --output-dir wheelhouse
@@ -97,6 +102,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install CI/CD Python requirements
+      run: |
+        python -m pip install -r .ci/cicd-requirements.txt
     - uses: actions/download-artifact@v4
       with:
         pattern: manylinux_wheels-*
@@ -125,8 +133,7 @@ jobs:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        source .ci/ubuntu_ci.sh
-        upload_artifacts_to_pypi
+        twine upload dist/*
 
   manylinux_wheel_test:
     runs-on: ubuntu-latest
@@ -188,10 +195,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Install CI/CD Python requirements
+        run: |
+          python -m pip install -r .ci/cicd-requirements.txt
       - name: Generate sdist
         run: |
-          source .ci/ubuntu_ci.sh
-          generate_sdist
+          python -m build --sdist .
       - name: Install dependencies
         run: |
           source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -25,10 +25,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install CI/CD Python requirements
+      run: |
+        python -m pip install -r .ci/cicd-requirements.txt
     - name: Create wheel
       run: |
-        source .ci/ubuntu_ci.sh
-        create_kivy_examples_wheel
+        KIVY_BUILD_EXAMPLES=1 python3 -m build --wheel .
     - name: Upload kivy-examples wheel as artifact
       uses: actions/upload-artifact@v4
       with:
@@ -70,9 +72,9 @@ jobs:
     - name: Build universal Kivy dependencies
       run: |
         ./tools/build_macos_dependencies.sh
-    - name: Install cibuildwheel
+    - name: Install CI/CD Python requirements
       run: |
-        python -m pip install cibuildwheel==2.17.0
+        python -m pip install -r .ci/cicd-requirements.txt
     - name: Build wheels
       run: |
         export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
@@ -95,6 +97,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install CI/CD Python requirements
+      run: |
+        python -m pip install -r .ci/cicd-requirements.txt
     - uses: actions/download-artifact@v4
       with:
         name: osx_wheels
@@ -122,8 +127,7 @@ jobs:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        source .ci/ubuntu_ci.sh
-        upload_artifacts_to_pypi
+        twine upload dist/*
 
   osx_wheel_test:
     name: "osx_wheel_test (${{ matrix.runs_on }}, ${{ matrix.python }})"

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -14,10 +14,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install CI/CD Python requirements
+      run: |
+        python -m pip install -r .ci/cicd-requirements.txt
     - name: Validate PEP8
       run: |
-        source .ci/ubuntu_ci.sh
-        validate_pep8
+        make style
 
   unit_test:
     runs-on: ubuntu-latest
@@ -52,8 +54,7 @@ jobs:
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |
-        source .ci/ubuntu_ci.sh
-        upload_coveralls
+        python -m coveralls
     - name: Test Kivy benchmarks
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -63,6 +63,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - run: |
+          python -m pip install -r .ci/cicd-requirements.txt
       - uses: actions/download-artifact@v4
         with:
           pattern: windows_wheels-*-*
@@ -95,8 +97,7 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.pypi_password }}
         run: |
-          . .\.ci\windows_ci.ps1
-          Upload-artifacts-to-pypi
+          twine upload dist/*
 
   windows_wheel_test:
     runs-on: windows-latest


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Over the past few years it happened multiple times that our CI/CD pipeline started to fail due to unpinned dependencies.

These changes are meant to move all the CI/CD specific dependencies into a separate `requirements` file, to avoid polluting the CI/CD scripts with multiple `pip install` statements.

This change also allows us to keep these dependencies versions monitored via renovatebot.

Cons:
- Now all the requirements specified in `cicd-requirements.txt` get installed even if something may not be needed in a specific run. We can avoid that by using cached dependencies, however, we're talking about small-sized requirements. 