### PR TITLE
port select must be given the executable name pip38 not the package name py38-pip (affects website: installation-osx.rst)

### DIFF
--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -36,7 +36,7 @@ If you're using `Macports <https://www.macports.org>`_, you can install Python w
 
     # Install and set pip as the default::
     port install py38-pip
-    port select --set pip py38-pip
+    port select --set pip pip38
 
 Frameworks
 ~~~~~~~~~~


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
