### PR TITLE
Refactoring some obsolete functions that generate compilation errors on Android (fix issue #8363)

### DIFF
--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -192,8 +192,9 @@ class MetricsBase(EventDispatcher):
         if platform == 'android':
             if USE_SDL2:
                 import jnius
-                Hardware = jnius.autoclass('org.renpy.android.Hardware')
-                value = Hardware.getDPI()
+                DisplayMetrics = autoclass('android.util.DisplayMetrics')
+                metrics = DisplayMetrics()
+                value = metrics.densityDpi
             else:
                 import android
                 value = android.get_dpi()

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -254,8 +254,9 @@ class MetricsBase(EventDispatcher):
         value = 1.0
         if platform == 'android':
             import jnius
-            Hardware = jnius.autoclass('org.renpy.android.Hardware')
-            value = Hardware.metrics.scaledDensity
+            DisplayMetrics  = jnius.autoclass('android.util.DisplayMetrics')
+            metrics = DisplayMetrics()
+            value = metrics.scaledDensity
         elif platform == 'ios':
             import ios
             value = ios.get_scale()


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

I carried out some refactorings in functions that use the jnius library according to Android references. This should resolve issue #8363