### PR TITLE
Fix double invocation of App._stop when using App.stop and App.run

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -978,11 +978,10 @@ Context.html#getFilesDir()>`_ is returned.
             from android import mActivity
             mActivity.finishAndRemoveTask()
         else:
-            self._stop()
+            stopTouchApp()
 
     def _stop(self, *largs):
         self.dispatch('on_stop')
-        stopTouchApp()
 
         # Clear the window children
         if self._app_window:


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy/issues/2397 and https://github.com/kivy/kivy/issues/4577


Previosly `on_stop` - or App.`_stop` in general -  would be triggered twice if an `App` instance was used in combination with `App.run` and `App.stop`. This was due to `App.run` invoking `App._stop` on its own as well. 

My proposed fix keeps this behaviour as is but changes `App.stop` to not call `App._stop` directly but instead use `stopTouchApp` or `EventLoop.close` to have then`App.run` invoke `App._stop` 

This should not cause any issues since `App._stop` is only ever invoked by `App.run`, `App.async_run` and previously `App.stop` as far as I am aware and running `App.run` still yield in the same results even if `App.stop` is never called by the user. The only change in behaviour would be using `App.stop` without ever calling `App.run` which shouldn't ever be the  case anyways.

This also voids the second `stopTouchApp` call in `App._stop`





MRE
```py
from kivy.app import App
from kivy.lang import Builder

root = Builder.load_string('''
Button:
    text: 'Exit'
    on_release: app.stop()
''')


class TestApp(App):
    def build(self):
        return root

    def on_stop(self):
        print('stopping')


if __name__ == '__main__':
    TestApp().run()
```


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
