### PR TITLE
`avplayer` audio provider: Fixes `seek` and `state` on iOS and macOS

### DIFF
--- a/kivy/core/audio/audio_avplayer.py
+++ b/kivy/core/audio/audio_avplayer.py
@@ -6,7 +6,7 @@ Works on iOS / OSX.
 __all__ = ('SoundAvplayer', )
 
 from kivy.core.audio import Sound, SoundLoader
-from pyobjus import autoclass
+from pyobjus import autoclass, protocol
 from pyobjus.dylib_manager import load_framework, INCLUDE
 
 load_framework(INCLUDE.AVFoundation)
@@ -40,19 +40,25 @@ class SoundAvplayer(Sound):
     def play(self):
         if not self._avplayer:
             return
+        self._avplayer.delegate = self
         self._avplayer.play()
         super(SoundAvplayer, self).play()
 
     def stop(self):
         if not self._avplayer:
             return
+        self._avplayer.delegate = None
         self._avplayer.stop()
         super(SoundAvplayer, self).stop()
 
     def seek(self, position):
         if not self._avplayer:
             return
-        self._avplayer.playAtTime_(float(position))
+        avplayer = self._avplayer
+        avplayer.stop()
+        avplayer.currentTime = float(position)
+        if self.state == 'play':
+            avplayer.play()
 
     def get_pos(self):
         if self._avplayer:
@@ -67,6 +73,10 @@ class SoundAvplayer(Sound):
         if self._avplayer:
             return self._avplayer.duration
         return super(SoundAvplayer, self)._get_length()
+
+    @protocol("AVAudioPlayerDelegate")
+    def audioPlayerDidFinishPlaying_successfully_(self, player, flag):
+        self.stop()
 
 
 SoundLoader.register(SoundAvplayer)


### PR DESCRIPTION
The previous implementation was using playAtTime_, but 100% sure it was not working as playAtTime_ schedules the audio to play at a specific time, not to seek within the current audio file. To seek to a specific position in the audio, we should use the currentTime property of AVAudioPlayer.

In addition, i added a delegate to correctly catch when the sound is stopping when reaching eof, which make the state property correctly work.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
