### PR TITLE
Fix numpy float/int error when using `CameraAndroid.decode_frame`

### DIFF
--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -188,7 +188,7 @@ class CameraAndroid(CameraBase):
         from cv2 import cvtColor
 
         w, h = self._resolution
-        arr = np.fromstring(buf, 'uint8').reshape((h + h / 2, w))
+        arr = np.fromstring(buf, 'uint8').reshape((h + h // 2, w))
         arr = cvtColor(arr, 93)  # NV21 -> BGR
         return arr
 


### PR DESCRIPTION
the call to np.reshape with (h + h/2, ...) could lead to reshaping with a float. This is fixed by using h + h//2 instead


Closes #8752 

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
