### PR TITLE
Fix TextInput cursor using padding_bottom instead of top

### DIFF
--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2650,7 +2650,7 @@ class TextInput(FocusBehavior, Widget):
     def _get_cursor_visual_pos(self):
         # Return the position of the cursor's top visible point
         cx, cy = map(int, self.cursor_pos)
-        max_y = self.top - self.padding[3]
+        max_y = self.top - self.padding[1]
         return [cx, min(max_y, cy)]
 
     def _get_line_options(self):


### PR DESCRIPTION
Reproduction:
```py
from kivy.app import App
from kivy.lang.builder import Builder

KV = '''
TextInput:
    padding: [10, 10, 10, 30]
'''


class TestApp(App):
    def build(self):
        return Builder.load_string(KV)


TestApp().run()
```

As you can see, the cursor and text position don't match. The root cause is that for cursor visual pos, textinput is calculating max_y as `self.top - self.padding_bottom` instead of `self.top - self.padding_top` (not real attributes, just pseudocode to make the point more clear).

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
