### PR TITLE
Fix `SDL_EventFilter` definitions to match SDL definitions (fixes build on GCC 14)

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -315,7 +315,7 @@ cdef class _WindowSDL2Storage:
         for joy_i in range(SDL_NumJoysticks()):
             SDL_JoystickOpen(joy_i)
 
-        SDL_SetEventFilter(<SDL_EventFilter *>_event_filter, <void *>self)
+        SDL_SetEventFilter(<SDL_EventFilter>_event_filter, <void *>self)
 
         SDL_EventState(SDL_DROPFILE, SDL_ENABLE)
         SDL_EventState(SDL_DROPTEXT, SDL_ENABLE)

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -471,7 +471,7 @@ cdef extern from "SDL.h":
     ctypedef enum SDL_Scancode:
         pass
 
-    ctypedef int SDL_EventFilter(void* userdata, SDL_Event* event)
+    ctypedef int (*SDL_EventFilter)(void* userdata, SDL_Event* event)
     # for windows only see
     # https://github.com/LuaDist/sdl/blob/master/include/begin_code.h#L68
     IF UNAME_SYSNAME == 'Windows':
@@ -537,7 +537,7 @@ cdef extern from "SDL.h":
     cdef void SDL_Delay(Uint32 ms) nogil
     cdef Uint8 SDL_EventState(Uint32 type, int state)
     cdef int SDL_PollEvent(SDL_Event * event) nogil
-    cdef void SDL_SetEventFilter(SDL_EventFilter *filter, void* userdata)
+    cdef void SDL_SetEventFilter(SDL_EventFilter filter, void* userdata)
     cdef SDL_RWops * SDL_RWFromFile(char *file, char *mode)
     cdef SDL_RWops * SDL_RWFromMem(void *mem, int size)
     cdef SDL_RWops * SDL_RWFromConstMem(void *mem, int size)


### PR DESCRIPTION
GCC 14 enables -Werror=incompatible-pointer-types which results in expected 'SDL_EventFilter' {aka 'int (*)(void *, SDL_Event *)'} but argument is of type 'int (**)(void *, SDL_Event *)' errors in the call to SDL_SetEventFilter.

The kivy EventFilter definitions didn't exactly match the SDL definitions at [1] and [2]. This patch updates the kivy definitions to match the SDL definitions.

This partially addresses #8557

[1] https://wiki.libsdl.org/SDL2/SDL_EventFilter
[2] https://wiki.libsdl.org/SDL2/SDL_SetEventFilter

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
