### PR TITLE
Add static method `from_bytes` to `SoundSDL2` to initialize an instance from audio sample in memory

### DIFF
--- a/kivy/core/audio_output/audio_sdl2.pyx
+++ b/kivy/core/audio_output/audio_sdl2.pyx
@@ -43,6 +43,8 @@ __all__ = ('SoundSDL2', 'MusicSDL2')
 
 include "../../../kivy/lib/sdl2.pxi"
 include "../../../kivy/graphics/common.pxi"  # For malloc and memcpy (on_pitch)
+from cpython cimport PyBytes_AsString, PyBytes_FromStringAndSize
+from libc.stdint cimport uintptr_t
 
 from kivy.core.audio_output import Sound, SoundLoader
 from kivy.logger import Logger
@@ -242,6 +244,24 @@ class SoundSDL2(Sound):
             cc.chunk.volume = int(self.volume * 128)
             if self.pitch != 1.:
                 self.on_pitch(self, self.pitch)
+
+    @staticmethod
+    def from_bytes(data):
+        instance = SoundSDL2()
+        cdef ChunkContainer cc = instance.cc
+
+        cdef char* c_data = PyBytes_AsString(data)
+
+        rw = SDL_RWFromMem(<void*>c_data, len(data))
+        cc.chunk = Mix_LoadWAV_RW(rw, 1)
+
+        if cc.chunk == NULL:
+            Logger.warning('AudioSDL2: Unable to load data: {}'.format(Mix_GetError()))
+        else:
+            cc.original_chunk = Mix_QuickLoad_RAW(cc.chunk.abuf, cc.chunk.alen)
+            cc.chunk.volume = int(instance.volume * 128)
+
+        return instance
 
     def unload(self):
         cdef ChunkContainer cc = self.cc


### PR DESCRIPTION
Kivy allows loading audio samples from filesystem by filename using the `source` property of `Sound` object, but sometimes the audio samples are generated in the memory, for example it happens when using text to speech engines like Picovoice's Orca or Piper and in environments like RPi running on a SD-card, writing the samples from memory to filesystem in a temporary file and then asking Kivy to instruct SDL to read that file again into memory may cause some unwanted side effects like delay or exhaustion of the SD-card.

`from_bytes` static method added in this pull request, lets the user instantiate `SoundSDL2` with data coming directly from memory.

I considered re-using the `source` property by adding a "mem:" prefix or something like that as a signal for `load` method, but it's a `StringProperty` and only accepts `str`, not `bytes`.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
