### PR TITLE
[Backport devel-2.3.x] Use PyPA `build` package to perform `bdist` and `kivy-examples`, to take advantage of build isolation

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -12,8 +12,7 @@ RUN [ "cross-build-start" ]
 RUN /bin/bash -c 'source .ci/ubuntu_ci.sh && \
     export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple" && \
     install_ubuntu_build_deps && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg wget libxrender-dev lsb-release libraspberrypi-dev raspberrypi-kernel-headers && \
-    install_kivy_test_run_pip_deps'
+    DEBIAN_FRONTEND=noninteractive apt-get -y install xorg wget libxrender-dev lsb-release libraspberrypi-dev raspberrypi-kernel-headers'
 
 # If we're on Debian buster, we need to install cmake from backports as the cmake version
 # in buster is too old to build sdl2

--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -18,27 +18,8 @@ update_version_metadata() {
 }
 
 generate_sdist() {
-  python3 -m pip install cython packaging setuptools
-  python3 setup.py sdist --formats=gztar
-  python3 -m pip uninstall cython -y
-}
-
-
-install_kivy_test_run_pip_deps() {
-  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python3 get-pip.py --user
-
-  python3 -m pip install --upgrade pip setuptools wheel
-  CYTHON_INSTALL=$(
-    KIVY_NO_CONSOLELOG=1 python3 -c \
-      "from kivy.tools.packaging.cython_cfg import get_cython_versions; print(get_cython_versions()[0])" \
-      --config "kivy:log_level:error"
-  )
-  python3 -m pip install -I "$CYTHON_INSTALL" coveralls
-}
-
-install_kivy_test_wheel_run_pip_deps() {
-  python3 -m pip install --upgrade pip setuptools wheel
+  python3 -m pip install build~=1.2.1
+  python3 -m build --sdist .
 }
 
 prepare_env_for_unittest() {
@@ -53,7 +34,8 @@ install_kivy() {
 
 
 create_kivy_examples_wheel() {
-  KIVY_BUILD_EXAMPLES=1 python3 -m pip wheel . -w dist/
+  python3 -m pip install build~=1.2.1
+  KIVY_BUILD_EXAMPLES=1 python3 -m build --wheel .
 }
 
 install_kivy_examples_wheel() {
@@ -110,6 +92,7 @@ EOF
 }
 
 upload_coveralls() {
+  python3 -m pip install -U coveralls
   python3 -m coveralls
 }
 

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -35,10 +35,10 @@ function Update-version-metadata {
 }
 
 function Generate-sdist {
-    python -m pip install cython packaging
-    python setup.py sdist --formats=gztar
-    python setup.py bdist_wheel --build_examples --universal
-    python -m pip uninstall cython -y
+    python -m pip install -U build
+    python -m build --sdist .
+    $env:KIVY_BUILD_EXAMPLES = '1'
+    python -m build --wheel .
 }
 
 function Generate-windows-wheels {
@@ -77,14 +77,6 @@ function Upload-windows-wheels-to-server($ip) {
     C:\tools\msys64\usr\bin\bash --login -c ".ci/windows-server-upload.sh $ip dist 'Kivy*' ci/win/kivy/"
 }
 
-function Install-kivy-test-run-win-deps {
-
-}
-
-function Install-kivy-test-run-pip-deps {
-    python -m pip install pip wheel setuptools --upgrade
-}
-
 function Install-kivy {
     python -m pip install --only-binary Pillow -e .[dev,full]
 }
@@ -94,8 +86,6 @@ function Install-kivy-wheel {
     ls $root
     ls $root/dist
     cd "$HOME"
-
-    python -m pip install pip wheel setuptools --upgrade
 
     $version=python -c "import sys; print('{}{}'.format(sys.version_info.major, sys.version_info.minor))"
     $bitness=python -c "import sys; print('win_amd64' if sys.maxsize > 2**32 else 'win32')"
@@ -108,8 +98,6 @@ function Install-kivy-wheel {
 function Install-kivy-sdist {
     $root=(pwd).Path
     cd "$HOME"
-
-    python -m pip install pip wheel setuptools --upgrade
 
     $kivy_fname=(ls $root/dist/Kivy-*.tar.gz).name
     python -m pip install "$root/dist/$kivy_fname[full,dev]"

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -21,10 +21,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - name: Install dependencies
-        run: |
-          source .ci/ubuntu_ci.sh
-          install_kivy_test_wheel_run_pip_deps
       - name: Create wheel
         run: |
           source .ci/ubuntu_ci.sh
@@ -200,7 +196,6 @@ jobs:
           source .ci/ubuntu_ci.sh
           install_ubuntu_build_deps
           ./tools/build_linux_dependencies.sh
-          install_kivy_test_wheel_run_pip_deps
       - name: Setup env
         run: |
           source .ci/ubuntu_ci.sh

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -25,10 +25,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.x
-    - name: Install dependencies
-      run: |
-        source .ci/ubuntu_ci.sh
-        install_kivy_test_wheel_run_pip_deps dev
     - name: Create wheel
       run: |
         source .ci/ubuntu_ci.sh
@@ -155,10 +151,6 @@ jobs:
         with:
           name: osx_wheels
           path: dist
-      - name: Install test dependencies
-        run: |
-          source .ci/ubuntu_ci.sh
-          install_kivy_test_wheel_run_pip_deps dev
       - name: Install Kivy wheel
         run: |
           source .ci/ubuntu_ci.sh
@@ -204,7 +196,6 @@ jobs:
           source .ci/ubuntu_ci.sh
           source .ci/osx_ci.sh
           install_platypus
-          install_kivy_test_run_pip_deps dev
       - name: Make app bundle
         run: |
           source .ci/osx_ci.sh
@@ -265,7 +256,6 @@ jobs:
           source .ci/osx_ci.sh
           source .ci/ubuntu_ci.sh
           activate_osx_app_venv
-          install_kivy_test_wheel_run_pip_deps dev
           install_kivy_examples_wheel dev
       - name: Test Kivy app
         run: |

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         ./tools/build_macos_dependencies.sh
-        install_kivy_test_run_pip_deps
     - name: Install Kivy
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -34,7 +34,6 @@ jobs:
         source .ci/ubuntu_ci.sh
         install_ubuntu_build_deps
         ./tools/build_linux_dependencies.sh
-        install_kivy_test_run_pip_deps
     - name: Setup env
       run: |
         source .ci/ubuntu_ci.sh
@@ -78,7 +77,6 @@ jobs:
         source .ci/ubuntu_ci.sh
         install_ubuntu_build_deps
         ./tools/build_linux_dependencies.sh
-        install_kivy_test_run_pip_deps
     - name: Setup env
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -22,11 +22,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
-    - name: Install dependencies
-      run: |
-        . .\.ci\windows_ci.ps1
-        Install-kivy-test-run-win-deps
-        Install-kivy-test-run-pip-deps
     - name: Install Kivy
       run: |
         . .\.ci\windows_ci.ps1

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -33,11 +33,6 @@ jobs:
       run: |
         . .\.ci\windows_ci.ps1
         Update-version-metadata
-    - name: Install dependencies
-      run: |
-        . .\.ci\windows_ci.ps1
-        Install-kivy-test-run-win-deps
-        Install-kivy-test-run-pip-deps
     - name: Generate sdist/kivy-examples
       if: matrix.arch == 'x64' && matrix.python == '3.8'
       # only windows kivy-examples is uploaded

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,9 @@ GIT_COMMAND := $(shell which git)
 
 IOSPATH := $(PATH):/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin
 
-BUILD_OPTS       = build_ext --inplace
-BUILD_OPTS_FORCE = $(BUILD_OPTS) -f
-BUILD_OPTS_DEBUG = $(BUILD_OPTS_FORCE) -g --cython-gdb
+BUILD_OPTS       =
 
-INSTALL_OPTIONS  = install
+INSTALL_OPTIONS  =
 INSTALL_ROOT     =
 INSTALL_PREFIX   =
 INSTALL_LAYOUT   =
@@ -41,23 +39,14 @@ endif
 ifneq ($(INSTALL_PREFIX),)
 	INSTALL_OPTIONS += --prefix=$(INSTALL_PREFIX)
 endif
-ifneq ($(INSTALL_LAYOUT),)
-	INSTALL_OPTIONS += --install-layout=$(INSTALL_LAYOUT)
-endif
 
 .PHONY: build force mesabuild pdf style hook test batchtest cover clean distclean theming
 
 build:
-	$(PYTHON) setup.py $(BUILD_OPTS)
-
-force:
-	$(PYTHON) setup.py $(BUILD_OPTS_FORCE)
-
-debug:
-	env CFLAGS="-Og" $(PYTHON) setup.py $(BUILD_OPTS_DEBUG)
+	$(PYTHON) -m pip install -e . $(BUILD_OPTS)
 
 mesabuild:
-	env USE_MESAGL=1 $(PYTHON) setup.py $(BUILD_OPTS)
+	env USE_MESAGL=1 $(PYTHON) -m pip install -e . $(BUILD_OPTS)
 
 ios:
 	-ln -s $(KIVYIOSROOT)/Python-2.7.1/python
@@ -122,7 +111,7 @@ cover:
 	coverage html --include='$(KIVY_DIR)*' --omit '$(KIVY_DIR)data/*,$(KIVY_DIR)lib/*,$(KIVY_DIR)tools/*,$(KIVY_DIR)tests/*'
 
 install:
-	$(PYTHON) setup.py $(INSTALL_OPTIONS)
+	$(PYTHON) -m pip install -e . $(INSTALL_OPTIONS)
 
 clean:
 	$(MAKE) -C doc clean
@@ -153,15 +142,13 @@ theming:
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  build          for a standard build"
+	@echo "  build          for a standard build (install) in editable mode"
 	@echo "  clean          remove generated and compiled files"
 	@echo "  cover          create an html coverage report of unittests"
-	@echo "  debug          for a debug build (with -g)"
 	@echo "  dist-clean     clean then use 'git clean'"
-	@echo "  force          for a forced build (with -f)"
 	@echo "  hook           add Pep-8 checking as a git precommit hook"
 	@echo "  html           to make standalone HTML files"
-	@echo "  install        run a setup.py install"
+	@echo "  install        install with extra options"
 	@echo "  mesabuild      for a build with MesaGL"
 	@echo "  style          to check Python code for style issues"
 	@echo "  test           run unittests (pytest)"

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,4 +1,3 @@
-Cython>=0.24
 # Frozen Sphinx requirements for easier pip installation
 sphinxcontrib-actdiag
 sphinxcontrib-blockdiag


### PR DESCRIPTION
Backport ccc61047e37e15b29acc1dab33e16972ad7aeae5 from #8690.