### PR TITLE
[Backport devel-2.3.x] Sunset `apple-silicon-m1` self-hosted runner, as now is supported by Github Hosted runners via `macos-latest` tag. Use `macos-13` for runs on Intel macs

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -131,14 +131,10 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: ['macos-latest', 'apple-silicon-m1']
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: ['macos-latest', 'macos-13']
         python: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          # apple-silicon-m1 does not support older python versions (3.8, 3.9)
-          - runs_on: apple-silicon-m1
-            python: '3.8'
-          - runs_on: apple-silicon-m1
-            python: '3.9'
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        runs_on: ['macos-latest', 'apple-silicon-m1']
+        # macos-latest (ATM macos-14) runs on Apple Silicon,
+        # macos-13 runs on Intel
+        runs_on: ['macos-latest', 'macos-13']
         python: ['3.x']
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Backport 9bb694f9e6bf065515c019594e603206753a1e5b from #8713.