### PR TITLE
[Backport devel-2.3.x] Pin build-time requirements versions, renovatebot will take care of the updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = [
-    "setuptools", "wheel", "packaging",
+    "setuptools~=69.2.0",
+    "wheel~=0.43.0",
+    "packaging~=24.0",
     "cython>=0.29.1,<=3.0.0",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
     'kivy_deps.sdl2_dev~=0.7.0; sys_platform == "win32"',


### PR DESCRIPTION
Backport e910b6e7f450f2af0c5d0d6df59f1260c59f71c8 from #8689.