### PR TITLE
[Backport devel-2.3.x] Fix PyInstaller hooks to work with v6.x.x #8653

### DIFF
--- a/kivy/tools/packaging/pyinstaller_hooks/__init__.py
+++ b/kivy/tools/packaging/pyinstaller_hooks/__init__.py
@@ -78,7 +78,12 @@ try:
 except ImportError:
     kivy_deps = None
 from kivy.factory import Factory
-from PyInstaller.depend import bindepend
+try:
+    # Pyinstaller >= 6
+    from PyInstaller.depend.bindepend import get_imports
+except ImportError:
+    # Pyinstaller < 6
+    from PyInstaller.depend.bindepend import selectImports as get_imports
 
 from os import environ
 if 'KIVY_DOC' not in environ:
@@ -367,7 +372,7 @@ def _find_gst_binaries():
 
     lib_filepaths = set()
     for plugin_filepath in plugin_filepaths:
-        plugin_deps = bindepend.selectImports(plugin_filepath)
+        plugin_deps = get_imports(plugin_filepath)
         lib_filepaths.update([path for _, path in plugin_deps])
 
     plugin_binaries = [(f, 'gst-plugins') for f in plugin_filepaths]


### PR DESCRIPTION
Backport 5d17b27dbf245283617edc549a195ef816d82065 from #8654.