### PR TITLE
[Backport devel-2.3.x] Update dependency wheel to ~=0.44.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools~=69.2.0",
-    "wheel~=0.43.0",
+    "wheel~=0.44.0",
     "packaging~=24.0",
     "cython>=0.29.1,<=3.0.0",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',


### PR DESCRIPTION
Backport 5b28aaa46290467c69a2ffef0dfe0944c8fdaa10 from #8797.