### PR TITLE
Remove duplicated code block for dependency management (applies to `stable` branches only)

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -334,45 +334,6 @@ for importer, modname, package in _packages:
             'deps: Error importing dependency "{}.{}": {}'.
             format(package, modname, str(e)))
 
-# if there are deps, import them so they can do their magic.
-import kivy.deps
-_packages = []
-for importer, modname, ispkg in pkgutil.iter_modules(kivy.deps.__path__):
-    if not ispkg:
-        continue
-    if modname.startswith('gst'):
-        _packages.insert(0, (importer, modname, 'kivy.deps'))
-    else:
-        _packages.append((importer, modname, 'kivy.deps'))
-
-try:
-    import kivy_deps
-    for importer, modname, ispkg in pkgutil.iter_modules(kivy_deps.__path__):
-        if not ispkg:
-            continue
-        if modname.startswith('gst'):
-            _packages.insert(0, (importer, modname, 'kivy_deps'))
-        else:
-            _packages.append((importer, modname, 'kivy_deps'))
-except ImportError:
-    pass
-
-_logging_msgs = []
-for importer, modname, package in _packages:
-    try:
-        mod = importer.find_module(modname).load_module(modname)
-
-        version = ''
-        if hasattr(mod, '__version__'):
-            version = ' {}'.format(mod.__version__)
-        _logging_msgs.append(
-            'deps: Successfully imported "{}.{}"{}'.
-            format(package, modname, version))
-    except ImportError as e:
-        Logger.warning(
-            'deps: Error importing dependency "{}.{}": {}'.
-            format(package, modname, str(e)))
-
 # Don't go further if we generate documentation
 if any(name in sys.argv[0] for name in (
         'sphinx-build', 'autobuild.py', 'sphinx'


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

A long time ago in a galaxy far far away, we had a merge issue and we ended up having an almost identical duplicated code block for dependency management on `stable` branches (that happened sometime around 1.9.0/2.0.0).

This PR applies to `devel-2.3.x` which has been branched out from `stable`, and will be merged back into `stable` when ready, so future `stable` releases will not be impacted by this issue.

FYI: I've noticed this issue during CI/CD runs for PyInstaller tests on Python 3.12, as this duplicated code block uses a now removed method.