### PR TITLE
Use coveralls Github Action instead of coveralls-python

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,5 +1,4 @@
 cibuildwheel~=2.21.1
 build~=1.2.1
-coveralls~=4.0.0
 twine~=5.1.0
 flake8~=7.1.0

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -54,10 +54,7 @@ jobs:
         test_kivy
     - name: Coveralls upload
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: |
-        python -m coveralls
+      uses: coverallsapp/github-action@v2
     - name: Test Kivy benchmarks
       run: |
         source .ci/ubuntu_ci.sh


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Taken from #8815 

`coveralls` does not support Python 3.13 yet, and switching to the official Github Action just makes sense (and simplifies things)
