### PR TITLE
[Backport devel-2.3.x] Set `MACOSX_DEPLOYMENT_TARGET` in `CIBW_ENVIRONMENT` to correctly tag the produced wheel compatibility

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -38,6 +38,7 @@ jobs:
   osx_wheels_create:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
     env:
+      CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=10.15"
       CIBW_BUILD: "cp37-macosx_x86_64 cp38-macosx_universal2 cp39-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2 cp312-macosx_universal2"
       CIBW_ARCHS_MACOS: "x86_64 universal2"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >


### PR DESCRIPTION
Backport 8d84d7b38e1ce063d84f0a672c2a4e326cec989d from #8725.