### PR TITLE
[Backport devel-2.3.x] Update GitHub Artifact Actions to v4 (major)

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -26,7 +26,7 @@ jobs:
           source .ci/ubuntu_ci.sh
           create_kivy_examples_wheel
       - name: Upload kivy-examples wheel as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux_examples_wheel
           path: dist
@@ -82,7 +82,7 @@ jobs:
       run: |
         python -m cibuildwheel --output-dir wheelhouse
     - name: Upload wheels as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: manylinux_wheels
         path: ./wheelhouse/*.whl
@@ -97,7 +97,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.x
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: manylinux_wheels
         path: dist
@@ -141,7 +141,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: manylinux_wheels
         path: dist
@@ -153,7 +153,7 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         install_kivy_wheel dev
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: linux_examples_wheel
         path: dist
@@ -171,7 +171,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
     - name: Upload benchmarks as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmarks
         path: .benchmarks-kivy

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -30,7 +30,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         create_kivy_examples_wheel
     - name: Upload kivy-examples wheel as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: osx_examples_wheel
         path: dist
@@ -79,7 +79,7 @@ jobs:
         export KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies
         export REPAIR_LIBRARY_PATH=$KIVY_DEPS_ROOT/dist/Frameworks:$KIVY_DEPS_ROOT/dist/Frameworks/SDL2_mixer.framework/Frameworks
         python -m cibuildwheel --output-dir wheelhouse
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: osx_wheels
         path: ./wheelhouse/*.whl
@@ -96,7 +96,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.x
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: osx_wheels
         path: dist
@@ -144,7 +144,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: osx_wheels
           path: dist
@@ -152,7 +152,7 @@ jobs:
         run: |
           source .ci/ubuntu_ci.sh
           install_kivy_wheel dev
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: osx_examples_wheel
           path: dist
@@ -202,7 +202,7 @@ jobs:
           source .ci/osx_ci.sh
           generate_osx_app_dmg_from_bundle
       - name: Upload dmg as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: osx_app
           path: app
@@ -218,7 +218,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: osx_app
           path: app
@@ -244,7 +244,7 @@ jobs:
         run: |
           source .ci/osx_ci.sh
           mount_osx_app
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: osx_examples_wheel
           path: dist

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -40,7 +40,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         upload_file_to_server "$SERVER_IP" "raspberrypi/kivy/"
     - name: Upload wheels as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: github.event_name == 'pull_request'
       with:
         name: armv7l_wheels

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -59,7 +59,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
     - name: Upload benchmarks as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmarks
         path: .benchmarks-kivy
@@ -90,7 +90,7 @@ jobs:
         source .ci/ubuntu_ci.sh
         generate_docs
     - name: Upload docs as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: docs
         path: doc/build/html

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -36,7 +36,7 @@ jobs:
         . .\.ci\windows_ci.ps1
         Test-kivy-benchmark
     - name: Upload benchmarks as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmarks
         path: .benchmarks-kivy

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -48,7 +48,7 @@ jobs:
         . .\.ci\windows_ci.ps1
         Generate-windows-wheels
     - name: Upload wheels as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: windows_wheels
         path: dist
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows_wheels
           path: dist
@@ -111,7 +111,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows_wheels
           path: dist
@@ -129,7 +129,7 @@ jobs:
           . .\.ci\windows_ci.ps1
           Test-kivy-benchmark
       - name: Upload benchmarks as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarks
           path: .benchmarks-kivy
@@ -143,7 +143,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: windows_wheels
           path: dist


### PR DESCRIPTION
Backport e5c51440607bb34d1ba91bf10e4e21a8ded01275 from #8699.