### PR TITLE
[Backport devel-2.3.x] Remove unused `sphinxcontrib-*diag` dependencies (and `funcparserlib`)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -35,16 +35,6 @@ Install Sphinx
   Get pip (https://pypi.python.org/pypi/pip). You'll use it to install the dependencies.
 
   To install pip, run ``python setup.py install`` in the pip directory. Now run:
-    
-
-  ``pip install sphinxcontrib-blockdiag sphinxcontrib-seqdiag``
-  
-
-  ``pip install sphinxcontrib-actdiag sphinxcontrib-nwdiag``
-    
-
-  Or just use the provided *doc-requirements.txt*:
-    
 
   ``pip install -r doc-requirements.txt``
   

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,5 +1,2 @@
 # Frozen Sphinx requirements for easier pip installation
-sphinxcontrib-actdiag
-sphinxcontrib-blockdiag
-sphinxcontrib-nwdiag
-sphinxcontrib-seqdiag
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,7 @@ dev =
     pytest-benchmark
     pyinstaller
     sphinx<=6.2.1
-    sphinxcontrib-blockdiag
-    sphinxcontrib-seqdiag
-    sphinxcontrib-actdiag
-    sphinxcontrib-nwdiag
     sphinxcontrib-jquery
-    funcparserlib==1.0.0a0
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
     kivy_deps.sdl2_dev~=0.8.0; sys_platform == "win32"
     kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"


### PR DESCRIPTION
Backport 413533b216bfd9a4bb8f082962cfbc5255f65d18 from #8711.