### PR TITLE
[Backport devel-2.3.x] Ensure `benchmarks` artifact names are unique, as required by `actions/upload-artifacts@v4` [build wheel]

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -168,14 +168,13 @@ jobs:
         source .ci/ubuntu_ci.sh
         test_kivy_install
     - name: Test Kivy benchmarks
-      if: matrix.python == '3.x' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
       run: |
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
     - name: Upload benchmarks as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarks
+        name: benchmarks-manylinux-wheels-python-${{ matrix.python }}
         path: .benchmarks-kivy
 
   sdist_test:

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Upload benchmarks as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarks
+        name: benchmarks-ubuntu-unittests-python-3.x
         path: .benchmarks-kivy
 
   gen_docs:

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -31,12 +31,11 @@ jobs:
         . .\.ci\windows_ci.ps1
         Test-kivy
     - name: Test Kivy benchmarks
-      if: matrix.python == '3.9' && matrix.arch == 'x64'
       run: |
         . .\.ci\windows_ci.ps1
         Test-kivy-benchmark
     - name: Upload benchmarks as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarks
+        name: benchmarks-windows-unittests-python-${{ matrix.python }}-${{ matrix.arch }}
         path: .benchmarks-kivy

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -129,14 +129,13 @@ jobs:
           . .\.ci\windows_ci.ps1
           Test-kivy-installed
       - name: Test Kivy benchmarks
-        if: matrix.python == '3.x' && matrix.arch == 'x64' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag'))
         run: |
           . .\.ci\windows_ci.ps1
           Test-kivy-benchmark
       - name: Upload benchmarks as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: benchmarks
+          name: benchmarks-windows-wheels-python-${{ matrix.python }}-${{ matrix.arch }}
           path: .benchmarks-kivy
 
   windows_sdist_test:


### PR DESCRIPTION
Backport 203f5501ff1e1d7aa3e9177579e9ae619eaa9b8a from #8710.