### PR TITLE
Remove deprecated textinput

### DIFF
--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -482,26 +482,6 @@ class FileChooserController(RelativeLayout):
 
     '''
 
-    file_encodings = ListProperty(
-        ['utf-8', 'latin1', 'cp1252'], deprecated=True)
-    '''Possible encodings for decoding a filename to unicode. In the case that
-    the user has a non-ascii filename, undecodable without knowing its
-    initial encoding, we have no other choice than to guess it.
-
-    Please note that if you encounter an issue because of a missing encoding
-    here, we'll be glad to add it to this list.
-
-    file_encodings is a :class:`~kivy.properties.ListProperty` and defaults to
-    ['utf-8', 'latin1', 'cp1252'].
-
-    .. versionadded:: 1.3.0
-
-    .. deprecated:: 1.8.0
-       This property is no longer used as the filechooser no longer decodes
-       the file names.
-
-    '''
-
     file_system = ObjectProperty(FileSystemLocal(),
                                  baseclass=FileSystemAbstract)
     '''The file system object used to access the file system. This should be a

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -3358,34 +3358,10 @@ class TextInput(FocusBehavior, Widget):
     :attr:`tab_width` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 4.
     '''
-
-    padding_x = VariableListProperty([0, 0], length=2, deprecated=True)
-    '''Horizontal padding of the text: [padding_left, padding_right].
-
-    padding_x also accepts a one argument form [padding_horizontal].
-
-    :attr:`padding_x` is a :class:`~kivy.properties.VariableListProperty` and
-    defaults to [0, 0]. This might be changed by the current theme.
-
-    .. deprecated:: 1.7.0
-        Use :attr:`padding` instead.
-    '''
-
+  
     def on_padding_x(self, instance, value):
         self.padding[0] = value[0]
         self.padding[2] = value[1]
-
-    padding_y = VariableListProperty([0, 0], length=2, deprecated=True)
-    '''Vertical padding of the text: [padding_top, padding_bottom].
-
-    padding_y also accepts a one argument form [padding_vertical].
-
-    :attr:`padding_y` is a :class:`~kivy.properties.VariableListProperty` and
-    defaults to [0, 0]. This might be changed by the current theme.
-
-    .. deprecated:: 1.7.0
-        Use :attr:`padding` instead.
-    '''
 
     def on_padding_y(self, instance, value):
         self.padding[1] = value[0]


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

This pull request involves the removal of deprecated properties from the `kivy/uix/filechooser.py` and `kivy/uix/textinput.py` files. These changes help in cleaning up the codebase by eliminating outdated and unused properties as proposed in issue #8177 .

### Removal of Deprecated Properties:

* `kivy/uix/filechooser.py`:
  - Removed the `file_encodings` property, which was deprecated since version 1.8.0. This property is no longer used as the filechooser no longer decodes file names. (`[kivy/uix/filechooser.pyL485-L504](diffhunk://#diff-861f30e5de00da3bf1eaaf2060871b6c7335871c2d058bddb4963ad260c09f02L485-L504)`)

* `kivy/uix/textinput.py`:
  - Removed the `padding_x` property, deprecated since version 1.7.0, which was used for horizontal padding of text. Developers should use the `padding` property instead. (`[kivy/uix/textinput.pyL3362-L3389](diffhunk://#diff-67d848ba06b2f91032fd6dc59a8956275118595997f9737872a39fb5983183d2L3362-L3389)`)
  - Removed the `padding_y` property, also deprecated since version 1.7.0, which was used for vertical padding of text. Developers should use the `padding` property instead. (`[kivy/uix/textinput.pyL3362-L3389](diffhunk://#diff-67d848ba06b2f91032fd6dc59a8956275118595997f9737872a39fb5983183d2L3362-L3389)`)

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
