### PR TITLE
Removed deprecated lines from config.py

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -295,41 +295,11 @@ Available configuration tokens
         property used by the :class:`~kivy.uix.scrollview.ScrollView` widget.
         Check the widget documentation for more information.
 
-    `scroll_friction`: float
-        Default value of the
-        :attr:`~kivy.uix.scrollview.ScrollView.scroll_friction`
-        property used by the :class:`~kivy.uix.scrollview.ScrollView` widget.
-        Check the widget documentation for more information.
-
-        .. deprecated:: 1.7.0
-            Please use
-            :class:`~kivy.uix.scrollview.ScrollView.effect_cls` instead.
-
     `scroll_timeout`: int
         Default value of the
         :attr:`~kivy.uix.scrollview.ScrollView.scroll_timeout`
         property used by the  :class:`~kivy.uix.scrollview.ScrollView` widget.
         Check the widget documentation for more information.
-
-    `scroll_stoptime`: int
-        Default value of the
-        :attr:`~kivy.uix.scrollview.ScrollView.scroll_stoptime`
-        property used by the :class:`~kivy.uix.scrollview.ScrollView` widget.
-        Check the widget documentation for more information.
-
-        .. deprecated:: 1.7.0
-            Please use
-            :class:`~kivy.uix.scrollview.ScrollView.effect_cls` instead.
-
-    `scroll_moves`: int
-        Default value of the
-        :attr:`~kivy.uix.scrollview.ScrollView.scroll_moves`
-        property used by the :class:`~kivy.uix.scrollview.ScrollView` widget.
-        Check the widget documentation for more information.
-
-        .. deprecated:: 1.7.0
-            Please use
-            :class:`~kivy.uix.scrollview.ScrollView.effect_cls` instead.
 
 :modules:
 
@@ -837,7 +807,6 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             # add token for scrollview
             Config.setdefault('widgets', 'scroll_timeout', '55')
             Config.setdefault('widgets', 'scroll_distance', '20')
-            Config.setdefault('widgets', 'scroll_friction', '1.')
 
             # remove old list_* token
             Config.remove_option('widgets', 'list_friction')
@@ -854,11 +823,6 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 5:
             Config.setdefault('graphics', 'resizable', '1')
-
-        elif version == 6:
-            # if the timeout is still the default value, change it
-            Config.setdefault('widgets', 'scroll_stoptime', '300')
-            Config.setdefault('widgets', 'scroll_moves', '5')
 
         elif version == 7:
             # desktop bool indicating whether to use desktop specific features


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

This pull request includes changes to the `kivy/config.py` file, focusing on the removal of deprecated properties and related configuration settings. The most important changes include the removal of deprecated scroll properties and their corresponding default values.

### Removal of Deprecated Properties:

* Removed the `scroll_friction`, `scroll_stoptime`, and `scroll_moves` properties from the documentation and code. These properties were deprecated in version 1.7.0 and users are advised to use `ScrollView.effect_cls` instead. (`kivy/config.py`)

### Cleanup of Configuration Settings:

* Removed the `scroll_friction` default setting from the `name` method. (`kivy/config.py`)
* Removed the `scroll_stoptime` and `scroll_moves` default settings from the `name` method for version 6. (`kivy/config.py`)

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
