### PR TITLE
[Backport devel-2.3.x] Install CI/CD deps also on `unit_test` job

### DIFF
--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -31,6 +31,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install CI/CD Python requirements
+      run: |
+        python -m pip install -r .ci/cicd-requirements.txt
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh


### PR DESCRIPTION
Backport fe59286e8e1687dbb8ce6eb6934a807638f6815e from #8720.