### PR TITLE
[Backport devel-2.3.x] Specify `MACOSX_DEPLOYMENT_TARGET=10.15` for all the self-built dependencies

### DIFF
--- a/tools/build_macos_dependencies.sh
+++ b/tools/build_macos_dependencies.sh
@@ -71,6 +71,7 @@ pushd $MACOS__LIBPNG__FOLDER
           -DCMAKE_INSTALL_PREFIX=../../dist \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
           -DPNG_TESTS=OFF \
           -DPNG_EXECUTABLES=OFF \
           -DPNG_SHARED=OFF \
@@ -88,14 +89,14 @@ popd
 
 echo "-- Build SDL2 (Universal)"
 pushd $MACOS__SDL2__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.15 \
         -project Xcode/SDL/SDL.xcodeproj -target Framework -configuration Release
 cp -r Xcode/SDL/build/Release/SDL2.framework ../../dist/Frameworks
 popd
 
 echo "-- Build SDL2_mixer (Universal)"
 pushd $MACOS__SDL2_MIXER__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.15 \
         -project Xcode/SDL_mixer.xcodeproj -target Framework -configuration Release
 cp -r Xcode/build/Release/SDL2_mixer.framework ../../dist/Frameworks
 popd
@@ -109,7 +110,7 @@ popd
 
 echo "-- Build SDL2_ttf (Universal)"
 pushd $MACOS__SDL2_TTF__FOLDER
-xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.13 \
+xcodebuild ONLY_ACTIVE_ARCH=NO MACOSX_DEPLOYMENT_TARGET=10.15 \
         -project Xcode/SDL_ttf.xcodeproj -target Framework -configuration Release \
         GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_DEFINITIONS) FT_CONFIG_OPTION_USE_PNG=1' \
         FRAMEWORK_SEARCH_PATHS='$(FRAMEWORK_SEARCH_PATHS) '"$FRAMEWORK_SEARCH_PATHS" \


### PR DESCRIPTION

Backport eb43391fe617602aaf2f599b07cbab2fc328fcef from #8724 

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
