### PR TITLE
[Backport devel-2.3.x] Update dependency cibuildwheel to ~=2.18.0

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,4 +1,4 @@
-cibuildwheel~=2.17.0
+cibuildwheel~=2.18.0
 build~=1.2.1
 coveralls~=4.0.0
 twine~=5.0.0


### PR DESCRIPTION
Backport ea500ff8e7ce3fd21c5781466b45eb5ab2891a98 from #8723.