### PR TITLE
[Backport devel-2.3.x] Update dependency twine to ~=5.1.0

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,5 +1,5 @@
 cibuildwheel~=2.18.0
 build~=1.2.1
 coveralls~=4.0.0
-twine~=5.0.0
+twine~=5.1.0
 flake8~=7.0.0


### PR DESCRIPTION
Backport 3223256d14b40ecc7866cc07100c486f71e6381a from #8730.