### PR TITLE
[Backport devel-2.3.x] Update dependency flake8 to ~=7.1.0

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -2,4 +2,4 @@ cibuildwheel~=2.18.0
 build~=1.2.1
 coveralls~=4.0.0
 twine~=5.1.0
-flake8~=7.0.0
+flake8~=7.1.0


### PR DESCRIPTION
Backport b072ca72a2c480ecd0c73dbaa3b13a1bc6521ff8 from #8758.