### PR TITLE
[Backport devel-2.3.x] Fix numpy float/int error when using `CameraAndroid.decode_frame`

### DIFF
--- a/kivy/core/camera/camera_android.py
+++ b/kivy/core/camera/camera_android.py
@@ -188,7 +188,7 @@ class CameraAndroid(CameraBase):
         from cv2 import cvtColor
 
         w, h = self._resolution
-        arr = np.fromstring(buf, 'uint8').reshape((h + h / 2, w))
+        arr = np.fromstring(buf, 'uint8').reshape((h + h // 2, w))
         arr = cvtColor(arr, 93)  # NV21 -> BGR
         return arr
 


### PR DESCRIPTION
Backport e1afc5751224429cf64519eba3adec658a609525 from #8754.