### PR TITLE
[Backport devel-2.3.x] Update dependency cibuildwheel to ~=2.19.1

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,4 +1,4 @@
-cibuildwheel~=2.18.0
+cibuildwheel~=2.19.1
 build~=1.2.1
 coveralls~=4.0.0
 twine~=5.1.0


### PR DESCRIPTION
Backport f1e8c4bd4d3857e4f98eb12c6bfe441e7109b0ac from #8753.