### PR TITLE
[Backport devel-2.3.x] Update dependency cibuildwheel to ~=2.20.0

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,4 +1,4 @@
-cibuildwheel~=2.19.1
+cibuildwheel~=2.20.0
 build~=1.2.1
 coveralls~=4.0.0
 twine~=5.1.0


### PR DESCRIPTION
Backport 690d2df4f0c2b476d683b673a932ce1a8bf49d4b from #8796.