### PR TITLE
[Backport devel-2.3.x] Use coveralls Github Action instead of coveralls-python

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,5 +1,4 @@
 cibuildwheel~=2.19.1
 build~=1.2.1
-coveralls~=4.0.0
 twine~=5.1.0
 flake8~=7.1.0

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -54,10 +54,7 @@ jobs:
         test_kivy
     - name: Coveralls upload
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: |
-        python -m coveralls
+      uses: coverallsapp/github-action@v2
     - name: Test Kivy benchmarks
       run: |
         source .ci/ubuntu_ci.sh


### PR DESCRIPTION
Backport b08688e01df22e822b527a6c159a4c615d5e28a3 from #8847.