### PR TITLE
[Backport devel-2.3.x] Update dependency cibuildwheel to ~=2.21.1

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,4 +1,4 @@
-cibuildwheel~=2.20.0
+cibuildwheel~=2.21.1
 build~=1.2.1
 coveralls~=4.0.0
 twine~=5.1.0


### PR DESCRIPTION
Backport 47e78ad3becb1feeec7d835e325e4ec8c384d112 from #8828.