### PR TITLE
Fix flipping TextureRegion.pixels ( Issue #7208 )

### DIFF
--- a/kivy/graphics/texture.pyx
+++ b/kivy/graphics/texture.pyx
@@ -1373,7 +1373,6 @@ cdef class TextureRegion(Texture):
         from kivy.graphics import Color, Rectangle
         fbo = Fbo(size=self.size)
         fbo.clear()
-        self.flip_vertical()
         with fbo:
             Color(1, 1, 1)
             Rectangle(size=self.size, texture=self,


### PR DESCRIPTION
self.flip_vertical() was appearing twice and flipping the pixels to the wrong direction.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
