### PR TITLE
[Backport devel-2.3.x] Add Python `3.13` to both test and support matrix

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -140,7 +140,7 @@ jobs:
     needs: [manylinux_wheel_create, kivy_examples_create]
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
     env:
       DISPLAY: ':99.0'
     steps:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -139,7 +139,7 @@ jobs:
         # macos-latest (ATM macos-14) runs on Apple Silicon,
         # macos-13 runs on Intel
         runs_on: ['macos-latest', 'macos-13']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -19,7 +19,7 @@ jobs:
         # macos-latest (ATM macos-14) runs on Apple Silicon,
         # macos-13 runs on Intel
         runs_on: ['macos-latest', 'macos-13']
-        python: ['3.x']
+        python: ['3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.x
+    - name: Set up Python 3
       uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.13
     - name: Install CI/CD Python requirements
       run: |
         python -m pip install -r .ci/cicd-requirements.txt
@@ -27,10 +27,10 @@ jobs:
       DISPLAY: ':99.0'
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.x
+    - name: Set up Python 3
       uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.13
     - name: Install CI/CD Python requirements
       run: |
         python -m pip install -r .ci/cicd-requirements.txt
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.x
+    - name: Set up Python 3
       uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.13
     - name: Install dependencies
       run: |
         source .ci/ubuntu_ci.sh

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         arch: ['x64']
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         arch: ['x64']
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel win]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel win]')
     steps:
@@ -104,7 +104,7 @@ jobs:
     needs: windows_wheels_create
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         arch: [ 'x64' ]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools~=69.2.0",
     "wheel~=0.44.0",
     "packaging~=24.0",
-    "cython>=0.29.1,<=3.0.0",
+    "cython>=0.29.1,<=3.0.11",
     'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
     'kivy_deps.sdl2_dev~=0.8.0; sys_platform == "win32"',
     'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [kivy]
 cython_min=0.29.1
-cython_max=3.0.0
+cython_max=3.0.11
 cython_exclude=
-python_versions=3.8 - 3.12
+python_versions=3.8 - 3.13
 
 [coverage:run]
 parallel = True

--- a/setup.py
+++ b/setup.py
@@ -1203,6 +1203,7 @@ if not build_examples:
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
             'Topic :: Artistic Software',
             'Topic :: Games/Entertainment',
             'Topic :: Multimedia :: Graphics :: 3D Rendering',


### PR DESCRIPTION
Backport c6b5e90d2d51bdc38cb6d77070b36ad2009918ac from #8815.