### PR TITLE
[Backport devel-2.3.x] Fix issue with `CompoundSelectionBehavior` silently ignoring `ValueError` in `on_selected_nodes` event

### DIFF
--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -682,8 +682,7 @@ class CompoundSelectionBehavior(object):
             This method must be called by the derived widget using super if it
             is overwritten.
         '''
-        try:
+        if node in self.selected_nodes:
             self.selected_nodes.remove(node)
             return True
-        except ValueError:
-            return False
+        return False


### PR DESCRIPTION
Backport 7172d9d9b19ded78fead66acf4c2603a4aad64b2 from #8673.