### PR TITLE
[Backport devel-2.3.x] `Label`: Prevent overwriting `disabled_color` attribute when `color` is updated

### DIFF
--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -379,6 +379,10 @@ class Label(Widget):
                 self._label.options['outline_color'] = (
                     self.disabled_outline_color if value else
                     self.outline_color)
+            elif self.disabled and name in ('color', 'outline_color'):
+                # When disabled, color or outline_color changes should not get
+                # assigned or trigger updates.
+                return
 
             # NOTE: Compatibility code due to deprecated properties
             # Must be removed along with padding_x and padding_y


### PR DESCRIPTION
Backport c0d4894384abb81cf4729984a1eaa4c437d266da from #8667.