### PR TITLE
[Backport devel-2.3.x] Fix `ConfigParser.write` error with  when `--save` is supplied as an argument

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -480,8 +480,8 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
     if need_save and 'KIVY_NO_CONFIG' not in environ:
         try:
-            with open(kivy_config_fn, 'w') as fd:
-                Config.write(fd)
+            Config.filename = kivy_config_fn
+            Config.write()
         except Exception as e:
             Logger.exception('Core: error while saving default'
                              'configuration file:', str(e))


### PR DESCRIPTION
Backport 9a0d7ec691444d63f9d4c35e9fa9b27205235a53 from #8681.