### PR TITLE
[Backport devel-2.3.x] Fix `xsel` import when clipboard is empty, and add timeout failsafe

### DIFF
--- a/kivy/core/clipboard/clipboard_xsel.py
+++ b/kivy/core/clipboard/clipboard_xsel.py
@@ -11,12 +11,9 @@ from kivy.core.clipboard._clipboard_ext import ClipboardExternalBase
 if platform != 'linux':
     raise SystemError('unsupported platform for xsel clipboard')
 
-try:
-    import subprocess
-    p = subprocess.Popen(['xsel'], stdout=subprocess.PIPE)
-    p.communicate()
-except:
-    raise
+import subprocess
+p = subprocess.Popen(['xsel', '--version'], stdout=subprocess.PIPE)
+p.communicate(timeout=1)
 
 
 class ClipboardXsel(ClipboardExternalBase):


### PR DESCRIPTION
Backport e97c3e561d9d2b8e1ed6ccb00fbadf80cf4d44e4 from #8682.