### PR TITLE
[Backport devel-2.3.x] Update `monitor` module to use `dp`

### DIFF
--- a/kivy/modules/monitor.py
+++ b/kivy/modules/monitor.py
@@ -19,6 +19,7 @@ __all__ = ('start', 'stop')
 
 from kivy.uix.label import Label
 from kivy.graphics import Rectangle, Color
+from kivy.metrics import dp
 from kivy.clock import Clock
 from functools import partial
 
@@ -38,15 +39,16 @@ def update_stats(win, ctx, *largs):
     _statsinput = 0
     m = max(1., _maxinput)
     for i, x in enumerate(ctx.stats):
-        ctx.statsr[i].size = (4, ctx.stats[i] / m * 20)
-        ctx.statsr[i].pos = (win.width - 64 * 4 + i * 4, win.height - 25)
+        ctx.statsr[i].size = (dp(4), ctx.stats[i] / m * dp(20))
+        ctx.statsr[i].pos = (
+            win.width - dp(64 * 4) + i * dp(4), win.height - dp(25))
 
 
 def _update_monitor_canvas(win, ctx, *largs):
     with win.canvas.after:
-        ctx.overlay.pos = (0, win.height - 25)
-        ctx.overlay.size = (win.width, 25)
-        ctx.rectangle.pos = (5, win.height - 20)
+        ctx.overlay.pos = (0, win.height - dp(25))
+        ctx.overlay.size = (win.width, dp(25))
+        ctx.rectangle.pos = (dp(5), win.height - dp(20))
 
 
 class StatsInput(object):
@@ -69,16 +71,16 @@ def start(win, ctx):
     ctx.statsr = []
     with win.canvas.after:
         ctx.color = Color(1, 0, 0, .5)
-        ctx.overlay = Rectangle(pos=(0, win.height - 25),
-                                size=(win.width, 25))
+        ctx.overlay = Rectangle(pos=(0, win.height - dp(25)),
+                                size=(win.width, dp(25)))
         ctx.color = Color(1, 1, 1)
-        ctx.rectangle = Rectangle(pos=(5, win.height - 20))
+        ctx.rectangle = Rectangle(pos=(dp(5), win.height - dp(20)))
         ctx.color = Color(1, 1, 1, .5)
         for i in range(64):
             ctx.stats.append(0)
-            ctx.statsr.append(
-                Rectangle(pos=(win.width - 64 * 4 + i * 4, win.height - 25),
-                          size=(4, 0)))
+            ctx.statsr.append(Rectangle(
+                pos=(win.width - dp(64 * 4) + i * dp(4), win.height - dp(25)),
+                size=(dp(4), 0)))
     win.bind(size=partial(_update_monitor_canvas, win, ctx))
     Clock.schedule_interval(partial(update_fps, ctx), .5)
     Clock.schedule_interval(partial(update_stats, win, ctx), 1 / 60.)


### PR DESCRIPTION
Backport 8a4bb3c3bd8944bbcb10a7c09c79059be20bbe80 from #8677.