### PR TITLE
[Backport devel-2.3.x] Fix typo and mistake at FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -278,12 +278,10 @@ execution.
 latest available version and retry.
 
 
-#### I get an "ImportError: No module named event". How come?
+#### I get an "ImportError: No module named _event". How come?
 
   If you use Kivy from our development version, you must compile it before
-using it. In the kivy directory, run
-
-      make force
+using it. Check [installation guide](https://kivy.org/doc/stable/gettingstarted/installation.html) for more information.
 
 ## Android Questions
 


### PR DESCRIPTION
Backport 53bed70326e0a70a736a72067b42fe43e9f05a45 from #8544.