### PR TITLE
[Backport devel-2.3.x] Make sure to pin a specific (or compatible) version of `sphinx` and related dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ dev =
     pytest-timeout
     pytest-benchmark
     pyinstaller
-    sphinx<=6.2.1
-    sphinxcontrib-jquery
+    sphinx~=6.2.1
+    sphinxcontrib-jquery~=4.1
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
     kivy_deps.sdl2_dev~=0.8.0; sys_platform == "win32"
     kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"


### PR DESCRIPTION
Backport 0c374c7cf6bf619653a582b57d21359dc14af3ab from #8715.