### PR TITLE
[Backport devel-2.3.x] Keep (or move) mandatory dependencies only in `install_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ install_requires =
     Kivy-Garden>=0.1.4
     docutils
     pygments
+    requests
+    filetype
     kivy_deps.angle~=0.4.0; sys_platform == "win32"
     kivy_deps.sdl2~=0.8.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
@@ -44,28 +46,13 @@ dev =
     responses
 base =
     pillow>=9.5.0,<11
-    requests
-    filetype
-    docutils
-    pygments
-    kivy_deps.angle~=0.4.0; sys_platform == "win32"
-    kivy_deps.sdl2~=0.8.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
-    pypiwin32; sys_platform == "win32"
 media =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
 full =
     pillow>=9.5.0,<11
-    docutils
-    pygments
-    filetype
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    kivy_deps.angle~=0.4.0; sys_platform == "win32"
-    kivy_deps.sdl2~=0.8.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
     ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
-    pypiwin32; sys_platform == "win32"
 gstreamer =
     kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
     # don't use 0.4.0 because it was deleted


### PR DESCRIPTION
Backport a1e159785af0fbbe98fac977115ca6de51c0d3f3 from #8656 

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
