### PR TITLE
fix: doc: highlight with python-console when needed

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -811,7 +811,7 @@ class BuilderBase(object):
         This effectively clears all the KV rules associated with this widget.
         For example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> w = Builder.load_string(\'''
             ... Widget:
@@ -859,7 +859,7 @@ class BuilderBase(object):
 
         For example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> w = Builder.load_string(\'''
             ... Widget:

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -489,7 +489,7 @@ class Widget(WidgetBase):
             A bool. True if the point is inside the bounding box, False
             otherwise.
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> Widget(pos=(10, 10), size=(50, 50)).collide_point(40, 40)
             True
@@ -509,7 +509,7 @@ class Widget(WidgetBase):
             bool. True if the other widget collides with this widget, False
             otherwise.
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> wid = Widget(size=(50, 50))
             >>> wid2 = Widget(size=(50, 50), pos=(25, 25))
@@ -637,7 +637,7 @@ class Widget(WidgetBase):
 
                 .. versionadded:: 1.9.0
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> from kivy.uix.button import Button
         >>> from kivy.uix.slider import Slider
@@ -701,7 +701,7 @@ class Widget(WidgetBase):
             `widget`: :class:`Widget`
                 Widget to remove from our children list.
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> from kivy.uix.button import Button
         >>> root = Widget()
@@ -977,7 +977,7 @@ class Widget(WidgetBase):
 
         walking this tree:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> # Call walk on box with loopback True, and restrict False
             >>> [type(widget) for widget in box.walk(loopback=True)]
@@ -1066,7 +1066,7 @@ class Widget(WidgetBase):
 
         walking this tree:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> # Call walk on box with loopback True
             >>> [type(widget) for widget in box.walk_reverse(loopback=True)]
@@ -1500,7 +1500,7 @@ class Widget(WidgetBase):
 
     Then, in python:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> widget = MyWidget()
         >>> print(widget.ids)


### PR DESCRIPTION
The [`python-console`](https://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer) (or `pycon`) should be used when displaying interpreter output instead of [`python`](https://pygments.org/docs/lexers/#pygments.lexers.python.PythonLexer). `python` is for source code.

By fixing it, the highlighting in the documentation would be better.

The PR is the same change every lines. There are still python highligthing in the documentation because they are really source code examples.


Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
