### PR TITLE
Revert #8415 and align `glShaderSource` `typedef` in `common_subset.h` with Khronos Headers

### DIFF
--- a/kivy/graphics/cgl.pxd
+++ b/kivy/graphics/cgl.pxd
@@ -471,7 +471,7 @@ ctypedef void (__stdcall *GLRENDERBUFFERSTORAGEPTR)(GLenum target, GLenum intern
 ctypedef void (__stdcall *GLSAMPLECOVERAGEPTR)(GLclampf value, GLboolean invert) nogil
 ctypedef void (__stdcall *GLSCISSORPTR)(GLint, GLint, GLsizei, GLsizei) nogil
 ctypedef void (__stdcall *GLSHADERBINARYPTR)(GLsizei, const GLuint *, GLenum, const void *, GLsizei) nogil
-ctypedef void (__stdcall *GLSHADERSOURCEPTR)(GLuint, GLsizei, const GLchar**, const GLint *) nogil
+ctypedef void (__stdcall *GLSHADERSOURCEPTR)(GLuint, GLsizei, const GLchar* const *, const GLint *) nogil
 ctypedef void (__stdcall *GLSTENCILFUNCPTR)(GLenum func, GLint ref, GLuint mask) nogil
 ctypedef void (__stdcall *GLSTENCILFUNCSEPARATEPTR)(GLenum face, GLenum func, GLint ref, GLuint mask) nogil
 ctypedef void (__stdcall *GLSTENCILMASKPTR)(GLuint mask) nogil
@@ -602,7 +602,7 @@ ctypedef struct GLES2_Context:
     void (__stdcall *glSampleCoverage)(GLclampf value, GLboolean invert) nogil
     void (__stdcall *glScissor)(GLint, GLint, GLsizei, GLsizei) nogil
     void (__stdcall *glShaderBinary)(GLsizei, const GLuint *, GLenum, const void *, GLsizei) nogil
-    void (__stdcall *glShaderSource)(GLuint, GLsizei, const GLchar**, const GLint *) nogil
+    void (__stdcall *glShaderSource)(GLuint, GLsizei, const GLchar* const *, const GLint *) nogil
     void (__stdcall *glStencilFunc)(GLenum func, GLint ref, GLuint mask) nogil
     void (__stdcall *glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask) nogil
     void (__stdcall *glStencilMask)(GLuint mask) nogil

--- a/kivy/graphics/cgl_backend/cgl_debug.pyx
+++ b/kivy/graphics/cgl_backend/cgl_debug.pyx
@@ -883,11 +883,11 @@ cdef void __stdcall gil_dbgScissor (GLint x, GLint y, GLsizei width, GLsizei hei
     gl_check_error()
 # Skipping generation of: "#cdef void __stdcall dbgShaderBinary (cgl_native.GLsizei n,  cgl_native.GLuint* shaders, cgl_native.GLenum binaryformat,  cgl_native.GLvoid* binary, cgl_native.GLsizei length)"
 
-cdef void __stdcall dbgShaderSource (GLuint shader, GLsizei count, const GLchar** string, const GLint* length) nogil:
+cdef void __stdcall dbgShaderSource (GLuint shader, GLsizei count, const GLchar* const* string, const GLint* length) nogil:
     with gil:
         gil_dbgShaderSource(shader, count, string, length)
 
-cdef void __stdcall gil_dbgShaderSource (GLuint shader, GLsizei count,  const GLchar** string, const GLint* length) with gil:
+cdef void __stdcall gil_dbgShaderSource (GLuint shader, GLsizei count,  const GLchar* const* string, const GLint* length) with gil:
     gl_debug_print("GL glShaderSource( shader = ", shader, ", count = ", count, ", string**=", repr(hex(<long long> string)), ", length*=", repr(hex(<long long> length)), ", )")
     cgl_native.glShaderSource ( shader, count, <const_char_ptr*>string, length)
     gl_check_error()

--- a/kivy/graphics/cgl_backend/cgl_gl.pyx
+++ b/kivy/graphics/cgl_backend/cgl_gl.pyx
@@ -102,7 +102,7 @@ cdef extern from "gl_redirect.h":
     void (__stdcall *glSampleCoverage)(GLclampf value, GLboolean invert) nogil
     void (__stdcall *glScissor)(GLint, GLint, GLsizei, GLsizei) nogil
     void (__stdcall *glShaderBinary)(GLsizei, const GLuint *, GLenum, const void *, GLsizei) nogil
-    void (__stdcall *glShaderSource)(GLuint, GLsizei, const GLchar**, const GLint *) nogil
+    void (__stdcall *glShaderSource)(GLuint, GLsizei, const GLchar* const *, const GLint *) nogil
     void (__stdcall *glStencilFunc)(GLenum func, GLint ref, GLuint mask) nogil
     void (__stdcall *glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask) nogil
     void (__stdcall *glStencilMask)(GLuint mask) nogil

--- a/kivy/graphics/cgl_backend/cgl_mock.pyx
+++ b/kivy/graphics/cgl_backend/cgl_mock.pyx
@@ -208,7 +208,7 @@ cdef void __stdcall mockScissor(GLint x, GLint y, GLsizei width, GLsizei height)
     pass
 cdef void __stdcall mockShaderBinary(GLsizei n, const GLuint* shaders, GLenum binaryformat, const GLvoid* binary, GLsizei length) nogil:
     pass
-cdef void __stdcall mockShaderSource(GLuint shader, GLsizei count, const GLchar** string, const GLint* length) nogil:
+cdef void __stdcall mockShaderSource(GLuint shader, GLsizei count, const GLchar* const* string, const GLint* length) nogil:
     pass
 cdef void __stdcall mockStencilFunc(GLenum func, GLint ref, GLuint mask) nogil:
     pass

--- a/kivy/include/common_subset.h
+++ b/kivy/include/common_subset.h
@@ -373,7 +373,7 @@ GL_APICALL void         GL_APIENTRY glPolygonOffset (GLfloat factor, GLfloat uni
 GL_APICALL void         GL_APIENTRY glReadPixels (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid* pixels);
 GL_APICALL void         GL_APIENTRY glSampleCoverage (GLclampf value, GLboolean invert);
 GL_APICALL void         GL_APIENTRY glScissor (GLint x, GLint y, GLsizei width, GLsizei height);
-GL_APICALL void         GL_APIENTRY glShaderSource (GLuint shader, GLsizei count, const GLchar** string, const GLint* length);
+GL_APICALL void         GL_APIENTRY glShaderSource (GLuint shader, GLsizei count, const GLchar* const * string, const GLint* length);
 GL_APICALL void         GL_APIENTRY glStencilFunc (GLenum func, GLint ref, GLuint mask);
 GL_APICALL void         GL_APIENTRY glStencilFuncSeparate (GLenum face, GLenum func, GLint ref, GLuint mask);
 GL_APICALL void         GL_APIENTRY glStencilMask (GLuint mask);


### PR DESCRIPTION
* Problem and solution reported here https://github.com/kivy/kivy/issues/8557.
* Build is broken with CLANG17 and GCC14 for Kivy 2.3.0+ (including master).
* @danfe (Alexey Dokuchaev) created this patch for FreeBSD port.
* This patch proves danfe's fix and just reverts breaking commit https://github.com/kivy/kivy/pull/8415.
* THIS IS PROOF OF CONCEPT ONLY.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
