### PR TITLE
Make `triggered` decorator work without being called first

### DIFF
--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -1116,6 +1116,11 @@ def triggered(timeout=0, interval=False):
 
     .. versionadded:: 1.10.1
     '''
+    fun = None
+
+    if callable(timeout):
+        fun = timeout
+        timeout = 0
 
     def wrapper_triggered(func):
 
@@ -1145,8 +1150,8 @@ def triggered(timeout=0, interval=False):
 
         return trigger_function
 
-    if callable(timeout):
-        return wrapper_triggered(timeout)
+    if fun is not None:
+        return wrapper_triggered(fun)
 
     return wrapper_triggered
 

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -1148,7 +1148,46 @@ def triggered(timeout=0, interval=False):
     return wrapper_triggered
 
 
-if 'KIVY_DOC_INCLUDE' in environ:
+class triggered_method:
+    """Make a trigger from a method.
+
+    Decorate a method with this and it will become a trigger. Supply a
+    numeric parameter to set a timeout.
+
+    Not suitable for methods that expect any arguments other than
+    ``dt``. However, you should make your method accept ``*args`` for
+    compatibility.
+
+    """
+
+    def __init__(self, func_or_timeout, interval=False):
+        if callable(func_or_timeout):
+            self.func = func_or_timeout
+            self.timeout = 0
+        else:
+            self.func = None
+            self.timeout = func_or_timeout
+        self.interval = interval
+
+    def __call__(self, func):
+        self.func = func
+        self.__doc__ = func.__doc__
+        return self
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            # EventDispatcher iterates over its attributes before it
+            # instantiates.  Don't try making any trigger in that
+            # case.
+            return
+        retval = Clock.create_trigger(
+            partial(self.func, instance), self.timeout, self.interval
+        )
+        setattr(instance, self.func.__name__, retval)
+        return retval
+
+
+if "KIVY_DOC_INCLUDE" in environ:
     #: Instance of :class:`ClockBaseBehavior`.
     Clock: ClockBase = None
 else:

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -1151,7 +1151,7 @@ def triggered(timeout=0, interval=False):
     return wrapper_triggered
 
 
-if "KIVY_DOC_INCLUDE" in environ:
+if 'KIVY_DOC_INCLUDE' in environ:
     #: Instance of :class:`ClockBaseBehavior`.
     Clock: ClockBase = None
 else:

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -1145,46 +1145,10 @@ def triggered(timeout=0, interval=False):
 
         return trigger_function
 
+    if callable(timeout):
+        return wrapper_triggered(timeout)
+
     return wrapper_triggered
-
-
-class triggered_method:
-    """Make a trigger from a method.
-
-    Decorate a method with this and it will become a trigger. Supply a
-    numeric parameter to set a timeout.
-
-    Not suitable for methods that expect any arguments other than
-    ``dt``. However, you should make your method accept ``*args`` for
-    compatibility.
-
-    """
-
-    def __init__(self, func_or_timeout, interval=False):
-        if callable(func_or_timeout):
-            self.func = func_or_timeout
-            self.timeout = 0
-        else:
-            self.func = None
-            self.timeout = func_or_timeout
-        self.interval = interval
-
-    def __call__(self, func):
-        self.func = func
-        self.__doc__ = func.__doc__
-        return self
-
-    def __get__(self, instance, owner=None):
-        if instance is None:
-            # EventDispatcher iterates over its attributes before it
-            # instantiates.  Don't try making any trigger in that
-            # case.
-            return
-        retval = Clock.create_trigger(
-            partial(self.func, instance), self.timeout, self.interval
-        )
-        setattr(instance, self.func.__name__, retval)
-        return retval
 
 
 if "KIVY_DOC_INCLUDE" in environ:

--- a/kivy/tests/test_clock.py
+++ b/kivy/tests/test_clock.py
@@ -131,6 +131,19 @@ def test_trigger_decorator_cancel(kivy_clock, clock_counter):
     assert clock_counter.counter == 0
 
 
+def test_trigger_decorator_no_call(kivy_clock, clock_counter):
+    from kivy.clock import triggered
+
+    @triggered
+    def triggered_callback():
+        clock_counter(dt=0)
+
+    triggered_callback()
+    assert clock_counter.counter == 0
+    kivy_clock.tick()
+    assert clock_counter.counter == 1
+
+
 def test_exception_caught(kivy_clock, clock_counter):
     exception = None
 


### PR DESCRIPTION
I kept missing that I had to decorate functions with `@triggered()` and not just `@triggered`. With this PR, plain `@triggered` will work.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
