### PR TITLE
[Backport devel-2.3.x] Fix `SDL_EventFilter` definitions to match SDL definitions (fixes build on GCC 14)

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -263,7 +263,7 @@ cdef class _WindowSDL2Storage:
         for joy_i in range(SDL_NumJoysticks()):
             SDL_JoystickOpen(joy_i)
 
-        SDL_SetEventFilter(<SDL_EventFilter *>_event_filter, <void *>self)
+        SDL_SetEventFilter(<SDL_EventFilter>_event_filter, <void *>self)
 
         SDL_EventState(SDL_DROPFILE, SDL_ENABLE)
         SDL_EventState(SDL_DROPTEXT, SDL_ENABLE)

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -469,7 +469,7 @@ cdef extern from "SDL.h":
     ctypedef enum SDL_Scancode:
         pass
 
-    ctypedef int SDL_EventFilter(void* userdata, SDL_Event* event)
+    ctypedef int (*SDL_EventFilter)(void* userdata, SDL_Event* event)
     # for windows only see
     # https://github.com/LuaDist/sdl/blob/master/include/begin_code.h#L68
     IF UNAME_SYSNAME == 'Windows':
@@ -535,7 +535,7 @@ cdef extern from "SDL.h":
     cdef void SDL_Delay(Uint32 ms) nogil
     cdef Uint8 SDL_EventState(Uint32 type, int state)
     cdef int SDL_PollEvent(SDL_Event * event) nogil
-    cdef void SDL_SetEventFilter(SDL_EventFilter *filter, void* userdata)
+    cdef void SDL_SetEventFilter(SDL_EventFilter filter, void* userdata)
     cdef SDL_RWops * SDL_RWFromFile(char *file, char *mode)
     cdef SDL_RWops * SDL_RWFromMem(void *mem, int size)
     cdef SDL_RWops * SDL_RWFromConstMem(void *mem, int size)


### PR DESCRIPTION
Backport d6ba697e37017a29a0749b47ed0a2f9d1aa44c15 from #8792.