### PR TITLE
Fixing LoggerHistory stores one extra record. ( Issue #7986 )

### DIFF
--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -330,7 +330,7 @@ class LoggerHistory(logging.Handler):
     history = []
 
     def emit(self, message):
-        LoggerHistory.history = [message] + LoggerHistory.history[:100]
+        LoggerHistory.history = [message] + LoggerHistory.history[:99]
 
     @classmethod
     def clear_history(cls):


### PR DESCRIPTION
In line 333 from logger.py, there was [message] + LoggerHistory.history[:100], this 100 was affecting the access to 101 LogRecords instead of 100, as there is already the first message being transmitted, so the correct would be [:99].

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
