### PR TITLE
Fixes "permission denied" error on `macos-14` runner during osx app build job

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -28,11 +28,11 @@ install_platypus() {
   gunzip Platypus.app/Contents/Resources/ScriptExec.gz
 
   mkdir -p /usr/local/bin
-  mkdir -p /usr/local/share/platypus
+  sudo mkdir -p /usr/local/share/platypus
   cp Platypus.app/Contents/Resources/platypus_clt /usr/local/bin/platypus
-  cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
-  cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
-  chmod -R 755 /usr/local/share/platypus
+  sudo cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
+  sudo cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
+  sudo chmod -R 755 /usr/local/share/platypus
 }
 
 generate_osx_app_bundle() {


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

See: https://github.com/actions/runner-images/issues/9272

Permissions have changed on `macos-14` runner image, and root access is required to perform changes on `/usr/local/share`.

Nothing changes on the user side, as this script is only meant to be run on a CI/CD environment.
