### PR TITLE
[Backport devel-2.3.x] Fixes "permission denied" error on `macos-14` runner during osx app build job

### DIFF
--- a/.ci/osx_ci.sh
+++ b/.ci/osx_ci.sh
@@ -28,11 +28,11 @@ install_platypus() {
   gunzip Platypus.app/Contents/Resources/ScriptExec.gz
 
   mkdir -p /usr/local/bin
-  mkdir -p /usr/local/share/platypus
+  sudo mkdir -p /usr/local/share/platypus
   cp Platypus.app/Contents/Resources/platypus_clt /usr/local/bin/platypus
-  cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
-  cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
-  chmod -R 755 /usr/local/share/platypus
+  sudo cp Platypus.app/Contents/Resources/ScriptExec /usr/local/share/platypus/ScriptExec
+  sudo cp -a Platypus.app/Contents/Resources/MainMenu.nib /usr/local/share/platypus/MainMenu.nib
+  sudo chmod -R 755 /usr/local/share/platypus
 }
 
 generate_osx_app_bundle() {


### PR DESCRIPTION
Backport 8e990219cbba8385276cd9cc30de3ce968795552 from #8924.