### PR TITLE
[Backport devel-2.3.x] Sphinx/docs: Avoid usage of deprecated `style` keyword

### DIFF
--- a/doc/sources/.templates/layout.html
+++ b/doc/sources/.templates/layout.html
@@ -96,7 +96,9 @@
     <title>{{ title|striptags }}{{ titlesuffix }}</title>
     <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    {%- for style in styles %} 
+      <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    {%- endfor %} 
 
     {%- if not embedded %}
     {%- block scripts %}


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Backport bde597c5748fc3436b0ec4211e8db152e62d3a24 from #8709 