### PR TITLE
Remove Python `3.8` from supported matrix and set minimum supported version to `3.9`

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -140,7 +140,7 @@ jobs:
     needs: [manylinux_wheel_create, kivy_examples_create]
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13' ]
     env:
       DISPLAY: ':99.0'
     steps:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -139,7 +139,7 @@ jobs:
         # macos-latest (ATM macos-14) runs on Apple Silicon,
         # macos-13 runs on Intel
         runs_on: ['macos-latest', 'macos-13']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13' ]
         arch: ['x64']
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13' ]
         arch: ['x64']
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel win]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel win]')
     steps:
@@ -34,7 +34,7 @@ jobs:
         . .\.ci\windows_ci.ps1
         Update-version-metadata
     - name: Generate sdist/kivy-examples
-      if: matrix.arch == 'x64' && matrix.python == '3.8'
+      if: matrix.arch == 'x64' && matrix.python == '3.9'
       # only windows kivy-examples is uploaded
       run: |
         . .\.ci\windows_ci.ps1
@@ -104,7 +104,7 @@ jobs:
     needs: windows_wheels_create
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13' ]
         arch: [ 'x64' ]
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cython_min=0.29.1
 cython_max=3.0.11
 cython_exclude=
-python_versions=3.8 - 3.13
+python_versions=3.9 - 3.13
 
 [coverage:run]
 parallel = True
@@ -14,7 +14,7 @@ plugins =
 concurrency = thread, multiprocessing
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     Kivy-Garden>=0.1.4
     docutils

--- a/setup.py
+++ b/setup.py
@@ -1296,7 +1296,6 @@ if not build_examples:
             'Operating System :: Microsoft :: Windows',
             'Operating System :: POSIX :: BSD :: FreeBSD',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
- Python `3.8` has been removed from supported matrix as reached EOL on 2024-10-07
- Minimum supported version is now Python `3.9`

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
