### PR TITLE
Fix a crash when loading a lot of images at once

### DIFF
--- a/kivy/cache.py
+++ b/kivy/cache.py
@@ -193,7 +193,7 @@ class Cache(object):
         import heapq
         time = Clock.get_time()
         heap_list = []
-        for key in Cache._objects[category]:
+        for key in list(Cache._objects[category]):
             obj = Cache._objects[category][key]
             if obj['lastaccess'] == obj['timestamp'] == time:
                 continue


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
I tried using `kivy.core.image.Image` to load a bunch of images at once. I feel like this might not be the greatest idea for my app's sake, but in any case, doing this caused a crash as Kivy's cache tried to unload things while another thread was loading things into it.

The fix is one line. May as well?

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
