### PR TITLE
Added is_utility_window configuration option for SDL2 window provider

### DIFF
--- a/kivy/config.py
+++ b/kivy/config.py
@@ -258,6 +258,10 @@ Available configuration tokens
         applicable for the SDL2 window provider.
         ``0`` means the icon will not be shown in the taskbar and ``1`` means
         it will.
+    `is_utility_window`: int, one of ``0`` or ``1``, defaults to ``0``
+        If set to ``1``, the window will be treated as a utility window.
+        If set to ``0``, the window will NOT be treated as a utility window.
+        Only works for the sdl2 window provider.
     `allow_screensaver`: int, one of 0 or 1, defaults to 1
         Allow the device to show a screen saver, or to go to sleep
         on mobile devices. Only works for the sdl2 window provider.
@@ -341,6 +345,9 @@ Available configuration tokens
     Check the specific module's documentation for a list of accepted
     arguments.
 
+.. versionchanged:: 2.3.0
+    `is_utility_window` has been added to the `graphics` section.
+    
 .. versionadded:: 2.2.0
     `always_on_top` have been added to the `graphics` section.
     `show_taskbar_icon` have been added to the `graphics` section.
@@ -404,7 +411,7 @@ from kivy.utils import platform
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 27
+KIVY_CONFIG_VERSION = 28
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -936,6 +943,9 @@ if not environ.get('KIVY_DOC_INCLUDE'):
 
         elif version == 26:
             Config.setdefault("graphics", "show_taskbar_icon", "1")
+
+        elif version == 27:
+            Config.setdefault("graphics", "is_utility_window", "0")
 
         # WARNING: When adding a new version migration here,
         # don't forget to increment KIVY_CONFIG_VERSION !

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -172,6 +172,11 @@ cdef class _WindowSDL2Storage:
 
         self.win_flags  = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI
 
+        is_utility_window = Config.getboolean('graphics', 'is_utility_window')
+
+        if is_utility_window:
+            self.win_flags |= SDL_WINDOW_UTILITY
+
         if self.sdl_manages_egl_context:
             self.win_flags |= SDL_WINDOW_OPENGL
 

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -258,6 +258,7 @@ cdef extern from "SDL.h":
         SDL_WINDOW_ALLOW_HIGHDPI
         SDL_WINDOW_SKIP_TASKBAR = 0x00010000    #,   /**< window should not be added to the taskbar */
         SDL_WINDOW_METAL = 0x20000000           #,          /**< window usable for Metal view */
+        SDL_WINDOW_UTILITY = 0x00020000         #,            /**< window should be treated as a utility window */
 
     ctypedef enum SDL_HitTestResult:
         SDL_HITTEST_NORMAL


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

This PR introduces the possibility to create utility windows, the last one to be implemented in #8010.

Options:

0 → default - The window IS NOT an utility window
1 → The window IS an utility window.

Test code:

```python
from kivy.config import Config
Config.set("graphics", "is_utility_window", 1)

from kivy.app import App
from kivy.uix.button import Button

class TestApp(App):
    def build(self):
        return Button(text=f"Is utility? {Config.get("graphics", "is_utility_window")}", font_size=40)

if __name__ == '__main__':
    TestApp().run()
```

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
