### PR TITLE
setup.cfg: The item `option.dependency_links` dropped by `pip` in 2019

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ install_requires =
     kivy_deps.sdl2~=0.8.0; sys_platform == "win32"
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
     pypiwin32; sys_platform == "win32"
-dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
 
 [options.extras_require]
 tuio = oscpy


### PR DESCRIPTION
`setup.cfg`:
```diff
- dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
```
> [!WARNING]
> Dependency links support has been dropped by pip starting with version 19.0 (released 2019-01-22).

https://setuptools.pypa.io/en/latest/deprecated/dependency_links.html

@misl6 Related to:
* #8127

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
