### PR TITLE
PEP 621: Migrate settings from setup.cfg into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = [ "description", "license", "readme", "version" ]
+dynamic = [ "description", "license", "readme", "urls", "version" ]
 
 dependencies = [
   "docutils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = [ "version" ]
+dynamic = [ "description", "version" ]
 
 dependencies = [
   "docutils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,93 @@
 [build-system]
 requires = [
-    "setuptools~=69.2.0",
-    "wheel~=0.44.0",
-    "packaging~=24.0",
-    "cython>=0.29.1,<=3.0.11",
-    'kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2_dev~=0.8.0; sys_platform == "win32"',
-    'kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"',
-    'kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"',
-    'kivy_deps.sdl2~=0.8.0; sys_platform == "win32"',
-    'kivy_deps.glew~=0.3.1; sys_platform == "win32"',
+  "cython>=0.29.1,<=3.0.11",
+  "kivy-deps-glew~=0.3.1; sys_platform=='win32'",
+  "kivy-deps-glew-dev~=0.3.1; sys_platform=='win32'",
+  "kivy-deps-gstreamer~=0.3.3; sys_platform=='win32'",
+  "kivy-deps-gstreamer-dev~=0.3.3; sys_platform=='win32'",
+  "kivy-deps-sdl2~=0.8.0; sys_platform=='win32'",
+  "kivy-deps-sdl2-dev~=0.8.0; sys_platform=='win32'",
+  "packaging~=24.0",
+  "setuptools~=69.2.0",
+  "wheel~=0.44.0",
 ]
+
+[project]
+name = "kivy"
+requires-python = ">=3.9"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+dynamic = [ "version" ]
+
+dependencies = [
+  "docutils",
+  "filetype",
+  "kivy-deps-angle~=0.4.0; sys_platform=='win32'",
+  "kivy-deps-glew~=0.3.1; sys_platform=='win32'",
+  "kivy-deps-sdl2~=0.8.0; sys_platform=='win32'",
+  "kivy-garden>=0.1.4",
+  "pygments",
+  "pypiwin32; sys_platform=='win32'",
+  "requests",
+]
+optional-dependencies.angle = [ "kivy-deps-angle~=0.4.0; sys_platform=='win32'" ]
+optional-dependencies.base = [ "pillow>=9.5,<11" ]
+optional-dependencies.dev = [
+  "flake8",
+  "kivy-deps-glew-dev~=0.3.1; sys_platform=='win32'",
+  "kivy-deps-gstreamer-dev~=0.3.3; sys_platform=='win32'",
+  "kivy-deps-sdl2-dev~=0.8.0; sys_platform=='win32'",
+  "pre-commit",
+  "pyinstaller",
+  "pytest>=3.6",
+  "pytest-asyncio!=0.11",
+  "pytest-benchmark",
+  "pytest-cov",
+  "pytest-timeout",
+  "responses",
+  "sphinx~=6.2.1",
+  "sphinxcontrib-jquery~=4.1",
+]
+optional-dependencies.full = [
+  "ffpyplayer; sys_platform=='linux' or sys_platform=='darwin'",
+  "kivy-deps-gstreamer~=0.3.3; sys_platform=='win32'",
+  "pillow>=9.5,<11",
+]
+optional-dependencies.glew = [ "kivy-deps-glew~=0.3.1; sys_platform=='win32'" ]
+optional-dependencies.gstreamer = [
+  "kivy-deps-gstreamer~=0.3.3; sys_platform=='win32'",
+  # don't use 0.4.0 because it was deleted
+]
+optional-dependencies.media = [
+  "ffpyplayer; sys_platform=='linux' or sys_platform=='darwin'",
+  "kivy-deps-gstreamer~=0.3.3; sys_platform=='win32'",
+]
+optional-dependencies.sdl2 = [ "kivy-deps-sdl2~=0.8.0; sys_platform=='win32'" ]
+optional-dependencies.tuio = [ "oscpy" ]
+
+[tool.setuptools]
+include-package-data = false
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchmarks-kivy --benchmark-save=kivy"
 markers = "incremental: mark a test as incremental."
+
+[tool.coverage.run]
+parallel = true
+branch = true
+omit = [ "*/pyinstaller/*_widget/*" ]
+plugins = [ "kivy.tools.coverage" ]
+concurrency = [ "thread", "multiprocessing" ]
+
+[tool.kivy]
+# Can the `[tool.kivy]` block be read from pyproject.toml or not yet?
+cython_min = "0.29.1"
+cython_max = "3.0.11"
+cython_exclude = ""
+python_versions = "3.9 - 3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = [ "description", "license", "version" ]
+dynamic = [ "description", "license", "readme", "version" ]
 
 dependencies = [
   "docutils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ requires = [
 
 [project]
 name = "kivy"
+authors = [
+    {name = "Kivy Team and other contributors", email = "kivy-dev@googlegroups.com"},
+]
 requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = [ "description", "version" ]
+dynamic = [ "description", "license", "version" ]
 
 dependencies = [
   "docutils",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,67 +1,9 @@
+# Can the `[kivy]` block be moved to pyproject.toml or not yet?
 [kivy]
 cython_min=0.29.1
 cython_max=3.0.11
 cython_exclude=
 python_versions=3.9 - 3.13
-
-[coverage:run]
-parallel = True
-branch = True
-omit =
-    */pyinstaller/*_widget/*
-plugins =
-    kivy.tools.coverage
-concurrency = thread, multiprocessing
-
-[options]
-python_requires = >=3.9
-install_requires =
-    Kivy-Garden>=0.1.4
-    docutils
-    pygments
-    requests
-    filetype
-    kivy_deps.angle~=0.4.0; sys_platform == "win32"
-    kivy_deps.sdl2~=0.8.0; sys_platform == "win32"
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
-    pypiwin32; sys_platform == "win32"
-dependency_links = https://github.com/kivy-garden/garden/archive/master.zip
-
-[options.extras_require]
-tuio = oscpy
-dev =
-    pytest>=3.6
-    pytest-cov
-    pytest_asyncio!=0.11.0
-    pytest-timeout
-    pytest-benchmark
-    pyinstaller
-    sphinx~=6.2.1
-    sphinxcontrib-jquery~=4.1
-    kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
-    kivy_deps.sdl2_dev~=0.8.0; sys_platform == "win32"
-    kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"
-    flake8
-    pre-commit
-    responses
-base =
-    pillow>=9.5.0,<11
-media =
-    kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
-full =
-    pillow>=9.5.0,<11
-    kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    ffpyplayer; sys_platform == "linux" or sys_platform == "darwin"
-gstreamer =
-    kivy_deps.gstreamer~=0.3.3; sys_platform == "win32"
-    # don't use 0.4.0 because it was deleted
-angle =
-    kivy_deps.angle~=0.4.0; sys_platform == "win32"
-sdl2 =
-    kivy_deps.sdl2~=0.8.0; sys_platform == "win32"
-glew =
-    kivy_deps.glew~=0.3.1; sys_platform == "win32"
 
 [flake8]
 ignore = E125,E126,E127,E128,E402,E741,E731,W503,F401,W504,F841,E722


### PR DESCRIPTION
@misl6 A second attempt at:
* #8127

Migrate settings from `setup.cfg` into `pyproject.toml` using [ini2toml](https://pypi.org/project/ini2toml) to do the file conversion and running [pyproject-fmt](https://pypi.org/project/pyproject-fmt) and then [validate-pyproject](https://github.com/abravalheri/validate-pyproject) to validate the results.
* Currently, flake8 is not yet compatible with `pyproject.toml` so leave its settings in `setup.cfg`.
* Can the `[kivy]` block in `setup.cfg` be migrated to a `[tool.kivy]` block in `pyproject.toml` on not yet?


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
