### PR TITLE
Python lint: Use `ruff` instead of `flake8`

### DIFF
--- a/.ci/cicd-requirements.txt
+++ b/.ci/cicd-requirements.txt
@@ -1,4 +1,4 @@
-cibuildwheel~=2.21.1
 build~=1.2.1
+cibuildwheel~=2.21.1
+ruff>=0.8.3,<1.0.0
 twine~=5.1.0
-flake8~=7.1.0

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PYTHON_VERSION_OK=$(shell $(PYTHON) -c 'import sys;\
 ifeq ($(PYTHON_VERSION_OK),0)
   $(error "detected Python $(PYTHON_VERSION) need Python >= $(PYTHON_VERSION_MIN)")
 endif
-CHECKSCRIPT = -m flake8
+CHECKSCRIPT = -m ruff check
 KIVY_DIR = kivy/
 PYTEST = $(PYTHON) -m pytest
 KIVY_USE_DEFAULTCONFIG = 1

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -991,4 +991,4 @@ if 'KIVY_DOC' not in environ and not libs_loaded:
     sys.exit(1)
 
 # resolve binding.
-from kivy.graphics.texture import Texture, TextureRegion
+from kivy.graphics.texture import Texture, TextureRegion  # noqa: F811

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1379,7 +1379,7 @@ class WindowBase(EventDispatcher):
         ::
 
             1. first set Window.custom_titlebar to True
-            2. then call Window.set_custom_titlebar with the widget/layout you want to set as titlebar as the argument # noqa: E501
+            2. then call Window.set_custom_titlebar with the widget/layout you want to set as titlebar as the argument
 
         If you want a child of the widget to receive touch events, in
         that child define a property `draggable` and set it to False
@@ -1408,7 +1408,7 @@ class WindowBase(EventDispatcher):
             :mod:`~kivy.core.window.WindowBase.custom_titlebar` must be set to True
             for the widget to be successfully set as a titlebar
 
-        """
+        """  # noqa: E501
 
         Logger.warning('Window: set_custom_titlebar '
                        'is not implemented in the current'

--- a/kivy/input/providers/mtdev.py
+++ b/kivy/input/providers/mtdev.py
@@ -324,7 +324,7 @@ else:
                         continue
 
                     # fill the slot
-                    if not (_slot in l_points):
+                    if _slot not in l_points:
                         l_points[_slot] = dict()
                     point = l_points[_slot]
                     ev_value = data.value

--- a/kivy/lib/ddsfile.py
+++ b/kivy/lib/ddsfile.py
@@ -53,7 +53,7 @@ DDS Format
     code.
 
 '''
-# flake8: noqa
+# ruff: noqa
 
 from struct import pack, unpack, calcsize
 

--- a/kivy/lib/mtdev.py
+++ b/kivy/lib/mtdev.py
@@ -18,7 +18,7 @@ documentation for further details.
     It might change in the future and we advise you don't rely on it in your
     code.
 '''
-# flake8: noqa
+# ruff: noqa
 
 import os
 import time

--- a/kivy/modules/_webdebugger.py
+++ b/kivy/modules/_webdebugger.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa
+# ruff: noqa
 
 import threading
 import json

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -75,12 +75,11 @@ from kivy.weakmethod import WeakMethod
 try:
     import ssl
 
-    HTTPSConnection = None
     from http.client import HTTPSConnection
 except ImportError:
     # depending the platform, if openssl support wasn't compiled before python,
     # this class is not available.
-    pass
+    HTTPSConnection = None
 
 
 # list to save UrlRequest and prevent GC on un-referenced objects

--- a/kivy/tools/image-testsuite/gimp28-testsuite.py
+++ b/kivy/tools/image-testsuite/gimp28-testsuite.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# flake8: noqa
+# ruff: noqa
 import os
 import re
 import random

--- a/kivy/tools/precommit_hooks/pre-commit-config.yaml
+++ b/kivy/tools/precommit_hooks/pre-commit-config.yaml
@@ -6,25 +6,27 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
-    -   id: no-commit-to-branch
-    -   id: check-executables-have-shebangs
-    -   id: check-ast
-    -   id: check-merge-conflict
-    -   id: check-toml
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
     -   id: check-added-large-files
+    -   id: check-ast
     -   id: check-case-conflict
+    -   id: check-executables-have-shebangs
     -   id: check-json
+    -   id: check-merge-conflict
     -   id: check-symlinks
+    -   id: check-toml
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: no-commit-to-branch
     -   id: pretty-format-json
         args:
         - --autofix
--   repo: https://github.com/pycqa/flake8
-    rev: 3.8.4
+    -   id: trailing-whitespace
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.2
     hooks:
-    -   id: flake8
+    -   id: ruff
+    #   args: [ --fix ]
+    # - id: ruff-format
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:

--- a/kivy/tools/stub-gl-debug.py
+++ b/kivy/tools/stub-gl-debug.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 from __future__ import print_function
 
 a = '''cdef void   glActiveTexture (cgl.GLenum texture)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,27 @@ requires = [
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchmarks-kivy --benchmark-save=kivy"
 markers = "incremental: mark a test as incremental."
+
+[tool.ruff]
+exclude = [
+    "__pycache__",
+    ".tox",
+    ".git/",
+    "doc/",
+    "build/",
+    ".eggs/",
+    "venv/",
+]
+lint.extend-ignore = [
+    "E402",
+    "E722",
+    "E731",
+    "E741",
+    "F401",
+    "F841",
+]
+lint.select = [
+    "E",
+    "F",
+    "W",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,9 +40,9 @@ dev =
     kivy_deps.gstreamer_dev~=0.3.3; sys_platform == "win32"
     kivy_deps.sdl2_dev~=0.8.0; sys_platform == "win32"
     kivy_deps.glew_dev~=0.3.1; sys_platform == "win32"
-    flake8
     pre-commit
     responses
+    ruff>=0.8.3,<1.0.0
 base =
     pillow>=9.5.0,<11
 media =
@@ -62,10 +62,3 @@ sdl2 =
 glew =
     kivy_deps.glew~=0.3.1; sys_platform == "win32"
 
-[flake8]
-ignore = E125,E126,E127,E128,E402,E741,E731,W503,F401,W504,F841,E722
-max-line-length = 80
-exclude = __pycache__,.tox,.git/,doc/,build/,.eggs/,venv/
-statistics = true
-show-source = true
-count = true


### PR DESCRIPTION
https://docs.astral.sh/ruff is an extremely fast Python linter and code formatter, written in Rust. With [over 800 linting rules](https://docs.astral.sh/ruff/rules), ruff can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [Black](https://github.com/psf/black), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [pyupgrade](https://pypi.org/project/pyupgrade/), [autoflake](https://pypi.org/project/autoflake/), and more, all while executing tens or hundreds of times faster than any individual tool.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
