### PR TITLE
Use `.items()` instead of extracting the dictionary value via explicit indexing

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -222,15 +222,15 @@ kivy_options = {
         'sdl2', 'dummy', 'gtk3', )}
 
 # Read environment
-for option in kivy_options:
+for option, value in kivy_options.items():
     key = 'KIVY_%s' % option.upper()
     if key in environ:
         try:
-            if type(kivy_options[option]) in (list, tuple):
+            if type(value) in {list, tuple}:
                 kivy_options[option] = environ[key].split(',')
             else:
                 kivy_options[option] = environ[key].lower() in \
-                    ('true', '1', 'yes')
+                    {'true', '1', 'yes'}
         except Exception:
             Logger.warning('Core: Wrong value for %s environment key' % key)
             Logger.exception('')

--- a/kivy/context.py
+++ b/kivy/context.py
@@ -59,10 +59,8 @@ class Context(dict):
         if not init:
             return
 
-        for name in _contexts:
-            context = _contexts[name]
-            instance = context['cls'](*context['args'], **context['kwargs'])
-            self[name] = instance
+        for name, context in _contexts.items():
+            self[name] = context['cls'](*context['args'], **context['kwargs'])
 
     def push(self):
         _context_stack.append(self)


### PR DESCRIPTION
% `ruff check --select=PLC0206 --output-format=concise`
```
kivy/__init__.py:225:1: PLC0206 Extracting value from dictionary without calling `.items()`
kivy/context.py:62:9: PLC0206 Extracting value from dictionary without calling `.items()`
Found 2 errors.
```
% [`ruff rule PLC0206`](https://docs.astral.sh/ruff/rules/dict-index-missing-items)
# dict-index-missing-items (PLC0206)

Derived from the **Pylint** linter.

## What it does
Checks for dictionary iterations that extract the dictionary value
via explicit indexing, instead of using `.items()`.

## Why is this bad?
Iterating over a dictionary with `.items()` is semantically clearer
and more efficient than extracting the value with the key.

## Example
```python
ORCHESTRA = {
    "violin": "strings",
    "oboe": "woodwind",
    "tuba": "brass",
    "gong": "percussion",
}

for instrument in ORCHESTRA:
    print(f"{instrument}: {ORCHESTRA[instrument]}")
```

Use instead:
```python
ORCHESTRA = {
    "violin": "strings",
    "oboe": "woodwind",
    "tuba": "brass",
    "gong": "percussion",
}

for instrument, section in ORCHESTRA.items():
    print(f"{instrument}: {section}")
```

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
