### PR TITLE
Replace legacy backticks with $( ) in linux dependencies build tool

### DIFF
--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -61,7 +61,7 @@ mkdir kivy-dependencies/dist
 # Build the dependencies
 pushd kivy-dependencies/build
 
-IS_RPI=`python3 -c "import platform; print('1' if 'raspberrypi' in platform.uname() else '0')"`
+IS_RPI=$(python3 -c "import platform; print('1' if 'raspberrypi' in platform.uname() else '0')")
 if [ "$(dpkg --print-architecture)" = "armhf" ]; then
   IS_ARMHF=1
 else


### PR DESCRIPTION
Fixes warning shown by shellcheck.

More information about the warning here: https://www.shellcheck.net/wiki/SC2006

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
