### PR TITLE
Add check (and add fallback) for `python3` cmd availability on linux dependencies build script

### DIFF
--- a/tools/build_linux_dependencies.sh
+++ b/tools/build_linux_dependencies.sh
@@ -61,7 +61,14 @@ mkdir kivy-dependencies/dist
 # Build the dependencies
 pushd kivy-dependencies/build
 
-IS_RPI=$(python3 -c "import platform; print('1' if 'raspberrypi' in platform.uname() else '0')")
+# Check if "python3" exists, otherwise use "python" as fallback (which is the case for manylinux)
+if command -v python3 &> /dev/null; then
+  PYTHON_EXECUTABLE=python3
+else
+  PYTHON_EXECUTABLE=python
+fi 
+
+IS_RPI=$($PYTHON_EXECUTABLE -c "import platform; print('1' if 'raspberrypi' in platform.uname() else '0')")
 if [ "$(dpkg --print-architecture)" = "armhf" ]; then
   IS_ARMHF=1
 else


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

PR #8946 transitioned from using `python` to `python3`. However, in certain scenarios, such as when using **manylinux images** for building wheels, the `python3` command may not be available.