### PR TITLE
Add `TouchRippleBehavior.ripple_pane` to its canvas when needed not during initialization

### DIFF
--- a/kivy/uix/behaviors/touchripple.py
+++ b/kivy/uix/behaviors/touchripple.py
@@ -136,7 +136,6 @@ class TouchRippleBehavior(object):
     def __init__(self, **kwargs):
         super(TouchRippleBehavior, self).__init__(**kwargs)
         self.ripple_pane = CanvasBase()
-        self.canvas.add(self.ripple_pane)
         self.bind(
             ripple_color=self._ripple_set_color,
             ripple_pos=self._ripple_set_ellipse,
@@ -152,6 +151,7 @@ class TouchRippleBehavior(object):
         '''
         Animation.cancel_all(self, 'ripple_rad', 'ripple_color')
         self._ripple_reset_pane()
+        self.canvas.add(self.ripple_pane)
         x, y = self.to_window(*self.pos)
         width, height = self.size
         if isinstance(self, RelativeLayout):
@@ -224,6 +224,7 @@ class TouchRippleBehavior(object):
     def _ripple_reset_pane(self):
         self.ripple_rad = self.ripple_rad_default
         self.ripple_pane.clear()
+        self.canvas.remove(self.ripple_pane)
 
 
 class TouchRippleButtonBehavior(TouchRippleBehavior):


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Currently, the `TouchRippleBehavior` adds its `ripple_pane` to the canvas during `__init__()`, which means any children added afterward will be drawn on top of the ripple effect, causing issue #7458. This PR fixes it.

Fixes: #7458 