### PR TITLE
Fix the `AttributeError` that occurs when `TouchRippleButtonBehavior` is disabled.

### DIFF
--- a/kivy/uix/behaviors/touchripple.py
+++ b/kivy/uix/behaviors/touchripple.py
@@ -137,6 +137,7 @@ class TouchRippleBehavior(object):
         super(TouchRippleBehavior, self).__init__(**kwargs)
         self.ripple_pane = CanvasBase()
         self.bind(
+            disabled=self._ripple_fade,
             ripple_color=self._ripple_set_color,
             ripple_pos=self._ripple_set_ellipse,
             ripple_rad=self._ripple_set_ellipse
@@ -200,6 +201,9 @@ class TouchRippleBehavior(object):
         )
         anim.bind(on_complete=self._ripple_anim_complete)
         anim.start(self)
+
+    def _ripple_fade(self, *args):
+        self.ripple_fade()
 
     def _ripple_set_ellipse(self, instance, value):
         ellipse = self.ripple_ellipse
@@ -304,13 +308,6 @@ class TouchRippleButtonBehavior(TouchRippleBehavior):
             self.dispatch('on_release')
         Clock.schedule_once(defer_release, self.ripple_duration_out)
         return True
-
-    def on_disabled(self, instance, value):
-        # ensure ripple animation completes if disabled gets set to True
-        if value:
-            self.ripple_fade()
-        return super(TouchRippleButtonBehavior, self).on_disabled(
-            instance, value)
 
     def on_press(self):
         pass


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

(This is not just a bug fix, as `TouchRippleBehavior` now calls `ripple_fade()` instead of `TouchRippleButtonBehavior` when the widget is disabled.)

Fixes: #8023 