### PR TITLE
Refactor ScrollView

### DIFF
--- a/kivy/effects/scroll.py
+++ b/kivy/effects/scroll.py
@@ -90,9 +90,10 @@ class ScrollEffect(KineticEffect):
         '''
         self.value = pos
         self.velocity = 0
-        if self.history:
-            val = self.history[-1][1]
-            self.history = [(time(), val)]
+        if (history := self.history):
+            val = history[-1][1]
+            history.clear()
+            history.append((time(), val))
 
     def on_value(self, *args):
         scroll_min = self.min

--- a/kivy/tests/test_effects.py
+++ b/kivy/tests/test_effects.py
@@ -1,0 +1,37 @@
+def test_expand_the_capacity_of_the_history(kivy_clock):
+    from kivy.effects.kinetic import KineticEffect
+    e = KineticEffect(max_history=3)
+    e.start(10, 1)
+    for i in range(2, 7):
+        e.update(i * 10, i)
+    assert list(e.history) == [(4, 40), (5, 50), (6, 60)]
+    e.max_history = 5
+    assert list(e.history) == [(4, 40), (5, 50), (6, 60)]
+
+
+def test_shrink_the_capacity_of_the_history(kivy_clock):
+    from kivy.effects.kinetic import KineticEffect
+    e = KineticEffect(max_history=3)
+    e.start(10, 1)
+    for i in range(2, 7):
+        e.update(i * 10, i)
+    assert list(e.history) == [(4, 40), (5, 50), (6, 60)]
+    e.max_history = 2
+    assert list(e.history) == [(5, 50), (6, 60)]
+
+
+def test_ScrollEffect_reset(kivy_clock):
+    from kivy.effects.scroll import ScrollEffect
+    e = ScrollEffect(value=11, velocity=22, max=100, min=-100)
+    e.start(10, 1)
+    e.update(20, 2)
+    assert list(e.history) == [(1, 10), (2, 20)]
+    e.reset(33)
+    assert e.value == 33
+    assert e.velocity == 0
+
+    # ??? is the time 'reset()' was called, no point of testing it
+    # assert list(e.history) == [(???, 20)]
+
+    assert len(e.history) == 1
+    assert e.history[0][1] == 20

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -818,11 +818,9 @@ class ScrollView(StencilView):
             'dy': 0,
             'user_stopped': in_bar,
             'frames': Clock.frames,
-            'time': touch.time_start,
         }
 
-        if (self.do_scroll_x and self.effect_x and not ud['in_bar_x']
-                and not ud['in_bar_y']):
+        if self.do_scroll_x and self.effect_x and not in_bar:
             # make sure the effect's value is synced to scroll value
             self._update_effect_bounds()
 
@@ -830,8 +828,7 @@ class ScrollView(StencilView):
             self.effect_x.start(touch.x)
             self._scroll_x_mouse = self.scroll_x
 
-        if (self.do_scroll_y and self.effect_y and not ud['in_bar_x']
-                and not ud['in_bar_y']):
+        if self.do_scroll_y and self.effect_y and not in_bar:
             # make sure the effect's value is synced to scroll value
             self._update_effect_bounds()
 
@@ -949,8 +946,6 @@ class ScrollView(StencilView):
                     touch.ud['sv.handled']['y'] = True
                 # Touch resulted in scroll should not defocus focused widget
                 touch.ud['sv.can_defocus'] = False
-            ud['dt'] = touch.time_update - ud['time']
-            ud['time'] = touch.time_update
             ud['user_stopped'] = True
         return rv
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

I've been reading the `ScrollView` source code and noticing a couple of code that could be improved.

## `ud['dt']` and `ud['time']`

`ud['dt']` is not used at all, and `ud['time']` is only used to calculate `ud['dt']`, making both unnecessary.

Edit: They were introduced in https://github.com/kivy/kivy/commit/6f2a399d0005f4fd08e00fd71285079520e225ee but were already unused from the beginning.

## `ud['frames']`

`_change_touch_mode()` seems to be called more often than `on_scroll_start()` when `diff_frames < 3`, maybe some calculation can be shifted to the `on_scroll_start()`.

```diff
class ScrollView(...):
    def on_scroll_start(...):
        ud[uid] = {
-           'frames': Clock.frames,
+           'frames': Clock.frames + 3,

    def _change_touch_mode(...):
-       diff_frames = Clock.frames - ud['frames']
        ...
-       if diff_frames < 3:
+       if Clock.frames < ud['frames']:
            Clock.schedule_once(self._change_touch_mode, 0)
            return
```

This might not be a worthy change, and I might revert it.

Edit: I reverted it.

## `in_bar`

`in_bar` is a local variable, defined as follows:

```python
in_bar = ud['in_bar_x'] or ud['in_bar_y']
```

so `not ud['in_bar_x'] and not ud['in_bar_y']` can be replaced with `not in_bar`.

## `KineticEffect.history`

`KineticEffect.history` holds a list object, and the only mutating operations it receives are: (1) appending a value to its tail and (2) removing a value from its head. This suggests that `collections.deque` might be more suitable than a list. Furthermore, this code block: 

```python
class KineticEffect(...):
    def update(...):
        ...
        self.history.append((t, val))
        if len(self.history) > self.max_history:
            self.history.pop(0)
```

This is something that `collections.deque` automatically does when we limit its capacity.

```python
self.history = deque(maxlen=self.max_history)
```