### PR TITLE
Remove deprecated `file_encodings` property from `FileChooserController`

### DIFF
--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -77,9 +77,9 @@ The `padding` property accepts a list of values, allowing for more flexible padd
 
 For more details on how to use the `padding` property, please refer to the related documentation.
 
-*Removal of `file_encodings` Property from `kivy.uix.filechooser.FileChooser`*
+*Removal of `file_encodings` Property from `kivy.uix.filechooser.FileChooserController`*
 
-In Kivy 3.x.x, the `file_encodings` property has been removed from the `kivy.uix.filechooser.FileChooser` class.
+In Kivy 3.x.x, the `file_encodings` property has been removed from the `kivy.uix.filechooser.FileChooserController` class.
 
 The `file_encodings` property was deprecated and it was kept for backward compatibility, however it was just ignored and not used internally.
 

--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -76,3 +76,11 @@ The `padding` property accepts a list of values, allowing for more flexible padd
 - `[padding_left, padding_top, padding_right, padding_bottom]` — e.g., `[10, 5, 10, 5]`
 
 For more details on how to use the `padding` property, please refer to the related documentation.
+
+*Removal of `file_encodings` Property from `kivy.uix.filechooser.FileChooser`*
+
+In Kivy 3.x.x, the `file_encodings` property has been removed from the `kivy.uix.filechooser.FileChooser` class.
+
+The `file_encodings` property was deprecated and it was kept for backward compatibility, however it was just ignored and not used internally.
+
+To migrate your code, you just need to remove any references to the `file_encodings` property in your codebase.

--- a/kivy/uix/filechooser.py
+++ b/kivy/uix/filechooser.py
@@ -482,26 +482,6 @@ class FileChooserController(RelativeLayout):
 
     '''
 
-    file_encodings = ListProperty(
-        ['utf-8', 'latin1', 'cp1252'], deprecated=True)
-    '''Possible encodings for decoding a filename to unicode. In the case that
-    the user has a non-ascii filename, undecodable without knowing its
-    initial encoding, we have no other choice than to guess it.
-
-    Please note that if you encounter an issue because of a missing encoding
-    here, we'll be glad to add it to this list.
-
-    file_encodings is a :class:`~kivy.properties.ListProperty` and defaults to
-    ['utf-8', 'latin1', 'cp1252'].
-
-    .. versionadded:: 1.3.0
-
-    .. deprecated:: 1.8.0
-       This property is no longer used as the filechooser no longer decodes
-       the file names.
-
-    '''
-
     file_system = ObjectProperty(FileSystemLocal(),
                                  baseclass=FileSystemAbstract)
     '''The file system object used to access the file system. This should be a


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

This pull request includes a change to the `FileChooserController` class in the `kivy/uix/filechooser.py` file.  The deprecated `file_encodings` property was removed, as proposed in issue https://github.com/kivy/kivy/issues/8177. 

* [`kivy/uix/filechooser.py`](diffhunk://#diff-861f30e5de00da3bf1eaaf2060871b6c7335871c2d058bddb4963ad260c09f02L485-L504): Removed the deprecated `file_encodings` property from the `FileChooserController` class. 

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
