### PR TITLE
Remove deprecated `padding_x` and `padding_y` properties in `TextInput`

### DIFF
--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -62,3 +62,17 @@ You need to update it to:
 
     # Pause the video
     video.state = 'pause'
+
+
+*Removal of `padding_x` and `padding_y` Properties from `kivy.uix.textinput.TextInput`*
+
+In Kivy 3.x.x the `padding_x` and `padding_y` properties have been **removed** from the `kivy.uix.textinput.TextInput` class. Instead, padding is now managed through the unified `padding` property.
+
+To update your code, replace instances of `padding_x` and `padding_y` with the `padding` property.
+
+The `padding` property accepts a list of values, allowing for more flexible padding configurations:
+
+- `[horizontal, vertical]` — e.g., `[10, 10]`
+- `[padding_left, padding_top, padding_right, padding_bottom]` — e.g., `[10, 5, 10, 5]`
+
+For more details on how to use the `padding` property, please refer to the related documentation.

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -3359,33 +3359,9 @@ class TextInput(FocusBehavior, Widget):
     defaults to 4.
     '''
 
-    padding_x = VariableListProperty([0, 0], length=2, deprecated=True)
-    '''Horizontal padding of the text: [padding_left, padding_right].
-
-    padding_x also accepts a one argument form [padding_horizontal].
-
-    :attr:`padding_x` is a :class:`~kivy.properties.VariableListProperty` and
-    defaults to [0, 0]. This might be changed by the current theme.
-
-    .. deprecated:: 1.7.0
-        Use :attr:`padding` instead.
-    '''
-
     def on_padding_x(self, instance, value):
         self.padding[0] = value[0]
         self.padding[2] = value[1]
-
-    padding_y = VariableListProperty([0, 0], length=2, deprecated=True)
-    '''Vertical padding of the text: [padding_top, padding_bottom].
-
-    padding_y also accepts a one argument form [padding_vertical].
-
-    :attr:`padding_y` is a :class:`~kivy.properties.VariableListProperty` and
-    defaults to [0, 0]. This might be changed by the current theme.
-
-    .. deprecated:: 1.7.0
-        Use :attr:`padding` instead.
-    '''
 
     def on_padding_y(self, instance, value):
         self.padding[1] = value[0]

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -3359,14 +3359,6 @@ class TextInput(FocusBehavior, Widget):
     defaults to 4.
     '''
 
-    def on_padding_x(self, instance, value):
-        self.padding[0] = value[0]
-        self.padding[2] = value[1]
-
-    def on_padding_y(self, instance, value):
-        self.padding[1] = value[0]
-        self.padding[3] = value[1]
-
     padding = VariableListProperty([6, 6, 6, 6])
     '''Padding of the text: [padding_left, padding_top, padding_right,
     padding_bottom].


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

This pull request focuses on removing deprecated properties and their associated methods from the `kivy/uix/textinput.py` file. The primary changes include the removal of the `padding_x` and `padding_y` properties and their corresponding documentation, as proposed in issue #8177.

Key changes:

* Removed the `padding_x` property and its documentation, which was deprecated in version 1.7.0.
* Removed the `padding_y` property and its documentation, which was also deprecated in version 1.7.0.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
