### PR TITLE
Remove deprecated `play` property from `Video` and `VideoPlayer`

### DIFF
--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -32,11 +32,11 @@ You need to update it to:
 Removals
 --------
 
-*Removal of `.play` attribute from `kivy.uix.video.Video` and `kivy.uix.videoplayer.VideoPlayer`*
+*Removal of `.play` property from `kivy.uix.video.Video` and `kivy.uix.videoplayer.VideoPlayer`*
 
-In Kivy 3.x.x, the `.play` attribute has been removed from the `kivy.uix.video.Video` and `kivy.uix.videoplayer.VideoPlayer` classes.
+In Kivy 3.x.x, the `.play` property has been removed from the `kivy.uix.video.Video` and `kivy.uix.videoplayer.VideoPlayer` classes.
 
-To migrate your code, you need to update the references to the `.play` attribute in your codebase. For example, if you have the following code in your Kivy 2.x.x codebase:
+To migrate your code, you need to update the references to the `.play` property in your codebase. For example, if you have the following code in your Kivy 2.x.x codebase:
 
 .. code-block:: python
 

--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -27,3 +27,38 @@ You need to update it to:
 .. code-block:: python
 
     from kivy.core.audio_output import SoundLoader
+
+
+Removals
+--------
+
+*Removal of `.play` attribute from `kivy.uix.video.Video` and `kivy.uix.videoplayer.VideoPlayer`*
+
+In Kivy 3.x.x, the `.play` attribute has been removed from the `kivy.uix.video.Video` and `kivy.uix.videoplayer.VideoPlayer` classes.
+
+To migrate your code, you need to update the references to the `.play` attribute in your codebase. For example, if you have the following code in your Kivy 2.x.x codebase:
+
+.. code-block:: python
+
+    video = Video(source='video.mp4')
+
+    # Play the video
+    video.play = True
+
+    # Stop the video
+    video.play = False
+
+You need to update it to:
+
+.. code-block:: python
+
+    video = Video(source='video.mp4')
+
+    # Play the video
+    video.state = 'play'
+
+    # Stop the video
+    video.state = 'stop'
+
+    # Pause the video
+    video.state = 'pause'

--- a/examples/cover/cover_video.py
+++ b/examples/cover/cover_video.py
@@ -24,7 +24,7 @@ class CoverVideo(CoverBehavior, Video):
 class MainApp(App):
 
     def build(self):
-        return CoverVideo(source='../widgets/cityCC0.mpg', state='pause')
+        return CoverVideo(source='../widgets/cityCC0.mpg', state='play')
 
 
 if __name__ == '__main__':

--- a/examples/cover/cover_video.py
+++ b/examples/cover/cover_video.py
@@ -24,7 +24,7 @@ class CoverVideo(CoverBehavior, Video):
 class MainApp(App):
 
     def build(self):
-        return CoverVideo(source='../widgets/cityCC0.mpg', play=True)
+        return CoverVideo(source='../widgets/cityCC0.mpg', state='pause')
 
 
 if __name__ == '__main__':

--- a/examples/kv/app_logo.kv
+++ b/examples/kv/app_logo.kv
@@ -2,7 +2,7 @@ Widget:
     Video:
         id: myvideo
         source: '../widgets/cityCC0.mpg'
-        play: mybutton.state == 'down'
+        state: 'play' if mybutton.state == 'down' else 'stop'
         canvas:
             Color:
                 rgb: (1, 1, 1)

--- a/examples/kv/app_video.kv
+++ b/examples/kv/app_video.kv
@@ -8,7 +8,7 @@ BoxLayout:
         id: myvideo
         source: '../widgets/cityCC0.mpg'
         fit_mode: "contain"
-        on_eos: self.play = True; print('woot we are looping!')
+        on_eos: self.state = 'play'; print('woot we are looping!')
 
     BoxLayout:
         size_hint_y: None
@@ -31,12 +31,12 @@ BoxLayout:
         ToggleButton:
             group: 'video'
             text: 'Play'
-            state: 'down' if myvideo.play else 'normal'
-            on_press: myvideo.play = True
+            state: 'down' if myvideo.state == 'play' else 'normal'
+            on_press: myvideo.state = 'play'
 
         ToggleButton:
             group: 'video'
             text: 'Stop'
-            state: 'down' if not myvideo.play else 'normal'
-            on_press: myvideo.play = False
+            state: 'down' if myvideo.state != 'play' else 'normal'
+            on_press: myvideo.state = 'stop'
 

--- a/kivy/tests/test_video.py
+++ b/kivy/tests/test_video.py
@@ -11,9 +11,9 @@ class VideoTestCase(unittest.TestCase):
         from kivy.clock import Clock
         from kivy.base import runTouchApp, stopTouchApp
         from kivy import kivy_examples_dir
-        from os.path import join, dirname, abspath
+        from os.path import join, abspath
         source = abspath(join(kivy_examples_dir, "widgets", "cityCC0.mpg"))
-        video = Video(source=source, play=True)
+        video = Video(source=source, state='play')
         Clock.schedule_once(lambda x: stopTouchApp(), 1)
 
         def unload_video(video, position):

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -81,7 +81,7 @@ class Video(Image):
     :attr:`state` is an :class:`~kivy.properties.OptionProperty` and defaults
     to 'stop'.
     '''
-    
+
     eos = BooleanProperty(False)
     '''Boolean, indicates whether the video has finished playing or not
     (reached the end of the stream).

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -199,14 +199,10 @@ class Video(Image):
             self._video.bind(on_load=self._on_load,
                              on_frame=self._on_video_frame,
                              on_eos=self._on_eos)
-            if self.state == 'play' or self.play:
+            if self.state == 'play':
                 self._video.play()
             self.duration = 1.
             self.position = 0.
-
-    def on_play(self, instance, value):
-        value = 'play' if value else 'stop'
-        return self.on_state(instance, value)
 
     def on_state(self, instance, value):
         if not self._video:

--- a/kivy/uix/video.py
+++ b/kivy/uix/video.py
@@ -81,30 +81,7 @@ class Video(Image):
     :attr:`state` is an :class:`~kivy.properties.OptionProperty` and defaults
     to 'stop'.
     '''
-
-    play = BooleanProperty(False, deprecated=True)
-    '''
-    .. deprecated:: 1.4.0
-        Use :attr:`state` instead.
-
-    Boolean, indicates whether the video is playing or not.
-    You can start/stop the video by setting this property::
-
-        # start playing the video at creation
-        video = Video(source='movie.mkv', play=True)
-
-        # create the video, and start later
-        video = Video(source='movie.mkv')
-        # and later
-        video.play = True
-
-    :attr:`play` is a :class:`~kivy.properties.BooleanProperty` and defaults to
-    False.
-
-    .. deprecated:: 1.4.0
-        Use :attr:`state` instead.
-    '''
-
+    
     eos = BooleanProperty(False)
     '''Boolean, indicates whether the video has finished playing or not
     (reached the end of the stream).

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -344,26 +344,6 @@ class VideoPlayer(GridLayout):
     to 'stop'.
     '''
 
-    play = BooleanProperty(False, deprecated=True)
-    '''
-    .. deprecated:: 1.4.0
-        Use :attr:`state` instead.
-
-    Boolean, indicates whether the video is playing or not. You can start/stop
-    the video by setting this property::
-
-        # start playing the video at creation
-        video = VideoPlayer(source='movie.mkv', play=True)
-
-        # create the video, and start later
-        video = VideoPlayer(source='movie.mkv')
-        # and later
-        video.play = True
-
-    :attr:`play` is a :class:`~kivy.properties.BooleanProperty` and defaults
-    to False.
-    '''
-
     image_overlay_play = StringProperty(
         'atlas://data/images/defaulttheme/player-play-overlay')
     '''Image filename used to show a "play" overlay when the video has not yet

--- a/kivy/uix/videoplayer.py
+++ b/kivy/uix/videoplayer.py
@@ -558,10 +558,6 @@ class VideoPlayer(GridLayout):
                          volume=self.setter('volume'),
                          state=self._set_state)
 
-    def on_play(self, instance, value):
-        value = 'play' if value else 'stop'
-        return self.on_state(instance, value)
-
     def on_volume(self, instance, value):
         if not self._video:
             return


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->

This pull request involves the removal of deprecated properties from the `Video` and `VideoPlayer` classes as proposed in issue #8177.

Key changes:

* Removed the deprecated `play` property from the `Video` class in `kivy/uix/video.py`. This property has been deprecated since version 1.4.0 in favor of the `state` attribute.
* Removed the deprecated `play` property from the `VideoPlayer` class in `kivy/uix/videoplayer.py`. Similar to the `Video` class, this property has been deprecated since version 1.4.0 in favor of the `state` attribute.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
