### PR TITLE
🐛 fix: KV Parser for f-strings now properly resolves nested attribute names

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -276,7 +276,7 @@ class ParserRuleProperty(object):
             yield from cls.get_names_from_expression(node.iter.value)
 
         if isinstance(node, ast.Attribute):
-            # Build the full dotted attribute path (e.g. "root.object.property")
+            # Build full dotted attribute path (e.g. "root.object.property")
             attribute_parts = []
             current_node = node
             while isinstance(current_node, ast.Attribute):

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -276,8 +276,17 @@ class ParserRuleProperty(object):
             yield from cls.get_names_from_expression(node.iter.value)
 
         if isinstance(node, ast.Attribute):
-            if isinstance(node.value, ast.Name):
-                yield f'{node.value.id}.{node.attr}'
+            # Build the full dotted attribute path (e.g. "root.object.property")
+            attribute_parts = []
+            current_node = node
+            while isinstance(current_node, ast.Attribute):
+                attribute_parts.append(current_node.attr)
+                current_node = current_node.value
+            if isinstance(current_node, ast.Name):
+                attribute_parts.append(current_node.id)
+                full_attribute = ".".join(reversed(attribute_parts))
+                yield full_attribute
+            return
 
         if isinstance(node, ast.Call):
             yield from cls.get_names_from_expression(node.func)

--- a/kivy/tests/test_lang.py
+++ b/kivy/tests/test_lang.py
@@ -426,6 +426,29 @@ class LangTestCase(unittest.TestCase):
         assert root.ids.target2.text == ''
         assert root.ids.target3.text == '400'
 
+    def test_fstring_nested_property_binding(self):
+        from kivy.uix.boxlayout import BoxLayout
+        from kivy.event import EventDispatcher
+        from kivy.properties import NumericProperty, ObjectProperty
+        from kivy.lang import Builder
+
+        class Person(EventDispatcher):
+            age = NumericProperty()
+
+        class TestContainer(BoxLayout):
+            person = ObjectProperty(Person(age=25))
+
+        root = Builder.load_string(dedent('''
+        TestContainer:
+            Label:
+                id: person
+                text: f"Person age: {root.person.age}"
+        '''))
+
+        assert root.ids.person.text == 'Person age: 25'
+        root.person.age = 30
+        assert root.ids.person.text == 'Person age: 30'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously this would not work as expected, i.e., even if `alice.age` is updated, the `Label` text would remain the same.
```python
from kivy.app import App
from kivy.event import EventDispatcher
from kivy.lang import Builder
from kivy.properties import NumericProperty


class Person(EventDispatcher):
    age = NumericProperty()


kv = """
BoxLayout:
    orientation: 'vertical'
    Button:
        text: 'Make Alice older'
        on_press: app.alice.age += 1
    Label:
        text: f'Alice is {app.alice.age} years old' # the only important line
"""


class MainApp(App):
    alice = Person(age=25)

    def build(self):
        return Builder.load_string(kv)


MainApp().run()
```

For instance, since the following code works, I don't think the behavior of f-strings in KV should be any different:
```yml
Label:
    text: 'Alice is ' + str(app.alice.age) + ' years old'
```

Previously, the `ParserRuleProperty.get_names_from_expression` method only handled simple attribute accesses by checking if an `ast.Attribute` node's value was an `ast.Name`. This meant that multi-level attribute chains (e.g., `app.some_object.some_property`) were not fully extracted, leading to incomplete dependency tracking for KV f-string expressions.

This commit updates the handling of `ast.Attribute` nodes by:
- Recursively traversing the attribute chain to collect all attribute names.
- Reversing the collected parts to build a complete dotted attribute path.
- Yielding the full attribute (e.g., "root.person.age") for proper binding.
- Adding a return statement to ensure that once the `ast.Attribute` node is processed, no further processing occurs on the same node, avoiding duplicate or incorrect yields.

This change ensures that KV expressions with multi-level attribute references update dynamically as expected.
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
