### PR TITLE
[WIP] Remove deprecated `padding_x` and  `padding_y` in Label

### DIFF
--- a/examples/canvas/lines.py
+++ b/examples/canvas/lines.py
@@ -136,7 +136,7 @@ Builder.load_string('''
                     allow_no_selection: False
                     size_hint_x: None
                     width: self.texture_size[0]
-                    padding_x: '5dp'
+                    padding: '5dp', 0, '5dp', 0
                     on_state:
                         if self.state == 'down': root.dashes = []
                         if self.state == 'down': root.dash_length = 1
@@ -148,7 +148,7 @@ Builder.load_string('''
                     allow_no_selection: False
                     size_hint_x: None
                     width: self.texture_size[0]
-                    padding_x: '5dp'
+                    padding: '5dp', 0, '5dp', 0
                     on_state:
                         if self.state == 'down': root.dashes = []
                         if self.state == 'down': root.dash_length = \
@@ -159,7 +159,7 @@ Builder.load_string('''
                     text: 'len'
                     size_hint_x: None
                     width: self.texture_size[0]
-                    padding_x: '5dp'
+                    padding: '5dp', 0, '5dp', 0
                 TextInput:
                     id: dash_len
                     size_hint_x: None
@@ -173,7 +173,7 @@ Builder.load_string('''
                     text: 'offset'
                     size_hint_x: None
                     width: self.texture_size[0]
-                    padding_x: '5dp'
+                    padding: '5dp', 0, '5dp', 0
                 TextInput:
                     id: dash_offset
                     size_hint_x: None
@@ -190,7 +190,7 @@ Builder.load_string('''
                     allow_no_selection: False
                     size_hint_x: None
                     width: self.texture_size[0]
-                    padding_x: '5dp'
+                    ppadding: '5dp', 0, '5dp', 0
                     on_state:
                         if self.state == 'down': root.dashes = list(map(lambda\
                             x: int(x or 0), dash_list_in.text.split(',')))

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -135,10 +135,6 @@ class LabelBase(object):
             padding_right, padding_bottom].
             ``padding`` should be int|float or a list|tuple with 1, 2 or 4
             elements.
-        `padding_x`: float, defaults to 0.0
-            Left/right padding
-        `padding_y`: float, defaults to 0.0
-            Top/bottom padding
         `halign`: str, defaults to "left"
             Horizontal text alignment inside the bounding box
         `valign`: str, defaults to "bottom"
@@ -196,10 +192,6 @@ class LabelBase(object):
         `limit_render_to_text_bbox` was added to allow to limit text rendering
         to the text bounding box (PIL only).
 
-    .. deprecated:: 2.2.0
-        `padding_x` and `padding_y` have been deprecated. Please use `padding`
-        instead.
-
     .. versionchanged:: 2.2.0
         `padding` is now a list and defaults to [0, 0, 0, 0]. `padding` accepts
         int|float or a list|tuple with 1, 2 or 4 elements.
@@ -214,10 +206,6 @@ class LabelBase(object):
     .. versionchanged:: 1.9.0
         `strip`, `strip_reflow`, `shorten_from`, `split_str`, and
         `unicode_errors` were added.
-
-    .. versionchanged:: 1.9.0
-        `padding_x` and `padding_y` has been fixed to work as expected.
-        In the past, the text was padded by the negative of their values.
 
     .. versionchanged:: 1.8.0
         `max_lines` parameters has been added.
@@ -309,16 +297,6 @@ class LabelBase(object):
                     f"{len(options['padding'])} elements."
                 )
 
-        options['padding_x'] = kwargs_get('padding_x')
-        options['padding_y'] = kwargs_get('padding_y')
-        for padding_option in ('padding_x', 'padding_y'):
-            if kwargs_get(padding_option):
-                Logger.warning(
-                    f"LabelBase: The use of the {padding_option} parameter is "
-                    "deprecated, and will be removed in future versions. Use "
-                    "padding instead."
-                )
-
         if 'size' in kwargs:
             options['text_size'] = kwargs['size']
         else:
@@ -336,15 +314,6 @@ class LabelBase(object):
         self.texture = None
         self.is_shortened = False
         self.resolve_font_name()
-        self._migrate_deprecated_padding_xy()
-
-    def _migrate_deprecated_padding_xy(self):
-        options = self.options
-        self.options['padding'] = list(self.options['padding'])
-        if options['padding_x']:
-            self.options['padding'][::2] = [options['padding_x']] * 2
-        if options['padding_y']:
-            self.options['padding'][1::2] = [options['padding_y']] * 2
 
     @staticmethod
     def register(name, fn_regular, fn_italic=None, fn_bold=None,
@@ -507,7 +476,7 @@ class LabelBase(object):
 
             `text` str, the text to be shortened.
             `margin` int, the amount of space to leave between the margins
-            and the text. This is in addition to :attr:`padding_x`.
+            and the text. This is in addition to :attr:`padding`.
 
         :returns:
             the text shortened to fit into a single line.

--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -531,7 +531,7 @@ class MarkupLabel(MarkupLabelBase):
             `w`: int, the width of the text in lines, including padding.
             `h`: int, the height of the text in lines, including padding.
             `margin` int, the additional space left on the sides. This is in
-            addition to :attr:`padding_x`.
+            addition to :attr:`padding`.
 
         :returns:
             3-tuple of (xw, h, lines), where w, and h is similar to the input

--- a/kivy/tests/visual_test_label.py
+++ b/kivy/tests/visual_test_label.py
@@ -80,20 +80,20 @@ kv = '''
                                 rgba: 0, 1, 0, 0.5
                             Rectangle:
                                 pos: self.pos
-                                size: self.width, self.padding_y
+                                size: self.width, self.padding[1]
                             Rectangle:
                                 pos: self.x, self.y + self.height -\
-                                self.padding_y
-                                size: self.width, self.padding_y
+                                self.padding[3]
+                                size: self.width, self.padding[3]
                             Color:
                                 rgba: 0, 0, 1, 0.5
                             Rectangle:
                                 pos: self.pos
-                                size: self.padding_x, self.height
+                                size: self.padding[0], self.height
                             Rectangle:
-                                pos: self.x + self.width - self.padding_x,\
+                                pos: self.x + self.width - self.padding[2],\
                                 self.y
-                                size: self.padding_x, self.height
+                                size: self.padding[2], self.height
                 Splitter:
                     sizable_from: 'left'
                     TextInput:
@@ -177,9 +177,7 @@ kv = '''
         TSliderButton:
             text: 'max_lines'
         TSliderButton:
-            text: 'padding_x'
-        TSliderButton:
-            text: 'padding_y'
+            text: 'padding'
         TextInput:
             size_hint: None, None
             size: 100, 50

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -323,10 +323,6 @@ class Label(Widget):
         fbind = self.fbind
         update = self._trigger_texture_update
 
-        # NOTE: Compatibility code due to deprecated properties.
-        fbind('padding_x', update, 'padding_x')
-        fbind('padding_y', update, 'padding_y')
-
         fbind('disabled', update, 'disabled')
         for x in d:
             fbind(x, update, x)
@@ -383,14 +379,6 @@ class Label(Widget):
                 # When disabled, color or outline_color changes should not get
                 # assigned or trigger updates.
                 return
-
-            # NOTE: Compatibility code due to deprecated properties
-            # Must be removed along with padding_x and padding_y
-            elif name == 'padding_x':
-                self._label.options['padding'][::2] = [value] * 2
-            elif name == 'padding_y':
-                self._label.options['padding'][1::2] = [value] * 2
-
             else:
                 self._label.options[name] = value
 
@@ -749,34 +737,6 @@ class Label(Widget):
 
     :attr:`strikethrough` is a :class:`~kivy.properties.BooleanProperty` and
     defaults to False.
-    '''
-
-    padding_x = NumericProperty(0, deprecated=True)
-    '''Horizontal padding of the text inside the widget box.
-
-    :attr:`padding_x` is a :class:`~kivy.properties.NumericProperty` and
-    defaults to 0.
-
-    .. versionchanged:: 1.9.0
-        `padding_x` has been fixed to work as expected.
-        In the past, the text was padded by the negative of its values.
-
-    .. deprecated:: 2.2.0
-        Please use :attr:`padding` instead.
-    '''
-
-    padding_y = NumericProperty(0, deprecated=True)
-    '''Vertical padding of the text inside the widget box.
-
-    :attr:`padding_y` is a :class:`~kivy.properties.NumericProperty` and
-    defaults to 0.
-
-    .. versionchanged:: 1.9.0
-        `padding_y` has been fixed to work as expected.
-        In the past, the text was padded by the negative of its values.
-
-    .. deprecated:: 2.2.0
-        Please use :attr:`padding` instead.
     '''
 
     padding = VariableListProperty([0, 0, 0, 0], lenght=4)

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -2665,8 +2665,6 @@ class TextInput(FocusBehavior, Widget):
                 'base_direction': self.base_direction,
                 'anchor_x': 'left',
                 'anchor_y': 'top',
-                'padding_x': 0,
-                'padding_y': 0,
                 'padding': (0, 0)
             }
             self._label_cached = Label(**kw)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Ref: #8177 

⚠️ DO NOT MERGE YET. MISSES MIGRATION DOCS AND IMPROVED TESTING ⚠️ 