### PR TITLE
Fallback mechanism for `SDL2` window creation when `GetDpiForWindow` returns `0` ( on Windows)

### DIFF
--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -404,9 +404,7 @@ class WindowSDL(WindowBase):
             except AttributeError:
                 pass
         else:
-            self._density = (
-                self._win.window_pixel_size[0] / self._win.window_size[0]
-            )
+            self._density = self._win._get_gl_size()[0] / self._size[0]
             if self._is_desktop:
                 self.dpi = self._density * 96.
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -393,15 +393,20 @@ class WindowSDL(WindowBase):
     def _update_density_and_dpi(self):
         if platform == 'win':
             from ctypes import windll
+            self.dpi = 96.
             self._density = 1.
             try:
                 hwnd = windll.user32.GetActiveWindow()
-                self.dpi = float(windll.user32.GetDpiForWindow(hwnd))
-                self._density = self.dpi / 96
+                dpi = float(windll.user32.GetDpiForWindow(hwnd))
+                if dpi:
+                    self.dpi = dpi
+                    self._density = self.dpi / 96
             except AttributeError:
                 pass
         else:
-            self._density = self._win._get_gl_size()[0] / self._size[0]
+            self._density = (
+                self._win.window_pixel_size[0] / self._win.window_size[0]
+            )
             if self._is_desktop:
                 self.dpi = self._density * 96.
 


### PR DESCRIPTION
change branch for PR #8865

try to fix issue https://github.com/kivy/kivy/issues/8770. If GetDpiForWindow return 0 when there is not valid active window (ex: active window is None), _density will be 0.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
