### PR TITLE
Added missing method, `goto_view()` to RecycleView layouts

### DIFF
--- a/kivy/uix/recycleview/layout.py
+++ b/kivy/uix/recycleview/layout.py
@@ -241,9 +241,11 @@ refresh_view_layout`.
                 adapter.invalidate()
 
     def goto_view(self, index):
-        '''Moves the views so that the view corresponding to `index` is
-        visible.
-        '''
+        """Moves the views so that the view corresponding to `index` is
+        visible.  A negative index is allowed.
+        """
+        # implement this method in the subclass, RecycleBoxLayout
+        # or RecycleGridLayout
         pass
 
     def on_viewclass(self, instance, value):


### PR DESCRIPTION
The RecycleView has a documented but unimplemented feature, goto_view(index), that moves the views the view corresponding to index is visible.  This is similar to the scroll_to(widget) method of a ScrollView.  

This PR implements goto_view(index) for RecycleBoxLayout and RecycleGridLayout.

Fixes these issues: 
https://github.com/kivy/kivy/issues/7200
https://github.com/kivy/kivy/issues/5014

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
