### PR TITLE
Resolve datetime deprecation warnings in CI scripts

### DIFF
--- a/.ci/ubuntu_ci.sh
+++ b/.ci/ubuntu_ci.sh
@@ -3,7 +3,7 @@ set -e -x
 
 update_version_metadata() {
   current_time=$(python -c "from time import time; from os import environ; print(int(environ.get('SOURCE_DATE_EPOCH', time())))")
-  date=$(python -c "from datetime import datetime; print(datetime.utcfromtimestamp($current_time).strftime('%Y%m%d'))")
+  date=$(python -c "from datetime import datetime, timezone; print(datetime.fromtimestamp($current_time, timezone.utc).strftime('%Y%m%d'))")
   echo "Version date is: $date"
   git_tag=$(git rev-parse HEAD)
   echo "Git tag is: $git_tag"

--- a/.ci/windows_ci.ps1
+++ b/.ci/windows_ci.ps1
@@ -25,7 +25,7 @@ function Handle-NonZero-ExitCode {
 
 function Update-version-metadata {
     $current_time = python -c "from time import time; from os import environ; print(int(environ.get('SOURCE_DATE_EPOCH', time())))"
-    $date = python -c "from datetime import datetime; print(datetime.utcfromtimestamp($current_time).strftime('%Y%m%d'))"
+    $date = python -c "from datetime import datetime, timezone; print(datetime.fromtimestamp($current_time, timezone.utc).strftime('%Y%m%d'))"
     echo "Version date is: $date"
     $git_tag = git rev-parse HEAD
     echo "Git tag is: $git_tag"


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime`  deprecation warnings:
```python
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
