### PR TITLE
Include information on new display when a `windowdisplaychanged` event is recognized

### DIFF
--- a/kivy/core/window/_window_sdl3.pyx
+++ b/kivy/core/window/_window_sdl3.pyx
@@ -910,7 +910,7 @@ cdef class _WindowSDL3Storage:
                     event.window.data1, event.window.data2
                 )
             elif event.type == SDL_EVENT_WINDOW_DISPLAY_CHANGED:
-                action = ('windowdisplaychanged',)
+                action = ('windowdisplaychanged', event.window.data1)
             elif event.type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
                 action = ('windowpixelsizechanged',)
             elif event.type == SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

The change modifies the `action` tuple for the `SDL_EVENT_WINDOW_DISPLAY_CHANGED` event to include `event.window.data1` as an additional parameter, potentially providing more context for this event.

Fixes issue #9038 