### PR TITLE
Add `WindowInfoAndroid` for `SDL3` Window manager

### DIFF
--- a/kivy/core/window/_window_sdl3.pyx
+++ b/kivy/core/window/_window_sdl3.pyx
@@ -22,7 +22,8 @@ from .window_info cimport (
     WindowInfomacOS,
     WindowInfoX11,
     WindowInfoWayland,
-    WindowInfoWindows
+    WindowInfoWindows,
+    WindowInfoAndroid
 )
 
 cdef int _event_filter(void *userdata, SDL_Event *event) with gil:
@@ -590,6 +591,27 @@ cdef class _WindowSDL3Storage:
 
         return window_info
 
+    def _get_window_info_android(self):
+        cdef WindowInfoAndroid window_info
+        window_info = WindowInfoAndroid()
+
+        window_info.set_window(
+            SDL_GetPointerProperty(
+                SDL_GetWindowProperties(self.win),
+                "SDL.window.android.window",
+                NULL,
+            )
+        )
+        window_info.set_surface(
+            SDL_GetPointerProperty(
+                SDL_GetWindowProperties(self.win),
+                "SDL.window.android.surface",
+                NULL,
+            )
+        )
+
+        return window_info
+
     def get_window_info(self):
         if platform == "macosx":
             return self._get_window_info_macos()
@@ -603,6 +625,9 @@ cdef class _WindowSDL3Storage:
                 return self._get_window_info_wayland()
             elif _video_driver == "x11":
                 return self._get_window_info_x11()
+        elif platform == "android":
+            return self._get_window_info_android()
+        return None
 
     def get_native_handle(self):
         # TODO: When we have support on all platforms, or at least on Linux

--- a/kivy/core/window/window_attrs.pxi
+++ b/kivy/core/window/window_attrs.pxi
@@ -84,7 +84,11 @@ cdef extern from *:
     #endif
 
     #if defined(__ANDROID__)
-        // Android
+        #include <system/window.h>
+        #include <EGL/egl.h>
+    #else
+        struct ANativeWindow;
+        typedef void *EGLSurface;
     #endif
 
     """
@@ -114,3 +118,8 @@ cdef extern from *:
     ctypedef void *NSWindow
     cdef NSWindow* _BridgedNSWindow(void* window)
     cdef UIWindow* _BridgedUIWindow(void* window)
+
+    # Android
+    cdef struct ANativeWindow:
+        pass
+    ctypedef void *EGLSurface

--- a/kivy/core/window/window_attrs.pxi
+++ b/kivy/core/window/window_attrs.pxi
@@ -84,7 +84,7 @@ cdef extern from *:
     #endif
 
     #if defined(__ANDROID__)
-        #include <system/window.h>
+        #include <android/native_window.h>
         #include <EGL/egl.h>
     #else
         struct ANativeWindow;

--- a/kivy/core/window/window_info.pxd
+++ b/kivy/core/window/window_info.pxd
@@ -30,3 +30,9 @@ cdef class WindowInfomacOS:
 cdef class WindowInfoiOS:
     cdef UIWindow *window
     cdef void set_window(self, void* window)
+
+cdef class WindowInfoAndroid:
+    cdef ANativeWindow *window
+    cdef EGLSurface surface
+    cdef void set_window(self, void* window)
+    cdef void set_surface(self, void* surface)

--- a/kivy/core/window/window_info.pyx
+++ b/kivy/core/window/window_info.pyx
@@ -69,3 +69,19 @@ cdef class WindowInfoiOS:
 
     cdef void set_window(self, void* window):
         self.window = _BridgedUIWindow(window)
+
+
+cdef class WindowInfoAndroid:
+    @property
+    def window(self):
+        return <uintptr_t>self.window
+
+    @property
+    def surface(self):
+        return <uintptr_t>self.surface
+
+    cdef void set_window(self, void* window):
+        self.window = <ANativeWindow *>window
+
+    cdef void set_surface(self, void* surface):
+        self.surface = <EGLSurface>surface


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.


Android is the latest platform missing a `WindowInfo` implementation to get the `window` handle as suggested by issue [#https://github.com/kivy/kivy/issues/8651](https://github.com/kivy/kivy/issues/8651) [Initially made for SDL2, now made possible via SDL3]

This PR adds an implementation for Android and SDL3, but the API is ready and can be latter used by another Window provider.