### PR TITLE
Simplify window border management logic on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ venv
 kivy/setupconfig.py
 
 kivy/core/clipboard/_clipboard_sdl3.c
+kivy/graphics/egl_backend/egl_angle.c

--- a/kivy/core/window/window_sdl3.py
+++ b/kivy/core/window/window_sdl3.py
@@ -330,29 +330,7 @@ class WindowSDL(WindowBase):
         else:
             w, h = self.system_size
             self._win.resize_window(w, h)
-            if platform == 'win':
-                if self.custom_titlebar:
-                    # check dragging+resize or just dragging
-                    if Config.getboolean('graphics', 'resizable'):
-                        import win32con
-                        import ctypes
-                        self._win.set_border_state(False)
-                        # make windows dispatch,
-                        # WM_NCCALCSIZE explicitly
-                        ctypes.windll.user32.SetWindowPos(
-                            self.native_handle,
-                            win32con.HWND_TOP,
-                            *self._win.get_window_pos(),
-                            *self.system_size,
-                            win32con.SWP_FRAMECHANGED
-                        )
-                    else:
-                        self._win.set_border_state(True)
-                else:
-                    self._win.set_border_state(self.borderless)
-            else:
-                self._win.set_border_state(self.borderless
-                                           or self.custom_titlebar)
+            self._win.set_border_state(self.borderless or self.custom_titlebar)
             self._win.set_fullscreen_mode(self.fullscreen)
 
         super(WindowSDL, self).create_window()


### PR DESCRIPTION
- Removes unnecessary Win32 API calls and custom border handling that are now natively supported by SDL3. Resolves minor issues related to SDL3 migration (when moving the Window) while unifying border state management across platforms.

- Tested on Windows 11 using `examples\miscellaneous\custom_titlebar.py`

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
