### PR TITLE
Automatically discover support for `wayland` (and ensures is available if specifically requested via `USE_WAYLAND`)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ c_options['use_ios'] = False
 c_options['use_android'] = False
 c_options['use_mesagl'] = False
 c_options['use_x11'] = False
-c_options['use_wayland'] = False
+c_options['use_wayland'] = None
 c_options['use_gstreamer'] = None
 c_options['use_avfoundation'] = platform in ['darwin', 'ios']
 c_options['use_osx_frameworks'] = platform == 'darwin'
@@ -540,6 +540,28 @@ if c_options['use_sdl3'] or can_autodetect_sdl3:
             c_options['use_sdl3'] = True
             sdl3_source = 'pkg-config'
 
+
+can_autodetect_wayland = (
+    platform == "linux" and c_options["use_wayland"] is None
+)
+
+if c_options["use_wayland"] or can_autodetect_wayland:
+    c_options["use_wayland"] = check_c_source_compiles(
+        textwrap.dedent(
+            """
+        #include <wayland-client.h>
+        int main() {
+            struct wl_display *display = wl_display_connect(NULL);
+            if (display == NULL) {
+                return 1;
+            }
+            wl_display_disconnect(display);
+            return 0;
+        }
+        """
+        ),
+        include_dirs=[],
+    )
 
 # -----------------------------------------------------------------------------
 # declare flags

--- a/setup.py
+++ b/setup.py
@@ -130,11 +130,15 @@ def check_c_source_compiles(code, include_dirs=None):
     # Create a temporary file which contains the code
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_file = os.path.join(tmpdir, "test.c")
+        build_dir = os.path.join(tmpdir, "build")
         with open(temp_file, "w", encoding="utf-8") as tf:
             tf.write(code)
         try:
             get_compiler().compile(
-                [temp_file], extra_postargs=[], include_dirs=include_dirs
+                [temp_file],
+                extra_postargs=[],
+                include_dirs=include_dirs,
+                output_dir=build_dir,
             )
         except Exception as ex:
             print(ex)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

When kivy is built with `SDL3` support, and `SDL3` can find (and is not explicitly disabled) `wayland`, kivy should be built with `wayland` support too, otherwise the returned `WindowInfoWayland` object (via `Window.get_window_info()`) may return unexpected values.

This PR:
- Adds an availability check by performing a build of a simple demo program, if available and not specifically set to `False`, now `wayland` support is included by default.
- If `wayland` support is requested via `USE_WAYLAND=1`, and the availability check failed, kivy will be built without `wayland` support.
- Ensures a clean build folder is used while performing the build (otherwise the example wheel fails to build due to a setuptools limitation when multiple top-level packages are present in the project root folder)