### PR TITLE
Change Emacs `kivy-mode` parent mode to `prog-mode`

### DIFF
--- a/kivy/tools/highlight/kivy-mode.el
+++ b/kivy/tools/highlight/kivy-mode.el
@@ -153,7 +153,7 @@
 
 
 ;;;###autoload
-(define-derived-mode kivy-mode fundamental-mode "kivy"
+(define-derived-mode kivy-mode prog-mode "kivy"
   "Simple mode to edit kivy.
 
 \\{kivy-mode-map}"


### PR DESCRIPTION
The included Emacs major mode for editing kv lang source code was based on the built in Emacs mode **fundamental-mode**, however, per [the Emacs documentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html), custom major modes should be derived from one of **text-mode**, **prog-mode**, or **special-mode** if applicable, or **fundamental mode** _only if none of those three are applicable_. prog-mode is intended for buffers that contain programming language source code, so naturally it is appropriate to use prog-mode as the parent of kivy-mode. 

This has the benefit of keeping the same minor modes bound to prog-mode active in kivy-mode buffers, while using fundamental-mode requires Emacs users to bind those minor modes to the kivy-mode-hook in addition to the prog-mode-hook. For example, a popular minor mode for prog-mode is **highlight-indent-guides-mode**. By using prog-mode as the parent for kivy-mode, this will also be activated in kivy-mode, without requiring it to be explicitly bound to kivy-mode.