### PR TITLE
Remove old Python 2 long from Cython files, fixes build with Cython `3.1.x`

### DIFF
--- a/kivy/graphics/context_instructions.pyx
+++ b/kivy/graphics/context_instructions.pyx
@@ -85,7 +85,7 @@ cdef tuple rgb_to_hsv(float r, float g, float b):
 
 cdef tuple hsv_to_rgb(float h, float s, float v):
     if s == 0.0: return v, v, v
-    cdef long i = long(h * 6.0)
+    cdef long i = <long>(h * 6.0)
     cdef float f = (h * <float>6.0) - i
     cdef float p = v * (<float>1.0 - s)
     cdef float q = v * (<float>1.0 - s * f)

--- a/kivy/graphics/opengl.pyx
+++ b/kivy/graphics/opengl.pyx
@@ -689,7 +689,7 @@ def glDrawElements(GLenum mode, GLsizei count, GLenum type, indices):
     cdef void *ptr = NULL
     if isinstance(indices, bytes):
         ptr = <void *>(<char *>(<bytes>indices))
-    elif isinstance(indices, (long, int)):
+    elif isinstance(indices, int):
         ptr = <void *>(<unsigned int>indices)
     else:
         raise TypeError("Argument 'indices' has incorrect type (expected bytes or int).")
@@ -1539,7 +1539,7 @@ def glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean norma
     cdef void *ptr = NULL
     if isinstance(data, bytes):
         ptr = <void *>(<char *>(<bytes>data))
-    elif isinstance(data, (long, int)):
+    elif isinstance(data, int):
         ptr = <void *>(<unsigned int>data)
     else:
         raise TypeError("Argument 'data' has incorrect type (expected bytes or int).")

--- a/kivy/weakproxy.pyx
+++ b/kivy/weakproxy.pyx
@@ -249,9 +249,6 @@ cdef class WeakProxy(object):
     def __int__(self):
         return int(self.__ref__())
 
-    def __long__(self):
-        return long(self.__ref__())
-
     def __float__(self):
         return float(self.__ref__())
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Cython now defaults to `language_version=3`, and `long` is not available anymore (was a thing only in Py2).
This PR removes Py2 `long` usage, and cleanups code where appropriate. 