### PR TITLE
Fix issues with Scrolling conflicts with scroll bars

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -798,14 +798,24 @@ class ScrollView(StencilView):
             return self.simulate_touch_down(touch)
 
         if in_bar:
+            e = None
             if (ud['in_bar_y'] and not
                     self._touch_in_handle(
                         self._handle_y_pos, self._handle_y_size, touch)):
                 self.scroll_y = (touch.y - self.y) / self.height
+                e = self.effect_y
             elif (ud['in_bar_x'] and not
                     self._touch_in_handle(
                         self._handle_x_pos, self._handle_x_size, touch)):
                 self.scroll_x = (touch.x - self.x) / self.width
+                e = self.effect_x
+
+            if e:
+                velocity = e.velocity
+                e.velocity = 0
+                self._update_effect_bounds()
+                if velocity > 0:
+                    e.trigger_velocity_update()
 
         # no mouse scrolling, so the user is going to drag the scrollview with
         # this touch.
@@ -1148,7 +1158,7 @@ class ScrollView(StencilView):
         self._bar_color = self.bar_color
         ev()
 
-    def _bind_inactive_bar_color(self, *l):
+    def _bind_inactive_bar_color(self, *args):
         self.funbind('bar_color', self._change_bar_color)
         self.fbind('bar_inactive_color', self._change_bar_color)
         Animation(

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -810,12 +810,12 @@ class ScrollView(StencilView):
                 self.scroll_x = (touch.x - self.x) / self.width
                 e = self.effect_x
 
+            e = self.effect_y if ud['in_bar_y'] else self.effect_x
             if e:
-                velocity = e.velocity
-                e.velocity = 0
                 self._update_effect_bounds()
-                if velocity > 0:
-                    e.trigger_velocity_update()
+                e.velocity = 0
+                e.overscroll = 0
+                e.trigger_velocity_update()
 
         # no mouse scrolling, so the user is going to drag the scrollview with
         # this touch.


### PR DESCRIPTION
Original Issue.

When scrollbar is already scrolling using either middle mouse button with smooth scrolling or when scrolling with content.
- The active scrolling effect is not cancelled when user clicks on the scroll bars,
-  ScrollView momentarily moves to the position user clicked and the continues earlier scrolling effect.

This fixes that issue,
- Stops the active scrolling and
- Resets scroll position to the place user has touched on the scrollview.

Possibly relevant issues. https://github.com/kivy/kivy/issues/4189

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
