### PR TITLE
Add type hints to core providers

### DIFF
--- a/kivy/core/audio_output/__init__.py
+++ b/kivy/core/audio_output/__init__.py
@@ -72,7 +72,7 @@ class SoundLoader:
         SoundLoader._classes.append(classobj)
 
     @staticmethod
-    def load(filename):
+    def load(filename) -> "Sound":
         '''Load a sound, and return a Sound() instance.'''
         rfn = resource_find(filename)
         if rfn is not None:

--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -148,4 +148,4 @@ else:
 providers += (('opencv', 'camera_opencv', 'CameraOpenCV'), )
 
 
-Camera = core_select_lib('camera', (providers))
+Camera: CameraBase = core_select_lib('camera', (providers))

--- a/kivy/core/clipboard/__init__.py
+++ b/kivy/core/clipboard/__init__.py
@@ -135,7 +135,7 @@ if USE_SDL3:
 _clipboards.append(
     ('dummy', 'clipboard_dummy', 'ClipboardDummy'))
 
-Clipboard = core_select_lib('clipboard', _clipboards, True)
+Clipboard: ClipboardBase = core_select_lib('clipboard', _clipboards, True)
 CutBuffer = None
 
 if platform == 'linux':

--- a/kivy/core/spelling/__init__.py
+++ b/kivy/core/spelling/__init__.py
@@ -132,4 +132,4 @@ _libs = (('enchant', 'spelling_enchant', 'SpellingEnchant'), )
 if sys.platform == 'darwin':
     _libs += (('osxappkit', 'spelling_osxappkit', 'SpellingOSXAppKit'), )
 
-Spelling = core_select_lib('spelling', _libs)
+Spelling: SpellingBase = core_select_lib('spelling', _libs)

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -1068,7 +1068,7 @@ if USE_SDL3:
 
 label_libs += [
     ('pil', 'text_pil', 'LabelPIL')]
-Text = Label = core_select_lib('text', label_libs)
+Label: LabelBase = core_select_lib('text', label_libs)
 
 if 'KIVY_DOC' not in os.environ:
     if not Label:

--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -215,4 +215,4 @@ video_providers += [
     ('null', 'video_null', 'VideoNull')]
 
 
-Video = core_select_lib('video', video_providers)
+Video: VideoBase = core_select_lib('video', video_providers)

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -2599,4 +2599,4 @@ if USE_SDL3:
 
 if platform == 'linux':
     window_impl += [('x11', 'window_x11', 'WindowX11')]
-Window = core_select_lib('window', window_impl, True)
+Window: WindowBase = core_select_lib('window', window_impl, True)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Hi, I suppose there's no reason not to have type hints on core providers, given that other global objects like `kivy.clock.Clock` and `kivy.lang.Builder` have one.

Also, is there a reason for `kivy.core.text.Text` to exist? It's not listed in the `__all__`, and the unit tests succeeds without it.