### PR TITLE
Allow multiple IO's to be used while handling images in Kivy Core Image implementations

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -225,11 +225,11 @@ class ImageLoaderBase(object):
         return None
 
     @staticmethod
-    def can_save(fmt, is_bytesio=False):
+    def can_save(fmt, is_bytesio_like=False):
         '''Indicate if the loader can save the Image object
 
         .. versionchanged:: 1.11.0
-            Parameter `fmt` and `is_bytesio` added
+            Parameter `fmt` and `is_bytesio_like` added
         '''
         return False
 
@@ -847,12 +847,13 @@ class Image(EventDispatcher):
             Filename can now be a BytesIO object.
 
         '''
-        is_bytesio = False
-        if isinstance(filename, BytesIO):
-            is_bytesio = True
+        is_bytesio_like = False
+        if hasattr(filename, 'read') and callable(getattr(filename, 'read', None)):
+            # BytesIO like(RawIO, RawIOBase, BytesIO..)
+            is_bytesio_like = True
             if not fmt:
                 raise Exception(
-                    "You must specify a format to save into a BytesIO object")
+                    "You must specify a format to save into a BytesIO like object")
         elif fmt is None:
             fmt = self._find_format_from_filename(filename)
 
@@ -860,7 +861,7 @@ class Image(EventDispatcher):
         size = None
         loaders = [
             x for x in ImageLoader.loaders
-            if x.can_save(fmt, is_bytesio=is_bytesio)
+            if x.can_save(fmt, is_bytesio_like=is_bytesio_like)
         ]
         if not loaders:
             return False

--- a/kivy/core/image/img_imageio.pyx
+++ b/kivy/core/image/img_imageio.pyx
@@ -367,8 +367,8 @@ class ImageLoaderImageIO(ImageLoaderBase):
         return [ImageData(w, h, imgtype, data, source=filename)]
 
     @staticmethod
-    def can_save(fmt, is_bytesio):
-        if is_bytesio:
+    def can_save(fmt, is_bytesio_like):
+        if is_bytesio_like:
             return False
         return fmt in ImageLoaderImageIO.extensions()
 

--- a/kivy/core/image/img_pil.py
+++ b/kivy/core/image/img_pil.py
@@ -43,8 +43,8 @@ class ImageLoaderPIL(ImageLoaderBase):
     '''
 
     @staticmethod
-    def can_save(fmt, is_bytesio):
-        if is_bytesio:
+    def can_save(fmt, is_bytesio_like):
+        if is_bytesio_like:
             return False
         return fmt in ImageLoaderPIL.extensions()
 

--- a/kivy/core/image/img_sdl3.py
+++ b/kivy/core/image/img_sdl3.py
@@ -26,7 +26,7 @@ class ImageLoaderSDL3(ImageLoaderBase):
                 'tga', 'tiff', 'webp', 'xcf', 'xpm', 'xv')
 
     @staticmethod
-    def can_save(fmt, is_bytesio):
+    def can_save(fmt, is_bytesio_like):
         return fmt in ('jpg', 'png')
 
     @staticmethod

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1492,7 +1492,7 @@ class WindowBase(EventDispatcher):
         self.trigger_create_window.cancel()
 
         # ensure the window creation will not be called twice
-        if platform in ('android'):
+        if platform in {'android'}:
             self._unbind_create_window()
 
         if not self.initialized:


### PR DESCRIPTION
Added changes to the CoreImage so we can use other types too.
+ Changed a check in `core/window/__init__` because it was invalid.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
