### PR TITLE
Remove redundant checks in image providers

### DIFF
--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -848,7 +848,7 @@ class Image(EventDispatcher):
 
         '''
         is_bytesio_like = False
-        if hasattr(filename, 'read') and callable(getattr(filename, 'read', None)):
+        if callable(getattr(filename, 'read', None)):
             # BytesIO like(RawIO, RawIOBase, BytesIO..)
             is_bytesio_like = True
             if not fmt:

--- a/kivy/core/image/_img_sdl3.pyx
+++ b/kivy/core/image/_img_sdl3.pyx
@@ -30,7 +30,7 @@ cdef SDL_IOStream *rwops_bridge_to_bytesio_like(bytesio):
     cdef SDL_IOStream *rwops
     cdef BytesIODataContainer *bytesiocontainer
 
-    # works only for write.    
+    # works only for write.
     bytesiocontainer.data = <void *>bytesio
     io_interface.seek = NULL
     io_interface.read = NULL
@@ -45,7 +45,7 @@ cdef SDL_IOStream *rwops_bridge_to_bytesio_like(bytesio):
 def save(filename, w, h, pixelfmt, pixels, flipped, imagefmt, quality=90):
     cdef bytes c_filename = None
     cdef SDL_IOStream *rwops
-    if not hasattr(filename, 'read') and not callable(getattr(filename, 'read', None)):
+    if not hasattr(filename, 'read'):
         c_filename = filename.encode('utf-8')
     cdef int pitch
 


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
