### PR TITLE
Allow blitting on a different `buffer`/`colorfmt` when using `ANGLE` as a GL provider on iOS

### DIFF
--- a/kivy/core/camera/camera_avfoundation.pyx
+++ b/kivy/core/camera/camera_avfoundation.pyx
@@ -128,7 +128,7 @@ class CameraAVFoundation(CameraBase):
         self._resolution = (width, height)
         
         if self._texture is None or self._texture.size != self._resolution:
-            if platform == 'ios':
+            if platform == 'ios' and Texture.have_gles_limits():
                 self._texture = Texture.create(self._resolution, colorfmt='bgra')
             else:
                 self._texture = Texture.create(self._resolution)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.

Blitting on a Texture with a different `colorfmt` has been historically disabled on iOS due to GLES limitations.
However, with the ANGLE GL provider is possible (and is the only way to populate the Texture).

This PR ensure the relevant code takes into account the used GL provider.