### PR TITLE
✨ feat: Add `on_ready` event to `App`: fire once after UI becomes visible

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -433,6 +433,10 @@ class App(EventDispatcher):
         `on_start`:
             Fired when the application is being started (before the
             :func:`~kivy.base.runTouchApp` call.
+        `on_ready`:
+            Fired once when the application UI becomes visible after the
+            first frame has been rendered. This occurs after `on_start`
+            and indicates the UI is ready for user interaction.
         `on_stop`:
             Fired when the application stops.
         `on_pause`:
@@ -557,7 +561,7 @@ class App(EventDispatcher):
     # Return the current running App instance
     _running_app = None
 
-    __events__ = ('on_start', 'on_stop', 'on_pause', 'on_resume',
+    __events__ = ('on_start', 'on_ready', 'on_stop', 'on_pause', 'on_resume',
                   'on_config_change', )
 
     # Stored so that we only need to determine this once
@@ -583,6 +587,9 @@ class App(EventDispatcher):
         #: The *root* widget returned by the :meth:`build` method or by the
         #: :meth:`load_kv` method if the kv file contains a root widget.
         self.root = None
+
+        # Flag to indicate if the app is ready, i.e., the UI is visible
+        self._ready_fired = False
 
     def build(self):
         '''Initializes the application; it will be called only once.
@@ -1010,6 +1017,21 @@ Context.html#getFilesDir()>`_ is returned.
         '''
         pass
 
+    def on_ready(self):
+        '''Event handler for the `on_ready` event which is fired once
+        when the application UI becomes visible after the first frame
+        has been rendered.
+
+        This is the ideal place for:
+        - UI measurements that require rendered content
+        - Screenshots of the initial UI state
+        - Performance benchmarks
+        - Analytics or logging of app readiness
+
+        This event will not fire again during the application's lifetime.
+        '''
+        pass
+
     def on_stop(self):
         '''Event handler for the `on_stop` event which is fired when the
         application has finished running (i.e. the window is about to be
@@ -1197,6 +1219,12 @@ Context.html#getFilesDir()>`_ is returned.
             return True
         if key == 27:
             return self.close_settings()
+
+    def _trigger_ready_once(self):
+        '''Internal method called by the window backend after first swap.'''
+        if not self._ready_fired:
+            self._ready_fired = True
+            self.dispatch('on_ready')
 
     def on_title(self, instance, title):
         if self._app_window:

--- a/kivy/tests/test_app_on_ready.py
+++ b/kivy/tests/test_app_on_ready.py
@@ -1,0 +1,22 @@
+import unittest
+
+from kivy.app import App
+from kivy.uix.button import Button
+
+
+class ReadyFlagApp(App):
+    def build(self):
+        self.ready_called = False
+        return Button(text='Hello')
+
+    def on_ready(self):
+        self.ready_called = True
+
+
+class TestOnReady(unittest.TestCase):
+    @staticmethod
+    def test_on_ready_is_called():
+        app = ReadyFlagApp()
+        # Simulate what backend does after first frame render
+        app._trigger_ready_once()
+        assert app.ready_called is True


### PR DESCRIPTION
## Summary

This PR introduces a new `on_ready` event to the `App` class. The event is fired once after the application UI becomes visible and the first frame has been rendered (after `build` and after `on_start`). This allows users to safely perform actions that require the UI to be ready (such as screenshots, intensive operations) without relying on awful workarounds to avoid long black screens.

If you search for "black screen" on Discord, you can find more than 500 results, which shows this is a very common theme while programming Kivy apps. Also, you can find some GitHub issues here with the same problem. The best workarounds I found were a combination of `Windows.on_draw` to `Clock.schedule_once`, which doesn't seem like the proper way of solving the issue.

## Details

- Adds `on_ready` to the `App` event list and documents it.
- Implements the event firing by tracking the first successful buffer swap in the SDL3 window backend.
- Ensures the event is dispatched only once per application lifecycle.
- Provides a public `on_ready` handler for users.
- Adds a unit test for the `on_ready` event.

## Example

```python
from kivy.app import App
from kivy.uix.button import Button

class MyApp(App):
    def build(self):
        return Button(text="Hello")

    def on_ready(self):
        print("UI is visible and ready!")

MyApp().run()
```

### Notes

Only implemented for the SDL3 window backend
Documented and tested; no API breaks (just added new code)

### Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
