### PR TITLE
Enhance Scrollview.scroll_to to stop animation, prior to scroll_to animation

### DIFF
--- a/kivy/effects/kinetic.py
+++ b/kivy/effects/kinetic.py
@@ -196,3 +196,22 @@ class KineticEffect(EventDispatcher):
         self.velocity -= self.velocity * self.friction * dt / self.std_dt
         self.apply_distance(self.velocity * dt)
         self.trigger_velocity_update()
+
+    def halt(self):
+        '''Stop the movement immediately without momentum.
+        This method immediately stops any ongoing kinetic scrolling effect by:
+        - Cancelling any scheduled velocity updates to prevent further movement
+        - Setting is_manual to False to indicate no manual interaction is in progress
+
+        Unlike the stop() method which calculates final velocity for momentum
+        scrolling, this method provides instant cessation of movement without
+        any residual animation.
+
+        This is useful when you need to programmatically stop scrolling in
+        response to user actions or when the scroll position needs to be fixed
+        immediately.  The halt() method is called by ScrollView.scroll_to to
+        stop scrolling animation prior to moving to the target widget.
+        '''
+        self.is_manual = False
+        self.velocity = 0
+        self.trigger_velocity_update.cancel()

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -1065,6 +1065,12 @@ class ScrollView(StencilView):
         sxp = min(1, max(0, self.scroll_x - dsx))
         syp = min(1, max(0, self.scroll_y - dsy))
 
+        # Stop any existing motion before starting new animation
+        if self.effect_x:
+            self.effect_x.halt()
+        if self.effect_y:
+            self.effect_y.halt()
+
         if animate:
             if animate is True:
                 animate = {'d': 0.2, 't': 'out_quad'}


### PR DESCRIPTION
This PR is the solution to this issue: https://github.com/kivy/kivy/issues/9072
When the ScrollView is scrolling or over-scrolling, scroll_to() does not work.
The fix adds a halt() method to KineticEffect, and calls the halt() method from scroll_to prior to the animation.

Details:
KineticEffect.halt() stops the movement immediately without momentum.
This method immediately stops any ongoing kinetic scrolling effect by:
- Cancelling any scheduled velocity updates to prevent further movement
- Setting is_manual to False to indicate no manual interaction is in progress

Unlike the stop() method which calculates final velocity for momentum
scrolling, this method provides instant cessation of movement without 
any residual animation.

This is useful when you need to programmatically stop scrolling in 
response to user actions or when the scroll position needs to be fixed
immediately.  The halt() method is called by ScrollView.scroll_to to 
stop scrolling animation prior to moving to the target widget. 

This PR fixes the issue.  

Here is a test case.  WIthout the fix if the buttons are moving under momentum, the scroll_to does not work.  With the fix, scroll_to works as expected.

```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.scrollview import ScrollView
from kivy.uix.button import Button
from kivy.properties import BooleanProperty
from kivy.metrics import dp

"""
Test code for identifying issue.  When the ScrollView is scrolling or over-scrolling, scroll_to() does not work.
The spinner in the top left selects the effect_cls for the ScrollView
The two buttons on the bottom "Scroll to top" and "Scroll to bottom" use, scroll_to() to scroll to the widget.
"""


kv = """
BoxLayout:
    orientation: 'vertical'
    spacing: dp(5)
    Spinner:
        size_hint_y: None
        height: dp(48)
        values: ['DampedScrollEffect', 'OpacityScrollEffect', 'ScrollEffect']
        text: 'DampedScrollEffect'
        on_text: 
            sv.effect_cls = self.text
            sv.rebind()
    SV:
        id: sv
        BoxLayout:
            id: scroll_box
            orientation: 'vertical'
            size_hint_y: None
            height: self.minimum_height
    BoxLayout:
        size_hint_y: None
        height: dp(48)
        Button:
            text: 'Scroll to top'
            on_release: 
                sv.scroll_to(scroll_box.children[-1])
        Button:
            text: 'Scroll to bottom'
            on_release: 
                sv.scroll_to(scroll_box.children[0])
"""


class SV(ScrollView):
    stop_animation = BooleanProperty(False)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.rebind()

    def rebind(self):
        self.effect_y.bind(velocity=lambda obj, v: self.show_info('velocity', v))
        self.effect_y.bind(value=lambda obj, v: self.show_info('value', v))
        self.effect_y.bind(is_manual=lambda obj, v: self.show_info('is_manual', v))
        self.effect_y.bind(overscroll=lambda obj, v: self.show_info('overscroll', v))
        self.effect_y.bind(displacement=lambda obj, v: self.show_info('displacement', v))

    def on_scroll_y(self, obj, v):
        print(f'scroll_y: {v}')

    def show_info(self, name, v):
        print(f'{name}: {v}')


class EvaluateScrollEffectsApp(App):
    def build(self):
        return Builder.load_string(kv)

    def on_start(self):
        for i in range(50):
            self.root.ids.scroll_box.add_widget(Button(text=f'Button {i}', size_hint_y=None, height=dp(48)))


EvaluateScrollEffectsApp().run()
```


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
