### PR TITLE
Kivy can now be used with venv for setup

### DIFF
--- a/doc/sources/guide/config.rst
+++ b/doc/sources/guide/config.rst
@@ -18,6 +18,9 @@ On desktop, this defaults to::
 
     <HOME_DIRECTORY>/.kivy/config.ini
 
+If you are using venv (Virtual Environment) it should look like this::
+    <PROJECT_DIRECTORY>/.kivy/config.ini
+
 Therefore, if your user is named "tito", the file will be here:
 
 - Windows: ``C:\Users\tito\.kivy\config.ini``

--- a/doc/sources/guide/config.rst
+++ b/doc/sources/guide/config.rst
@@ -21,7 +21,7 @@ On desktop, this defaults to::
 If you are using venv (Virtual Environment) it should look like this::
     <PROJECT_DIRECTORY>/.kivy/config.ini
 
-Therefore, if your user is named "tito", the file will be here:
+If you are not using a virtual environment and your user is named "tito", the file will be here:
 
 - Windows: ``C:\Users\tito\.kivy\config.ini``
 - macOS: ``/Users/tito/.kivy/config.ini``

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -347,17 +347,21 @@ if any('pyinstaller' in arg.lower() for arg in sys.argv):
     environ['KIVY_PACKAGING'] = '1'
 
 if not environ.get('KIVY_DOC_INCLUDE'):
+    user_home_dir = expanduser('~')
+    kivy_home_dir = None
+
     # Configuration management
     if 'KIVY_HOME' in environ:
         kivy_home_dir = expanduser(environ['KIVY_HOME'])
-    else:
-        user_home_dir = expanduser('~')
-        if platform == 'android':
-            user_home_dir = environ['ANDROID_APP_PATH']
-        elif platform == 'ios':
-            user_home_dir = join(expanduser('~'), 'Documents')
-        kivy_home_dir = join(user_home_dir, '.kivy')
+    elif platform == 'android':
+        user_home_dir = environ['ANDROID_APP_PATH']
+    elif platform == 'ios':
+        user_home_dir = join(user_home_dir, 'Documents')
+    elif sys.prefix != sys.base_prefix:
+        # Detection if venv being used with the framework
+        user_home_dir = sys.path[0]
 
+    kivy_home_dir = kivy_home_dir or user_home_dir
     kivy_config_fn = join(kivy_home_dir, 'config.ini')
     kivy_usermodules_dir = join(kivy_home_dir, 'mods')
     icon_dir = join(kivy_home_dir, 'icon')

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -348,6 +348,7 @@ if any('pyinstaller' in arg.lower() for arg in sys.argv):
 
 if not environ.get('KIVY_DOC_INCLUDE'):
     user_home_dir = expanduser('~')
+    kivy_home_dir = None
 
     # Configuration management
     if 'KIVY_HOME' in environ:
@@ -360,6 +361,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         # Detection if venv being used with the framework
         user_home_dir = sys.path[0]
 
+    kivy_home_dir = kivy_home_dir or join(user_home_dir, '.kivy')
     kivy_config_fn = join(kivy_home_dir, 'config.ini')
     kivy_usermodules_dir = join(kivy_home_dir, 'mods')
     icon_dir = join(kivy_home_dir, 'icon')

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -361,7 +361,6 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         # Detection if venv being used with the framework
         user_home_dir = sys.path[0]
 
-    kivy_home_dir = kivy_home_dir or user_home_dir
     kivy_config_fn = join(kivy_home_dir, 'config.ini')
     kivy_usermodules_dir = join(kivy_home_dir, 'mods')
     icon_dir = join(kivy_home_dir, 'icon')

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -348,7 +348,6 @@ if any('pyinstaller' in arg.lower() for arg in sys.argv):
 
 if not environ.get('KIVY_DOC_INCLUDE'):
     user_home_dir = expanduser('~')
-    kivy_home_dir = None
 
     # Configuration management
     if 'KIVY_HOME' in environ:


### PR DESCRIPTION
I did something wrong with the git commands. The old PR: https://github.com/kivy/kivy/pull/9093

Kivy now better supports virtual environments (venvs). It can detect venv configurations and will place its configuration folder within the venv directory when launched through one. This allows for multiple, isolated Kivy builds on the same system without conflicting with the global ~/.kivy configuration.