### PR TITLE
Fixing Orthogonal Nested ScrollViews

### DIFF
--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -913,6 +913,27 @@ class ScrollView(StencilView):
                 return
             ud['dx'] += abs(touch.dx)
             ud['dy'] += abs(touch.dy)
+
+            # In the case of nested scroll views, we are in the inner SV.
+            # if user intent is orthogonal to this SV's allowed axis,
+            # yield to parent immediately by returning False, then the parent
+            # will handle the scroll.
+
+            if ud['dx'] > self.scroll_distance and not self.do_scroll_x:
+                if self.do_scroll_y and self.effect_y:
+                    self.effect_y.cancel()
+                if self.do_scroll_x and self.effect_x:
+                    self.effect_x.cancel()
+                touch.ud[self._get_uid('svavoid')] = True
+                return False
+            if ud['dy'] > self.scroll_distance and not self.do_scroll_y:
+                if self.do_scroll_x and self.effect_x:
+                    self.effect_x.cancel()
+                if self.do_scroll_y and self.effect_y:
+                    self.effect_y.cancel()
+                touch.ud[self._get_uid('svavoid')] = True
+                return False
+
             if ((ud['dx'] > self.scroll_distance and self.do_scroll_x) or
                     (ud['dy'] > self.scroll_distance and self.do_scroll_y)):
                 ud['mode'] = 'scroll'


### PR DESCRIPTION
The modifications allow orthoganal nested ScrollViews to work as expected.

Previously, if a `ScrollView` was nested inside another `ScrollView`, the
inner scrollview would consume all touches, preventing the outer scrollview
from scrolling, even when the movement was orthogonal to the inner's scroll
axis.

Now, when two `ScrollView` widgets are nested with perpendicular scrolling
directions (e.g., inner vertical, outer horizontal), touches are routed
according to movement direction:

- **Same-axis movement**: The inner `ScrollView` handles scrolling.
- **Orthogonal movement**: The touch is released to the parent `ScrollView`,
  allowing it to scroll.

This behavior is automatic and requires no configuration changes.
It makes nested scrolling more intuitive.

The changes are limited to the on_scroll_move method.

The direction of the touch is determined only at the beginning of the on touch move, changing orientation(from vertical to horizontal for example) requires releasing the touch and starting a new touch.  Only one `ScrollView` is active at a time.

This PR fixed the following issues:
https://github.com/kivy/kivy/issues/5617
https://github.com/kivy/kivy/issues/6889
https://github.com/kivy/kivy/issues/4052
https://github.com/kivy/kivy/issues/2986


<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
