### PR TITLE
Convert vertical scroll to horizontal on shift and fix nested wheel event handling (`ScrollView`). Move `modifiers` initialization from `MouseMotionEvent` to `MotionEvent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ kivy/core/clipboard/_clipboard_sdl3.c
 kivy/graphics/egl_backend/egl_angle.c
 kivy/core/image/_img_sdl3.cpp
 wheelhouse/
+/.vscode

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -102,6 +102,8 @@ angle          2D angle. Accessed via the `a` property.
 button         Mouse button ('left', 'right', 'middle', 'scrollup' or
                'scrolldown'). Accessed via the `button` property.
 markerid       Marker or Fiducial ID. Accessed via the `fid` property.
+modifiers      Keyboard modifiers active during the event (e.g., 'shift',
+               'ctrl', 'alt'). Accessed via the `modifiers` property.
 pos            2D position. Accessed via the `x`, `y` or `pos` properties.
 pos3d          3D position. Accessed via the `x`, `y` or `z` properties.
 pressure       Pressure of the contact. Accessed via the `pressure` property.
@@ -176,6 +178,7 @@ class MotionEvent(MotionEventBase):
     __attrs__ = \
         ('device', 'push_attrs', 'push_attrs_stack',
          'is_touch', 'type_id', 'id', 'dispatch_mode', 'shape', 'profile',
+         'modifiers',  # keyboard modifiers
          # current position, in 0-1 range
          'sx', 'sy', 'sz',
          # first position set, in 0-1 range
@@ -247,6 +250,14 @@ class MotionEvent(MotionEventBase):
 
         #: Currently pressed button.
         self.button = None
+
+        #: List of keyboard modifiers currently active during the event.
+        #: Common modifiers include 'shift', 'ctrl', 'alt', 'meta'.
+        #: This is typically set by input providers for mouse and keyboard
+        #: events.
+        #:
+        #: .. versionadded:: 3.0.0
+        self.modifiers = []
 
         #: Profiles currently used in the event.
         self.profile = []

--- a/kivy/input/providers/mouse.py
+++ b/kivy/input/providers/mouse.py
@@ -98,7 +98,6 @@ class MouseMotionEvent(MotionEvent):
 
     def __init__(self, *args, **kwargs):
         self.multitouch_sim = False
-        self.modifiers = []
         super().__init__(*args, **kwargs)
 
     def depack(self, args):

--- a/kivy/tests/test_uix_scrollview.py
+++ b/kivy/tests/test_uix_scrollview.py
@@ -352,6 +352,43 @@ class ScrollViewTestCase(GraphicUnitTest):
         EventLoop.idle()
         assert 0 > e.velocity > -10 * scroll.scroll_wheel_distance
 
+    def test_scroll_key_modifier_simple(self):
+        EventLoop.ensure_window()
+        win = EventLoop.window
+        scroll = ScrollView(size=(500, 500), do_scroll_x=True, do_scroll_y=True)
+        scroll.add_widget(Label(size_hint=(None, None), size=(2000, 2000)))
+
+        # set initial scroll pos
+        scroll.scroll_x = 0.5
+        scroll.scroll_y = 0.5
+
+        # 1. scrolldown WITHOUT shift -> scroll_y changes
+        t = UTMotionEvent("unittest", next(touch_id), {
+            "x": scroll.center_x / float(win.width),
+            "y": scroll.center_y / float(win.height)
+        })
+        t.profile.append('button')
+        t.button = 'scrolldown'
+        scroll.on_touch_down(t)
+        assert scroll.scroll_x == 0.5
+        assert scroll.scroll_y != 0.5
+
+        # reset
+        scroll.scroll_x = 0.5
+        scroll.scroll_y = 0.5
+
+        # 2. scrolldown WITH shift -> scroll_x changes
+        t = UTMotionEvent("unittest", next(touch_id), {
+            "x": scroll.center_x / float(win.width),
+            "y": scroll.center_y / float(win.height)
+        })
+        t.modifiers = ['shift']
+        t.profile.append('button')
+        t.button = 'scrolldown'
+        scroll.on_touch_down(t)
+        assert scroll.scroll_x != 0.5
+        assert scroll.scroll_y == 0.5
+
 
 if __name__ == '__main__':
     import unittest

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -231,6 +231,18 @@ Wheel behavior is always active and is NOT affected by the
 :attr:`parallel_delegation` or :attr:`delegate_to_outer` properties.
 Those only control touch and touchpad gesture behavior.
 
+**Using "shift" keyboard modifier:**
+
+When the "shift" key is pressed during mouse wheel scrolling, vertical scrolling
+(scrollup/scrolldown) is converted to horizontal scrolling
+(scrollleft/scrollright). This allows the user to change the scrolling direction
+in a ScrollView that supports both directions.
+
+.. versionadded:: 3.0.0
+
+    ScrollView now allows the "shift" key modifier to convert vertical mouse
+    wheel scrolling into horizontal scrolling.
+
 .. versionchanged:: VERSION_NEXT
 
     The ScrollView widget now supports nesting to arbitrary levels
@@ -2475,11 +2487,11 @@ class ScrollView(StencilView):
             # under cursor
             # No delegation through hierarchy - matches standard web browser UX
             if is_wheel:
-                # Try only the innermost ScrollView
-                if inner_sv._scroll_initialize(touch):
-                    return True
-                # Innermost couldn't handle it - don't try outer levels
-                # This prevents scroll hijacking when inner reaches boundary
+                # Find the innermost ScrollView in the hierarchy that can
+                # handle this wheel event (direction/axis)
+                for sv in reversed(hierarchy.scrollviews):
+                    if sv._scroll_initialize(touch):
+                        return True
                 return False
 
             # Non-wheel touch: Initialize scrolling on the innermost child
@@ -2610,8 +2622,16 @@ class ScrollView(StencilView):
         ud["in_bar_y"] = in_bar_y
 
         if "button" in touch.profile and touch.button.startswith("scroll"):
+            btn = touch.button
+            # If "shift" is pressed, convert vertical scroll to horizontal
+            if "shift"in touch.modifiers:
+                if btn == 'scrolldown':
+                    btn = 'scrollright'
+                elif btn == 'scrollup':
+                    btn = 'scrollleft'
+
             if self._handle_mouse_wheel_scroll(
-                    touch.button, in_bar_x, in_bar_y
+                    btn, in_bar_x, in_bar_y
             ):
                 touch.ud[self._get_uid("svavoid")] = True
                 # Start velocity check for scroll stop after mouse wheel


### PR DESCRIPTION
This PR introduces three related improvements to scroll and input event handling:

**1. Shift + scroll wheel → horizontal scroll**

When the `shift` key is held during mouse wheel scrolling, vertical scroll events are converted to horizontal:
- `scrolldown` → `scrollright`
- `scrollup` → `scrollleft`

**2. Fix nested ScrollView wheel event handling**

Previously, `on_touch_down` only attempted to initialize scroll on the innermost `ScrollView`, silently ignoring outer ones if the inner couldn't handle the event (e.g., orthogonal axes). Now it iterates through the hierarchy in reverse to find the first ScrollView that can actually handle the wheel event, matching the expected behavior.

**3. Fix modifiers initialization location**

`self.modifiers = []` was incorrectly initialized in `MouseMotionEvent` (provider-specific), as introduced in #9121. It has been moved to the base `MotionEvent` class, where it now lives alongside proper documentation, making modifiers available to all input providers, not just mouse.

Depends on:
- https://github.com/kivy/kivy/pull/9121

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
