### PR TITLE
Add support for the `limit_render_to_text_bbox` feature in the SDL provider.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ kivy/setupconfig.py
 
 kivy/core/clipboard/_clipboard_sdl3.c
 kivy/graphics/egl_backend/egl_angle.c
+/.kivy
+kivy/core/image/_img_sdl3.cpp

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -184,13 +184,17 @@ class LabelBase(object):
             or `'weak_rtl'` (Pango only)
         `text_language`: str, defaults to None (user locale)
             RFC-3066 format language tag as a string (Pango only)
-        `limit_render_to_text_bbox`: bool, defaults to False. PIL only.
+        `limit_render_to_text_bbox`: bool, defaults to False. Available for SDL3
+            and PIL text providers.
             If set to ``True``, this parameter indicates that rendering should
             be limited to the bounding box of the text, excluding any
             additional white spaces designated for ascent and descent.
             By limiting the rendering to the bounding box of the text, it
             ensures a more precise alignment with surrounding elements when
             utilizing properties such as `valign`, `y`, `pos`, `pos_hint`, etc.
+
+    .. versionadded:: 3.0.0
+        `limit_render_to_text_bbox` was implemented for SDL3 text provider.
 
     .. versionadded:: 2.3.0
         `limit_render_to_text_bbox` was added to allow to limit text rendering

--- a/kivy/core/text/text_sdl3.py
+++ b/kivy/core/text/text_sdl3.py
@@ -52,6 +52,7 @@ class LabelSDL3(LabelBase):
     def _render_text(self, text, x, y):
         if self.options['limit_render_to_text_bbox']:
             y-= self._baseline_offset
+
         self._surface.render(self, text, x, y)
 
     def _render_end(self):

--- a/kivy/core/text/text_sdl3.py
+++ b/kivy/core/text/text_sdl3.py
@@ -9,8 +9,13 @@ __all__ = ('LabelSDL3', )
 
 from kivy.core.text import LabelBase
 try:
-    from kivy.core.text._text_sdl3 import (_SurfaceContainer, _get_extents,
-                                           _get_fontdescent, _get_fontascent)
+    from kivy.core.text._text_sdl3 import (
+        _SurfaceContainer,
+        _get_extents,
+        _get_tight_extents,
+        _get_fontdescent,
+        _get_fontascent,
+    )
 except ImportError:
     from kivy.core import handle_win_lib_import_error
     handle_win_lib_import_error(
@@ -20,13 +25,20 @@ except ImportError:
 
 class LabelSDL3(LabelBase):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._baseline_offset = 0
+
     def _get_font_id(self):
         return '|'.join([str(self.options[x]) for x
             in ('font_size', 'font_name_r', 'bold',
                 'italic', 'underline', 'strikethrough')])
 
     def get_extents(self, text):
-        return _get_extents(self, text)
+        if self.options['limit_render_to_text_bbox']:
+            return _get_tight_extents(self, text)
+        else:
+            return _get_extents(self, text)
 
     def get_descent(self):
         return _get_fontdescent(self)
@@ -38,6 +50,8 @@ class LabelSDL3(LabelBase):
         self._surface = _SurfaceContainer(self._size[0], self._size[1])
 
     def _render_text(self, text, x, y):
+        if self.options['limit_render_to_text_bbox']:
+            y-= self._baseline_offset
         self._surface.render(self, text, x, y)
 
     def _render_end(self):

--- a/kivy/lib/sdl3.pxi
+++ b/kivy/lib/sdl3.pxi
@@ -750,6 +750,9 @@ cdef extern from "SDL_ttf.h":
     #*/
     cdef int  TTF_GetFontAscent( TTF_Font *font)
 
+    # Query the metrics (dimensions) of a font's glyph for a UNICODE codepoint.
+    cdef int TTF_GetGlyphMetrics(TTF_Font *font, Uint32 ch, int *minx, int *maxx, int *miny, int *maxy, int *advance);
+
     ## Get the offset from the baseline to the bottom of the font
     #   This is a negative value, relative to the baseline.
     # */

--- a/kivy/uix/label.py
+++ b/kivy/uix/label.py
@@ -1193,7 +1193,7 @@ class Label(Widget):
     such as `valign`, `y`, `pos`, `pos_hint`, etc.
 
     .. note::
-        This feature requires the PIL text provider.
+        This feature is available for SDL3 and PIL providers.
 
     :attr:`limit_render_to_text_bbox` is a
     :class:`~kivy.properties.BooleanProperty` and defaults to False.


### PR DESCRIPTION
This PR adds support for the same feature introduced in this [PR](https://github.com/kivy/kivy/pull/8510), but for the SDL text provider.


https://github.com/user-attachments/assets/8564abb8-4a5a-4091-8515-e440efa6992d


### Test code
```python
import os

os.environ["KIVY_TEXT"] = "sdl3"

from kivy.app import App
from kivy.base import EventLoop
from kivy.core.window import Window
from kivy.lang import Builder

Window.clearcolor = 0.15,0.15, 0.15, 1

class MainApp(App):
    root_widget = Builder.load_string(r"""

FloatLayout
    BoxLayout:
        size_hint_y: None
        height: dp(100)
        orientation: "vertical"
        pos_hint: {"top": 1}
        TextInput:
            id: ti
            text: "a"
        ToggleButton:
            text: "limit_render_to_text_bbox"
            on_state:
                label_widget.limit_render_to_text_bbox = not self.state == "normal"

    FloatLayout:
        size_hint: 0.8, 0.5
        pos_hint: {"center_x": 0.5, "center_y": 0.5}
        canvas.before:
            Color:
                rgba: (0.5, 0.5, 0.5, 1)
            Rectangle:
                pos: self.pos
                size: self.size
            
            Color:
                rgba: (1, 0, 0, 1)
            Line:
                points: self.x, self.center_y, self.right, self.center_y
        
            
        Label:
            id: label_widget
            opacity: .5
            # text: (self.font_name.split('/')[-1], self.font_name)[0]
            text: ti.text
            font_size: sp(300)
            size_hint: None, None
            size: self.texture_size
            pos_hint: {"center_x": 0.5, "y": 0}
            limit_render_to_text_bbox: False

            canvas.before:
                Color:
                    rgba: (0, 0, 1, 1)
                Rectangle:
                    pos: self.pos
                    size: self.size
                                        
        BoxLayout:
            pos_hint: {"center_x": 0.5}
            size_hint_y: 0.25

            BoxLayout:
                CheckBox:
                    group: "pos"
                    size_hint_x: None
                    width: dp(50)
                    on_active:
                        label_widget.pos_hint = {"center_x": 0.5, "top": 1}
                Label:
                    text: "Top"
                    text_size: self.size
                    halign: "left"
                    valign: "center"
            
            BoxLayout:
                CheckBox:
                    group: "pos"
                    size_hint_x: None
                    width: dp(50)
                    on_active:
                        label_widget.pos_hint = {"center_x": 0.5, "center_y": 0.5}
                Label:
                    text: "Center"
                    text_size: self.size
                    halign: "left"
                    valign: "center"
            
            BoxLayout:
                CheckBox:
                    group: "pos"
                    active: True
                    size_hint_x: None
                    width: dp(50)
                    on_active:
                        label_widget.pos_hint = {"center_x": 0.5, "y": 0}
                Label:
                    text: "Bottom"
                    text_size: self.size
                    halign: "left"
                    valign: "center"

""")

    def build(self):
        EventLoop.window.bind(on_keyboard=self._hook_keyboard)
        return self.root_widget

    def _hook_keyboard(self, window, key, keycode, text, modifiers):
        # print('keyboard ays :', key, keycode, text, modifiers )

        if text == "d":
            self.root.ids.label_widget.font_name = get_next_font(
                self.root.ids.label_widget.font_name, "left"
            )
        if text == "f":
            self.root.ids.label_widget.font_name = get_next_font(
                self.root.ids.label_widget.font_name, "right"
            )


def get_font_list():
    import pathlib

    def get_fonts(fonts_path):
        """Get a list of all the fonts available on this system."""

        if not fonts_path:
            return []
        font_list = []
        for fdir in fonts_path:
            font_list += pathlib.Path(fdir).rglob("*.ttf")

        nflist = []
        for i, x in enumerate(font_list):
            if not str(x).split("/")[-1].startswith("._"):
                nflist.append(str(x))

        return sorted([*set(nflist)])

    from os.path import abspath, dirname, join

    from kivy.core.text import Label as CoreLabel

    return get_fonts(
        fonts_path=[abspath(join(dirname(__file__), "..", "data", "fonts"))]
        + CoreLabel.get_system_fonts_dir()
    )


font_list = get_font_list()


def get_next_font(pfont_name, l_r):
    try:
        idx = font_list.index(pfont_name)
    except ValueError:
        return font_list[0]

    try:
        font_name = str(font_list[idx + (-1 if l_r == "left" else 1)])
    except IndexError:
        font_name = font_list[0]
    return font_name


if __name__ == "__main__":
    MainApp().run()

```
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
