### PR TITLE
Android Video Provider

### DIFF
--- a/doc/sources/guide/environment.rst
+++ b/doc/sources/guide/environment.rst
@@ -149,7 +149,7 @@ KIVY_TEXT
 KIVY_VIDEO
     Implementation to use for rendering video
 
-    Values: gstplayer, ffpyplayer, ffmpeg, null
+    Values: gstplayer, ffpyplayer, ffmpeg, android , null
 
 KIVY_AUDIO
     Implementation to use for playing audio

--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -64,6 +64,7 @@ class VideoBase(EventDispatcher):
         kwargs.setdefault('eos', 'stop')
         kwargs.setdefault('async', True)
         kwargs.setdefault('autoplay', False)
+        kwargs.setdefault('fps', 30)
 
         super(VideoBase, self).__init__()
 
@@ -77,12 +78,13 @@ class VideoBase(EventDispatcher):
         self._autoplay = kwargs.get('autoplay')
         self._async = kwargs.get('async')
         self.eos = kwargs.get('eos')
+        self._fps = kwargs.get('fps')
         if self.eos == 'pause':
             Logger.warning("'pause' is deprecated. Use 'stop' instead.")
             self.eos = 'stop'
         self.filename = kwargs.get('filename')
 
-        Clock.schedule_interval(self._update, 1 / 30.)
+        Clock.schedule_interval(self._update, 1 / self._fps)
 
         if self._autoplay:
             self.play()
@@ -212,6 +214,7 @@ except ImportError:
 video_providers += [
     ('ffmpeg', 'video_ffmpeg', 'VideoFFMpeg'),
     ('ffpyplayer', 'video_ffpyplayer', 'VideoFFPy'),
+    ('android', 'video_android', 'VideoAndroid'),
     ('null', 'video_null', 'VideoNull')]
 
 

--- a/kivy/core/video/video_android.py
+++ b/kivy/core/video/video_android.py
@@ -4,7 +4,7 @@
 
 
 __all__ = ('VideoAndroid', )
-from jnius import autoclass,java_method, PythonJavaClass
+from jnius import autoclass, java_method, PythonJavaClass
 from kivy.clock import mainthread
 from kivy.logger import Logger
 from kivy.core.video import VideoBase
@@ -40,7 +40,7 @@ class VideoAndroid(VideoBase):
     _mediaplayer = None
 
     def __init__(self, **kwargs):
-        super(VideoAndroid,self).__init__(**kwargs)
+        super(VideoAndroid, self).__init__(**kwargs)
         self._mediaplayer = None
         self._surface_texture = None
         self._surface = None
@@ -95,7 +95,7 @@ class VideoAndroid(VideoBase):
         # FBO for Kivy texture
         self._fbo = Fbo(size=(w, h))
         self._fbo['resolution'] = (float(w), float(h))
-        self._fbo['angle'] =  float(math.radians(self._rotation))
+        self._fbo['angle'] = float(math.radians(self._rotation))
         self._fbo.shader.fs = '''
             #extension GL_OES_EGL_image_external : require
             #ifdef GL_ES
@@ -142,7 +142,7 @@ class VideoAndroid(VideoBase):
 
     def unload(self):
         Logger.info(f"VideoAndroid: Unload")
-    # Safely release MediaPlayer
+        # Safely release MediaPlayer
         if hasattr(self, "_mediaplayer"):
             try:
                 self._mediaplayer.release()
@@ -175,10 +175,9 @@ class VideoAndroid(VideoBase):
     def _get_duration(self):
         return self._mediaplayer.getDuration() / 1000.0 if self._mediaplayer else 0
 
-    
     def _get_state(self):
         return self._state
-    
+
     def _set_volume(self, volume):
         if self._mediaplayer:
             self._mediaplayer.setVolume(volume, volume)
@@ -205,14 +204,14 @@ class VideoAndroid(VideoBase):
             self._mediaplayer.pause()
             self._set_position(0)
             self._state = ""
-            #self.unload()
+            # self.unload()
 
     def seek(self, percent, precise=True):
         self._set_position(percent)
 
     # Called automatically by VideoBase
     def _update(self, dt):
-        
+
         if not self._surface_texture:
             return
         self._surface_texture.updateTexImage()
@@ -222,11 +221,8 @@ class VideoAndroid(VideoBase):
         if self._texture:
             self.dispatch("on_frame")
 
-        #if self._mediaplayer: # and not self._mediaplayer.isPlaying():
-            
     def _completion_callback(self,):
         self._do_eos()
-
 
     @mainthread
     def _do_eos(self):

--- a/kivy/core/video/video_android.py
+++ b/kivy/core/video/video_android.py
@@ -1,0 +1,156 @@
+# Author : Sk Sahil (Sahil-pixel)
+# Video core provider for Android using Android MediaPlayer & OpenGL Texture
+# https://github.com/Sahil-pixel/AndroidVideo4Kivy/blob/main/android_video.py
+
+
+__all__ = ('VideoAndroid', )
+from jnius import autoclass
+from kivy.clock import mainthread
+from kivy.logger import Logger
+from kivy.core.video import VideoBase
+from kivy.graphics import Rectangle, Callback
+from kivy.graphics.texture import Texture
+from kivy.graphics.fbo import Fbo
+
+MediaPlayer = autoclass("android.media.MediaPlayer")
+Surface = autoclass("android.view.Surface")
+SurfaceTexture = autoclass("android.graphics.SurfaceTexture")
+GLES11Ext = autoclass("android.opengl.GLES11Ext")
+GL_TEXTURE_EXTERNAL_OES = GLES11Ext.GL_TEXTURE_EXTERNAL_OES
+
+
+Logger.info('VideoAndroid: Using Android MediaPlayer')
+
+
+class VideoAndroid(VideoBase):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._mediaplayer = None
+        self._surface_texture = None
+        self._surface = None
+        self._video_texture = None
+        self._fbo = None
+        self._texture_cb = None
+        self._resolution = (0, 0)
+
+    def load(self):
+        self.unload()
+        if not self._filename:
+            Logger.error("VideoAndroid: No filename set")
+            return
+
+        self._mediaplayer = MediaPlayer()
+        self._mediaplayer.setDataSource(self._filename)
+        self._mediaplayer.prepare()
+
+        w = self._mediaplayer.getVideoWidth()
+        h = self._mediaplayer.getVideoHeight()
+        self._resolution = (w, h)
+
+        # Create OES texture
+        self._video_texture = Texture(
+            width=w, height=h, target=GL_TEXTURE_EXTERNAL_OES, colorfmt="rgba")
+        self._video_texture.wrap = "clamp_to_edge"
+
+        # SurfaceTexture + Surface
+        self._surface_texture = SurfaceTexture(int(self._video_texture.id))
+        self._surface_texture.setDefaultBufferSize(w, h)
+        self._surface = Surface(self._surface_texture)
+        self._mediaplayer.setSurface(self._surface)
+
+        # FBO for Kivy texture
+        self._fbo = Fbo(size=(w, h))
+        self._fbo.shader.fs = """
+            #extension GL_OES_EGL_image_external : require
+            #ifdef GL_ES
+                precision highp float;
+            #endif
+            varying vec4 frag_color;
+            varying vec2 tex_coord0;
+            uniform samplerExternalOES texture1;
+            void main() {
+                gl_FragColor = texture2D(texture1, tex_coord0);
+            }
+        """
+        with self._fbo:
+            self._texture_cb = Callback(
+                lambda instr: self._video_texture.bind)
+            Rectangle(size=(w, h))
+
+        self._texture = self._fbo.texture
+        self.dispatch("on_load")
+
+    def unload(self):
+        if self._mediaplayer:
+            try:
+                self._mediaplayer.release()
+            except Exception:
+                pass
+        del self._mediaplayer
+        del self._video_texture
+        del self._fbo
+        del self._texture_cb
+        del self._surface_texture
+        del self._surface
+        self._texture = None
+        self._state = ""
+        self._resolution = (0, 0)
+
+    # Property overrides
+    def _get_position(self):
+        return self._mediaplayer.getCurrentPosition() / 1000.0 if self._mediaplayer else 0
+
+    def _set_position(self, pos):
+        if self._mediaplayer:
+            self._mediaplayer.seekTo(int(pos * 1000))
+
+    def _get_duration(self):
+        return self._mediaplayer.getDuration() / 1000.0 if self._mediaplayer else 0
+
+    def _set_volume(self, volume):
+        if self._mediaplayer:
+            self._mediaplayer.setVolume(volume, volume)
+
+    # Controls
+    def play(self):
+        if not self._mediaplayer:
+            self.load()
+        if self._mediaplayer and self._state != "playing":
+            self._mediaplayer.start()
+            self._state = "playing"
+
+    def pause(self):
+        if self._mediaplayer and self._state == "playing":
+            self._mediaplayer.pause()
+            self._state = "paused"
+
+    def stop(self):
+        if self._mediaplayer:
+            self._mediaplayer.stop()
+        self._state = "stopped"
+
+    # Called automatically by VideoBase
+    def _update(self, dt):
+        if not self._surface_texture:
+            return
+        self._surface_texture.updateTexImage()
+        self._texture_cb.ask_update()
+        self._fbo.draw()
+        self._texture = self._fbo.texture
+        if self._texture:
+            self.dispatch("on_frame")
+
+        if self._mediaplayer and not self._mediaplayer.isPlaying():
+            self._do_eos()
+
+    @mainthread
+    def _do_eos(self):
+        if self.eos == "pause":
+            self.pause()
+        elif self.eos == "stop":
+            self.stop()
+        elif self.eos == "loop":
+            self.position = 0
+            self.play()
+        self.dispatch("on_eos")

--- a/kivy/core/video/video_android.py
+++ b/kivy/core/video/video_android.py
@@ -23,6 +23,7 @@ Logger.info('VideoAndroid: Using Android MediaPlayer')
 
 
 class VideoAndroid(VideoBase):
+    _mediaplayer=None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -155,3 +156,4 @@ class VideoAndroid(VideoBase):
             self.position = 0
             self.play()
         self.dispatch("on_eos")
+

--- a/kivy/core/video/video_android.py
+++ b/kivy/core/video/video_android.py
@@ -16,7 +16,7 @@ MediaPlayer = autoclass("android.media.MediaPlayer")
 Surface = autoclass("android.view.Surface")
 SurfaceTexture = autoclass("android.graphics.SurfaceTexture")
 GLES11Ext = autoclass("android.opengl.GLES11Ext")
-GL_TEXTURE_EXTERNAL_OES = GLES11Ext.GL_TEXTURE_EXTERNAL_OES
+
 
 
 Logger.info('VideoAndroid: Using Android MediaPlayer')
@@ -49,6 +49,7 @@ class VideoAndroid(VideoBase):
         self._resolution = (w, h)
 
         # Create OES texture
+        GL_TEXTURE_EXTERNAL_OES = GLES11Ext.GL_TEXTURE_EXTERNAL_OES
         self._video_texture = Texture(
             width=w, height=h, target=GL_TEXTURE_EXTERNAL_OES, colorfmt="rgba")
         self._video_texture.wrap = "clamp_to_edge"


### PR DESCRIPTION
## Description
This PR adds a new **Android Video provider** for Kivy using `MediaPlayer` and OpenGL textures.  
It allows video playback on Android without relying on ffpyplayer or gstreamer, using the native Android APIs.

## Changes
- Added `VideoAndroid` provider.
- Implemented OpenGL texture binding from `MediaPlayer`.
- Added rotation handling.
- Integrated with Kivy core video system.


## Notes
- This is a first implementation, so further feedback from maintainers is expected.
- Unit tests and docs will need input from maintainers for style and coverage.
