### PR TITLE
Add a fixture and utility functions for using `pytest` to test a Kivy app

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -21,6 +21,7 @@ import sys
 from functools import partial
 import os
 import threading
+from typing import Callable, Optional
 from kivy.graphics.cgl import cgl_get_backend_name
 from kivy.input.motionevent import MotionEvent
 log = logging.getLogger('unittest')
@@ -36,6 +37,49 @@ make_screenshots = os.environ.get('KIVY_UNITTEST_SCREENSHOTS')
 http_server = None
 http_server_ready = threading.Event()
 kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
+
+
+def advance_frames(frames: int) -> None:
+    """Draw a few frames.
+
+    Generally more useful than ``time.sleep``, since the duration of a frame
+    can vary widely based on things not in your app's control.
+
+    """
+    from kivy.base import EventLoop
+
+    for _ in range(frames):
+        EventLoop.idle()
+
+
+def idle_until(
+        condition: Optional[Callable[[], bool]] = None,
+        timeout: Optional[int] = None,
+        message: str = "Timed out"
+):
+    """Advance frames until ``condition()`` is ``True``
+
+    With integer ``timeout``, give up after that many frames,
+    raising ``TimeoutError``. You can customize its ``message``.
+
+    May be used as a decorator upon the condition function.
+
+    """
+    from kivy.base import EventLoop
+
+    if not (timeout or condition):
+        raise ValueError("Need timeout or condition")
+    if condition is None:
+        return partial(idle_until, timeout=timeout, message=message)
+    if timeout is None:
+        while not condition():
+            EventLoop.idle()
+        return
+    for _ in range(timeout):
+        if condition():
+            return
+        EventLoop.idle()
+    raise TimeoutError(message)
 
 
 def requires_graphics(func):


### PR DESCRIPTION
I found stdlib's `unittest` unpleasant to work with, so I converted all my `GraphicUnitTest`s to use `pytest` instead. This code came in handy, and may be generally useful.

The `kivy_init` fixture does the same stuff as `setUp()` and `tearDown()` in `GraphicUnitTest`. It is up to the user to make a fixture for their app in particular.

`advance_frames` is the same as in `GraphicUnitTest`.

`idle_until` runs the event loop until some predicate holds true. Useful for letting needed events fire before you start to test.

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
