### PR TITLE
:construction_worker: Fix cmake install error in macOS CI

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   kivy_examples_create:
     # we need examples wheel for tests, but only windows actually uploads kivy-examples to pypi/server
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs_on: macos-latest
+          - runs_on: macos-14
             python: '3.x'
     steps:
     - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
         path: ./wheelhouse/*.whl
 
   osx_wheel_upload:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: osx_wheels_create
     if: github.event_name != 'pull_request'
     env:
@@ -136,9 +136,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        # macos-latest (ATM macos-14) runs on Apple Silicon,
         # macos-13 runs on Intel
-        runs_on: ['macos-latest', 'macos-13']
+        # macos-14 runs on Apple Silicon
+        runs_on: ['macos-13', 'macos-14']
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     env:
       KIVY_GL_BACKEND: 'mock'
@@ -170,7 +170,7 @@ jobs:
           test_kivy_install
 
   osx_app_create:
-    runs-on: macos-latest
+    runs-on: macos-14
     if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
     env:
       KIVY_SPLIT_EXAMPLES: 0
@@ -212,7 +212,7 @@ jobs:
           path: app
 
   osx_app_upload_test:
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: [osx_app_create, kivy_examples_create]
     env:
       KIVY_GL_BACKEND: 'mock'

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        # macos-latest (ATM macos-14) runs on Apple Silicon,
         # macos-13 runs on Intel
-        runs_on: ['macos-latest', 'macos-13']
+        # macos-14 runs on Apple Silicon
+        runs_on: ['macos-13', 'macos-14']
         python: ['3.13']
     steps:
     - uses: actions/checkout@v4
@@ -28,6 +28,8 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install build dependencies
       run: |
+        # we had cmake installed from installed a different Homebrew tap (local/pinned) in the past
+        brew uninstall cmake || true
         brew install pkg-config cmake ninja
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Resolves brew install failure when cmake is already installed from a different tap (local/pinned vs homebrew/core). The workflow now uninstalls any existing cmake installation before installing from homebrew/core to avoid tap conflicts.
The error was:
```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.
To install this version, you must first uninstall the existing formula:
  brew uninstall cmake
Then you can install the desired version:
  brew install cmake
```

Also use explicit macOS version 14 rather than latest.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
