### PR TITLE
Skip the copy of logo folder on `Android` and `iOS` to avoid warnings in logs

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -371,7 +371,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             mkdir(kivy_home_dir)
         if not exists(kivy_usermodules_dir):
             mkdir(kivy_usermodules_dir)
-        if platform != 'android' and not exists(icon_dir):
+        if platform not in {'android', 'ios'} and not exists(icon_dir):
             try:
                 shutil.copytree(join(kivy_data_dir, 'logo'), icon_dir)
             except:

--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -371,7 +371,7 @@ if not environ.get('KIVY_DOC_INCLUDE'):
             mkdir(kivy_home_dir)
         if not exists(kivy_usermodules_dir):
             mkdir(kivy_usermodules_dir)
-        if not exists(icon_dir):
+        if platform != 'android' and not exists(icon_dir):
             try:
                 shutil.copytree(join(kivy_data_dir, 'logo'), icon_dir)
             except:


### PR DESCRIPTION
…because p4a uses something else so this is not needed and is annoying for users because it warns about needed permissions.