### PR TITLE
GitHub Actions: Test macOS on the latest stable release of Python

### DIFF
--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -15,17 +15,19 @@ jobs:
     name: "unit_test (${{ matrix.runs_on }}, ${{ matrix.python }})"
     runs-on: ${{ matrix.runs_on }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 runs on Intel
-        # macos-14 runs on Apple Silicon
-        runs_on: ['macos-13', 'macos-14']
-        python: ['3.13']
+        # macos-latest runs on Apple Silicon
+        runs_on: ['macos-13', 'macos-latest']
+        python: ['3.x']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
     - name: Install build dependencies
       run: |
         # we had cmake installed from installed a different Homebrew tap (local/pinned) in the past


### PR DESCRIPTION
Automated testing should tell us if things are broken on the latest stable version of Python before users do.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input
> [x-ranges](https://github.com/npm/node-semver#x-ranges-12x-1x-12-) to specify the latest stable version of Python (for the specified major version).
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
