### PR TITLE
Fix kivy/tests/common.py on Python < 3.10

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -10,6 +10,8 @@ The screenshots live in the 'kivy/tests/results' folder and are in PNG format,
 320x240 pixels.
 '''
 
+from __future__ import annotations
+
 __all__ = (
     'GraphicUnitTest', 'UnitTestTouch', 'UTMotionEvent', 'async_run',
     'requires_graphics', 'ensure_web_server')


### PR DESCRIPTION
Fixes GitHub Actions error on Python 3.9.
> TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
