### PR TITLE
inputs - add disconnect/connect events, change JOYSTICK to GAMEPAD api

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1067,7 +1067,8 @@ class WindowBase(EventDispatcher):
         'on_dropfile', 'on_drop_text', 'on_drop_end', 'on_request_close',
         'on_cursor_enter', 'on_cursor_leave', 'on_joy_axis',
         'on_joy_hat', 'on_joy_ball', 'on_joy_button_down',
-        'on_joy_button_up', 'on_memorywarning', 'on_textedit',
+        'on_joy_button_up', 'on_joy_added', 'on_joy_removed',
+        'on_memorywarning', 'on_textedit',
         # internal
         'on_pre_resize')
 
@@ -2027,6 +2028,18 @@ class WindowBase(EventDispatcher):
         '''Event called when a joystick has a button released.
 
         .. versionadded:: 1.9.0'''
+        pass
+
+    def on_joy_added(self, deviceid):
+        '''Event called when a joystick has been plugged in.
+
+        .. versionadded:: 3.0.0'''
+        pass
+
+    def on_joy_removed(self, deviceid):
+        '''Event called when a joystick has been unplugged.
+
+        .. versionadded:: 3.0.0'''
         pass
 
     def on_keyboard(self, key, scancode=None, codepoint=None,

--- a/kivy/core/window/window_sdl3.py
+++ b/kivy/core/window/window_sdl3.py
@@ -215,6 +215,18 @@ class WindowSDL(WindowBase):
     def get_window_info(self):
         return self._win.get_window_info()
 
+    def _open_gamepad(self, device_id=-1):
+        ptr = self._win._open_gamepad(device_id)
+        if ptr:
+            Logger.info(f"Gamepad {device_id} open")
+            return ptr
+        Logger.warning(f"Cannot open gamepad {device_id}")
+        return None
+
+    def _close_gamepad(self, device_id):
+        self._win._close_gamepad(device_id)
+        Logger.info(f"Gamepad {device_id} closed")
+
     def _set_minimum_size(self, *args):
         minimum_width = self.minimum_width
         minimum_height = self.minimum_height
@@ -668,6 +680,13 @@ class WindowSDL(WindowBase):
             elif action == 'joybuttonup':
                 stickid, buttonid = args
                 self.dispatch('on_joy_button_up', stickid, buttonid)
+
+            elif action == 'joyadded':
+                joy_id = args[0]
+                self.dispatch('on_joy_added', joy_id)
+            elif action == 'joyremoved':
+                joy_id = args[0]
+                self.dispatch('on_joy_removed', joy_id)
 
             elif action in ('keydown', 'keyup'):
                 mod, key, scancode, kstr = args

--- a/kivy/lib/sdl3.pxi
+++ b/kivy/lib/sdl3.pxi
@@ -13,6 +13,9 @@ cdef extern from "SDL_joystick.h":
     cdef int SDL_HAT_DOWN = 0x04
     cdef int SDL_HAT_LEFT = 0x08
 
+cdef extern from "SDL_gamepad.h":
+    cdef struct SDL_Gamepad
+
 cdef extern from "SDL.h":
     ctypedef unsigned char Uint8
     ctypedef unsigned long Uint32
@@ -199,6 +202,8 @@ cdef extern from "SDL.h":
         SDL_EVENT_JOYSTICK_HAT_MOTION
         SDL_EVENT_JOYSTICK_BUTTON_DOWN
         SDL_EVENT_JOYSTICK_BUTTON_UP
+        SDL_EVENT_GAMEPAD_ADDED
+        SDL_EVENT_GAMEPAD_REMOVED
         SDL_EVENT_FINGER_DOWN
         SDL_EVENT_FINGER_UP
         SDL_EVENT_FINGER_MOTION
@@ -363,6 +368,11 @@ cdef extern from "SDL.h":
         SDL_JoystickID which
         Uint8 button
         Uint8 state
+    cdef struct SDL_GamepadDeviceEvent:
+        SDL_EventType type
+        Uint32 reserved
+        Uint64 timestamp
+        SDL_JoystickID which
     cdef struct SDL_QuitEvent:
         pass
     cdef struct SDL_UserEvent:
@@ -403,6 +413,7 @@ cdef extern from "SDL.h":
         SDL_TouchButtonEvent tbutton
         SDL_MultiGestureEvent mgesture
         SDL_DollarGestureEvent dgesture
+        SDL_GamepadDeviceEvent gdevice
 
     cdef struct SDL_RendererInfo:
         char *name
@@ -494,7 +505,7 @@ cdef extern from "SDL.h":
     cdef int SDL_INIT_VIDEO          = 0x00000020  # SDL_INIT_VIDEO implies SDL_INIT_EVENTS */
     cdef int SDL_INIT_JOYSTICK       = 0x00000200  # SDL_INIT_JOYSTICK implies SDL_INIT_EVENTS */
     cdef int SDL_INIT_HAPTIC         = 0x00001000
-    cdef int SDL_INIT_GAMECONTROLLER = 0x00002000  # SDL_INIT_GAMECONTROLLER implies SDL_INIT_JOYSTICK */
+    cdef int SDL_INIT_GAMEPAD        = 0x00002000  # SDL_INIT_GAMEPAD implies SDL_INIT_JOYSTICK */
     cdef int SDL_INIT_EVENTS         = 0x00004000
     cdef int SDL_INIT_NOPARACHUTE    = 0x00100000  # Don't catch fatal signals */
 
@@ -639,9 +650,13 @@ cdef extern from "SDL.h":
     cdef int SDL_GL_GetSwapInterval()
     cdef void SDL_GL_SwapWindow(SDL_Window * window) nogil
     cdef int SDL_GL_DestroyContext(SDL_GLContext context)
-
-    cdef void SDL_GetJoysticks(int *numjoysticks)
+    cdef SDL_JoystickID * SDL_GetJoysticks(int *count);
     cdef SDL_Joystick * SDL_OpenJoystick(int index)
+    cdef void SDL_CloseJoystick(SDL_Joystick * index)
+    cdef SDL_JoystickID * SDL_GetGamepads(int *count)
+    cdef SDL_Gamepad * SDL_OpenGamepad(SDL_JoystickID instance_id)
+    cdef SDL_Gamepad * SDL_GetGamepadFromID(SDL_JoystickID instance_id)
+    cdef void SDL_CloseGamepad(SDL_Gamepad *gamepad)
     cdef SDL_Window * SDL_GetKeyboardFocus()
     cdef Uint8 *SDL_GetKeyboardState(int *numkeys)
     cdef SDL_Keymod SDL_GetModState()


### PR DESCRIPTION
There are 2 APIs for "joystick" inputs, JOYSTICK and GAMEPAD, gamepad is more modern approach, and gamepads are unified with mappings, (e.g. on joystick on gamepad brand A, bumpers are 4 and 5, on brand B they are 6 and 8 - on GAMEPAD they are mapped exactly the same way)

also, gamepads are initialized ONLY at start of app, when pad gets disconnected you need to restart app - this PR change it, app can detect disconnect and connect, and reopen the connection for it

and you can call "open_gamepads" on demand
tested on linux desktop and android

how to test?
```
#!/usr/bin/env python

from kivy.app import App
from kivy.core.window import Window
from kivy.uix.button import Button


class GamepadApp(App):
    def build(self):
        self.button = Button(text="Manual connect gamepads...")
        self.button.bind(on_release=self.on_button)
        self._bind_events()
        return self.button

    def on_button(self, *largs):
        Window._open_gamepad(-1)

    def _bind_events(self):
        Window.bind(on_joy_added=self.on_joy_added)
        Window.bind(on_joy_removed=self.on_joy_removed)
        Window.bind(on_joy_hat=self.on_joy_hat)
        Window.bind(on_joy_ball=self.on_joy_ball)
        Window.bind(on_joy_axis=self.on_joy_axis)
        Window.bind(on_joy_button_up=self.on_joy_button_up)
        Window.bind(on_joy_button_down=self.on_joy_button_down)

    def joy_motion(self, event, id, axis, value):
        print(event, id, axis, value)

    def on_joy_added(self, win, device_id):
        print(f"Gamepads {device_id} connected")
        Window._open_gamepad(device_id)

    def on_joy_removed(self, win, device_id):
        print(f"Gamepads {device_id} disconnected")
        Window._close_gamepad(device_id)

    def on_joy_axis(self, win, stickid, axisid, value):
        self.joy_motion('axis', stickid, axisid, value)

    def on_joy_ball(self, win, stickid, ballid, xvalue, yvalue):
        self.joy_motion('ball', stickid, ballid, (xvalue, yvalue))

    def on_joy_hat(self, win, stickid, hatid, value):
        self.joy_motion('hat', stickid, hatid, value)

    def on_joy_button_down(self, win, stickid, buttonid):
        print('button_down', stickid, buttonid)

    def on_joy_button_up(self, win, stickid, buttonid):
        print('button_up', stickid, buttonid)


if __name__ == "__main__":
    GamepadApp().run()
```



Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
