### PR TITLE
lang/parser.py: Remove Python 3.6 abstract syntax tree workaround

### DIFF
--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -230,11 +230,7 @@ class ParserRuleProperty(object):
 
         if isinstance(node, (ast.JoinedStr, ast.BoolOp)):
             for n in node.values:
-                if isinstance(n, ast.Str):
-                    # NOTE: required for python3.6
-                    yield from cls.get_names_from_expression(n.s)
-                else:
-                    yield from cls.get_names_from_expression(n.value)
+                yield from cls.get_names_from_expression(n.value)
 
         if isinstance(node, ast.BinOp):
             yield from cls.get_names_from_expression(node.right)


### PR DESCRIPTION
Required for the support of Python 3.14.

Fix `unit_test` pytest warnings on Python 3.13:
> test_lang.py: 16 warnings
  /home/runner/work/kivy/kivy/kivy/lang/parser.py:233: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    if isinstance(n, ast.Str):

> test_lang.py::LangTestCase::test_bind_fstring
test_lang.py::LangTestCase::test_fstring_nested_property_binding
  /home/runner/work/kivy/kivy/kivy/lang/parser.py:235: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
    yield from cls.get_names_from_expression(n.s)

_What's new in Python 3.14?_
> [ast](https://docs.python.org/3.14/whatsnew/3.14.html#id10)
Remove the following classes, which have been deprecated aliases of [Constant](https://docs.python.org/3.14/library/ast.html#ast.Constant) since Python 3.8 and have emitted deprecation warnings since Python 3.12:
> * Bytes
> * Ellipsis
> * NameConstant
> * Num
> * Str

@misl6 
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
