### PR TITLE
Fix wrong seek with Gstreamer

### DIFF
--- a/kivy/core/video/video_gstplayer.py
+++ b/kivy/core/video/video_gstplayer.py
@@ -95,7 +95,7 @@ class VideoGstplayer(VideoBase):
         self.player.play()
 
     def seek(self, percent, precise=True):
-        self.player.seek(percent,precise)
+        self.player.seek(percent, precise)
 
     def _get_position(self):
         return self.player.get_position()

--- a/kivy/core/video/video_gstplayer.py
+++ b/kivy/core/video/video_gstplayer.py
@@ -95,7 +95,7 @@ class VideoGstplayer(VideoBase):
         self.player.play()
 
     def seek(self, percent, precise=True):
-        self.player.seek(percent)
+        self.player.seek(percent,precise)
 
     def _get_position(self):
         return self.player.get_position()

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -404,9 +404,7 @@ class WindowSDL(WindowBase):
             except AttributeError:
                 pass
         else:
-            self._density = (
-                self._win.window_pixel_size[0] / self._win.window_size[0]
-            )
+            self._density = self._win._get_gl_size()[0] / self._size[0]
             if self._is_desktop:
                 self.dpi = self._density * 96.
 

--- a/kivy/core/window/window_sdl2.py
+++ b/kivy/core/window/window_sdl2.py
@@ -393,15 +393,20 @@ class WindowSDL(WindowBase):
     def _update_density_and_dpi(self):
         if platform == 'win':
             from ctypes import windll
+            self.dpi = 96.
             self._density = 1.
             try:
                 hwnd = windll.user32.GetActiveWindow()
-                self.dpi = float(windll.user32.GetDpiForWindow(hwnd))
-                self._density = self.dpi / 96
+                dpi = float(windll.user32.GetDpiForWindow(hwnd))
+                if dpi:
+                    self.dpi = dpi
+                    self._density = self.dpi / 96
             except AttributeError:
                 pass
         else:
-            self._density = self._win._get_gl_size()[0] / self._size[0]
+            self._density = (
+                self._win.window_pixel_size[0] / self._win.window_size[0]
+            )
             if self._is_desktop:
                 self.dpi = self._density * 96.
 

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -348,7 +348,7 @@ cdef class GstPlayer:
             return -1
         return position / float(GST_SECOND)
 
-    def seek(self, float percent, bool precise):
+    def seek(self, float percent, precise):
         with nogil:
             self._seek(percent,precise)
 
@@ -388,7 +388,7 @@ cdef class GstPlayer:
             return 0
         return position
 
-    cdef void _seek(self, float percent, bool precise) nogil:
+    cdef void _seek(self, float percent, precise) nogil:
         cdef GstState current_state, pending_state
         cdef gboolean ret
         cdef gint64 seek_t, duration

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -30,6 +30,7 @@ cdef extern from 'gst/gst.h':
         GST_FORMAT_TIME
 
     ctypedef enum GstSeekFlags:
+        GST_SEEK_FLAG_KEY_UNIT
         GST_SEEK_FLAG_FLUSH
         GST_SEEK_FLAG_ACCURATE
 
@@ -347,9 +348,9 @@ cdef class GstPlayer:
             return -1
         return position / float(GST_SECOND)
 
-    def seek(self, float percent):
+    def seek(self, float percent, bool precise):
         with nogil:
-            self._seek(percent)
+            self._seek(percent,precise)
 
     #
     # C-like API, that doesn't require the GIL
@@ -387,7 +388,7 @@ cdef class GstPlayer:
             return 0
         return position
 
-    cdef void _seek(self, float percent) nogil:
+    cdef void _seek(self, float percent, bool precise) nogil:
         cdef GstState current_state, pending_state
         cdef gboolean ret
         cdef gint64 seek_t, duration
@@ -399,7 +400,10 @@ cdef class GstPlayer:
             seek_t = 0
         else:
             seek_t = <gint64>(percent * duration)
-        seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE
+        if precise:
+            seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT | GST_SEEK_FLAG_ACCURATE
+        else:
+            seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT
         gst_element_get_state(self.pipeline, &current_state,
                 &pending_state, <GstClockTime>GST_SECOND)
         if current_state == GST_STATE_READY:

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -401,7 +401,7 @@ cdef class GstPlayer:
         else:
             seek_t = <gint64>(percent * duration)
         if precise:
-            seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT | GST_SEEK_FLAG_ACCURATE
+            seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE
         else:
             seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT
         gst_element_get_state(self.pipeline, &current_state,

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -30,8 +30,8 @@ cdef extern from 'gst/gst.h':
         GST_FORMAT_TIME
 
     ctypedef enum GstSeekFlags:
-        GST_SEEK_FLAG_KEY_UNIT
         GST_SEEK_FLAG_FLUSH
+        GST_SEEK_FLAG_ACCURATE
 
     ctypedef enum GstStateChangeReturn:
         pass
@@ -399,7 +399,7 @@ cdef class GstPlayer:
             seek_t = 0
         else:
             seek_t = <gint64>(percent * duration)
-        seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT
+        seek_flags = GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE
         gst_element_get_state(self.pipeline, &current_state,
                 &pending_state, <GstClockTime>GST_SECOND)
         if current_state == GST_STATE_READY:

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -348,7 +348,7 @@ cdef class GstPlayer:
             return -1
         return position / float(GST_SECOND)
 
-    def seek(self, float percent, precise):
+    def seek(self, float percent, bint precise):
         with nogil:
             self._seek(percent,precise)
 
@@ -388,7 +388,7 @@ cdef class GstPlayer:
             return 0
         return position
 
-    cdef void _seek(self, float percent, precise) nogil:
+    cdef void _seek(self, float percent, bint precise) nogil:
         cdef GstState current_state, pending_state
         cdef gboolean ret
         cdef gint64 seek_t, duration

--- a/kivy/lib/gstplayer/_gstplayer.pyx
+++ b/kivy/lib/gstplayer/_gstplayer.pyx
@@ -350,7 +350,7 @@ cdef class GstPlayer:
 
     def seek(self, float percent, bint precise):
         with nogil:
-            self._seek(percent,precise)
+            self._seek(percent, precise)
 
     #
     # C-like API, that doesn't require the GIL


### PR DESCRIPTION
This PR fix issue with Gstreamer only https://github.com/kivy/kivy/issues/6292.
As mentioned in this issue, to be precise with the seek function we need to use flags ACCURATE instead  of KEY_UNIT.
I test it for one of by project and it work like charm.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
