### PR TITLE
GitHub Actions: Upgrade from deprecated macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   kivy_examples_create:
     # we need examples wheel for tests, but only windows actually uploads kivy-examples to pypi/server
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs_on: macos-14
+          - runs_on: macos-latest
             python: '3.x'
     steps:
     - uses: actions/checkout@v5
@@ -87,7 +87,7 @@ jobs:
         path: ./wheelhouse/*.whl
 
   osx_wheel_upload:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: osx_wheels_create
     if: github.event_name != 'pull_request'
     env:
@@ -136,9 +136,9 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
-        # macos-13 runs on Intel
-        # macos-14 runs on Apple Silicon
-        runs_on: ['macos-13', 'macos-14']
+        # macos-15-intel runs on Intel x64
+        # macos-latest runs on Apple Silicon ARM
+        runs_on: ['macos-15-intel', 'macos-latest']
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     env:
       KIVY_GL_BACKEND: 'mock'
@@ -170,7 +170,7 @@ jobs:
           test_kivy_install
 
   osx_app_create:
-    runs-on: macos-14
+    runs-on: macos-latest
     if: github.event_name != 'pull_request' && (github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build app osx]')) || contains(github.event.pull_request.title, '[build app osx]')
     env:
       KIVY_SPLIT_EXAMPLES: 0
@@ -212,7 +212,7 @@ jobs:
           path: app
 
   osx_app_upload_test:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [osx_app_create, kivy_examples_create]
     env:
       KIVY_GL_BACKEND: 'mock'

--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 runs on Intel
-        # macos-latest and macos-26 run on Apple Silicon
-        runs_on: ['macos-13', 'macos-26', 'macos-latest']
+        # macos-15-intel runs on Intel x64
+        # macos-latest and macos-26 run on Apple Silicon ARM
+        runs_on: ['macos-15-intel', 'macos-26', 'macos-latest']
         python: ['3.x']
     steps:
     - if: matrix.runs_on == 'macos-26'


### PR DESCRIPTION
The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |
* Let's prepare for actions/runner-images#13046

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
