### PR TITLE
Document `Builder` attributes

### DIFF
--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -265,7 +265,8 @@ class BuilderBase(object):
             Not necessarily real files on disk; see :meth:`load_string`.
         `dynamic_classes`:  dict
             Classes crated in Kivy-language code.
-            They were created with the ``<Class@Superclass>:`` syntax, rather than in Python.
+            They were created with the ``<Class@Superclass>:`` syntax,
+            rather than in Python.
         `templates`: dict
             Superseded by :attr:`dynamic_classes` in version 1.0.5.
             Modern Kivy apps should not use templates.


### PR DESCRIPTION
I thought I had to keep track of what kv-lang files I'd loaded on my own, but `Builder` does that. I'm documenting it so other people don't think they have to roll their own file tracking, either. And why not document the other attributes while I'm at it? They are, apparently, public.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
