### PR TITLE
Change base image for building linux dependencies for wheels to `manylinux_2_28`

### DIFF
--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -71,7 +71,7 @@ jobs:
       if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
       run: |
         docker run --rm -v `pwd`:/root:rw --workdir=/root \
-           quay.io/pypa/manylinux2014_${{ matrix.cibw_archs }} \
+           quay.io/pypa/manylinux_2_28_${{ matrix.cibw_archs }} \
            bash -ec 'source .ci/ubuntu_ci.sh && install_manylinux_build_deps && ./tools/build_linux_dependencies.sh'
     - name: Generate version metadata
       run: |


### PR DESCRIPTION
Bump the manylinux image to `manylinux_2_28` when building the manylinux wheels

The default image changed from `manylinux2014` to `manylinux_2_28` in cibuildwheel v3.0.0: https://github.com/pypa/cibuildwheel/releases/tag/v3.0.0

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
