### PR TITLE
Fix ZeroDivisionError when showing hidden window on Windows

### DIFF
--- a/kivy/core/window/window_sdl3.py
+++ b/kivy/core/window/window_sdl3.py
@@ -402,11 +402,12 @@ class WindowSDL(WindowBase):
     def show(self):
         if self._is_desktop:
             self._win.show()
-            # Update density and DPI now that window is visible
-            # This fixes ZeroDivisionError when window starts hidden
+        # Update density and DPI now that window is visible
+        # This fixes ZeroDivisionError when window starts hidden
             self._update_density_and_dpi()
         else:
             Logger.warning('Window: show() is used only on desktop OSes.')
+
 
     def raise_window(self):
         if self._is_desktop:


### PR DESCRIPTION

### Summary
This PR fixes a ZeroDivisionError that occurs when a hidden window is shown on Windows. The fix calls `_update_density_and_dpi()` after `Window.show()`.

### Issue
#9170 

### How to test
```python
from kivy.core.window import Window
Window.hide()
Window.show()  # Should not raise ZeroDivisionError
assert Window._density > 0
