### PR TITLE
Expose `SDL_GL_ALPHA_SIZE` as a config parameter

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -31,7 +31,7 @@ RUN /bin/bash -c 'pip install auditwheel'
 RUN ./tools/build_linux_dependencies.sh
 
 # Build the wheel.
-RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL3=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_SDL_GL_ALPHA_SIZE=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
+RUN KIVY_SPLIT_EXAMPLES=1 USE_X11=1 USE_SDL3=1 USE_PANGOFT2=0 USE_GSTREAMER=0 KIVY_DEPS_ROOT=$(pwd)/kivy-dependencies KIVY_CROSS_PLATFORM="$KIVY_CROSS_PLATFORM" python3 -m pip -v wheel --extra-index-url https://www.piwheels.org/simple . -w /kivy-wheel
 
 # Delocate the wheel.
 # bullseye: manylinux_2_31_armv7l, bookworm: manylinux_2_35_armv7l

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -291,6 +291,10 @@ Available configuration tokens
         .. warning::
             For shaping to work reliably across platforms, set
             `Window.clearcolor` to `(0, 0, 0, 0)`.
+    `alpha_size: int (default: 0 on the Raspberry Pi and 8 on all other platforms)
+        Specifies the minimum number of bits for the alpha channel of the color buffer.
+        Set this to 0, so SDL3 works without X11.
+        Only applicable for the SDL3 window provider.
 
 :input:
 
@@ -362,6 +366,9 @@ Available configuration tokens
     Check the specific module's documentation for a list of accepted
     arguments.
 
+.. versionadded:: 3.0.0
+    `alpha_size` have been added to the `graphics` section.
+
 .. versionadded:: 2.2.0
     `always_on_top` have been added to the `graphics` section.
     `show_taskbar_icon` have been added to the `graphics` section.
@@ -420,12 +427,12 @@ from weakref import ref
 
 from kivy import kivy_config_fn
 from kivy.logger import Logger, logger_config_update
-from kivy.utils import platform
+from kivy.utils import pi_version, platform
 
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
 # Version number of current configuration format
-KIVY_CONFIG_VERSION = 28
+KIVY_CONFIG_VERSION = 29
 
 Config = None
 '''The default Kivy configuration object. This is a :class:`ConfigParser`
@@ -961,6 +968,11 @@ if not environ.get('KIVY_DOC_INCLUDE'):
         elif version == 27:
             if Config.get("kivy", "window_shape") == "data/images/defaultshape.png":
                 Config.set("kivy", "window_shape", "")
+
+        elif version == 28:
+            Config.setdefault(
+                "graphics", "alpha_size", "8" if pi_version is None else "0"
+            )
 
         # WARNING: When adding a new version migration here,
         # don't forget to increment KIVY_CONFIG_VERSION !

--- a/kivy/core/window/_window_sdl3.pyx
+++ b/kivy/core/window/_window_sdl3.pyx
@@ -161,7 +161,10 @@ cdef class _WindowSDL3Storage:
         SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8)
-        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, KIVY_SDL_GL_ALPHA_SIZE)
+
+        config_alpha_size = Config.getint('graphics', 'alpha_size')
+        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, config_alpha_size)
+
         SDL_GL_SetAttribute(SDL_GL_RETAINED_BACKING, 0)
         SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1)
 

--- a/setup.py
+++ b/setup.py
@@ -223,18 +223,11 @@ c_options['use_osx_frameworks'] = platform == 'darwin'
 c_options['use_angle_gl_backend'] = platform in ['darwin', 'ios']
 c_options['debug_gl'] = False
 
-# Set the alpha size, this will be 0 on the Raspberry Pi and 8 on all other
-# platforms, so SDL3 works without X11
-c_options['kivy_sdl_gl_alpha_size'] = 8 if pi_version is None else 0
-
 # now check if environ is changing the default values
 for key in list(c_options.keys()):
     ukey = key.upper()
     if ukey in environ:
-        # kivy_sdl_gl_alpha_size should be an integer, the rest are booleans
-        value = int(environ[ukey])
-        if key != 'kivy_sdl_gl_alpha_size':
-            value = bool(value)
+        value = bool(int(environ[ukey]))
         print('Environ change {0} -> {1}'.format(key, value))
         c_options[key] = value
 
@@ -311,9 +304,7 @@ class KivyBuildExt(build_ext, object):
         # generate content
         print('Build configuration is:')
         for opt, value in c_options.items():
-            # kivy_sdl_gl_alpha_size is already an integer
-            if opt != 'kivy_sdl_gl_alpha_size':
-                value = int(bool(value))
+            value = int(bool(value))
             print(' * {0} = {1}'.format(opt, value))
             opt = opt.upper()
             config_h += '#define __{0} {1}\n'.format(opt, value)


### PR DESCRIPTION
This is used, so SDL3 works without X11

This is required when using Kivy on a machine without X11 installed e.g. Ubuntu server

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
