### PR TITLE
Fix pep8 failure

### DIFF
--- a/kivy/core/text/markup.py
+++ b/kivy/core/text/markup.py
@@ -474,10 +474,7 @@ class MarkupLabel(MarkupLabelBase):
                     )
                 )
             elif halign == 'right' or auto_halign_r:
-                x = max(
-                    0, 
-                    int(w - lw - padding_right)
-                )
+                x = max(0, int(w - lw - padding_right))
             layout_line.x = x
             layout_line.y = y
             psp = pph = 0
@@ -488,14 +485,12 @@ class MarkupLabel(MarkupLabelBase):
                 # calculate sub/super script pos
                 if options['script'] == 'superscript':
                     script_pos = max(0,
-                                    psp if psp and wh < pph else self.get_descent()
-                    )
+                                     psp if psp and wh < pph else self.get_descent())
                     psp = script_pos
                     pph = wh
                 elif options['script'] == 'subscript':
-                    script_pos = min(lh - wh, 
-                                     ((psp + pph) - wh) if pph and wh < pph else lh - wh
-                    )
+                    script_pos = min(
+                        lh - wh, ((psp + pph) - wh) if pph and wh < pph else lh - wh)
                     pph = wh
                     psp = script_pos
                 else:


### PR DESCRIPTION
This PR fixes the last merge which broke pep8 compliance.

https://github.com/kivy/kivy/pull/9080

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
