### PR TITLE
Fix `ZeroDivisionError` when showing hidden window on Windows

### DIFF
--- a/kivy/core/window/window_sdl3.py
+++ b/kivy/core/window/window_sdl3.py
@@ -402,8 +402,8 @@ class WindowSDL(WindowBase):
     def show(self):
         if self._is_desktop:
             self._win.show()
-            # Update density and DPI now that window is visible
-            # This fixes ZeroDivisionError when window starts hidden
+            # Update density and DPI now that window is visible.
+            # This fixes ZeroDivisionError when window starts hidden.
             self._update_density_and_dpi()
         else:
             Logger.warning('Window: show() is used only on desktop OSes.')


### PR DESCRIPTION
closes #9177
This PR fixes the indentation and improves clarity in the show() method of the SDL3 window provider (kivy/core/window/window_sdl3.py).
The update ensures the comment and function call for updating density and DPI are properly indented within the if self._is_desktop block.
Additionally, this fix prevents potential ZeroDivisionError when the window starts hidden.
