### PR TITLE
Test free-threaded Python with pytest-run-parallel

### DIFF
--- a/.github/workflows/test_osx_python.yml
+++ b/.github/workflows/test_osx_python.yml
@@ -51,3 +51,8 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         test_kivy
+    - name: Test Kivy with pytest-run-parallel
+      run: |
+        source .ci/ubuntu_ci.sh
+        python -m pip install pytest-run-parallel[psutil]
+        pytest --iterations=8 --parallel-threads=auto --doctest-modules # kivy

--- a/.github/workflows/test_ubuntu_python.yml
+++ b/.github/workflows/test_ubuntu_python.yml
@@ -64,6 +64,11 @@ jobs:
       run: |
         source .ci/ubuntu_ci.sh
         test_kivy_benchmark
+    - name: Test Kivy with pytest-run-parallel
+      run: |
+        source .ci/ubuntu_ci.sh
+        python -m pip install pytest-run-parallel[psutil]
+        pytest --iterations=8 --parallel-threads=auto --doctest-modules # kivy
     - name: Upload benchmarks as artifact
       uses: actions/upload-artifact@v5
       with:

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -30,6 +30,11 @@ jobs:
       run: |
         . .\.ci\windows_ci.ps1
         Test-kivy
+    - name: Test Kivy with pytest-run-parallel
+      run: |
+        . .\.ci\windows_ci.ps1
+        python -m pip install pytest-run-parallel[psutil]
+        pytest --iterations=8 --parallel-threads=auto --doctest-modules # kivy
     - name: Test Kivy benchmarks
       run: |
         . .\.ci\windows_ci.ps1


### PR DESCRIPTION
To be confident about free-threaded compatibility, it is recommended to test with [`pytest-run-parallel`](https://github.com/Quansight-Labs/pytest-run-parallel).
https://py-free-threading.github.io/testing

Something like:
% `uvx --with=pytest-run-parallel pytest --iterations=8 --parallel-threads=auto` 
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
