### PR TITLE
fix(recycleview): decrement _cache_count when reusing cached widgets

### DIFF
--- a/kivy/uix/recycleview/views.py
+++ b/kivy/uix/recycleview/views.py
@@ -236,6 +236,7 @@ class RecycleDataAdapter(EventDispatcher):
         If found in the cache it's removed from the source
         before returning. It doesn't check the current views.
         '''
+        global _cache_count
         # is it in the dirtied views?
         dirty_views = self.dirty_views
         if viewclass is None:
@@ -251,12 +252,14 @@ class RecycleDataAdapter(EventDispatcher):
             elif _cached_views[viewclass]:
                 # global cache has this class, update data
                 view, stale = _cached_views[viewclass].pop(), True
+                _cache_count -= 1
             elif dirty_class:
                 # random any dirty view element - update data
                 view, stale = dirty_class.popitem()[1], True
         elif _cached_views[viewclass]:  # otherwise go directly to cache
             # global cache has this class, update data
             view, stale = _cached_views[viewclass].pop(), True
+            _cache_count -= 1
 
         if view is None:
             view = self.create_view(index, data_item, viewclass)


### PR DESCRIPTION
Decrement _cache_count when widgets are popped from _cached_views in RecycleDataAdapter.get_view() to maintain accurate cache count.

In RecycleDataAdapter.get_view(), _cache_count was incremented when widgets were added to _cached_views but never decremented when they were reused. This caused _cache_count to grow unbounded even though the actual cache size remained small.  This caused unnecessary cleanup calls to _clean_cache().

FWIW I stumbled on this bug when investing a report of a memory leak.  Good news, there is no memory leak.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
