### PR TITLE
Temporarily avoid pytest v9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,9 @@ install_requires =
 [options.extras_require]
 tuio = oscpy
 dev =
-    pytest>=3.6,<3.9  # See: kivy/kivy#9208
+    pytest>=3.6
     pytest-cov
-    pytest_asyncio>=1.2.0
+    pytest_asyncio==1.2.0  # See: kivy/kivy#9208
     pytest-timeout
     pytest-benchmark
     pyinstaller


### PR DESCRIPTION
Workaround until compatibility with pytest v9 is fixed.
* #9208
* https://docs.pytest.org/en/stable/changelog.html
```diff
[options.extras_require]
dev =
-   pytest_asyncio!=0.11.0
+   pytest_asyncio==1.2.0  # See: kivy/kivy#9208
```

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
