### PR TITLE
Replace DampedScroll Effect, enhance and address numeric instability.

### DIFF
--- a/examples/widgets/scrollview_damped_effect_tuning.py
+++ b/examples/widgets/scrollview_damped_effect_tuning.py
@@ -27,13 +27,13 @@ BoxLayout:
     spacing: dp(10)
     padding: dp(10)
     on_size: print(self.size)
-    
+
     # Left side - Parameter controls
     BoxLayout:
         orientation: 'vertical'
         size_hint_x: 0.4
         spacing: dp(8)
-        
+
         Label:
             size_hint_y: None
             height: dp(40)
@@ -41,13 +41,13 @@ BoxLayout:
             font_size: '16sp'
             bold: True
             color: 1, 1, 1, 1
-        
+
         # Rubber Band Coefficient
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: dp(80)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(25)
@@ -55,7 +55,7 @@ BoxLayout:
                 font_size: '12sp'
                 halign: 'left'
                 text_size: self.size
-            
+
             Slider:
                 id: rubber_band_slider
                 min: 0.1
@@ -65,20 +65,20 @@ BoxLayout:
                 size_hint_y: None
                 height: dp(30)
                 on_value: app.update_rubber_band(self.value)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(20)
                 text: 'Lower = Stiffer | Higher = More elastic'
                 font_size: '9sp'
                 color: 0.7, 0.7, 0.7, 1
-        
+
         # Spring Stiffness
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: dp(80)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(25)
@@ -86,7 +86,7 @@ BoxLayout:
                 font_size: '12sp'
                 halign: 'left'
                 text_size: self.size
-            
+
             Slider:
                 id: spring_stiffness_slider
                 min: 20
@@ -96,20 +96,20 @@ BoxLayout:
                 size_hint_y: None
                 height: dp(30)
                 on_value: app.update_spring_stiffness(self.value)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(20)
                 text: 'Lower = Slower bounce | Higher = Faster bounce'
                 font_size: '9sp'
                 color: 0.7, 0.7, 0.7, 1
-        
+
         # Spring Mass
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: dp(80)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(25)
@@ -117,7 +117,7 @@ BoxLayout:
                 font_size: '12sp'
                 halign: 'left'
                 text_size: self.size
-            
+
             Slider:
                 id: spring_mass_slider
                 min: 0.1
@@ -127,20 +127,20 @@ BoxLayout:
                 size_hint_y: None
                 height: dp(30)
                 on_value: app.update_spring_mass(self.value)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(20)
                 text: 'Affects momentum and bounce speed'
                 font_size: '9sp'
                 color: 0.7, 0.7, 0.7, 1
-        
+
         # Min Overscroll
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: dp(80)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(25)
@@ -148,7 +148,7 @@ BoxLayout:
                 font_size: '12sp'
                 halign: 'left'
                 text_size: self.size
-            
+
             Slider:
                 id: min_overscroll_slider
                 min: 0.0
@@ -158,20 +158,20 @@ BoxLayout:
                 size_hint_y: None
                 height: dp(30)
                 on_value: app.update_min_overscroll(self.value)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(20)
                 text: 'Threshold for activating overscroll'
                 font_size: '9sp'
                 color: 0.7, 0.7, 0.7, 1
-        
+
         # Friction (inherited from KineticEffect)
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: dp(80)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(25)
@@ -179,7 +179,7 @@ BoxLayout:
                 font_size: '12sp'
                 halign: 'left'
                 text_size: self.size
-            
+
             Slider:
                 id: friction_slider
                 min: 0.01
@@ -189,20 +189,20 @@ BoxLayout:
                 size_hint_y: None
                 height: dp(30)
                 on_value: app.update_friction(self.value)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(20)
                 text: 'Deceleration rate (momentum scrolling)'
                 font_size: '9sp'
                 color: 0.7, 0.7, 0.7, 1
-        
+
         # Min Velocity (inherited from KineticEffect)
         BoxLayout:
             orientation: 'vertical'
             size_hint_y: None
             height: dp(80)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(25)
@@ -210,7 +210,7 @@ BoxLayout:
                 font_size: '12sp'
                 halign: 'left'
                 text_size: self.size
-            
+
             Slider:
                 id: min_velocity_slider
                 min: 0.1
@@ -220,14 +220,14 @@ BoxLayout:
                 size_hint_y: None
                 height: dp(30)
                 on_value: app.update_min_velocity(self.value)
-            
+
             Label:
                 size_hint_y: None
                 height: dp(20)
                 text: 'Higher = stops earlier (more abrupt), Lower = slow creep'
                 font_size: '9sp'
                 color: 0.7, 0.7, 0.7, 1
-        
+
         # Calculated critical damping display
         Label:
             size_hint_y: None
@@ -235,7 +235,7 @@ BoxLayout:
             text: f'Critical Damping: {app.critical_damping:.2f}'
             font_size: '11sp'
             color: 0.3, 1.0, 0.3, 1
-        
+
         # Reset button
         Button:
             size_hint_y: None
@@ -244,15 +244,15 @@ BoxLayout:
             font_size: '12sp'
             bold: True
             on_press: app.reset_defaults()
-        
+
         # Spacer
         Widget:
-    
+
     # Right side - ScrollView with test content
     BoxLayout:
         orientation: 'vertical'
         size_hint_x: 0.6
-        
+
         Label:
             size_hint_y: None
             height: dp(40)
@@ -260,7 +260,7 @@ BoxLayout:
             font_size: '16sp'
             bold: True
             color: 0.3, 0.8, 1.0, 1
-        
+
         ScrollView:
             id: test_scroll
             do_scroll_x: False
@@ -268,7 +268,7 @@ BoxLayout:
             scroll_type: ['bars', 'content']
             bar_width: dp(10)
             bar_color: 0.3, 0.8, 1.0, 0.8
-            
+
             BoxLayout:
                 id: scroll_content
                 orientation: 'vertical'
@@ -325,7 +325,7 @@ class DampedScrollEffectTuningApp(App):
         '''Store reference to the Y effect for updates.'''
         self.effect = self.scroll_view.effect_y
         print(f"\nEffect stored: {type(self.effect).__name__}")
-        print(f"Initial parameters:")
+        print("Initial parameters:")
         print(f"  - rubber_band_coeff: {self.effect.rubber_band_coeff}")
         print(f"  - spring_stiffness: {self.effect.spring_stiffness}")
         print(f"  - spring_mass: {self.effect.spring_mass}")

--- a/kivy/effects/dampedscroll.py
+++ b/kivy/effects/dampedscroll.py
@@ -66,31 +66,31 @@ class DampedScrollEffect(ScrollEffect):
 
     rubber_band_coeff = NumericProperty(0.55)
     '''Rubber band resistance coefficient. Higher values = less resistance.
-    
+
     Flutter/iOS typically use ~0.55. Lower values (0.3-0.4) feel stiffer,
     higher values (0.6-0.8) feel more elastic.
-    
+
     :attr:`rubber_band_coeff` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 0.55.
     '''
 
     spring_mass = NumericProperty(1.0)
     '''Mass for spring simulation (affects bounce-back speed).
-    
+
     :attr:`spring_mass` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 1.0.
     '''
 
     spring_stiffness = NumericProperty(100.0)
     '''Stiffness for spring simulation (affects bounce-back speed).
-    
+
     :attr:`spring_stiffness` is a :class:`~kivy.properties.NumericProperty` and
     defaults to 100.0.
     '''
 
     min_overscroll = NumericProperty(.5)
     '''An overscroll less than this amount will be normalized to 0.
-    
+
     :attr:`min_overscroll` is a :class:`~kivy.properties.NumericProperty` and
     defaults to .5.
     '''


### PR DESCRIPTION
## Replace DampedScrollEffect with Critically Damped Implementation

### Summary

This PR addresses the numeric instability issues in Kivy's `DampedScrollEffect` by replacing the underdamped spring physics with a critically damped system that prevents oscillation while maintaining a natural, iOS/Flutter-like scroll feel.

### Problem

The current `DampedScrollEffect` suffers from numeric instability that causes oscillation at certain parameter values.
This causes two minor problems: 
1) The scrollbar will remain highlighted
2) power is wasted


### Solution

Replaced with a **critically damped spring implementation** (ξ = 1.0) inspired by iOS UIScrollView and Flutter's BouncingScrollPhysics:

**Key improvements:**
- **Critical damping formula**: `damping = 2 × √(stiffness × mass)` - automatically calculated to prevent oscillation
- **Logarithmic resistance**: During drag, resistance increases naturally (rubber band feel)
- **Guaranteed stability**: Mathematically impossible to oscillate regardless of parameter values
- **Frame-rate independent**: Robust at any FPS

### Changes

1. **New implementation** with improved physics model:
   - Critically damped spring for bounce-back
   - Logarithmic resistance function for overscroll drag
   - Semi-implicit integration for better stability

2. **Tunable parameters**:
   - `rubber_band_coeff` (0.55 default): Controls overscroll resistance
   - `spring_stiffness` (100.0 default): Controls bounce-back speed
   - `spring_mass` (1.0 default): Controls momentum weight
   - All inherited parameters from `KineticEffect` (friction, min_velocity, etc.)

3. **Interactive tuning demo** (`scrollview_damped_effect_tuning.py`):
   - Live parameter adjustment with sliders
   - Added to kivy-examples

### Backward Compatibility
The attributes have changed from the previous version introduced in version 1.7.0

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
