### PR TITLE
Fix reversed state and disabled images for Button and ToggleButton styles in style.kv

### DIFF
--- a/kivy/data/style.kv
+++ b/kivy/data/style.kv
@@ -10,8 +10,8 @@
             pos: int(self.center_x - self.texture_size[0] / 2.), int(self.center_y - self.texture_size[1] / 2.)
 
 <-Button,-ToggleButton>:
-    state_image: self.background_normal if self.pressed else self.background_down
-    disabled_image: self.background_disabled_normal if self.pressed else self.background_disabled_down
+    state_image: self.background_down if self.pressed else self.background_normal
+    disabled_image: self.background_disabled_down if self.pressed else self.background_disabled_normal
     canvas:
         Color:
             rgba: self.background_color


### PR DESCRIPTION
This pull request updates the button styling logic in the `kivy/data/style.kv` file to correct the image selection for different button states. The main change is to ensure that the appropriate background images are displayed when buttons are pressed or disabled.

Button state logic fixes:

* The `state_image` property now shows `background_down` when the button is pressed and `background_normal` otherwise, correcting the previous logic.
* The `disabled_image` property now shows `background_disabled_down` when pressed and `background_disabled_normal` otherwise, ensuring disabled buttons display the correct image.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
