### PR TITLE
EventManager: Remove "Experimental" warnings from classes related to the event manager

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -1033,9 +1033,8 @@ class WindowBase(EventDispatcher):
 
     .. versionadded:: 2.1.0
 
-    .. warning::
-        This is an experimental property and it remains so while this warning
-        is present.
+    .. versionchanged:: 3.0.0
+        Removed "Experimental" warning.
     '''
 
     event_managers_dict = None
@@ -1050,9 +1049,8 @@ class WindowBase(EventDispatcher):
 
     .. versionadded:: 2.1.0
 
-    .. warning::
-        This is an experimental property and it remains so while this warning
-        is present.
+    .. versionchanged:: 3.0.0
+        Removed "Experimental" warning.
     '''
 
     trigger_create_window = None
@@ -1231,10 +1229,8 @@ class WindowBase(EventDispatcher):
 
         .. versionadded:: 2.1.0
 
-        .. warning::
-            This is an experimental method and it remains so until this warning
-            is present as it can be changed or removed in the next versions of
-            Kivy.
+        .. versionchanged:: 3.0.0
+            Removed "Experimental" warning.
         '''
         self.event_managers.insert(0, manager)
         for type_id in manager.type_ids:
@@ -1248,10 +1244,8 @@ class WindowBase(EventDispatcher):
 
         .. versionadded:: 2.1.0
 
-        .. warning::
-            This is an experimental method and it remains so until this warning
-            is present as it can be changed or removed in the next versions of
-            Kivy.
+        .. versionchanged:: 3.0.0
+            Removed "Experimental" warning.
         '''
         self.event_managers.remove(manager)
         for type_id in manager.type_ids:

--- a/kivy/eventmanager/__init__.py
+++ b/kivy/eventmanager/__init__.py
@@ -2,15 +2,13 @@
 Event Manager
 =============
 
+.. versionadded:: 2.1.0
+
 The :class:`EventManagerBase` is the abstract class intended for specific
 implementation of dispatching motion events
 (instances of :class:`~kivy.input.motionevent.MotionEvent`) to widgets through
 :meth:`~kivy.uix.widget.Widget.on_motion` method of the
 :class:`~kivy.uix.widget.Widget` class.
-
-.. warning::
-    This feature is experimental and it remains so while this warning is
-    present.
 
 Manager is a layer between the window and its widgets.
 :class:`~kivy.core.window.WindowBase` will forward all the events it receives
@@ -89,6 +87,9 @@ Currently there are three dispatch modes (behaviors) recognized by the
 
 Note that window does not have a `motion_filter` property and therefore does
 not have a list of filtered widgets from its `children` list.
+
+.. versionchanged:: 3.0.0
+    Removed "Experimental" warning.
 '''
 
 MODE_DEFAULT_DISPATCH = 'default'

--- a/kivy/input/motionevent.py
+++ b/kivy/input/motionevent.py
@@ -205,17 +205,22 @@ class MotionEvent(MotionEventBase):
         #: True if the MotionEvent is a touch.
         self.is_touch = is_touch
 
-        #: (Experimental) String to identify event type.
+        #: String to identify event type.
         #:
         #: .. versionadded:: 2.1.0
+        #:
+        #: .. versionchanged:: 3.0.0
+        #:    Removed "Experimental" warning.
         self.type_id = type_id
 
-        #: (Experimental) Used by a event manager or a widget to assign
-        #: the dispatching mode. Defaults to
-        #: :const:`~kivy.eventmanager.MODE_DEFAULT_DISPATCH`. See
+        #: Used by an event manager or a widget to assign the dispatching mode.
+        #: Defaults to :const:`~kivy.eventmanager.MODE_DEFAULT_DISPATCH`. See
         #: :mod:`~kivy.eventmanager` for available modes.
         #:
         #: .. versionadded:: 2.1.0
+        #:
+        #: .. versionchanged:: 3.0.0
+        #:    Removed "Experimental" warning.
         self.dispatch_mode = MODE_DEFAULT_DISPATCH
 
         #: Attributes to push by default, when we use :meth:`push` : x, y, z,

--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -542,9 +542,8 @@ class Widget(WidgetBase):
 
         .. versionadded:: 2.1.0
 
-        .. warning::
-            This is an experimental method and it remains so while this warning
-            is present.
+        .. versionchanged:: 3.0.0
+            Removed "Experimental" warning.
         '''
         if self.disabled or me.dispatch_mode == MODE_DONT_DISPATCH:
             return
@@ -786,12 +785,11 @@ class Widget(WidgetBase):
 
         .. versionadded:: 2.1.0
 
+        .. versionchanged:: 3.0.0
+            Removed "Experimental" warning.
+
         .. note::
             Method can be called multiple times with the same arguments.
-
-        .. warning::
-            This is an experimental method and it remains so while this warning
-            is present.
         '''
         a_widget = widget or self
         motion_filter = self.motion_filter
@@ -812,12 +810,11 @@ class Widget(WidgetBase):
 
         .. versionadded:: 2.1.0
 
+        .. versionchanged:: 3.0.0
+            Removed "Experimental" warning.
+
         .. note::
             Method can be called multiple times with the same arguments.
-
-        .. warning::
-            This is an experimental method and it remains so while this warning
-            is present.
         '''
         a_widget = widget or self
         motion_filter = self.motion_filter
@@ -1623,7 +1620,6 @@ class Widget(WidgetBase):
 
     .. versionadded:: 2.1.0
 
-    .. warning::
-        This is an experimental property and it remains so while this warning
-        is present.
+    .. versionchanged:: 3.0.0
+        Removed "Experimental" warning.
     '''


### PR DESCRIPTION
This pull request removes "Experimental" warnings introduced by the event manager feature https://github.com/kivy/kivy/pull/7658.

"Experimental" warnings should be removed before the `hover` feature is re-integrated into Kivy https://github.com/kivy/kivy/issues/9236. This request should be merged after the request https://github.com/kivy/kivy/pull/9237.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
