### PR TITLE
Fix double dispatch on disable

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -1573,7 +1573,6 @@ class Widget(WidgetBase):
                 self.inc_disabled()
             else:
                 self.dec_disabled()
-            return True
 
     def inc_disabled(self, count=1):
         self._disabled_count += count


### PR DESCRIPTION
This fixes the double dispatch on disable as reported in issue: #9230 
The alias property setter was returning True causing a dispatch.  The dispatch is already provided programmatically, causing a double dispatch. 

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
