### PR TITLE
Fix pytest 9 compatibility

### DIFF
--- a/kivy/tests/common.py
+++ b/kivy/tests/common.py
@@ -549,7 +549,7 @@ def async_run(func=None, app_cls_func=None):
         if kivy_eventloop == 'asyncio':
             try:
                 import pytest_asyncio
-                return pytest.mark.asyncio(pytest_asyncio.fixture(func))
+                return pytest.mark.asyncio(func)
             except ImportError:
                 return pytest.mark.skip(
                     reason='KIVY_EVENTLOOP == "asyncio" but '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires = [
 [tool.pytest.ini_options]
 addopts = "--benchmark-skip --benchmark-warmup=on --benchmark-warmup-iterations=5 --benchmark-disable-gc --benchmark-name=short --benchmark-sort=mean --benchmark-group-by=fullfunc --benchmark-storage=.benchmarks-kivy --benchmark-save=kivy"
 markers = "incremental: mark a test as incremental."
+asyncio_mode = "auto"
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
Fix pytest 9 compatibility when building for openSUSE by adding asyncio_mode = "auto" to pyproject.toml and updating the common test, because pytest 9 changed its default asyncio handling which caused tests to fail