### PR TITLE
update user_data_dir, create user_cache_dir, Move Kivy configuration to app-specific directories for desktop OS, 

### DIFF
--- a/kivy/core/window/_window_sdl3.pyx
+++ b/kivy/core/window/_window_sdl3.pyx
@@ -14,8 +14,17 @@ from kivy.graphics.egl_backend.egl_angle cimport EGLANGLE
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 
-if not environ.get('KIVY_DOC_INCLUDE'):
+# Will be initialized after Config is ready
+is_desktop = False
+
+def _init_is_desktop():
+    '''Initialize is_desktop from Config after it's ready.'''
+    global is_desktop
     is_desktop = Config.get('kivy', 'desktop') == '1'
+
+# Register callback (skip during documentation generation)
+if not environ.get('KIVY_DOC_INCLUDE'):
+    Config.on_config_ready(_init_is_desktop)
 
 from .window_info cimport (
     WindowInfoiOS,

--- a/kivy/graphics/cgl.pyx
+++ b/kivy/graphics/cgl.pyx
@@ -61,9 +61,12 @@ def _update_verify_gl_main_thread(*args):
     global verify_gl_main_thread
     verify_gl_main_thread = Config.getboolean('graphics', 'verify_gl_main_thread')
 
-if not environ.get('KIVY_DOC_INCLUDE'):
+def _init_verify_gl_main_thread():
     Config.add_callback(_update_verify_gl_main_thread, 'graphics', 'verify_gl_main_thread')
     _update_verify_gl_main_thread()
+
+if not environ.get('KIVY_DOC_INCLUDE'):
+    Config.on_config_ready(_init_verify_gl_main_thread)
 
 
 cpdef cgl_get_initialized_backend_name():

--- a/kivy/input/postproc/dejitter.py
+++ b/kivy/input/postproc/dejitter.py
@@ -36,10 +36,18 @@ class InputPostprocDejitter(object):
     '''
 
     def __init__(self):
-        self.jitterdist = Config.getfloat('postproc', 'jitter_distance')
-        ignore_devices = Config.get('postproc', 'jitter_ignore_devices')
-        self.ignore_devices = ignore_devices.split(',')
+        # Set defaults (will be updated when Config is ready)
+        self.jitterdist = 0.004
+        self.ignore_devices = ['mouse', 'mactouch']
         self.last_touches = {}
+        # Register callback to update from Config when ready
+        Config.on_config_ready(self._init_from_config)
+
+    def _init_from_config(self):
+        '''Update settings from Config after it's ready.'''
+        self.jitterdist = Config.getfloat('postproc', 'jitter_distance')
+        ignore_devices_str = Config.get('postproc', 'jitter_ignore_devices')
+        self.ignore_devices = ignore_devices_str.split(',')
 
     def taxicab_distance(self, p, q):
         # Get the taxicab/manhattan/citiblock distance for efficiency reasons

--- a/kivy/input/postproc/doubletap.py
+++ b/kivy/input/postproc/doubletap.py
@@ -26,11 +26,19 @@ class InputPostprocDoubleTap(object):
     '''
 
     def __init__(self):
-        dist = Config.getint('postproc', 'double_tap_distance')
-        self.double_tap_distance = dist / 1000.0
-        tap_time = Config.getint('postproc', 'double_tap_time')
-        self.double_tap_time = tap_time / 1000.0
+        # Set defaults (will be updated when Config is ready)
+        self.double_tap_distance = 20 / 1000.0
+        self.double_tap_time = 250 / 1000.0
         self.touches = {}
+        # Register callback to update from Config when ready
+        Config.on_config_ready(self._init_from_config)
+
+    def _init_from_config(self):
+        '''Update settings from Config after it's ready.'''
+        distance = Config.getint('postproc', 'double_tap_distance')
+        self.double_tap_distance = distance / 1000.0
+        time_val = Config.getint('postproc', 'double_tap_time')
+        self.double_tap_time = time_val / 1000.0
 
     def find_double_tap(self, ref):
         '''Find a double tap touch within self.touches.

--- a/kivy/input/postproc/ignorelist.py
+++ b/kivy/input/postproc/ignorelist.py
@@ -24,6 +24,13 @@ class InputPostprocIgnoreList(object):
     '''
 
     def __init__(self):
+        # Set default (will be updated when Config is ready)
+        self.ignore_list = ()
+        # Register callback to update from Config when ready
+        Config.on_config_ready(self._init_from_config)
+
+    def _init_from_config(self):
+        '''Update settings from Config after it's ready.'''
         self.ignore_list = strtotuple(Config.get('postproc', 'ignore'))
 
     def collide_ignore(self, touch):

--- a/kivy/input/postproc/retaintouch.py
+++ b/kivy/input/postproc/retaintouch.py
@@ -28,10 +28,18 @@ class InputPostprocRetainTouch(object):
     '''
 
     def __init__(self):
-        self.timeout = Config.getint('postproc', 'retain_time') / 1000.0
-        self.distance = Config.getint('postproc', 'retain_distance') / 1000.0
+        # Set defaults (will be updated when Config is ready)
+        self.timeout = 100 / 1000.0
+        self.distance = 50 / 1000.0
         self._available = []
         self._links = {}
+        # Register callback to update from Config when ready
+        Config.on_config_ready(self._init_from_config)
+
+    def _init_from_config(self):
+        '''Update settings from Config after it's ready.'''
+        self.timeout = Config.getint('postproc', 'retain_time') / 1000.0
+        self.distance = Config.getint('postproc', 'retain_distance') / 1000.0
 
     def process(self, events):
         # check if module is disabled

--- a/kivy/input/postproc/tripletap.py
+++ b/kivy/input/postproc/tripletap.py
@@ -28,11 +28,19 @@ class InputPostprocTripleTap(object):
     '''
 
     def __init__(self):
-        dist = Config.getint('postproc', 'triple_tap_distance')
-        self.triple_tap_distance = dist / 1000.0
-        time = Config.getint('postproc', 'triple_tap_time')
-        self.triple_tap_time = time / 1000.0
+        # Set defaults (will be updated when Config is ready)
+        self.triple_tap_distance = 20 / 1000.0
+        self.triple_tap_time = 250 / 1000.0
         self.touches = {}
+        # Register callback to update from Config when ready
+        Config.on_config_ready(self._init_from_config)
+
+    def _init_from_config(self):
+        '''Update settings from Config after it's ready.'''
+        distance = Config.getint('postproc', 'triple_tap_distance')
+        self.triple_tap_distance = distance / 1000.0
+        time_val = Config.getint('postproc', 'triple_tap_time')
+        self.triple_tap_time = time_val / 1000.0
 
     def find_triple_tap(self, ref):
         '''Find a triple tap touch within *self.touches*.

--- a/kivy/logger.py
+++ b/kivy/logger.py
@@ -570,6 +570,10 @@ Logger = logging.getLogger('kivy')
 Logger.logfile_activated = None
 Logger.trace = partial(Logger.log, logging.TRACE)
 
+# Set default log level to INFO (will be updated from Config after it loads)
+# This prevents TRACE/DEBUG spam during early import before Config is ready
+Logger.setLevel(logging.INFO)
+
 file_log_handler = (
     FileHandler()
     if 'KIVY_NO_FILELOG' not in os.environ

--- a/kivy/modules/__init__.py
+++ b/kivy/modules/__init__.py
@@ -293,8 +293,8 @@ class ModuleBase:
 
 Modules = ModuleBase()
 Modules.add_path(kivy.kivy_modules_dir)
-if 'KIVY_DOC' not in os.environ:
-    Modules.add_path(kivy.kivy_usermodules_dir)
+# Note: kivy.kivy_usermodules_dir is added later in App._init_config()
+# after the path has been determined based on the app name
 
 if __name__ == '__main__':
     print(Modules.list())

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -783,11 +783,20 @@ implementation_map = {
     "urllib": UrlRequestUrllib,
 }
 
-if not os.environ.get("KIVY_DOC_INCLUDE"):
+# Will be initialized after Config is ready
+prefered_implementation = "default"
+UrlRequest = None
+
+def _init_url_implementation():
+    '''Initialize preferred URL implementation from Config after it's ready.'''
+    global prefered_implementation, UrlRequest
     prefered_implementation = Config.getdefault(
         "network", "implementation", "default"
     )
-else:
-    prefered_implementation = "default"
+    UrlRequest = implementation_map.get(prefered_implementation)
 
-UrlRequest = implementation_map.get(prefered_implementation)
+# Register callback (skip during documentation generation)
+if not os.environ.get("KIVY_DOC_INCLUDE"):
+    Config.on_config_ready(_init_url_implementation)
+else:
+    UrlRequest = implementation_map.get(prefered_implementation)

--- a/kivy/tests/conftest.py
+++ b/kivy/tests/conftest.py
@@ -5,7 +5,7 @@ kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
 
 try:
     from .fixtures import kivy_app, kivy_clock, kivy_metrics, \
-        kivy_exception_manager
+        kivy_exception_manager, kivy_init
 except (SyntaxError, ImportError):
     # async app tests would be skipped due to async_run forcing it to skip so
     # it's ok to fail here as it won't be used anyway

--- a/kivy/tests/test_uix_settings.py
+++ b/kivy/tests/test_uix_settings.py
@@ -6,7 +6,7 @@ from kivy.config import ConfigParser
 from kivy.uix.settings import Settings
 
 
-def test_settings_create_json_panel_errors():
+def test_settings_create_json_panel_errors(kivy_init):
     config = ConfigParser()
 
     with pytest.raises(

--- a/kivy/uix/actionbar.py
+++ b/kivy/uix/actionbar.py
@@ -53,11 +53,20 @@ from kivy.properties import ObjectProperty, NumericProperty, BooleanProperty, \
 from kivy.metrics import sp
 from kivy.lang import Builder
 from functools import partial
+from os import environ
 
 
+# Will be initialized after Config is ready
 window_icon = ''
-if Config:
+
+def _init_window_icon():
+    '''Initialize window_icon from Config after it's ready.'''
+    global window_icon
     window_icon = Config.get('kivy', 'window_icon')
+
+# Register callback (skip during documentation generation)
+if 'KIVY_DOC_INCLUDE' not in environ:
+    Config.on_config_ready(_init_window_icon)
 
 
 class ActionBarException(Exception):

--- a/kivy/uix/behaviors/compoundselection.py
+++ b/kivy/uix/behaviors/compoundselection.py
@@ -130,13 +130,20 @@ from time import time
 from os import environ
 
 from kivy.properties import NumericProperty, BooleanProperty, ListProperty
+from kivy.config import Config
 
 
-if 'KIVY_DOC' not in environ:
-    from kivy.config import Config
+# Will be initialized after Config is ready
+_is_desktop = False
+
+def _init_is_desktop():
+    '''Initialize _is_desktop from Config after it's ready.'''
+    global _is_desktop
     _is_desktop = Config.getboolean('kivy', 'desktop')
-else:
-    _is_desktop = False
+
+# Register callback (skip during documentation generation)
+if 'KIVY_DOC_INCLUDE' not in environ:
+    Config.on_config_ready(_init_is_desktop)
 
 
 class CompoundSelectionBehavior(object):

--- a/kivy/uix/behaviors/drag.py
+++ b/kivy/uix/behaviors/drag.py
@@ -48,17 +48,25 @@ The following example creates a draggable label::
 
 __all__ = ('DragBehavior', )
 
+import os
 from kivy.clock import Clock
 from kivy.properties import NumericProperty, ReferenceListProperty
 from kivy.config import Config
 from kivy.metrics import sp
 from functools import partial
 
-# When we are generating documentation, Config doesn't exist
+# Will be initialized after Config is ready
 _scroll_timeout = _scroll_distance = 0
-if Config:
+
+def _init_scroll_settings():
+    '''Initialize scroll settings from Config after it's ready.'''
+    global _scroll_timeout, _scroll_distance
     _scroll_timeout = Config.getint('widgets', 'scroll_timeout')
     _scroll_distance = Config.getint('widgets', 'scroll_distance')
+
+# Register callback (skip during documentation generation)
+if 'KIVY_DOC_INCLUDE' not in os.environ:
+    Config.on_config_ready(_init_scroll_settings)
 
 
 class DragBehavior(object):

--- a/kivy/uix/behaviors/focus.py
+++ b/kivy/uix/behaviors/focus.py
@@ -80,17 +80,25 @@ documentation.
 
 __all__ = ('FocusBehavior', )
 
+from os import environ
 from kivy.properties import OptionProperty, ObjectProperty, BooleanProperty, \
     AliasProperty
 from kivy.config import Config
 from kivy.base import EventLoop
 
-# When we are generating documentation, Config doesn't exist
+# Will be initialized after Config is ready
 _is_desktop = False
 _keyboard_mode = 'system'
-if Config:
+
+def _init_focus_behavior():
+    '''Initialize focus behavior settings from Config after it's ready.'''
+    global _is_desktop, _keyboard_mode
     _is_desktop = Config.getboolean('kivy', 'desktop')
     _keyboard_mode = Config.get('kivy', 'keyboard_mode')
+
+# Register callback (skip during documentation generation)
+if 'KIVY_DOC_INCLUDE' not in environ:
+    Config.on_config_ready(_init_focus_behavior)
 
 
 class FocusBehavior(object):

--- a/kivy/uix/scrollview.py
+++ b/kivy/uix/scrollview.py
@@ -239,6 +239,7 @@ Those only control touch and touchpad gesture behavior.
 
 __all__ = ("ScrollView",)
 
+import os
 from functools import partial
 from math import isclose
 from enum import Enum
@@ -468,16 +469,23 @@ class ScrollViewHierarchy:
 # within this threshold of the minimum (0.0) or maximum (1.0) position.
 # Used for parallel nested scrolling to determine when to delegate
 # to outer ScrollView.
-# Note: Set to 15% to account for elastic overscroll bounce-back
+# Note: Set to 5% to account for elastic overscroll bounce-back
 _BOUNDARY_THRESHOLD = 0.05  # 5% from edge
 
-# When we are generating documentation, Config doesn't exist
+# Will be initialized after Config is ready
 _scroll_timeout = _scroll_distance = 0
-if Config:
+
+def _init_scroll_settings():
+    '''Initialize scroll settings from Config after it's ready.'''
+    global _scroll_timeout, _scroll_distance
     _scroll_timeout = Config.getint("widgets", "scroll_timeout")
     _scroll_distance = "{}sp".format(
         Config.getint("widgets", "scroll_distance")
     )
+
+# Register callback (skip during documentation generation)
+if 'KIVY_DOC_INCLUDE' not in os.environ:
+    Config.on_config_ready(_init_scroll_settings)
 
 
 class ScrollView(StencilView):

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -231,14 +231,21 @@ _textinput_list = []
 # cache the result
 _is_osx = sys.platform == 'darwin'
 
-# When we are generating documentation, Config doesn't exist
+# Will be initialized after Config is ready
 _is_desktop = False
 _scroll_timeout = _scroll_distance = 0
-if Config:
+
+def _init_textinput_settings():
+    '''Initialize textinput settings from Config after it's ready.'''
+    global _is_desktop, _scroll_timeout, _scroll_distance
     _is_desktop = Config.getboolean('kivy', 'desktop')
     _scroll_timeout = Config.getint('widgets', 'scroll_timeout')
     _scroll_distance = '{}sp'.format(Config.getint('widgets',
                                                    'scroll_distance'))
+
+# Register callback (skip during documentation generation)
+if 'KIVY_DOC_INCLUDE' not in environ:
+    Config.on_config_ready(_init_textinput_settings)
 
 # register an observer to clear the textinput cache when OpenGL will reload
 if 'KIVY_DOC' not in environ:


### PR DESCRIPTION
This PR is a response to #8571 
The scope of the changes:
The `user_data_dir` is update for Linux, correcting the path.
The `user_cache_data_dir` is created for all platforms.
On Desktop OS, the .kivy directory is now in a app specific path, rather that the global ` ~/.kivy/`

Kivy now isolates configuration, logs, and user modules per application instead of sharing ~/.kivy/ globally. This improves security, enables per-app settings, and follows platform conventions for data storage.
Note that while in development, if under a venv, the `.kivy' dir will be located in the main project dir.

Details:
Config and Clock initialization is deferred until App.__init__() to access the app name for directory paths. A lazy proxy pattern with callbacks ensures backward compatibility for modules accessing Config at import time.

Key changes:
- ConfigProxy and ClockProxy defer initialization until App.__init__()
- Config.on_config_ready() callback mechanism for early module access
- App-specific paths: user_data_dir/<AppName>/.kivy/config.ini
- New App.user_cache_dir property for temporary/cache data
- Fixed Linux XDG compliance (use XDG_DATA_HOME, not XDG_CONFIG_HOME)
- Default logger level set to INFO before Config loads

Breaking changes:
- Desktop apps: config.ini moves from ~/.kivy/ to app-specific location
- No automatic migration; users can set KIVY_HOME for compatibility
- Modules importing Config at top-level must use callbacks to know when the config is initialized

Migration guide updated with detailed instructions for users and framework developers.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
