### PR TITLE
Add example and documentation for app-specific KIVY_HOME for desktop platforms

### DIFF
--- a/doc/sources/guide/config.rst
+++ b/doc/sources/guide/config.rst
@@ -74,6 +74,33 @@ or before each run of the application change it manually in the console:
 After the change of ``KIVY_HOME``, the folder will behave exactly the same
 as the default ``.kivy/`` folder mentioned above.
 
+App-Specific Configuration
+---------------------------
+
+For production desktop applications, it's recommended to use app-specific
+configuration directories rather than the shared ``~/.kivy`` directory.
+This ensures each application has isolated configuration, logs, and modules.
+
+The recommended approach is to set ``KIVY_HOME`` to ``<App.user_data_dir>/.kivy``
+before importing Kivy. This follows platform conventions:
+
+- Windows: ``%APPDATA%\<appname>\.kivy``
+- macOS: ``~/Library/Application Support/<appname>/.kivy``
+- Linux: ``~/.local/share/<appname>/.kivy``
+
+**Important**: ``KIVY_HOME`` must be set **before** importing any Kivy modules,
+as Kivy reads this variable during initialization.
+
+See ``examples/kivy_home/`` for a complete, ready-to-use implementation that
+handles platform detection and path configuration automatically. Simply copy
+``set_kivy_home.py`` to your project and call it before importing Kivy::
+
+    from set_kivy_home import set_app_name
+    set_app_name('MyApp')  # Must be before kivy import
+    
+    from kivy.app import App
+    # Now Kivy uses app-specific configuration
+
 Understanding config tokens
 ---------------------------
 

--- a/doc/sources/guide/environment.rst
+++ b/doc/sources/guide/environment.rst
@@ -32,7 +32,7 @@ KIVY_MODULES_DIR
 
 KIVY_HOME
     Location of the Kivy home. This directory is used for local configuration,
-    and must be in a writable location.
+    logs, and modules, and must be in a writable location.
 
     Defaults to:
      - Desktop: `<user home>/.kivy`
@@ -40,6 +40,25 @@ KIVY_HOME
      - iOS: `<user home>/Documents/.kivy`
 
     .. versionadded:: 1.9.0
+
+    **App-Specific Configuration (Desktop Platforms)**
+
+    By default on desktop platforms, all Kivy applications share the same
+    `~/.kivy` directory. For production applications, it's recommended to
+    set KIVY_HOME to an app-specific directory to ensure isolated configuration,
+    logs, and modules.
+
+    Best practice: Set KIVY_HOME to `<App.user_data_dir>/.kivy` before importing
+    Kivy. This follows platform conventions and ensures each application has its
+    own configuration environment.
+
+    See the example in `examples/kivy_home/` for a ready-to-use implementation
+    that sets KIVY_HOME based on your application name and platform conventions.
+
+    Example paths when KIVY_HOME is set app-specifically:
+     - Windows: `%APPDATA%\<appname>\.kivy`
+     - macOS: `~/Library/Application Support/<appname>/.kivy`
+     - Linux: `~/.local/share/<appname>/.kivy` (or `$XDG_DATA_HOME/<appname>/.kivy`)
 
 KIVY_SDL3_PATH
     If set, the SDL3 libraries and headers from this path are used when

--- a/examples/kivy_home/README.txt
+++ b/examples/kivy_home/README.txt
@@ -1,0 +1,99 @@
+App-Specific KIVY_HOME Configuration
+=====================================
+
+Overview
+--------
+This example demonstrates how to configure KIVY_HOME for app-specific 
+configuration directories. By default, Kivy stores configuration, logs, 
+and modules in a shared ~/.kivy directory. This example shows how to 
+give each application its own isolated environment.
+
+
+When to Use This
+----------------
+Use this approach when:
+
+1. Developing multiple Kivy applications on the same system
+   - Each app needs separate configuration
+   - Prevents configuration conflicts between apps
+
+2. Deploying desktop applications
+   - Professional apps should have isolated settings
+   - Follows platform conventions (AppData, Application Support, etc.)
+
+3. Testing and development
+   - Test with clean configuration without affecting other apps
+   - Easy to reset settings (just delete app-specific directory)
+
+
+How It Works
+------------
+1. set_app_name() is called BEFORE importing Kivy
+2. KIVY_HOME environment variable is set to: <user_data_dir>/.kivy
+3. Kivy reads KIVY_HOME and stores config/logs there
+4. Each app gets its own isolated directory structure
+
+
+Directory Structure
+-------------------
+After calling set_app_name('MyApp'), you'll get:
+
+Windows:
+    %APPDATA%/myapp/.kivy/config.ini
+    %APPDATA%/myapp/.kivy/logs/
+
+macOS:
+    ~/Library/Application Support/myapp/.kivy/config.ini
+    ~/Library/Application Support/myapp/.kivy/logs/
+
+Linux:
+    ~/.local/share/myapp/.kivy/config.ini
+    ~/.local/share/myapp/.kivy/logs/
+
+
+Usage in Your App
+-----------------
+Copy set_kivy_home.py to your project and use it like this:
+
+    from set_kivy_home import set_app_name  # BEFORE kivy import!
+    set_app_name('MyApp')
+    
+    from kivy.app import App  # Now Kivy uses app-specific paths
+    
+    class MyApp(App):
+        pass
+    
+    MyApp().run()
+
+
+Important Notes
+---------------
+- set_app_name() MUST be called before importing ANY Kivy modules
+- If KIVY_HOME is already set (env variable), this does nothing
+- On mobile (iOS/Android), this does nothing (already app-specific)
+- App name is normalized: lowercase, 'app' suffix removed
+- The .kivy directory is created automatically
+
+
+Relationship to user_data_dir
+------------------------------
+- App.user_data_dir: Application data storage directory
+- KIVY_HOME: Kivy framework config/logs (subdirectory of user_data_dir)
+
+Best practice: KIVY_HOME should be user_data_dir/.kivy
+This keeps all application-specific data together.
+
+
+Running the Demo
+----------------
+    python demo_app.py
+
+The demo will display all configuration paths and show that KIVY_HOME
+is properly set to an app-specific directory.
+
+
+Further Reading
+---------------
+- Kivy Configuration: https://kivy.org/doc/stable/guide/config.html
+- Environment Variables: https://kivy.org/doc/stable/guide/environment.html
+- App.user_data_dir: https://kivy.org/doc/stable/api-kivy.app.html

--- a/examples/kivy_home/demo_app.py
+++ b/examples/kivy_home/demo_app.py
@@ -1,0 +1,126 @@
+"""
+Demo: App-Specific KIVY_HOME Configuration
+===========================================
+
+This example demonstrates how to set KIVY_HOME to an app-specific directory
+BEFORE importing Kivy. This ensures your application has isolated configuration,
+logs, and cache directories.
+
+Key Points:
+    1. set_app_name() must be called BEFORE importing kivy
+    2. KIVY_HOME will be set to: <user_data_dir>/.kivy
+    3. Config, logs, and modules will be stored there
+    4. Each app gets its own isolated environment
+
+Try running this multiple times with different app names to see separate
+configurations created.
+"""
+
+# CRITICAL: Import and call set_app_name BEFORE importing kivy
+from set_kivy_home import set_app_name
+
+set_app_name('KivyHomeDemo')
+
+# Now safe to import Kivy
+import os
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.properties import StringProperty
+
+
+kv = """
+BoxLayout:
+    orientation: 'vertical'
+    padding: '20dp'
+    spacing: '10dp'
+
+    Label:
+        text: 'App-Specific KIVY_HOME Demo'
+        size_hint_y: None
+        height: '48dp'
+        font_size: '20sp'
+        bold: True
+
+    ScrollView:
+        Label:
+            text: app.info_text
+            size_hint_y: None
+            height: self.texture_size[1]
+            text_size: self.width, None
+            halign: 'left'
+            valign: 'top'
+
+    Button:
+        text: 'Print Paths to Console'
+        size_hint_y: None
+        height: '48dp'
+        on_release: app.print_paths()
+"""
+
+
+class KivyHomeDemoApp(App):
+    info_text = StringProperty('')
+
+    def build(self):
+        return Builder.load_string(kv)
+
+    def on_start(self):
+        """Display configuration paths when app starts."""
+        kivy_home = os.environ.get('KIVY_HOME', 'Not set')
+        user_data_dir = self.user_data_dir
+        if kivy_home != 'Not set':
+            config_path = os.path.join(kivy_home, 'config.ini')
+            logs_dir = os.path.join(kivy_home, 'logs')
+        else:
+            config_path = 'N/A'
+            logs_dir = 'N/A'
+
+        self.info_text = f"""
+Configuration Paths:
+
+KIVY_HOME:
+{kivy_home}
+
+Config File:
+{config_path}
+
+Logs Directory:
+{logs_dir}
+
+App.user_data_dir:
+{user_data_dir}
+
+Notice:
+- KIVY_HOME should be under user_data_dir
+- Config, logs, and modules are stored in KIVY_HOME
+- This ensures each app has isolated settings
+- Each app gets its own directory based on its name
+
+Try This:
+1. Run this demo
+2. Change 'KivyHomeDemo' to another name in the code
+3. Run again - see separate directories created
+        """.strip()
+
+    def print_paths(self):
+        """Print paths to console for easy copy/paste."""
+        kivy_home = os.environ.get('KIVY_HOME', 'Not set')
+        if kivy_home != 'Not set':
+            config_file = os.path.join(kivy_home, 'config.ini')
+            logs_directory = os.path.join(kivy_home, 'logs')
+        else:
+            config_file = 'N/A'
+            logs_directory = 'N/A'
+
+        print("\n" + "=" * 60)
+        print("App-Specific Configuration Paths")
+        print("=" * 60)
+        print(f"KIVY_HOME:        {kivy_home}")
+        print(f"Config file:      {config_file}")
+        print(f"Logs directory:   {logs_directory}")
+        print(f"user_data_dir:    {self.user_data_dir}")
+        print("=" * 60 + "\n")
+
+
+if __name__ == '__main__':
+    KivyHomeDemoApp().run()

--- a/examples/kivy_home/set_kivy_home.py
+++ b/examples/kivy_home/set_kivy_home.py
@@ -1,0 +1,118 @@
+"""
+Set KIVY_HOME for App-Specific Configuration
+=============================================
+
+This module provides a utility to set KIVY_HOME to an app-specific directory
+before importing Kivy. This ensures each application has its own isolated
+configuration, logs, and cache directories.
+
+Usage:
+    from set_kivy_home import set_app_name  # BEFORE importing kivy
+    set_app_name('MyApp')
+
+    from kivy.app import App  # Now safe to import
+
+Platform Paths:
+    Windows: %APPDATA%/<appname>/.kivy
+    macOS: ~/Library/Application Support/<appname>/.kivy
+    Linux: $XDG_DATA_HOME/<appname>/.kivy (typically ~/.local/share/<appname>/.kivy)
+
+Note:
+    This must be called BEFORE importing any kivy modules, otherwise
+    RuntimeError will be raised.
+"""
+
+from os import environ
+import sys
+from sys import platform as _sys_platform
+from pathlib import Path
+
+
+def _get_platform():
+    """Get the current platform (from kivy.utils)."""
+    # On Android sys.platform returns 'linux2', so prefer to check the
+    # existence of environ variables set during Python initialization
+    kivy_build = environ.get('KIVY_BUILD', '')
+    if kivy_build in {'android', 'ios'}:
+        return kivy_build
+    elif 'P4A_BOOTSTRAP' in environ:
+        return 'android'
+    elif 'ANDROID_ARGUMENT' in environ:
+        # We used to use this method to detect android platform,
+        # leaving it here to be backwards compatible with `pydroid3`
+        # and similar tools outside kivy's ecosystem
+        return 'android'
+    elif _sys_platform in ('win32', 'cygwin'):
+        return 'win'
+    elif _sys_platform == 'darwin':
+        return 'macosx'
+    elif _sys_platform.startswith('linux'):
+        return 'linux'
+    elif _sys_platform.startswith('freebsd'):
+        return 'linux'
+    return 'unknown'
+
+
+def set_app_name(app_name):
+    """
+    Set the app name for desktop platforms to configure KIVY_HOME.
+
+    This function sets KIVY_HOME to an app-specific directory based on
+    platform conventions. It must be called BEFORE importing any Kivy modules.
+
+    Args:
+        app_name (str): The name of your application. The name will be
+            normalized (lowercased, 'app' suffix stripped) to match
+            App.user_data_dir behavior.
+
+    Raises:
+        RuntimeError: If kivy.config has already been imported.
+        ValueError: If the platform is unknown.
+
+    Example:
+        >>> from set_kivy_home import set_app_name
+        >>> set_app_name('MyApp')
+        >>> from kivy.app import App
+        >>> # KIVY_HOME is now set to app-specific directory
+
+    Note:
+        - If KIVY_HOME is already set, this function does nothing
+        - On mobile platforms (iOS, Android), this function does nothing
+        - The .kivy directory will be created if it doesn't exist
+    """
+    platform = _get_platform()
+
+    # Skip if KIVY_HOME already set or on mobile platforms
+    if environ.get('KIVY_HOME', None) or platform in ('ios', 'android'):
+        return
+
+    # Check that Config hasn't been imported yet
+    if 'kivy.config' in sys.modules:
+        raise RuntimeError(
+            "Config has already been imported. "
+            "set_app_name must execute before kivy.config to ensure "
+            "proper initialization order."
+        )
+
+    # Normalize app name (lowercase, strip 'app' suffix)
+    # This matches the behavior of App.user_data_dir
+    name = app_name.lower()
+    name = name[:-3] if name.endswith('app') else name
+
+    # Set platform-specific path
+    if platform == 'win':
+        kivy_home = Path(environ['APPDATA']) / f'{name}/.kivy'
+    elif platform == 'macosx':
+        kivy_home = Path(f'~/Library/Application Support/{name}/.kivy')
+    elif platform == 'linux':
+        p = Path(environ.get('XDG_DATA_HOME', '~/.local/share'))
+        kivy_home = p / f'{name}/.kivy'
+    else:
+        raise ValueError(f'Unknown platform: {platform}')
+
+    # Expand ~ and create directory
+    kivy_home = kivy_home.expanduser()
+    kivy_home.mkdir(parents=True, exist_ok=True)
+
+    # Set environment variable
+    environ['KIVY_HOME'] = str(kivy_home)

--- a/kivy/app.py
+++ b/kivy/app.py
@@ -406,6 +406,41 @@ to both case.
 
 .. versionadded:: 2.0.0
 
+App-Specific KIVY_HOME Configuration
+-------------------------------------
+
+By default on desktop platforms, all Kivy applications share the same
+``~/.kivy`` directory for configuration, logs, and modules. For production
+applications, it's recommended to use app-specific directories to ensure
+isolated configuration environments.
+
+The ``KIVY_HOME`` environment variable controls where Kivy stores its
+configuration file (``config.ini``), logs, and user modules. Best practice
+is to set ``KIVY_HOME`` to ``<App.user_data_dir>/.kivy`` before importing
+Kivy, which follows platform conventions:
+
+- Windows: ``%APPDATA%\\<appname>\\.kivy``
+- macOS: ``~/Library/Application Support/<appname>/.kivy``
+- Linux: ``~/.local/share/<appname>/.kivy``
+
+**Important**: ``KIVY_HOME`` must be set **before** importing any Kivy modules,
+as it is read during Kivy's initialization.
+
+A complete, ready-to-use implementation is available in ``examples/kivy_home/``.
+Simply copy ``set_kivy_home.py`` to your project and call it before importing
+Kivy::
+
+    from set_kivy_home import set_app_name
+    set_app_name('MyApp')  # Must be before kivy import
+
+    from kivy.app import App
+    # Now Kivy uses app-specific configuration
+
+For more information, see:
+- :ref:`environment` - Environment variables documentation
+- :ref:`configure kivy` - Configuration file documentation
+- ``examples/kivy_home/`` - Complete working example
+
 '''
 
 __all__ = ('App', 'runTouchApp', 'async_runTouchApp', 'stopTouchApp')


### PR DESCRIPTION
Provides a ready-to-use implementation and example for setting KIVY_HOME to an app-specific directory before importing Kivy. This ensures each application has isolated configuration, logs, and modules rather than sharing ~/.kivy on desktop platforms.
This is related to issue #8571 

Changes:
- Add examples/kivy_home/ with set_kivy_home.py utility and demo app
- Update environment.rst to document app-specific KIVY_HOME configuration
- Update config.rst to reference the example
- Update app.py module docstring with KIVY_HOME guidance

Platform-specific paths when using app-specific KIVY_HOME:
- Windows: %APPDATA%\<appname>\.kivy
- macOS: ~/Library/Application Support/<appname>/.kivy
- Linux: ~/.local/share/<appname>/.kivy (XDG compliant)

The example includes:
- Platform detection and path generation
- App name normalization (lowercase, strip 'app' suffix)
- Runtime check to ensure KIVY_HOME is set before kivy.config import
- Complete demo app showing configuration paths
- Documentation explaining when and how to use it

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
