### PR TITLE
Fix collision check to use '<' instead of '<=' for the upper bounds

### DIFF
--- a/kivy/uix/widget.py
+++ b/kivy/uix/widget.py
@@ -494,7 +494,7 @@ class Widget(WidgetBase):
             >>> Widget(pos=(10, 10), size=(50, 50)).collide_point(40, 40)
             True
         '''
-        return self.x <= x <= self.right and self.y <= y <= self.top
+        return self.x <= x < self.right and self.y <= y < self.top
 
     def collide_widget(self, wid):
         '''


### PR DESCRIPTION
This change makes collision checking consistent between the left and bottom sides, and the right and top sides of a widget

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
