### PR TITLE
`boxshadow`: add `optimize` option

### DIFF
--- a/kivy/graphics/boxshadow.pxd
+++ b/kivy/graphics/boxshadow.pxd
@@ -14,6 +14,7 @@ cdef class BoxShadow(InstructionGroup):
     cdef tuple _border_radius
     cdef tuple _spread_radius
     cdef bint _optimize
+    cdef tuple _optimize_fbo_size
     cdef VertexInstruction _fbo_rect
     cdef VertexInstruction _texture_container
     cdef Scale _fbo_scale


### PR DESCRIPTION
Closes #8593 

CC: @DexerBR 

~~We set `optimize` to `False` by default because it affects quality. Although it can change performance, we prioritize *better output quality* over the *performance* gain.~~

I get around ~250 fps with optimization disabled, with vsync off and maxfps 2000. 
and around ~340 fps with optimization enabled.

Test code:

```python
from kivy.app import App
from kivy.animation import Animation
from kivy.lang import Builder
from kivy.clock import Clock
from kivy.properties import BooleanProperty

KV = """
Screen:
    canvas:
        Color:
            rgba: 1, 1, 1, 1
        Rectangle:
            pos: self.pos
            size: self.size


    Button:
        id: button
        pos_hint: {"center_x": .5, "center_y": .5}
        size_hint: .3, .3
        background_color: 0,0,0,0

        canvas.before:
            Color:
                rgba: 0, 0, 0, 0.5

            BoxShadow:
                optimize: app.optimize_enabled
                pos: self.pos
                size: self.size
                offset: 0, 0
                border_radius: [self.size[0]/8]*4
                blur_radius:20

        canvas.after:
            Color:
                rgba: 1, 1,1, 1
            SmoothRoundedRectangle:
                pos: self.pos
                size: self.size
                radius: [self.size[0]/8,]

    Label:
        id: fps_label
        text: "FPS: 0"
        color: 0, 0, 0, 1
        size_hint: None, None
        size: self.texture_size
        pos: 10, self.parent.height - self.height - 10

    ToggleButton:
        id: optimize_toggle
        text: "optimize: ON" if self.state == "down" else "optimize: OFF"
        size_hint: None, None
        size: 160, 36
        pos: 10, 10
        state: "down" if app.optimize_enabled else "normal"
        on_state: app.optimize_enabled = (self.state == "down")
"""


class Example(App):
    optimize_enabled = BooleanProperty(False)

    def change_size_widget(self):
        Animation(size_hint=(0.8, 0.8)).start(self.root.ids.button)

    def build(self):
        root = Builder.load_string(KV)
        Clock.schedule_interval(self._update_fps, 0)
        Clock.schedule_once(lambda *_: self._pulse_size(root.ids.button), 0)
        return root

    def _update_fps(self, _dt):
        label = self.root.ids.fps_label
        label.text = f"FPS: {Clock.get_fps():.1f}"
        label.size = label.texture_size

    def _pulse_size(self, widget):
        grow = Animation(size_hint=(0.85, 0.85), duration=0.8, t="in_out_sine")
        shrink = Animation(size_hint=(0.3, 0.3), duration=0.8, t="in_out_sine")
        anim = grow + shrink
        anim.bind(on_complete=lambda *_: self._pulse_size(widget))
        anim.start(widget)


Example().run()
```

Screen recording drops fps a bit.


https://github.com/user-attachments/assets/67628f93-12f7-4b04-bb0f-97e15a64c4ed



Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.