### PR TITLE
Change `on_active` to `on_activated` to reflect the current implementation

### DIFF
--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -619,9 +619,9 @@ In KV language:
         text: "ON" if self.activated else "OFF"
         color: (0, 1, 0, 1) if self.activated else (1, 1, 1, 1)
 
-**New `on_active` Event**
+**New `on_activated` Event**
 
-Replace `on_state` bindings with `on_active`:
+Replace `on_state` bindings with `on_activated`:
 
 .. code-block:: python
 
@@ -637,7 +637,7 @@ Replace `on_state` bindings with `on_active`:
     
     # Kivy 3.x.x
     class MyToggle(ToggleButtonBehavior, Label):
-        def on_active(self, instance, value):
+        def on_activated(self, instance, value):
             if value:
                 print("Activated")
                 self.color = (0, 1, 0, 1)
@@ -655,7 +655,7 @@ In KV language, bind to property changes:
     
     # Kivy 3.x.x
     <MyToggle@ToggleButton>:
-        on_active: app.handle_toggle(self, self.activated)
+        on_activated: app.handle_toggle(self, self.activated)
 
 **New `toggle_on` Property**
 
@@ -684,7 +684,7 @@ This is useful when you want instant visual feedback:
             super().__init__(**kwargs)
             self.toggle_on = 'press'  # Toggle immediately
         
-        def on_active(self, instance, value):
+        def on_activated(self, instance, value):
             self.text = "ON" if value else "OFF"
 
 **Scoped Groups (New Tuple Syntax)**
@@ -859,7 +859,7 @@ You no longer need to manually clean up groups:
 +===========================+===========================+========================================+
 | `state` property          | `'normal'` or `'down'`    | Replaced with `activated` (bool)       |
 +---------------------------+---------------------------+----------------------------------------+
-| `on_state` event          | Fired on state change     | Replaced with `on_active`              |
+| `on_state` event          | Fired on state change     | Replaced with `on_activated`              |
 +---------------------------+---------------------------+----------------------------------------+
 | `toggle_on` property      | Not available             | **New** - 'press' or 'release'         |
 +---------------------------+---------------------------+----------------------------------------+

--- a/examples/widgets/recycleview/key_viewclass.py
+++ b/examples/widgets/recycleview/key_viewclass.py
@@ -85,7 +85,7 @@ KV = '''
         title: root.title
     CheckBox:
         active: app.get_active_value(root.index, False)
-        on_active: app.handle_update(self.active, root.index)
+        on_activated: app.handle_update(self.activated, root.index)
 
 <RVSpinnerLine>:
     NumberedLabel:


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
