### PR TITLE
`Clock`: Enhance and fix `@triggered` decorator (instance isolation, debouncing, lazy initialization) and add deterministic pytest fixture for manual clock advancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ kivy/core/clipboard/_clipboard_sdl3.c
 kivy/graphics/egl_backend/egl_angle.c
 kivy/core/image/_img_sdl3.cpp
 wheelhouse/
+/.vscode

--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -875,6 +875,68 @@ You no longer need to manually clean up groups:
 +---------------------------+---------------------------+----------------------------------------+
 
 
+=====
+Clock
+=====
+
+*Improved @triggered Decorator Behavior, Instance Isolation and Debouncing*
+
+In Kivy 3.x.x, the :func:`~kivy.clock.triggered` decorator has been significantly
+improved. Previously, when used as a method decorator, it shared a single trigger
+and state across all instances of a class. This meant that calling the method on
+one instance would throttle calls on all other instances, and arguments from
+different instances could overwrite each other.
+
+**Behavior Changes**
+
+* Improved **Instance Isolation**: Each instance now has its own isolated trigger and
+  argument storage. Calling a triggered method on ``widget_a`` no longer affects
+  ``widget_b``.
+* Improved **Lazy Initialization**: Triggers are now created only when the decorated
+  function is first called, improving initialization performance.
+* New **is_triggered Property**: A new ``is_triggered`` property was added to the decorated
+  function/method, allowing you to check if a call is currently pending.
+* New **debounce Parameter**: A new ``debounce=False`` (default) parameter was
+  added.
+
+  * **Throttling** (default): Subsequent calls while a trigger is active
+    update the arguments but do *not* reset the timer. The function fires once
+    after the initial timeout.
+  * **Debouncing** (``debounce=True``): Subsequent calls cancel any pending
+    execution and reschedule it. The function only fires after the caller
+    stops calling it for the duration of the ``timeout``.
+
+**Migration Impact**
+
+This is primarily a **bug fix** and a set of **new features**. It should not
+require code changes for most applications. However, if your codebase
+intentionally relied on the legacy shared throttling behavior across different
+instances, you can restore this behavior by using the **``@classmethod``** 
+decorator above ``@triggered``. 
+
+This ensures the trigger is bound to the class object rather than individual 
+instances, restoring the shared behavior in an idiomatic way.
+
+.. code-block:: python
+
+    class MyWidget(Widget):
+        # Default in 3.x.x: Isolated per instance
+        @triggered(0.1)
+        def sync_ui(self, *args):
+            pass
+
+        # Shared behavior (same as legacy 2.x.x): Shared by all instances
+        @classmethod
+        @triggered(0.1)
+        def sync_shared_data(cls, *args):
+            pass
+
+        # Optional: Debouncing (0.1s from the LAST call)
+        @triggered(0.1, debounce=True)
+        def search_input(self, text):
+            pass
+
+
 Application Storage Directories
 ================================
 

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -456,7 +456,8 @@ __all__ = (
 
 from sys import platform
 from os import environ
-from functools import wraps, partial
+from functools import wraps, partial, update_wrapper
+from weakref import WeakKeyDictionary, ref as weakref_ref
 from kivy.context import register_context
 from kivy.config import Config
 from kivy.logger import Logger
@@ -1094,62 +1095,227 @@ def mainthread(func):
     return delayed_func
 
 
-def triggered(timeout=0, interval=False):
-    '''Decorator that will trigger the call of the function at the specified
-    timeout, through the method :meth:`CyClockBase.create_trigger`. Subsequent
-    calls to the decorated function (while the timeout is active) are ignored.
+# The @triggered decorator uses two classes to handle the duality of Python 
+# functions (global functions vs. instance methods):
+#
+# 1. _TriggeredWrapper (The Descriptor):
+#    - Lives at the module level (global) or class level.
+#    - For global functions: Manages its own `_trigger` and state in __call__.
+#    - For class methods: Implements the Descriptor Protocol (__get__) to
+#      intercept access via an instance (e.g., `widget.method()`).
+#    - Uses a WeakKeyDictionary to map instances to their respective
+#      _BoundTrigger objects, ensuring no memory leaks.
+#
+# 2. _BoundTrigger (The Instance State):
+#    - The object returned when accessing a method on an instance.
+#    - Maintains a `Clock.create_trigger` and argument buffers 
+#      (`_args`, `_kwargs`) that are fully ISOLATED for each instance of the
+#      widget/object.
+#    - This isolation allows debouncing/throttling to work independently:
+#      triggering on 'Widget A' does not affect or cancel the schedule of
+#      'Widget B'.
+#
+# This separation resolves "cross-talk" between instances while keeping
+# the decorator flexible enough for use outside of classes.
 
-    It can be helpful when an expensive function (i.e. call to a server) can be
-    triggered by different methods. Setting a proper timeout will delay the
-    calling and only one of them will be triggered.
 
-        @triggered(timeout, interval=False)
-        def callback(id):
-            print('The callback has been called with id=%d' % id)
+class _TriggeredWrapper:
+    def __init__(self, func, timeout, interval, debounce):
+        self._func = func
+        self._timeout = timeout
+        self._interval = interval
+        self._debounce = debounce
+        self._args = []
+        self._kwargs = {}
+        self._trigger = None
+        self._instances = WeakKeyDictionary()
+        update_wrapper(self, func, updated=())
 
-        >> callback(id=1)
-        >> callback(id=2)
-        The callback has been called with id=2
+    @property
+    def is_triggered(self):
+        """Returns True if the trigger is currently scheduled."""
+        if self._trigger is not None:
+            return self._trigger.is_triggered
+        return False
 
-    The decorated callback can also be unscheduled using:
+    def _ensure_trigger(self):
+        if self._trigger is None:
+            self._trigger = Clock.create_trigger(
+                self.cb_function, timeout=self._timeout, interval=self._interval
+            )
 
-        >> callback.cancel()
+    def cb_function(self, dt):
+        self._func(*tuple(self._args), **self._kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self._ensure_trigger()
+        if self._debounce:
+            self._trigger.cancel()
+        self._args[:] = args
+        self._kwargs.clear()
+        self._kwargs.update(kwargs)
+        self._trigger()
+
+    def cancel(self):
+        if self._trigger is not None:
+            self._trigger.cancel()
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        if instance not in self._instances:
+            # Create a bound version for this instance
+            inst_weak = weakref_ref(instance)
+            inst_args = []
+            inst_kwargs = {}
+            func = self._func
+            timeout = self._timeout
+            interval = self._interval
+            debounce = self._debounce
+
+            def inst_cb(dt):
+                inst = inst_weak()
+                if inst is not None:
+                    func(inst, *tuple(inst_args), **inst_kwargs)
+
+            inst_trigger = Clock.create_trigger(
+                inst_cb, timeout=timeout, interval=interval
+            )
+
+            bound_trigger = _BoundTrigger(
+                inst_trigger, inst_args, inst_kwargs, inst_weak, debounce
+            )
+            update_wrapper(bound_trigger, func)
+            self._instances[instance] = bound_trigger
+
+        return self._instances[instance]
+
+
+class _BoundTrigger(object):
+
+    def __init__(self, trigger, args, kwargs, inst_weak, debounce):
+        self._trigger = trigger
+        self._args = args
+        self._kwargs = kwargs
+        self._inst_weak = inst_weak
+        self._debounce = debounce
+
+    def __call__(self, *args, **kwargs):
+        if self._inst_weak() is not None:
+            if self._debounce:
+                self._trigger.cancel()
+            self._args[:] = args
+            self._kwargs.clear()
+            self._kwargs.update(kwargs)
+            self._trigger()
+
+    @property
+    def is_triggered(self):
+        """Returns True if the trigger is currently scheduled."""
+        return self._trigger.is_triggered
+
+    def cancel(self):
+        """Unschedule the trigger."""
+        self._trigger.cancel()
+
+
+def triggered(timeout=0, interval=False, debounce=False):
+    """Decorator that schedules the execution of a function after a specified
+    timeout using :meth:`CyClockBase.create_trigger`.
+
+    This decorator provides several key behaviors:
+
+    * **Throttling** (default): Subsequent calls while a trigger is active are
+      ignored. The function fires once after the initial timeout.
+    * **Debouncing**: If ``debounce=True``, subsequent calls cancel any
+      pending execution and reschedule it. The function only fires after the
+      caller stops calling it for the duration of the ``timeout``.
+    * **Last Arguments Win**: If called multiple times before the trigger
+      fires, the arguments from the **latest** call are used.
+    * **Instance Isolation**: When used as a method decorator, each instance
+      gets its own isolated trigger and state.
+    * **Thread Safety**: Safe to call from external threads.
+
+    The decorated function gains a ``.cancel()`` method to unschedule any
+    pending execution, and an ``.is_triggered`` property to check its status.
+
+    :param timeout: The delay (in seconds) before the function is called.
+    :type timeout: float, defaults to 0
+    :param interval: If True, the trigger will be repeating (standard Clock
+        interval behavior).
+    :type interval: bool, defaults to False
+    :param debounce: If True, subsequent calls will cancel and reschedule the
+        trigger.
+    :type debounce: bool, defaults to False
+
+    Example of a global function without debouncing::
+
+        @triggered(0.1)
+        def sync_data(user_id):
+            print(f"Syncing data for {user_id}")
+
+        sync_data(1)
+        sync_data(2)  # Overwrites arguments of the first call
+        # 0.1s later: "Syncing data for 2"
+
+    Example of a global function with debouncing::
+
+        @triggered(0.1, debounce=True)
+        def sync_data(user_id):
+            print(f"Syncing data for {user_id}")
+
+        sync_data(1)
+        # 0.05s later
+        sync_data(2)  # Cancels the first call and reschedules for 0.1s from now
+        # 0.1s after the LAST call ("sync_data(2)"): "Syncing data for 2"
+
+    Example of an instance method::
+
+        class DataMapper:
+            @triggered(0.2)
+            def refresh(self, *args):
+                # This will be throttled per-instance
+                pass
+
+        dm1, dm2 = DataMapper(), DataMapper()
+        dm1.refresh() # Scheduled
+        dm2.refresh() # Scheduled independently
+
+    Example with ``classmethod`` and ``staticmethod`` (always put
+    ``@triggered`` below them)::
+
+        class Utils:
+            @classmethod
+            @triggered(0.1)
+            def global_refresh(cls, *args):
+                # shared by all instances
+                pass
+
+            @staticmethod
+            @triggered(0.1, debounce=True)
+            def log_event(message):
+                pass
+
+    To cancel a pending call::
+
+        sync_data.cancel()
 
     .. versionadded:: 1.10.1
-    '''
+    .. versionchanged:: 3.0.0
+        Fixed behavior for instance methods to ensure state isolation between
+        different objects. Added ``debounce`` parameter.
+    """
     fun = None
 
+    # handle both shorthand usage (@triggered)
+    # and parameterized usage (@triggered(0.1))
     if callable(timeout):
         fun = timeout
         timeout = 0
 
     def wrapper_triggered(func):
-
-        _args = []
-        _kwargs = {}
-
-        def cb_function(dt):
-            func(*tuple(_args), **_kwargs)
-
-        cb_trigger = Clock.create_trigger(
-            cb_function,
-            timeout=timeout,
-            interval=interval)
-
-        @wraps(func)
-        def trigger_function(*args, **kwargs):
-            _args[:] = []
-            _args.extend(list(args))
-            _kwargs.clear()
-            _kwargs.update(kwargs)
-            cb_trigger()
-
-        def trigger_cancel():
-            cb_trigger.cancel()
-
-        setattr(trigger_function, 'cancel', trigger_cancel)
-
-        return trigger_function
+        return _TriggeredWrapper(func, timeout, interval, debounce)
 
     if fun is not None:
         return wrapper_triggered(fun)

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -1095,7 +1095,7 @@ def mainthread(func):
     return delayed_func
 
 
-# The @triggered decorator uses two classes to handle the duality of Python 
+# The @triggered decorator uses two classes to handle the duality of Python
 # functions (global functions vs. instance methods):
 #
 # 1. _TriggeredWrapper (The Descriptor):
@@ -1108,7 +1108,7 @@ def mainthread(func):
 #
 # 2. _BoundTrigger (The Instance State):
 #    - The object returned when accessing a method on an instance.
-#    - Maintains a `Clock.create_trigger` and argument buffers 
+#    - Maintains a `Clock.create_trigger` and argument buffers
 #      (`_args`, `_kwargs`) that are fully ISOLATED for each instance of the
 #      widget/object.
 #    - This isolation allows debouncing/throttling to work independently:

--- a/kivy/tests/conftest.py
+++ b/kivy/tests/conftest.py
@@ -4,8 +4,8 @@ import os
 kivy_eventloop = os.environ.get('KIVY_EVENTLOOP', 'asyncio')
 
 try:
-    from .fixtures import kivy_app, kivy_clock, kivy_metrics, \
-        kivy_exception_manager
+    from .fixtures import kivy_app, kivy_clock, kivy_clock_advance, \
+        kivy_metrics, kivy_exception_manager
 except (SyntaxError, ImportError):
     # async app tests would be skipped due to async_run forcing it to skip so
     # it's ok to fail here as it won't be used anyway

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -17,7 +17,7 @@ import weakref
 import time
 import os.path
 
-__all__ = ('kivy_clock', 'kivy_metrics', 'kivy_exception_manager', 'kivy_app',
+__all__ = ('kivy_clock', 'kivy_clock_advance', 'kivy_metrics', 'kivy_exception_manager', 'kivy_app',
            'kivy_init')
 
 @pytest.fixture()
@@ -89,6 +89,28 @@ def kivy_clock():
         Clock.stop_clock()
     finally:
         context.pop()
+
+
+@pytest.fixture()
+def kivy_clock_advance(kivy_clock):
+    """A fixture that provides a helper to advance the Clock
+       deterministically by mocking its time and ticking it.
+       Usage:
+           def test_foo(kivy_clock_advance):
+               kivy_clock_advance(0.1)  # advances the clock by 0.1s
+    """
+    class ClockController:
+        def __init__(self, clock):
+            self.clock = clock
+            self.now = 100.0
+            clock.time = lambda: self.now
+            clock._last_tick = self.now
+
+        def __call__(self, secs):
+            self.now += secs
+            self.clock.tick()
+
+    return ClockController(kivy_clock)
 
 
 @pytest.fixture()

--- a/kivy/tests/fixtures.py
+++ b/kivy/tests/fixtures.py
@@ -17,7 +17,8 @@ import weakref
 import time
 import os.path
 
-__all__ = ('kivy_clock', 'kivy_clock_advance', 'kivy_metrics', 'kivy_exception_manager', 'kivy_app',
+__all__ = ('kivy_clock', 'kivy_clock_advance', 'kivy_metrics',
+           'kivy_exception_manager', 'kivy_app',
            'kivy_init')
 
 @pytest.fixture()

--- a/kivy/tests/test_clock_triggered.py
+++ b/kivy/tests/test_clock_triggered.py
@@ -1,0 +1,280 @@
+import gc
+from kivy.clock import triggered
+
+
+class ClockCounter:
+    def __init__(self):
+        self.counter = 0
+        self.last_args = None
+        self.last_kwargs = None
+
+    def __call__(self, *args, **kwargs):
+        self.counter += 1
+        self.last_args = args
+        self.last_kwargs = kwargs
+
+
+def test_triggered_global(kivy_clock):
+    counter = ClockCounter()
+
+    @triggered(0)
+    def my_func(*args, **kwargs):
+        counter(*args, **kwargs)
+
+    # Trigger multiple times
+    my_func(1, a="a")
+    my_func(2, b="b")
+
+    assert counter.counter == 0
+    kivy_clock.tick()
+
+    # Should be called once with the second call's arguments
+    assert counter.counter == 1
+    assert counter.last_args == (2,)
+    assert counter.last_kwargs == {"b": "b"}
+
+
+def test_triggered_instance_isolation(kivy_clock):
+    class MyClass:
+        def __init__(self, name):
+            self.name = name
+            self.counter = ClockCounter()
+
+        @triggered(0)
+        def my_method(self, *args, **kwargs):
+            self.counter(*args, **kwargs)
+
+    obj1 = MyClass("obj1")
+    obj2 = MyClass("obj2")
+
+    # Trigger both
+    obj1.my_method(1)
+    obj2.my_method(2)
+
+    assert obj1.counter.counter == 0
+    assert obj2.counter.counter == 0
+
+    kivy_clock.tick()
+
+    # Both should have been called independently
+    assert obj1.counter.counter == 1
+    assert obj1.counter.last_args == (1,)
+
+    assert obj2.counter.counter == 1
+    assert obj2.counter.last_args == (2,)
+
+
+def test_triggered_instance_throttling(kivy_clock):
+    class MyClass:
+        def __init__(self):
+            self.counter = ClockCounter()
+
+        @triggered(0)
+        def my_method(self, *args, **kwargs):
+            self.counter(*args, **kwargs)
+
+    obj = MyClass()
+
+    # Trigger twice on same instance
+    obj.my_method(1)
+    obj.my_method(2)
+
+    kivy_clock.tick()
+
+    # Should be called once with second arguments
+    assert obj.counter.counter == 1
+    assert obj.counter.last_args == (2,)
+
+
+def test_triggered_instance_cancel(kivy_clock):
+    class MyClass:
+        def __init__(self):
+            self.counter = ClockCounter()
+
+        @triggered(0)
+        def my_method(self, *args, **kwargs):
+            self.counter(*args, **kwargs)
+
+    obj = MyClass()
+    obj.my_method(1)
+    obj.my_method.cancel()
+
+    kivy_clock.tick()
+    assert obj.counter.counter == 0
+
+
+def test_triggered_memory_leak(kivy_clock):
+    import weakref
+
+    class MyClass:
+        @triggered(0)
+        def my_method(self):
+            pass
+
+    obj = MyClass()
+    # Access the method to create the trigger entry in _instances
+    method = obj.my_method
+
+    obj_ref = weakref.ref(obj)
+
+    # Check that obj is still alive
+    assert obj_ref() is not None
+
+    # Delete objective and trigger collection
+    del obj
+    del method
+    gc.collect()
+
+    # Object should be collected (meaning WeakKeyDictionary in TriggeredWrapper works)
+    assert obj_ref() is None
+
+
+def test_triggered_lazy_init(kivy_clock):
+    # This is a bit internal but we can check if _trigger is None initially
+    from kivy.clock import _TriggeredWrapper
+
+    def my_func():
+        pass
+
+    wrapper = _TriggeredWrapper(my_func, 0, False, False)
+    assert wrapper._trigger is None
+
+    # Calling it should create the trigger
+    wrapper()
+    assert wrapper._trigger is not None
+
+
+def test_triggered_debounce(kivy_clock):
+    import time
+
+    counter = ClockCounter()
+
+    @triggered(0.1, debounce=True)
+    def my_func(val):
+        counter(val)
+
+    # Call 1: scheduled for +0.1s
+    my_func(1)
+
+    # Advance enough for debounce still pending
+    time.sleep(0.05)
+    kivy_clock.tick()
+    assert counter.counter == 0
+
+    # Call 2: cancels Call 1 and reschedules for +0.1s from now
+    my_func(2)
+
+    # Advance enough to fire; should use args from Call 2
+    time.sleep(0.15)
+    kivy_clock.tick()
+
+    assert counter.counter == 1
+    assert counter.last_args == (2,)
+
+
+def test_triggered_callable_as_timeout(kivy_clock):
+    # Test @triggered without arguments (shorthand for @triggered())
+    counter = ClockCounter()
+
+    @triggered
+    def my_func(dt):
+        counter()
+
+    my_func(0)
+    kivy_clock.tick()
+    assert counter.counter == 1
+
+
+def test_triggered_is_triggered(kivy_clock):
+    import time
+    results = []
+
+    @triggered(0.1)
+    def my_callback(val):
+        results.append(val)
+
+    # Global function
+    assert not my_callback.is_triggered
+    my_callback(1)
+    assert my_callback.is_triggered
+    
+    time.sleep(0.15)
+    kivy_clock.tick()
+
+    assert len(results) == 1
+    assert not my_callback.is_triggered
+
+    # Instance method
+    class MyWidget:
+        @triggered(0.1)
+        def my_method(self, val):
+            results.append((self, val))
+
+    w = MyWidget()
+    assert not w.my_method.is_triggered
+    w.my_method(2)
+    assert w.my_method.is_triggered
+
+    time.sleep(0.15)
+    kivy_clock.tick()
+
+    assert len(results) == 2
+    assert results[1] == (w, 2)
+    assert not w.my_method.is_triggered
+
+    # Test cancel
+    w.my_method(3)
+    assert w.my_method.is_triggered
+    w.my_method.cancel()
+    assert not w.my_method.is_triggered
+
+
+def test_triggered_classmethod(kivy_clock):
+    import time
+    results = []
+
+    class MyClass:
+        @classmethod
+        @triggered(0.1)
+        def my_classmethod(cls, val):
+            results.append((cls, val))
+
+    c1 = MyClass()
+    c2 = MyClass()
+
+    # Both instances and the class itself should share the SAME trigger
+    c1.my_classmethod(1)
+    assert c1.my_classmethod.is_triggered
+    assert c2.my_classmethod.is_triggered # Shared!
+    
+    c2.my_classmethod(2) # Overwrites 1
+    
+    time.sleep(0.15)
+    kivy_clock.tick()
+
+    assert len(results) == 1
+    assert results[0] == (MyClass, 2)
+
+
+def test_triggered_staticmethod(kivy_clock):
+    import time
+    results = []
+
+    class MyClass:
+        @staticmethod
+        @triggered(0.1)
+        def my_staticmethod(val):
+            results.append(val)
+
+    # All access points share the same trigger
+    MyClass.my_staticmethod(1)
+    obj = MyClass()
+    assert obj.my_staticmethod.is_triggered
+    
+    obj.my_staticmethod(2)
+    
+    time.sleep(0.15)
+    kivy_clock.tick()
+
+    assert len(results) == 1
+    assert results[0] == 2

--- a/kivy/tests/test_clock_triggered.py
+++ b/kivy/tests/test_clock_triggered.py
@@ -197,7 +197,7 @@ def test_triggered_is_triggered(kivy_clock):
     assert not my_callback.is_triggered
     my_callback(1)
     assert my_callback.is_triggered
-    
+
     time.sleep(0.15)
     kivy_clock.tick()
 
@@ -246,9 +246,9 @@ def test_triggered_classmethod(kivy_clock):
     c1.my_classmethod(1)
     assert c1.my_classmethod.is_triggered
     assert c2.my_classmethod.is_triggered # Shared!
-    
+
     c2.my_classmethod(2) # Overwrites 1
-    
+
     time.sleep(0.15)
     kivy_clock.tick()
 
@@ -270,9 +270,9 @@ def test_triggered_staticmethod(kivy_clock):
     MyClass.my_staticmethod(1)
     obj = MyClass()
     assert obj.my_staticmethod.is_triggered
-    
+
     obj.my_staticmethod(2)
-    
+
     time.sleep(0.15)
     kivy_clock.tick()
 

--- a/kivy/tests/test_clock_triggered.py
+++ b/kivy/tests/test_clock_triggered.py
@@ -144,9 +144,7 @@ def test_triggered_lazy_init(kivy_clock):
     assert wrapper._trigger is not None
 
 
-def test_triggered_debounce(kivy_clock):
-    import time
-
+def test_triggered_debounce(kivy_clock_advance):
     counter = ClockCounter()
 
     @triggered(0.1, debounce=True)
@@ -156,17 +154,15 @@ def test_triggered_debounce(kivy_clock):
     # Call 1: scheduled for +0.1s
     my_func(1)
 
-    # Advance enough for debounce still pending
-    time.sleep(0.05)
-    kivy_clock.tick()
+    # Advance enough for debounce still pending (0.05 < 0.1)
+    kivy_clock_advance(0.05)
     assert counter.counter == 0
 
     # Call 2: cancels Call 1 and reschedules for +0.1s from now
     my_func(2)
 
     # Advance enough to fire; should use args from Call 2
-    time.sleep(0.15)
-    kivy_clock.tick()
+    kivy_clock_advance(0.15)
 
     assert counter.counter == 1
     assert counter.last_args == (2,)
@@ -185,8 +181,7 @@ def test_triggered_callable_as_timeout(kivy_clock):
     assert counter.counter == 1
 
 
-def test_triggered_is_triggered(kivy_clock):
-    import time
+def test_triggered_is_triggered(kivy_clock_advance):
     results = []
 
     @triggered(0.1)
@@ -198,8 +193,8 @@ def test_triggered_is_triggered(kivy_clock):
     my_callback(1)
     assert my_callback.is_triggered
 
-    time.sleep(0.15)
-    kivy_clock.tick()
+    # Advancing manually
+    kivy_clock_advance(0.15)
 
     assert len(results) == 1
     assert not my_callback.is_triggered
@@ -215,8 +210,7 @@ def test_triggered_is_triggered(kivy_clock):
     w.my_method(2)
     assert w.my_method.is_triggered
 
-    time.sleep(0.15)
-    kivy_clock.tick()
+    kivy_clock_advance(0.15)
 
     assert len(results) == 2
     assert results[1] == (w, 2)
@@ -229,8 +223,7 @@ def test_triggered_is_triggered(kivy_clock):
     assert not w.my_method.is_triggered
 
 
-def test_triggered_classmethod(kivy_clock):
-    import time
+def test_triggered_classmethod(kivy_clock_advance):
     results = []
 
     class MyClass:
@@ -249,15 +242,13 @@ def test_triggered_classmethod(kivy_clock):
 
     c2.my_classmethod(2) # Overwrites 1
 
-    time.sleep(0.15)
-    kivy_clock.tick()
+    kivy_clock_advance(0.15)
 
     assert len(results) == 1
     assert results[0] == (MyClass, 2)
 
 
-def test_triggered_staticmethod(kivy_clock):
-    import time
+def test_triggered_staticmethod(kivy_clock_advance):
     results = []
 
     class MyClass:
@@ -273,8 +264,7 @@ def test_triggered_staticmethod(kivy_clock):
 
     obj.my_staticmethod(2)
 
-    time.sleep(0.15)
-    kivy_clock.tick()
+    kivy_clock_advance(0.15)
 
     assert len(results) == 1
     assert results[0] == 2


### PR DESCRIPTION
### Summary
This PR refactors the `@triggered` decorator to improve its behavior, especially when used inside classes (instance methods). It fixes a long-standing issue where different instances of the same class shared the same trigger state.

### Key Features
- **Instance Isolation**: Methods now have independent triggers for each object, preventing one widget from canceling another's schedule.
- **Debouncing**: Added a new `debounce=True` option to reset the timer on every call.
- **Lazy Initialization**: Triggers are now instantiated only upon their first call. This eliminates the overhead of creating Clock objects for thousands of widgets at once, saving memory and CPU.
- Added `.is_triggered` property and improved `.cancel()` method support.

### Migration Note
The legacy shared behavior (where all instances shared one trigger) can be restored by simply adding `@classmethod` above the `@triggered` decorator.

### Documentation
- Updated `clock.py` with detailed technical comments on the Descriptor pattern.
- Updated `migration.rst` with examples for new behaviors and decorator stacking conventions.


### Tests
- Added extensive tests for the `@triggered` decorator, including instance isolation, debouncing, and lazy initialization.
- **kivy_clock_advance (new fixture)**: Introduced a deterministic way to test time-based logic. It allows "advancing the clock" virtually, eliminating flaky test failures caused by CPU load in CI environments. Instead of real-time `sleep` or other methods based on real time, tests now can jump instantly to a specific point in the future.

Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.
