### PR TITLE
Fixes upload for iOS wheels, use name instead of pattern as now we only have a single artifact

### DIFF
--- a/.github/workflows/ios_wheels.yml
+++ b/.github/workflows/ios_wheels.yml
@@ -66,8 +66,7 @@ jobs:
           python -m pip install -r .ci/cicd-requirements.txt
       - uses: actions/download-artifact@v7
         with:
-          pattern: ios_wheels-*
-          merge-multiple: true
+          name: ios_wheels
           path: dist
       - name: Rename wheels
         if: github.event.ref_type != 'tag'


### PR DESCRIPTION

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
