### PR TITLE
docs(install): add meson to from-source build deps

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -68,7 +68,7 @@ Using apt::
 
     # Install build tools, and dependencies to perform a full build (including SDL3 dependencies)
     sudo apt-get -y install python3-dev build-essential git make autoconf automake libtool \
-          pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev \
+          pkg-config cmake meson ninja-build libasound2-dev libpulse-dev libaudio-dev \
           libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev \
           libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
           libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
@@ -85,7 +85,7 @@ Using dnf::
 
     # Install build tools, and dependencies to perform a full build (including SDL3 dependencies)
     yum -y install autoconf automake cmake gcc gcc-c++ git make pkgconfig \
-            ninja-build alsa-lib-devel pulseaudio-libs-devel \
+            meson ninja-build alsa-lib-devel pulseaudio-libs-devel \
             libX11-devel libXext-devel libXrandr-devel libXcursor-devel libXfixes-devel \
             libXi-devel libXScrnSaver-devel dbus-devel ibus-devel fcitx-devel \
             systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel \

--- a/doc/sources/installation/installation-osx.rst
+++ b/doc/sources/installation/installation-osx.rst
@@ -55,10 +55,10 @@ To install Kivy from source, please follow the :ref:`installation guide<kivy-whe
 :ref:`Kivy install step<kivy-source-install>` and then install the additional dependencies
 below before continuing.
 
-**pkg-config**, **cmake**, **ninja** are required to build Kivy from source. If you're using ``brew`` as your
-package manager, you can install it with::
+**pkg-config**, **cmake**, **meson**, **ninja** are required to build Kivy from source. If you're using ``brew`` as your
+package manager, you can install them with::
 
-    brew install pkg-config cmake ninja
+    brew install pkg-config cmake meson ninja
 
 Now that you have all the dependencies for kivy, you need to make sure
 you have the command line tools installed::

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -61,7 +61,7 @@ Using apt::
 
     sudo apt update
     apt-get -y install build-essential git make autoconf automake libtool \
-          pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev \
+          pkg-config cmake meson ninja-build libasound2-dev libpulse-dev libaudio-dev \
           libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev \
           libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev \
           libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -44,7 +44,12 @@ required, and they are available for free. You can either:
   under "Tools for Visual Studio 2019". More info about this topic can be found
   `in the Kivy wiki <https://github.com/kivy/kivy/wiki/Using-Visual-C---Build-Tools-instead-of-Visual-Studio-on-Windows>`_.
 
-Now that the compiler is installed, continue to :ref:`install Kivy<kivy-source-install>`.
+In addition to the compiler, **meson** and **ninja** are required to build the bundled
+ThorVG vector graphics library. Both are available on PyPI::
+
+    python -m pip install meson ninja
+
+Now that the compiler and build tools are installed, continue to :ref:`install Kivy<kivy-source-install>`.
 
 Making Python available anywhere
 --------------------------------


### PR DESCRIPTION
Following the addition of the bundled ThorVG vector graphics library (kivy.lib.thorvg), Meson is now required alongside CMake / Ninja / pkg-config to build Kivy from source on every desktop platform. Update the per-platform installation guides accordingly:

* installation-linux.rst: add 'meson' to the apt and yum install lists.
* installation-osx.rst:   add 'meson' to the brew install line and to
                          the surrounding prose.
* installation-rpi.rst:   add 'meson' to the apt install list.
* installation-windows.rst: add a 'pip install meson ninja' step
                          (Windows users typically get both via PyPI,
                          which is also what the CI workflow does).

Requested in #9297 review.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
