### PR TITLE
Tests: replace httpbin with local pytest-httpserver for UrlRequest

### DIFF
--- a/kivy/tests/test_urlrequest/conftest.py
+++ b/kivy/tests/test_urlrequest/conftest.py
@@ -9,13 +9,49 @@ via the ``ca_file=`` parameter.
 
 Two server fixtures are exposed:
 
-* ``httpserver`` (provided by ``pytest-httpserver``): plain HTTP.
+* ``httpserver`` (provided by ``pytest-httpserver``): plain HTTP, bound
+  to ``localhost`` on a random port via the
+  ``httpserver_listen_address`` override below.
 * ``httpsserver``: a separately constructed HTTPS server backed by the
   same ``trustme`` CA used for ``ca_cert_path``.
+
+Also installs a session-scoped, autouse stub for ``socket.getfqdn``.
+``werkzeug``'s ``BaseWSGIServer`` (which backs ``pytest-httpserver``)
+calls ``socket.getfqdn(host)`` after binding to populate
+``server_name``. On some CI hosts (notably macOS GitHub runners) the
+reverse-DNS lookup for the loopback address hangs for tens of seconds,
+which trips ``pytest-timeout`` before the server even finishes
+starting. The FQDN is purely cosmetic for our loopback servers, so we
+short-circuit it.
 """
+import socket
 import ssl
 
 import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _fast_loopback_getfqdn():
+    """Bypass slow reverse-DNS for loopback addresses during this session."""
+    original = socket.getfqdn
+    loopback = {'', '0.0.0.0', '::', '127.0.0.1', '::1', 'localhost'}
+
+    def _stub(name=''):
+        if name in loopback:
+            return 'localhost'
+        return original(name)
+
+    socket.getfqdn = _stub
+    try:
+        yield
+    finally:
+        socket.getfqdn = original
+
+
+@pytest.fixture(scope="session")
+def httpserver_listen_address():
+    """Force ``pytest-httpserver`` to bind to ``localhost`` on a random port."""
+    return ("localhost", 0)
 
 
 @pytest.fixture(scope="session")

--- a/kivy/tests/test_urlrequest/conftest.py
+++ b/kivy/tests/test_urlrequest/conftest.py
@@ -10,10 +10,17 @@ via the ``ca_file=`` parameter.
 Two server fixtures are exposed:
 
 * ``httpserver`` (provided by ``pytest-httpserver``): plain HTTP, bound
-  to ``localhost`` on a random port via the
+  to ``127.0.0.1`` on a random port via the
   ``httpserver_listen_address`` override below.
 * ``httpsserver``: a separately constructed HTTPS server backed by the
   same ``trustme`` CA used for ``ca_cert_path``.
+
+Both servers bind explicitly to ``127.0.0.1``. Binding to ``localhost``
+turned out to be a 1000x slowdown on Windows: the client side resolves
+``localhost`` to ``::1`` first and waits ~2 seconds for the IPv6
+connection attempt to time out before falling back to IPv4 (the server
+only listens on IPv4). Using ``127.0.0.1`` avoids the dual-stack
+fallback entirely.
 
 Also installs a session-scoped, autouse stub for ``socket.getfqdn``.
 ``werkzeug``'s ``BaseWSGIServer`` (which backs ``pytest-httpserver``)
@@ -50,8 +57,13 @@ def _fast_loopback_getfqdn():
 
 @pytest.fixture(scope="session")
 def httpserver_listen_address():
-    """Force ``pytest-httpserver`` to bind to ``localhost`` on a random port."""
-    return ("localhost", 0)
+    """Force ``pytest-httpserver`` to bind to ``127.0.0.1`` on a random port.
+
+    Binding to ``127.0.0.1`` (rather than ``localhost``) avoids a ~2s
+    IPv6 connection-timeout penalty on Windows when the client side
+    tries ``::1`` first and the server only listens on IPv4.
+    """
+    return ("127.0.0.1", 0)
 
 
 @pytest.fixture(scope="session")
@@ -75,15 +87,28 @@ def _https_ssl_context(ca):
     return context
 
 
-@pytest.fixture
-def httpsserver(_https_ssl_context):
-    """A pytest-httpserver instance serving over HTTPS."""
+@pytest.fixture(scope="session")
+def _httpsserver_session(_https_ssl_context):
     pytest.importorskip("pytest_httpserver")
     from pytest_httpserver import HTTPServer
 
-    server = HTTPServer(host="localhost", port=0, ssl_context=_https_ssl_context)
+    server = HTTPServer(host="127.0.0.1", port=0, ssl_context=_https_ssl_context)
     server.start()
-    yield server
-    server.clear()
-    if server.is_running():
-        server.stop()
+    try:
+        yield server
+    finally:
+        if server.is_running():
+            server.stop()
+
+
+@pytest.fixture
+def httpsserver(_httpsserver_session):
+    """A pytest-httpserver instance serving over HTTPS.
+
+    Mirrors the function-scoped/session-backed pattern used by
+    pytest-httpserver's own ``httpserver`` fixture: the server is
+    started once per session and reused across tests, with each test
+    seeing a clean expectation slate.
+    """
+    yield _httpsserver_session
+    _httpsserver_session.clear()

--- a/kivy/tests/test_urlrequest/conftest.py
+++ b/kivy/tests/test_urlrequest/conftest.py
@@ -1,0 +1,53 @@
+"""
+Shared fixtures for UrlRequest tests.
+
+Provides a ``trustme``-backed CA so that an ``HTTPServer`` from
+``pytest-httpserver`` can be served over HTTPS in addition to the default
+HTTP one, and exposes the path of the CA's PEM file as ``ca_cert_path``
+so the client (UrlRequest) can validate the local server's certificate
+via the ``ca_file=`` parameter.
+
+Two server fixtures are exposed:
+
+* ``httpserver`` (provided by ``pytest-httpserver``): plain HTTP.
+* ``httpsserver``: a separately constructed HTTPS server backed by the
+  same ``trustme`` CA used for ``ca_cert_path``.
+"""
+import ssl
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def ca():
+    trustme = pytest.importorskip("trustme")
+    return trustme.CA()
+
+
+@pytest.fixture(scope="session")
+def ca_cert_path(ca, tmp_path_factory):
+    cert_path = tmp_path_factory.mktemp("ca") / "ca.pem"
+    ca.cert_pem.write_to_path(str(cert_path))
+    return str(cert_path)
+
+
+@pytest.fixture(scope="session")
+def _https_ssl_context(ca):
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    localhost_cert = ca.issue_cert("localhost", "127.0.0.1")
+    localhost_cert.configure_cert(context)
+    return context
+
+
+@pytest.fixture
+def httpsserver(_https_ssl_context):
+    """A pytest-httpserver instance serving over HTTPS."""
+    pytest.importorskip("pytest_httpserver")
+    from pytest_httpserver import HTTPServer
+
+    server = HTTPServer(host="localhost", port=0, ssl_context=_https_ssl_context)
+    server.start()
+    yield server
+    server.clear()
+    if server.is_running():
+        server.stop()

--- a/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
+++ b/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
@@ -8,6 +8,8 @@ like ``httpbin.org``. Running everything in-process makes the suite both
 fast and deterministic, eliminating the historical CI flakiness that
 came from depending on third-party HTTP services.
 '''
+import json
+import socket
 import threading
 from base64 import b64encode
 from datetime import datetime
@@ -23,7 +25,10 @@ from kivy.network.urlrequest import UrlRequestUrllib as UrlRequest
 # Helpers
 # ---------------------------------------------------------------------------
 
-TERMINAL_EVENTS = ('success', 'redirect', 'error', 'failure')
+# 'finish' is included because, when ``on_finish`` is registered, it is
+# the very last callback dispatched after the terminal event (success /
+# redirect / error / failure) and therefore the right thing to wait for.
+TERMINAL_EVENTS = ('success', 'redirect', 'error', 'failure', 'finish')
 
 
 def wait_for_terminal_event(kivy_clock, queue, timeout=10):
@@ -56,12 +61,20 @@ def ensure_called_from_thread(queue):
         assert item[0] == tid, f"Callback dispatched from wrong thread: {item!r}"
 
 
-def check_progress_then_terminal(queue):
-    """Assert the queue follows the expected progress* + terminal pattern."""
+def check_progress_then_terminal(queue, expected=('success', 'redirect')):
+    """Assert the queue follows the expected ``progress*`` + terminal pattern.
+
+    ``expected`` is the set of acceptable terminal event names. The default
+    matches the historical "happy path" assertion. The first and
+    second-to-last events must be ``progress``, the last must be in
+    ``expected``, the initial progress must report 0 bytes so far, and
+    the final progress must report ``bytes_so_far == total_size``.
+    """
     assert len(queue) >= 3, f"Expected >=3 events, got {list(queue)!r}"
     assert queue[0][1] == 'progress'
     assert queue[-2][1] == 'progress'
-    assert queue[-1][1] in ('success', 'redirect')
+    assert queue[-1][1] in expected, \
+        f"Expected terminal in {expected!r}, got {queue[-1]!r}"
     assert queue[0][2][0] == 0
     assert queue[-2][2][0] == queue[-2][2][1]
 
@@ -86,6 +99,9 @@ class UrlRequestQueue:
     def _on_progress(self, req, *args):
         self.queue.append((threading.get_ident(), 'progress', args))
 
+    def _on_finish(self, req, *args):
+        self.queue.append((threading.get_ident(), 'finish', args))
+
 
 def _basic_auth_header(user, password):
     token = b64encode(f"{user}:{password}".encode('utf-8')).decode('utf-8')
@@ -99,6 +115,22 @@ def _embed_userinfo(url, user, password):
     if parsed.port:
         netloc = f"{netloc}:{parsed.port}"
     return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _grab_unused_port():
+    """Bind a temporary loopback socket, return its port, then release.
+
+    Used by ``test_on_error`` to obtain an address that will refuse a TCP
+    connection. There is a small race window before the OS could rebind
+    the port, but on a CI runner during a single test the chance of
+    collision is negligible.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
 
 
 # ---------------------------------------------------------------------------
@@ -123,10 +155,12 @@ def _register_basic_auth_route(server, user, password):
 def _register_get_route(server, path='/get', body=b'a' * 4096):
     """Register a ``/get`` endpoint that returns a sized payload.
 
-    The body is intentionally larger than the default ``chunk_size`` of
-    8192 bytes is *not* required; we just need enough bytes that
-    ``UrlRequest`` actually emits a couple of ``on_progress`` events
-    before the terminal one.
+    The body is sized so that with a small ``chunk_size`` (the tests
+    pass ``chunk_size=512``) ``UrlRequest`` emits a handful of
+    ``on_progress`` events before the terminal one. The default
+    ``chunk_size`` of 8192 would yield only a single chunk for this
+    payload, so callers exercising the progress callback should pass a
+    smaller ``chunk_size``.
     """
     server.expect_request(path).respond_with_data(
         body, content_type='application/octet-stream'
@@ -235,3 +269,197 @@ def test_ca_file(request, kivy_clock, scheme, ca_cert_path):
 
     ensure_called_from_thread(obj.queue)
     check_progress_then_terminal(obj.queue)
+
+
+@pytest.mark.timeout(30)
+def test_on_finish(kivy_clock, httpserver):
+    """``on_finish`` fires after the terminal callback for a successful GET."""
+    httpserver.expect_request('/get').respond_with_data(b'ok')
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/get'),
+        on_success=obj._on_success,
+        on_finish=obj._on_finish,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    assert [event for _, event, _ in obj.queue] == ['success', 'finish']
+
+
+@pytest.mark.timeout(30)
+def test_on_redirect(kivy_clock, httpserver):
+    """A 3xx response invokes ``on_redirect`` rather than ``on_success``."""
+    httpserver.expect_request('/redirect').respond_with_data(
+        b'', status=302,
+        headers={'Location': httpserver.url_for('/elsewhere')},
+    )
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/redirect'),
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+        on_failure=obj._on_failure,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    check_progress_then_terminal(obj.queue, expected=('redirect',))
+    assert req.resp_status in (301, 302, 303, 307, 308)
+
+
+@pytest.mark.timeout(30)
+def test_on_failure(kivy_clock, httpserver):
+    """A 4xx/5xx response invokes ``on_failure`` rather than ``on_error``."""
+    httpserver.expect_request('/missing').respond_with_data(
+        b'not found', status=404, content_type='text/plain',
+    )
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/missing'),
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+        on_failure=obj._on_failure,
+        chunk_size=64,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    check_progress_then_terminal(obj.queue, expected=('failure',))
+    assert req.resp_status == 404
+
+
+@pytest.mark.timeout(30)
+def test_on_error(kivy_clock):
+    """A connection error invokes ``on_error`` with the underlying exception.
+
+    Points the request at a closed loopback port so the OS responds with
+    a TCP RST immediately, making the test fast and deterministic.
+    """
+    port = _grab_unused_port()
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        f'http://127.0.0.1:{port}/get',
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+        on_failure=obj._on_failure,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    assert [event for _, event, _ in obj.queue] == ['error']
+    assert req.error is not None
+    assert isinstance(req.error, OSError)
+
+
+@pytest.mark.timeout(30)
+def test_post(kivy_clock, httpserver):
+    """Setting ``req_body`` switches the method to POST and forwards the body."""
+    payload = b'name=value&other=thing'
+    httpserver.expect_request(
+        '/submit', method='POST', data=payload,
+    ).respond_with_data(b'ok')
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/submit'),
+        req_body=payload,
+        on_success=obj._on_success,
+        on_finish=obj._on_finish,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    assert [event for _, event, _ in obj.queue] == ['success', 'finish']
+    assert req.resp_status == 200
+
+
+@pytest.mark.timeout(30)
+def test_decode_json(kivy_clock, httpserver):
+    """An ``application/json`` response is auto-parsed into a Python object."""
+    httpserver.expect_request('/data').respond_with_json({'a': 1, 'b': [2, 3]})
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/data'),
+        on_success=obj._on_success,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    assert obj.queue[-1][1] == 'success'
+    (result,) = obj.queue[-1][2]
+    assert result == {'a': 1, 'b': [2, 3]}
+
+
+@pytest.mark.timeout(30)
+def test_decode_disabled(kivy_clock, httpserver):
+    """``decode=False`` bypasses the application/json auto-parser."""
+    body = {'a': 1, 'b': [2, 3]}
+    httpserver.expect_request('/data').respond_with_json(body)
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/data'),
+        on_success=obj._on_success,
+        decode=False,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    assert obj.queue[-1][1] == 'success'
+    (result,) = obj.queue[-1][2]
+    # Still a string (utf-8 decoded), but never passed through json.loads.
+    assert isinstance(result, str)
+    assert json.loads(result) == body
+
+
+@pytest.mark.timeout(30)
+def test_file_path(kivy_clock, httpserver, tmp_path):
+    """``file_path`` writes the response body to disk instead of memory."""
+    body = b'\x00\x01\x02binary payload\xff' * 64
+    httpserver.expect_request('/blob').respond_with_data(
+        body, content_type='application/octet-stream',
+    )
+    out_path = tmp_path / 'response.bin'
+    obj = UrlRequestQueue()
+
+    req = UrlRequest(
+        httpserver.url_for('/blob'),
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        file_path=str(out_path),
+        chunk_size=64,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    assert obj.queue[-1][1] == 'success'
+    assert out_path.exists()
+    assert out_path.read_bytes() == body

--- a/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
+++ b/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
@@ -48,7 +48,7 @@ def wait_for_terminal_event(kivy_clock, queue, timeout=10):
         if (datetime.now() - start).total_seconds() > timeout:
             break
         kivy_clock.tick()
-        sleep(.05)
+        sleep(.005)
     raise AssertionError(
         f"Timed out waiting for a terminal event; queue={list(queue)!r}"
     )
@@ -346,8 +346,12 @@ def test_on_failure(kivy_clock, httpserver):
 def test_on_error(kivy_clock):
     """A connection error invokes ``on_error`` with the underlying exception.
 
-    Points the request at a closed loopback port so the OS responds with
-    a TCP RST immediately, making the test fast and deterministic.
+    Points the request at a closed loopback port. On Linux/macOS the OS
+    returns ECONNREFUSED instantly. On Windows the connect attempt is
+    silently retried for ~1s before timing out, so a short ``timeout=``
+    is supplied to keep the test fast across platforms; either failure
+    mode produces an ``OSError`` (``ConnectionRefusedError`` /
+    ``TimeoutError``), which is what the test asserts.
     """
     port = _grab_unused_port()
     obj = UrlRequestQueue()
@@ -359,6 +363,7 @@ def test_on_error(kivy_clock):
         on_error=obj._on_error,
         on_redirect=obj._on_redirect,
         on_failure=obj._on_failure,
+        timeout=0.5,
         debug=True,
     )
     wait_for_terminal_event(kivy_clock, obj.queue)

--- a/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
+++ b/kivy/tests/test_urlrequest/test_urlrequest_urllib.py
@@ -1,52 +1,75 @@
 '''
 UrlRequest tests
 ================
+
+These tests exercise the ``urllib``-backed UrlRequest implementation
+against a local ``pytest-httpserver`` instance instead of public services
+like ``httpbin.org``. Running everything in-process makes the suite both
+fast and deterministic, eliminating the historical CI flakiness that
+came from depending on third-party HTTP services.
 '''
-import os
 import threading
 from base64 import b64encode
 from datetime import datetime
 from time import sleep
+from urllib.parse import urlparse, urlunparse
 
 import pytest
+
 from kivy.network.urlrequest import UrlRequestUrllib as UrlRequest
 
 
-def wait_request_is_finished(kivy_clock, request, timeout=10):
-    start_time = datetime.now()
-    timed_out = False
-    while not request.is_finished and not timed_out:
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TERMINAL_EVENTS = ('success', 'redirect', 'error', 'failure')
+
+
+def wait_for_terminal_event(kivy_clock, queue, timeout=10):
+    """Wait until the test queue's last event is a terminal one.
+
+    Polling ``UrlRequest.is_finished`` is racy: depending on Clock
+    scheduling, the worker thread may have produced its terminal item
+    before the main-thread Clock dispatcher has actually delivered every
+    pending ``progress`` event to the registered callback. By keying off
+    the queue contents instead we observe the same state the assertions
+    do.
+    """
+    start = datetime.now()
+    while True:
+        if queue and queue[-1][1] in TERMINAL_EVENTS:
+            return
+        if (datetime.now() - start).total_seconds() > timeout:
+            break
         kivy_clock.tick()
-        sleep(.1)
-        timed_out = (datetime.now() - start_time).total_seconds() > timeout
-    assert request.is_finished
+        sleep(.05)
+    raise AssertionError(
+        f"Timed out waiting for a terminal event; queue={list(queue)!r}"
+    )
 
 
 def ensure_called_from_thread(queue):
-    """Ensures the callback is called from this thread (main)."""
+    """Ensures every callback was dispatched from this (main) thread."""
     tid = threading.get_ident()
-    assert queue[0][0] == tid
-    assert queue[-2][0] == tid
-    assert queue[-1][0] == tid
+    for item in queue:
+        assert item[0] == tid, f"Callback dispatched from wrong thread: {item!r}"
 
 
-def check_queue_values(queue):
-    """Helper function verifying the queue contains the expected values."""
-    # we should have 2 progress minimum and one success
-    assert len(queue) >= 3
-
+def check_progress_then_terminal(queue):
+    """Assert the queue follows the expected progress* + terminal pattern."""
+    assert len(queue) >= 3, f"Expected >=3 events, got {list(queue)!r}"
     assert queue[0][1] == 'progress'
     assert queue[-2][1] == 'progress'
     assert queue[-1][1] in ('success', 'redirect')
-
     assert queue[0][2][0] == 0
     assert queue[-2][2][0] == queue[-2][2][1]
 
 
 class UrlRequestQueue:
 
-    def __init__(self, queue):
-        self.queue = queue
+    def __init__(self):
+        self.queue = []
 
     def _on_success(self, req, *args):
         self.queue.append((threading.get_ident(), 'success', args))
@@ -57,99 +80,158 @@ class UrlRequestQueue:
     def _on_error(self, req, *args):
         self.queue.append((threading.get_ident(), 'error', args))
 
+    def _on_failure(self, req, *args):
+        self.queue.append((threading.get_ident(), 'failure', args))
+
     def _on_progress(self, req, *args):
         self.queue.append((threading.get_ident(), 'progress', args))
 
 
-@pytest.mark.skipif(os.environ.get('NONETWORK'), reason="No network")
-def test_callbacks(kivy_clock):
-    obj = UrlRequestQueue([])
-    queue = obj.queue
-    req = UrlRequest('http://google.com',
-                     on_success=obj._on_success,
-                     on_progress=obj._on_progress,
-                     on_error=obj._on_error,
-                     on_redirect=obj._on_redirect,
-                     debug=True)
-    wait_request_is_finished(kivy_clock, req)
-
-    if req.error and req.error.errno == 11001:
-        pytest.skip('Cannot connect to get address')
-
-    ensure_called_from_thread(queue)
-    check_queue_values(queue)
+def _basic_auth_header(user, password):
+    token = b64encode(f"{user}:{password}".encode('utf-8')).decode('utf-8')
+    return {'Authorization': f'Basic {token}'}
 
 
-@pytest.mark.skipif(os.environ.get('NONETWORK'), reason="No network")
-def test_auth_header(kivy_clock):
-    obj = UrlRequestQueue([])
-    queue = obj.queue
-    head = {
-        "Authorization": "Basic {}".format(b64encode(
-            "{}:{}".format('user', 'passwd').encode('utf-8')
-        ).decode('utf-8'))
-    }
+def _embed_userinfo(url, user, password):
+    """Insert ``user:password@`` into ``url``'s authority component."""
+    parsed = urlparse(url)
+    netloc = f"{user}:{password}@{parsed.hostname}"
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+# ---------------------------------------------------------------------------
+# Server route registration
+# ---------------------------------------------------------------------------
+
+def _register_basic_auth_route(server, user, password):
+    """Register a ``/basic-auth/<user>/<password>`` endpoint on ``server``.
+
+    Mirrors the ``httpbin`` semantics used by previous revisions of these
+    tests: returns a small JSON object on success and 401 otherwise.
+    """
+    expected = _basic_auth_header(user, password)['Authorization']
+    path = f"/basic-auth/{user}/{password}"
+
+    server.expect_request(path, headers={'Authorization': expected}) \
+        .respond_with_json({'authenticated': True, 'user': user})
+    server.expect_request(path) \
+        .respond_with_data('Unauthorized', status=401)
+
+
+def _register_get_route(server, path='/get', body=b'a' * 4096):
+    """Register a ``/get`` endpoint that returns a sized payload.
+
+    The body is intentionally larger than the default ``chunk_size`` of
+    8192 bytes is *not* required; we just need enough bytes that
+    ``UrlRequest`` actually emits a couple of ``on_progress`` events
+    before the terminal one.
+    """
+    server.expect_request(path).respond_with_data(
+        body, content_type='application/octet-stream'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(30)
+def test_callbacks(kivy_clock, httpserver):
+    """A plain GET fires progress* + success on the main thread."""
+    _register_get_route(httpserver)
+    obj = UrlRequestQueue()
+
     req = UrlRequest(
-        'http://httpbin.org/basic-auth/user/passwd',
+        httpserver.url_for('/get'),
+        on_success=obj._on_success,
+        on_progress=obj._on_progress,
+        on_error=obj._on_error,
+        on_redirect=obj._on_redirect,
+        chunk_size=512,
+        debug=True,
+    )
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
+
+    ensure_called_from_thread(obj.queue)
+    check_progress_then_terminal(obj.queue)
+
+
+@pytest.mark.timeout(30)
+def test_auth_header(kivy_clock, httpserver):
+    """An explicit Authorization header is forwarded to the server."""
+    _register_basic_auth_route(httpserver, 'user', 'passwd')
+    obj = UrlRequestQueue()
+    head = _basic_auth_header('user', 'passwd')
+
+    req = UrlRequest(
+        httpserver.url_for('/basic-auth/user/passwd'),
         on_success=obj._on_success,
         on_progress=obj._on_progress,
         on_error=obj._on_error,
         on_redirect=obj._on_redirect,
         req_headers=head,
-        debug=True
+        debug=True,
     )
-    wait_request_is_finished(kivy_clock, req, timeout=60)
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
 
-    if req.error and req.error.errno == 11001:
-        pytest.skip('Cannot connect to get address')
-
-    ensure_called_from_thread(queue)
-    check_queue_values(queue)
-    assert queue[-1][2] == ({'authenticated': True, 'user': 'user'}, )
+    ensure_called_from_thread(obj.queue)
+    check_progress_then_terminal(obj.queue)
+    assert obj.queue[-1][2] == ({'authenticated': True, 'user': 'user'},)
 
 
-@pytest.mark.skipif(os.environ.get('NONETWORK'), reason="No network")
-def test_auth_auto(kivy_clock):
-    obj = UrlRequestQueue([])
-    queue = obj.queue
+@pytest.mark.timeout(30)
+def test_auth_auto(kivy_clock, httpserver):
+    """``user:passwd@`` in the URL is converted into a Basic auth header."""
+    _register_basic_auth_route(httpserver, 'user', 'passwd')
+    obj = UrlRequestQueue()
+    url = _embed_userinfo(
+        httpserver.url_for('/basic-auth/user/passwd'), 'user', 'passwd'
+    )
+
     req = UrlRequest(
-        'http://user:passwd@httpbin.org/basic-auth/user/passwd',
+        url,
         on_success=obj._on_success,
         on_progress=obj._on_progress,
         on_error=obj._on_error,
         on_redirect=obj._on_redirect,
-        debug=True
+        debug=True,
     )
-    wait_request_is_finished(kivy_clock, req, timeout=60)
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
 
-    if req.error and req.error.errno == 11001:
-        pytest.skip('Cannot connect to get address')
-
-    ensure_called_from_thread(queue)
-    check_queue_values(queue)
-    assert queue[-1][2] == ({'authenticated': True, 'user': 'user'}, )
+    ensure_called_from_thread(obj.queue)
+    check_progress_then_terminal(obj.queue)
+    assert obj.queue[-1][2] == ({'authenticated': True, 'user': 'user'},)
 
 
-@pytest.mark.skipif(os.environ.get('nonetwork'), reason="no network")
-@pytest.mark.parametrize("scheme", ("http", "https"))
-def test_ca_file(kivy_clock, scheme):
-    """Passing a `ca_file` should not crash on http scheme, refs #6946"""
-    import certifi
-    obj = UrlRequestQueue([])
-    queue = obj.queue
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize('scheme', ('http', 'https'))
+def test_ca_file(request, kivy_clock, scheme, ca_cert_path):
+    """Passing a `ca_file` should not crash on either scheme, refs #6946."""
+    if scheme == 'http':
+        server = request.getfixturevalue('httpserver')
+    else:
+        server = request.getfixturevalue('httpsserver')
+
+    _register_get_route(server)
+    obj = UrlRequestQueue()
+
     req = UrlRequest(
-        f"{scheme}://httpbin.org/get",
+        server.url_for('/get'),
         on_success=obj._on_success,
         on_progress=obj._on_progress,
         on_error=obj._on_error,
         on_redirect=obj._on_redirect,
-        ca_file=certifi.where(),
-        debug=True
+        ca_file=ca_cert_path,
+        chunk_size=512,
+        debug=True,
     )
-    wait_request_is_finished(kivy_clock, req, timeout=60)
+    wait_for_terminal_event(kivy_clock, obj.queue)
+    assert req.is_finished
 
-    if req.error and req.error.errno == 11001:
-        pytest.skip('Cannot connect to get address')
-
-    ensure_called_from_thread(queue)
-    check_queue_values(queue)
+    ensure_called_from_thread(obj.queue)
+    check_progress_then_terminal(obj.queue)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ dev =
     pytest_asyncio!=0.11.0
     pytest-timeout
     pytest-benchmark
-    pytest-httpserver
-    trustme
+    pytest-httpserver==1.1.5
+    trustme==1.2.1
     pyinstaller
     sphinx~=6.2.1
     sphinxcontrib-jquery~=4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ dev =
     pytest_asyncio!=0.11.0
     pytest-timeout
     pytest-benchmark
+    pytest-httpserver
+    trustme
     pyinstaller
     sphinx~=6.2.1
     sphinxcontrib-jquery~=4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ dev =
     pytest_asyncio!=0.11.0
     pytest-timeout
     pytest-benchmark
-    pytest-httpserver==1.1.5
+    pytest-httpserver==1.1.3
     trustme==1.2.1
     pyinstaller
     sphinx~=6.2.1


### PR DESCRIPTION
## Summary

The `UrlRequestUrllib` tests have been intermittently flaky in CI. Two
prior PRs identified the two distinct failure modes but neither landed:

- [#9139 — :white_check_mark: Improve urlrequest test reliability](https://github.com/kivy/kivy/pull/9139)
  (DRAFT) diagnosed the `is_finished` race: `UrlRequest.is_finished`
  can be observed `True` before the Clock-dispatched terminal callback
  has actually delivered every queued event, so the queue's last entry
  could still be `'progress'` when the test ran its assertions.
- [#9186 — Use httpbingo.org instead of httpbin.org](https://github.com/kivy/kivy/pull/9186)
  (OPEN) tried to swap the external service. As the author noted in
  the comments, this didn't really fix the issue — the tests were
  still tied to a third-party host.

This PR closes out both threads by making the suite self-contained and
race-free.

### Changes

- Replace all `httpbin.org` URLs with routes registered on a local
  `pytest-httpserver` instance. Tests no longer depend on the public
  internet at all.
- Add a `httpsserver` fixture (in a new `kivy/tests/test_urlrequest/conftest.py`)
  backed by a `trustme`-issued CA, so `test_ca_file[https]` validates a
  real certificate against `UrlRequest`'s `ca_file=` parameter.
- Replace `wait_request_is_finished` with `wait_for_terminal_event`,
  which waits on the test callback queue's last entry being one of
  `success`/`redirect`/`error`/`failure`. This is what the assertions
  actually depend on, so it removes the race that #9139 spotted.
- Drop the `nonetwork`/`NONETWORK` skip markers and the `errno == 11001`
  skip dance — there is no external network to fail to.
- Add `@pytest.mark.timeout(30)` per test so a wedged worker thread
  cannot hang CI.
- Add `pytest-httpserver` and `trustme` to the `dev` extras in
  `setup.cfg`.
- Tests: expand UrlRequest urllib coverage to all callbacks and key options

The `UrlRequestRequests` test file is untouched: it already uses
`responses` to mock at the requests-library layer.

Closes #9186.
Supersedes #9139.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label. <!-- suggest: `Component: tests/CI` (matches #9139 / #9186) -->
* [ ] Applied the `api-deprecation` or `api-break` label. <!-- N/A: no public API change -->
* [ ] Applied the `release-highlight` label to be highlighted in release notes. <!-- N/A: internal test infra -->
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR. <!-- this PR _is_ a tests-only change -->
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed. <!-- N/A: test-only; helpers carry docstrings -->
