### PR TITLE
Bump minimum Python version from 3.9 to 3.11

### DIFF
--- a/.ci/Dockerfile.armv7l
+++ b/.ci/Dockerfile.armv7l
@@ -1,4 +1,4 @@
-ARG image=balenalib/raspberrypi3-debian-python:3.9-bullseye
+ARG image=balenalib/raspberrypi3-debian-python:3.11-bookworm
 FROM $image
 
 ENV KIVY_CROSS_PLATFORM=rpi

--- a/.github/workflows/manylinux_wheels.yml
+++ b/.github/workflows/manylinux_wheels.yml
@@ -47,10 +47,10 @@ jobs:
         include:
           - os: ubuntu-latest
             cibw_archs: x86_64
-            cibw_build: 'cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64'
+            cibw_build: 'cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64'
           - os: ubuntu-22.04-arm
             cibw_archs: aarch64
-            cibw_build: 'cp38-manylinux_aarch64 cp39-manylinux_aarch64 cp310-manylinux_aarch64 cp311-manylinux_aarch64 cp312-manylinux_aarch64 cp313-manylinux_aarch64 cp314-manylinux_aarch64'
+            cibw_build: 'cp311-manylinux_aarch64 cp312-manylinux_aarch64 cp313-manylinux_aarch64 cp314-manylinux_aarch64'
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel linux]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel linux]')
     steps:
@@ -137,7 +137,7 @@ jobs:
     needs: [manylinux_wheel_create, kivy_examples_create]
     strategy:
       matrix:
-        python: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python: [ '3.11', '3.12', '3.13', '3.14' ]
     env:
       DISPLAY: ':99.0'
     steps:

--- a/.github/workflows/osx_wheels_app.yml
+++ b/.github/workflows/osx_wheels_app.yml
@@ -41,7 +41,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel osx]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel osx]')
     env:
       CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=10.15"
-      CIBW_BUILD: "cp38-macosx_universal2 cp39-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2 cp312-macosx_universal2 cp313-macosx_universal2 cp314-macosx_universal2"
+      CIBW_BUILD: "cp311-macosx_universal2 cp312-macosx_universal2 cp313-macosx_universal2 cp314-macosx_universal2"
       CIBW_ARCHS_MACOS: "x86_64 universal2"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
         DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
@@ -150,7 +150,7 @@ jobs:
         # macos-15-intel runs on Intel x64
         # macos-latest runs on Apple Silicon ARM
         runs_on: ['macos-15-intel', 'macos-latest']
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.11', '3.12', '3.13', '3.14']
     env:
       KIVY_GL_BACKEND: 'mock'
     steps:

--- a/.github/workflows/rpi_wheels.yml
+++ b/.github/workflows/rpi_wheels.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel armv7l]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel armv7l]')
     strategy:
       matrix:
-        image_version: ['3.9-bullseye', '3.11-bookworm']
+        image_version: ['3.11-bookworm']
     steps:
     - uses: actions/checkout@v6
     - name: Generate version metadata

--- a/.github/workflows/test_windows_python.yml
+++ b/.github/workflows/test_windows_python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.11', '3.12', '3.13', '3.14']
         arch: ['x64']
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_wheels.yml
+++ b/.github/workflows/windows_wheels.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python: [ '3.11', '3.12', '3.13', '3.14' ]
         arch: ['x64']
     if: github.event_name == 'schedule' || (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.head_commit.message, '[build wheel win]') || contains(github.event.pull_request.title, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel win]')
     steps:
@@ -55,7 +55,7 @@ jobs:
         . .\.ci\windows_ci.ps1
         Update-version-metadata
     - name: Generate sdist/kivy-examples
-      if: matrix.arch == 'x64' && matrix.python == '3.9'
+      if: matrix.arch == 'x64' && matrix.python == '3.11'
       # only windows kivy-examples is uploaded
       run: |
         . .\.ci\windows_ci.ps1
@@ -125,7 +125,7 @@ jobs:
     needs: windows_wheels_create
     strategy:
       matrix:
-        python: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python: [ '3.11', '3.12', '3.13', '3.14' ]
         arch: [ 'x64' ]
     steps:
       - uses: actions/checkout@v6

--- a/doc/sources/gettingstarted/installation.rst
+++ b/doc/sources/gettingstarted/installation.rst
@@ -54,8 +54,8 @@ If no wheels are available ``pip`` will build the package from sources (i.e. on 
 Alternatively, installing :ref:`from source<kivy-source-install>` is required for newer Python versions not listed
 above or if the wheels do not work or fail to run properly.
 
-On RPi, when using a 32 bit OS, wheels are provided for Python 3.9 (Raspberry Pi OS Bullseye)
-and Python 3.11 (Raspberry Pi OS Bookworm) via the `PiWheels <https://www.piwheels.org/>`_ project.
+On RPi, when using a 32 bit OS, wheels are provided for Python 3.11 (Raspberry Pi OS Bookworm)
+via the `PiWheels <https://www.piwheels.org/>`_ project.
 
 For other Python versions, on 32 bit OSes, you will need to install from source.
 

--- a/doc/sources/installation/installation-rpi.rst
+++ b/doc/sources/installation/installation-rpi.rst
@@ -18,8 +18,8 @@ Installing Python
 
 Python and python-pip must be installed from the package manager:
 
-Raspberry Pi OS Bullseye/Bookworm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Raspberry Pi OS Bookworm
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using apt::
 
@@ -54,8 +54,8 @@ To install Kivy from source, please follow the :ref:`installation guide<kivy-whe
 :ref:`Kivy install step<kivy-source-install>` and then install the dependencies below
 before continuing.
 
-Raspberry Pi OS Bullseye/Bookworm
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Raspberry Pi OS Bookworm
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using apt::
 
@@ -70,26 +70,23 @@ Using apt::
 
     apt-get install xorg wget libxrender-dev lsb-release libraspberrypi-dev raspberrypi-kernel-headers
 
-Cross-Compilation for Raspberry Pi OS Bullseye/Bookworm (32 bit)
+Cross-Compilation for Raspberry Pi OS Bookworm (32 bit)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Kivy performs a dockerized cross-compilation for Raspberry Pi OS Bullseye/Bookworm (32 bit) wheels.
-The base images used for cross-compilation are the `balenalib`_ images for raspberrypi3 (bullseye and bookworm).
+Kivy performs a dockerized cross-compilation for Raspberry Pi OS Bookworm (32 bit) wheels.
+The base images used for cross-compilation are the `balenalib`_ images for raspberrypi3 (bookworm).
 
 .. _balenalib: https://www.balena.io/docs/reference/base-images/base-images-ref/
 
 The docker images are built using the `Dockerfile.armv7l` file in the `.ci` directory.
 
-The raspberrypi3 balenalib images have almost the same environment as the real Raspberry Pi OS Bullseye/Bookworm (32 bit) system,
+The raspberrypi3 balenalib images have almost the same environment as the real Raspberry Pi OS Bookworm (32 bit) system,
 which makes it possible to include/exclude RPi specific features (like the `egl_rpi` window provider) during the build process.
 
-We have an helper, named `generate_rpi_wheels`, that can be used to easily generate the wheels and copy the artifacts for Raspberry Pi OS Bullseye/Bookworm (32 bit).
+We have an helper, named `generate_rpi_wheels`, that can be used to easily generate the wheels and copy the artifacts for Raspberry Pi OS Bookworm (32 bit).
 To cross-compile the wheels, you need to run the following commands::
 
     source .ci/ubuntu_ci.sh
-
-    # Generate wheels for Raspberry Pi OS Bullseye (32 bit, Python 3.9)
-    generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.9-bullseye
 
     # Generate wheels for Raspberry Pi OS Bookworm (32 bit, Python 3.11)
     generate_rpi_wheels balenalib/raspberrypi3-debian-python:3.11-bookworm

--- a/doc/sources/installation/installation-windows.rst
+++ b/doc/sources/installation/installation-windows.rst
@@ -82,7 +82,7 @@ You can launch a .py file with Python using the *Send to* menu:
 #. Open Windows Explorer (the file explorer in Windows 8), and to go the address
    'shell:sendto'. You should get the special Windows directory `SendTo`.
 #. Paste the previously copied ``python.exe`` file **as a shortcut**.
-#. Rename it to python <python-version>. E.g. ``python39``.
+#. Rename it to python <python-version>. E.g. ``python311``.
 
 You can now execute your application by right clicking on the `.py` file ->
 "Send To" -> "python <python-version>".

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cython_min=0.29.1
 cython_max=3.2.0
 cython_exclude=
-python_versions=3.9 - 3.13
+python_versions=3.11 - 3.13
 
 [coverage:run]
 parallel = True
@@ -14,7 +14,7 @@ plugins =
 concurrency = thread, multiprocessing
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.11
 install_requires =
     Kivy-Garden>=0.1.4
     docutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 cython_min=0.29.1
 cython_max=3.2.0
 cython_exclude=
-python_versions=3.11 - 3.13
+python_versions=3.11 - 3.14
 
 [coverage:run]
 parallel = True

--- a/setup.py
+++ b/setup.py
@@ -1722,8 +1722,6 @@ if not build_examples:
             'Operating System :: Microsoft :: Windows',
             'Operating System :: POSIX :: BSD :: FreeBSD',
             'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
             'Programming Language :: Python :: 3.13',

--- a/setup.py
+++ b/setup.py
@@ -1725,6 +1725,7 @@ if not build_examples:
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
             'Programming Language :: Python :: 3.13',
+            'Programming Language :: Python :: 3.14',
             'Topic :: Artistic Software',
             'Topic :: Games/Entertainment',
             'Topic :: Multimedia :: Graphics :: 3D Rendering',


### PR DESCRIPTION
Drops Python 3.9 and 3.10 support across packaging metadata, CI matrices, RPi cross-compile tooling, and user-facing installation docs. Also drops cp38/cp39/cp310 from the cibuildwheel build sets on manylinux and macOS so we no longer publish wheels below the new floor, and bumps the Windows sdist trigger pin to 3.11.

The RPi wheels matrix and installation docs are simplified to Bookworm/Python 3.11 only (Bullseye/3.9 is removed).

Added Python 3.14 to the supported versions.  The existing `ffpyplayer; ... and python_version < "3.14"` carve-out
in setup.cfg is intentionally left in place until upstream ffpyplayer publishes 3.14 wheels.

### Follow-up: removing the ffpyplayer 3.14 carve-out

The `python_version < "3.14"` guard on `ffpyplayer` in `setup.cfg` and the matching `KIVY_TEST_AUDIO=0` skip in `.github/workflows/test_ubuntu_python.yml` are tracked upstream by:

- [matham/ffpyplayer#185](https://github.com/matham/ffpyplayer/pull/185) — *GitHub Actions: Test on Python 3.14* (open, all CI green, one approval, awaiting maintainer merge).
- [matham/ffpyplayer#186](https://github.com/matham/ffpyplayer/pull/186) — closed in favor of #185; originally demonstrated `python3.14 -m pip install ffpyplayer` fails (SDL_version.h not found).
- [matham/ffpyplayer#191](https://github.com/matham/ffpyplayer/pull/191) — open prerequisite (LAME sourceforge URL fixes), pulled into #185.

Once `ffpyplayer#185` is merged and a release with 3.14 wheels is published to PyPI, a follow-up PR can drop both workarounds.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
