### PR TITLE
[WIP] Optimize `glReadPixels` helper

### DIFF
--- a/kivy/graphics/opengl.pyx
+++ b/kivy/graphics/opengl.pyx
@@ -1158,31 +1158,26 @@ def glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
 
     We support only GL_RGB/GL_RGBA as a format and GL_UNSIGNED_BYTE as a
     type.
+
+    .. versionchanged:: 3.0.0
+       The return value is now a :class:`bytearray` instead of a :class:`bytes` object.
     '''
     assert format in (GL_RGB, GL_RGBA)
     assert type == GL_UNSIGNED_BYTE
 
-    cdef object py_pixels = None
     cdef long size
-    cdef char *data
+    cdef bytearray data
 
     size = width * height * sizeof(GLubyte)
     if format == GL_RGB:
         size *= 3
     else:
         size *= 4
-    data = <char *>malloc(size)
-    if data == NULL:
-        raise MemoryError('glReadPixels()')
+    data = bytearray(size)
 
     cgl.glPixelStorei(GL_PACK_ALIGNMENT, 1)
-    cgl.glReadPixels(x, y, width, height, format, type, data)
-    try:
-        py_pixels = data[:size]
-    finally:
-        free(data)
-
-    return py_pixels
+    cgl.glReadPixels(x, y, width, height, format, type, <GLubyte*>data)
+    return data
 
 def glReadPixels_inplace(GLint x, GLint y, GLsizei width, GLsizei height,
                          GLenum format, GLenum type, unsigned char[::1] out_buf):
@@ -1196,6 +1191,8 @@ def glReadPixels_inplace(GLint x, GLint y, GLsizei width, GLsizei height,
 
     We support only GL_RGB/GL_RGBA as a format and GL_UNSIGNED_BYTE as a
     type.
+
+    .. versionadded:: 3.0.0
     '''
     cdef long bytes_per_pixel
 

--- a/kivy/tests/test_graphics.py
+++ b/kivy/tests/test_graphics.py
@@ -1189,3 +1189,24 @@ class Test_glReadPixels_inplace(GraphicUnitTest):
             glReadPixels_inplace
         with pytest.raises(ValueError):
             glReadPixels_inplace(0, 0, 1, 1, GL_RGB565, GL_UNSIGNED_BYTE, bytearray(16))
+
+
+class Test_glReadPixels(GraphicUnitTest):
+    @requires_graphics
+    def test_read_pixels(self):
+        from kivy.graphics.opengl import GL_RGB, GL_UNSIGNED_BYTE, glReadPixels
+        self.Window.clearcolor = (1, 0, 0, 1)
+        self.advance_frames(1)
+        pixels = glReadPixels(0, 0, 1, 1, GL_RGB, GL_UNSIGNED_BYTE)
+        assert pixels == b'\xff\x00\x00'
+
+    def test_unsupported_type(self):
+        from kivy.graphics.opengl import GL_RGB, GL_FLOAT, glReadPixels
+        with pytest.raises(AssertionError):
+            glReadPixels(0, 0, 1, 1, GL_RGB, GL_FLOAT)
+
+    def test_unsupported_format(self):
+        from kivy.graphics.opengl import GL_RGB565, GL_UNSIGNED_BYTE, \
+            glReadPixels
+        with pytest.raises(AssertionError):
+            glReadPixels(0, 0, 1, 1, GL_RGB565, GL_UNSIGNED_BYTE)


### PR DESCRIPTION
<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [x] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [x] **Unittests** are included in PR.
* [x] Properly documented, including `versionadded`, `versionchanged` as needed.

The current implementation of `glReadPixels` performs two memory allocations: one for internal use and one for the return value. Removing the former improves performance. Here is the code I used to benchmark it:

```python
from functools import partial

from kivy.config import Config
Config.set("graphics", "width", 800)
Config.set("graphics", "height", 600)
from kivy.app import App
from kivy.lang import Builder


KV = '''
Button:
    text: "timeit glReadPixels"
    font_size: 50
    on_release: app.timeit_glReadPixels()
'''


class TestApp(App):
    def build(self):
        return Builder.load_string(KV)

    def timeit_glReadPixels(self):
        from timeit import timeit
        from kivy.graphics.opengl import (
            glReadPixels, GL_RGBA, GL_RGB, GL_UNSIGNED_BYTE,
        )

        f = partial(glReadPixels, 0, 0, *self.root.size, GL_RGBA, GL_UNSIGNED_BYTE)
        print("GL_RGBA:", timeit(f, number=1000))
        f = partial(glReadPixels, 0, 0, *self.root.size, GL_RGB, GL_UNSIGNED_BYTE)
        print("GL_RGB: ", timeit(f, number=1000))


if __name__ == "__main__":
    TestApp().run()
```

Results on my Linux desktop:

- The `GL_RGB` format becomes 18% faster (from 5.7 seconds to 4.7 seconds).
- The `GL_RGBA` format becomes 87% faster (from 3.6 seconds to 0.5 seconds).