### PR TITLE
Remove any reference to deprecated and now removed `on_dropfile` and document it in migration docs

### DIFF
--- a/doc/sources/migration.rst
+++ b/doc/sources/migration.rst
@@ -108,6 +108,36 @@ The `file_encodings` property was deprecated and it was kept for backward compat
 To migrate your code, you just need to remove any references to the `file_encodings` property in your codebase.
 
 
+*Removal of deprecated `on_dropfile` Window event name*
+
+In Kivy 3.x.x, the previously deprecated `on_dropfile` event name has been removed.
+Use `on_drop_file` instead.
+
+The event was renamed in Kivy 2.1.0, so any remaining compatibility code that still binds
+to `on_dropfile` now needs to be updated.
+
+.. code-block:: python
+
+    # Kivy 2.x.x (legacy/deprecated name)
+    from kivy.core.window import Window
+
+    def handle_drop(window, filename):
+        print(filename)
+
+    Window.bind(on_dropfile=handle_drop)
+
+    # Kivy 3.x.x
+    from kivy.core.window import Window
+
+    def handle_drop(window, filename, x, y, *args):
+        print(filename, x, y)
+
+    Window.bind(on_drop_file=handle_drop)
+
+If you dispatch or override the event directly, also rename any `on_dropfile`
+method implementations to `on_drop_file`.
+
+
 *Removal of the Kv-lang Templates feature*
 
 In Kivy 3.x.x, the deprecated Kivy language Templates feature (introduced in 1.0.5,

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -24,7 +24,7 @@ from kivy.event import EventDispatcher
 from kivy.properties import ListProperty, ObjectProperty, AliasProperty, \
     NumericProperty, OptionProperty, StringProperty, BooleanProperty, \
     ColorProperty
-from kivy.utils import platform, reify, deprecated, pi_version
+from kivy.utils import platform, pi_version
 from kivy.context import get_current_context
 from kivy.uix.behaviors import FocusBehavior
 from kivy.setupconfig import USE_SDL3
@@ -1062,7 +1062,7 @@ class WindowBase(EventDispatcher):
         'on_touch_move', 'on_touch_up', 'on_mouse_down',
         'on_mouse_move', 'on_mouse_up', 'on_keyboard', 'on_key_down',
         'on_key_up', 'on_textinput', 'on_drop_begin', 'on_drop_file',
-        'on_dropfile', 'on_drop_text', 'on_drop_end', 'on_request_close',
+        'on_drop_text', 'on_drop_end', 'on_request_close',
         'on_cursor_enter', 'on_cursor_leave', 'on_joy_axis',
         'on_joy_hat', 'on_joy_ball', 'on_joy_button_down',
         'on_joy_button_up', 'on_memorywarning', 'on_textedit',
@@ -2154,12 +2154,6 @@ class WindowBase(EventDispatcher):
         .. versionchanged:: 2.1.0
             Renamed from `on_dropfile` to `on_drop_file`.
         '''
-        pass
-
-    @deprecated(msg='Deprecated in 2.1.0, use on_drop_file event instead. '
-                    'Event on_dropfile will be removed in the next two '
-                    'releases.')
-    def on_dropfile(self, filename):
         pass
 
     def on_drop_text(self, text, x, y, *args):


### PR DESCRIPTION
This pull request removes the last traces of the deprecated `on_dropfile` event from Kivy, finalizing its replacement with the `on_drop_file` event. It also updates the migration documentation to help users transition away from the old event name.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [x] Title is descriptive/clear for inclusion in release notes.
* [x] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [x] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
