### PR TITLE
fix(setup.py): honour KIVY_SDL3_PATH on macOS host (fixes #9316)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -517,6 +517,7 @@ elif platform == 'android':
 # If KIVY_SDL3_PATH is explicitly provided by the caller (e.g. a kivy-ios
 # cross-build running on a macOS host), treat it as an unconditional request
 # to use SDL3 via that path rather than system frameworks.
+# Regression: https://github.com/kivy/kivy/issues/9316
 if c_options['use_sdl3'] is None and environ.get('KIVY_SDL3_PATH'):
     print('KIVY_SDL3_PATH set, enabling SDL3 and bypassing framework probe.')
     c_options['use_sdl3'] = True
@@ -590,8 +591,9 @@ if c_options['use_sdl3'] or can_autodetect_sdl3:
     if c_options['use_osx_frameworks'] and platform == 'darwin' \
             and not environ.get('KIVY_SDL3_PATH'):
         # check the existence of frameworks
-        # (skipped when KIVY_SDL3_PATH is set — path-based config takes
-        # precedence over the system/vendored framework probe)
+        # Guard: skipped when KIVY_SDL3_PATH is set — path-based config takes
+        # precedence over the system/vendored framework probe.
+        # Regression: https://github.com/kivy/kivy/issues/9316
         if KIVY_DEPS_ROOT:
             default_sdl3_frameworks_search_path = join(
                 KIVY_DEPS_ROOT, "dist", "Frameworks"

--- a/setup.py
+++ b/setup.py
@@ -514,6 +514,14 @@ elif platform == 'android':
     c_options['use_android'] = True
     c_options['use_sdl3'] = True
 
+# If KIVY_SDL3_PATH is explicitly provided by the caller (e.g. a kivy-ios
+# cross-build running on a macOS host), treat it as an unconditional request
+# to use SDL3 via that path rather than system frameworks.
+if c_options['use_sdl3'] is None and environ.get('KIVY_SDL3_PATH'):
+    print('KIVY_SDL3_PATH set, enabling SDL3 and bypassing framework probe.')
+    c_options['use_sdl3'] = True
+    c_options['use_osx_frameworks'] = False
+
 # detect gstreamer, only on desktop
 # works if we forced the options or in autodetection
 if platform not in ('ios', 'android') and (c_options['use_gstreamer']
@@ -579,8 +587,11 @@ can_autodetect_sdl3 = (
 if c_options['use_sdl3'] or can_autodetect_sdl3:
     print('Detecting SDL3...')
     sdl3_valid = False
-    if c_options['use_osx_frameworks'] and platform == 'darwin':
+    if c_options['use_osx_frameworks'] and platform == 'darwin' \
+            and not environ.get('KIVY_SDL3_PATH'):
         # check the existence of frameworks
+        # (skipped when KIVY_SDL3_PATH is set — path-based config takes
+        # precedence over the system/vendored framework probe)
         if KIVY_DEPS_ROOT:
             default_sdl3_frameworks_search_path = join(
                 KIVY_DEPS_ROOT, "dist", "Frameworks"


### PR DESCRIPTION
**Problem**

When building Kivy for iOS on a macOS host with `KIVY_SDL3_PATH` set (e.g. via kivy-ios), the build system ignores the supplied path and falls back to probing `/Library/Frameworks/SDL3.framework` instead. This causes builds to either pick up the wrong SDL3 or fail to find it entirely.

**Root cause**

`use_sdl3` auto-detection was gated on `sys.platform == 'ios'`, which is only true when CPython itself runs on iOS. When cross-compiling from a macOS host (`sys.platform == 'darwin'`), the auto-detection never fires, and the macOS framework probe runs unconditionally — silently ignoring `KIVY_SDL3_PATH`.

**Fix**

If `KIVY_SDL3_PATH` is set, treat it as the authoritative SDL3 location: auto-enable `use_sdl3` and skip the framework probe. Setting `KIVY_SDL3_PATH` is now sufficient on its own — callers no longer need the `USE_SDL3=1` / `USE_OSX_FRAMEWORKS=0` workaround.

**Who is affected**

Any macOS host build where SDL3 is not in `/Library/Frameworks/` — including iOS cross-builds via kivy-ios, cibuildwheel iOS pipelines, Homebrew installs (`/opt/homebrew/`), and custom SDL3 builds.

Fixes #9316. Related: kivy/kivy-ios#998 (item 5).

---

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.