### PR TITLE
Minor changes to the copyright part on the docs

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -13,10 +13,11 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
-import os
-import sys
+from datetime import datetime
 import configparser
+import os
 import sphinx
+import sys
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
@@ -66,7 +67,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'Kivy'
-copyright = '2010-2025, Kivy Team and other contributors'
+copyright = f'2010-{datetime.now().year}, Kivy Team and other contributors'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/sources/index.rst
+++ b/doc/sources/index.rst
@@ -22,6 +22,7 @@ your concern isn't addressed in the documentation, feel free to
 `contact us <https://github.com/kivy/kivy/blob/master/CONTACT.md>`_.
 
 .. include:: contents.rst.inc
+.. |year| date:: %Y
 
 Appendix
 ========
@@ -48,4 +49,4 @@ For a list of authors, please see the file ``AUTHORS`` that accompanies the
 Kivy source code distribution (next to ``LICENSE``).
 
 
-Kivy -- Copyright 2010-2025, The Kivy Authors.
+Kivy -- Copyright 2010-|year|, The Kivy Authors.


### PR DESCRIPTION
Automatically set the year for the copyright sections of the docs as this is forgotten to do manually each year.