### PR TITLE
:bug: Fix docs version chooser after Sphinx upgrade (#9326)

### DIFF
--- a/doc/sources/.static/kivy.js
+++ b/doc/sources/.static/kivy.js
@@ -313,13 +313,22 @@ document.addEventListener("DOMContentLoaded", function() {
     var selector = document.getElementById("version_selector");
 
     if (selector) {
-        selector.addEventListener('change', function() {
-            // Clean up the path into segments, ignoring empty spaces
-            var paths = window.location.pathname.split('/').filter(Boolean);
+        // Docs are served under "/doc/<version>/...", so the version is the
+        // path segment right after "doc". Keep the raw split (with its leading
+        // empty segment) so the rest of the path is preserved exactly and no
+        // spurious trailing slash is introduced when switching versions.
+        function version_index(segments) {
+            var doc_index = segments.indexOf('doc');
+            return doc_index === -1 ? -1 : doc_index + 1;
+        }
 
-            if (paths.length > 0) {
-                paths[0] = this.value;
-                document.location.pathname = '/' + paths.join('/') + '/';
+        selector.addEventListener('change', function() {
+            var segments = window.location.pathname.split('/');
+            var index = version_index(segments);
+
+            if (index !== -1 && index < segments.length) {
+                segments[index] = this.value;
+                document.location.pathname = segments.join('/');
             }
         });
 
@@ -331,8 +340,9 @@ document.addEventListener("DOMContentLoaded", function() {
                 return response.json();
             })
             .then(function(versions) {
-                var paths = window.location.pathname.split('/').filter(Boolean);
-                var current = paths[0];
+                var segments = window.location.pathname.split('/');
+                var index = version_index(segments);
+                var current = index === -1 ? undefined : segments[index];
 
                 selector.innerHTML = '';
 


### PR DESCRIPTION
The jQuery to vanilla-JS refactor in #9326 broke the sidebar version chooser. Docs are served under "/doc/<version>/...", but the new code used `pathname.split('/').filter(Boolean)[0]`, which points at the "doc" segment instead of the version. As a result no version was ever preselected, and switching versions rewrote the wrong segment (dropping the "/doc/" prefix). It also appended a trailing slash, producing URLs like "/doc/master/tutorials/pong.html/" that 404 on the server.

Anchor on the "doc" path segment to locate the version, and rebuild the path from the raw split so the rest of the URL is preserved exactly with no spurious trailing slash.

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
