### PR TITLE
Control statements for kv-lang if/elif/else, for, slot, and factory

### DIFF
--- a/doc/sources/guide/lang.rst
+++ b/doc/sources/guide/lang.rst
@@ -419,6 +419,144 @@ This class, created just by the declaration of this rule, inherits from the
 Button class and allows us to change default values and create bindings for all
 its instances without adding any new code on the Python side.
 
+Control statements
+------------------
+
+.. versionadded:: 3.0.0
+
+By default a rule builds a *fixed* tree of widgets. Control statements let that
+tree change at runtime -- widgets that appear and disappear, and lists that grow
+and shrink -- described directly in kv and kept up to date automatically. At any
+child position a rule may contain an ``if`` / ``elif`` / ``else``, ``for``,
+``slot`` or ``factory`` block. Each block is *reactive*: whenever a property
+used in its header changes, the block rebuilds the content it manages. There is
+nothing to wire up -- reassign the property and the tree follows.
+
+Conditional content
+~~~~~~~~~~~~~~~~~~~~
+
+Use ``if`` / ``elif`` / ``else`` to mount widgets only while a condition holds:
+
+.. code-block:: kv
+
+    <LoginBox@BoxLayout>:
+        logged_in: False
+        Label:
+            text: 'Account'
+        if self.logged_in:
+            Button:
+                text: 'Log out'
+        else:
+            Button:
+                text: 'Log in'
+
+Toggling ``logged_in`` swaps one button for the other. Unlike a widget hidden
+with ``opacity`` or ``disabled``, an inactive branch's widgets are not in the
+tree at all -- no ghost touch target and no leftover layout space. A branch may
+also set the host widget's own properties, declare a ``canvas`` or bind event
+handlers while it is active. Branch properties are ordinary one-way bindings
+added while the branch is active: leaving a branch never reverts a value, so
+give the chain an ``else`` when something must come back.
+
+Repeated content
+~~~~~~~~~~~~~~~~
+
+Use ``for`` to build one copy of the body per item, kept in sync as the iterable
+changes:
+
+.. code-block:: kv
+
+    <FruitList@BoxLayout>:
+        orientation: 'vertical'
+        fruits: ['apple', 'pear', 'plum']
+        for fruit in self.fruits:
+            Label:
+                text: fruit
+
+Reassigning ``fruits`` re-renders the list -- no ``add_widget`` loop and no
+manual bookkeeping. The header accepts Python's *comprehension* syntax (what is
+valid inside a list comprehension, not statement syntax), so tuple targets and
+a trailing ``if`` filter work, and the loop variables are available in the
+body's expressions:
+
+.. code-block:: kv
+
+    for i, fruit in enumerate(self.fruits) if fruit != 'pear':
+        Label:
+            text: f'{i}: {fruit}'
+
+There is no ``for`` / ``else``; the idiomatic empty state is a paired
+``if not self.fruits:`` block next to the loop.
+
+Add a ``key:`` line to give each item a stable identity: same key, same
+widgets. Existing widgets (and their live state, such as text being edited)
+are kept and moved rather than rebuilt when the list changes, and an item
+replaced under a stable key refreshes the kept widgets through their bindings:
+
+.. code-block:: kv
+
+    for fruit in self.fruits:
+        key: fruit
+        TextInput:
+            text: fruit
+
+Slots and factory
+~~~~~~~~~~~~~~~~~
+
+Two further blocks round out the set.
+
+``slot`` declares a named, fillable hole in a reusable container rule, with
+fallback content that the call site can override -- the same idea as Vue slots
+or the web-components ``<slot>``. Build the shell once and drop different
+content into it at each call site, without subclassing:
+
+.. code-block:: kv
+
+    # a reusable frame with a header slot and a default (body) slot
+    <Card@BoxLayout>:
+        orientation: 'vertical'
+        slot header:
+            Label:                       # fallback, shown if the caller fills nothing
+                text: 'Untitled'
+        slot:                            # default slot: plain children land here
+
+    # call site -- fill the header, drop the body content straight in
+    Card:
+        slot header:
+            Label:
+                text: 'Inbox'
+                bold: True
+        Label:                           # plain child, routed into the default slot
+            text: 'You have 3 new messages'
+
+A slot definition may also declare *slot-scoped locals* -- reactive values
+computed by the defining rule and read by fallback and fill content through
+the reserved ``slot`` name (``text: slot.title``) -- so a shell can hand data
+to whatever content the caller drops in.
+
+``factory <expr>`` builds a single child whose class is chosen by an expression
+(a class object, or a name resolved through the :class:`~kivy.factory.Factory`),
+rebuilt when the class changes. Because the expression is ordinary Python,
+picking a class at runtime needs no extra machinery:
+
+.. code-block:: kv
+
+    <MessageList@BoxLayout>:
+        orientation: 'vertical'
+        messages: []
+        for message in self.messages:
+            factory 'StrongLabel' if message.unread else 'Label':
+                text: message.text
+
+Learn more
+~~~~~~~~~~
+
+Control statements come with a handful of rules -- for example they cannot
+appear at the top level of a file, and inside a ``canvas`` block only ``if`` and
+``for`` are allowed. For the full description, including reactive ids,
+iteration-local values and graphics control flow inside ``canvas``, see the
+:ref:`control statements <kv_control_statements>` reference.
+
 Re-using styles in multiple widgets
 -----------------------------------
 

--- a/doc/sources/sphinxext/kivy_pygments_theme.py
+++ b/doc/sources/sphinxext/kivy_pygments_theme.py
@@ -12,7 +12,10 @@ class KivyStyle(Style):
     styles = {
         # No corresponding class for the following:
         #Text:                     "", # class:  ''
-        Whitespace:                "underline #ffffff",      # class: 'w'
+        # Leave whitespace unstyled: recent Pygments emits Whitespace ('w')
+        # tokens for interior spaces too, so any decoration here (an underline
+        # used to) shows up under every space in a code block.
+        Whitespace:                "",                       # class: 'w'
         Error:                     "#FF0000 border:#FF0000", # class: 'err'
         Other:                     "#FF0000",                # class 'x'
 

--- a/examples/kv/app_todo.kv
+++ b/examples/kv/app_todo.kv
@@ -1,0 +1,137 @@
+#:import uuid uuid
+
+# A tiny todo app written entirely in kv, showcasing the control statements:
+# slot (with a slot-scoped local and ids in fills), if/else, for (with key:
+# and an iteration-local) and factory.
+# Run it with:  python3 kvrun.py app_todo.kv
+#
+# State is a {uid: task} dict. A kv dict literal is a DictProperty, which
+# dispatches on in-place key ops -- so one task can be updated/added/removed
+# with `tasks[uid] = ...` / `del tasks[uid]`, no whole-container copy.
+# Note the dict.items(x) / dict.values(x) form: passing the property as a bare
+# argument lets kv bind it (x.items() would hide `x` behind the call and the
+# binding would never fire) -- the usual kv binding gotchas apply to control
+# headers too.
+
+# the two presentations the factory switches between per task
+<TodoLabel@Label>:
+    task: None
+    halign: 'left'
+    valign: 'middle'
+    text_size: self.size
+    text: root.task['text'] if root.task else ''
+
+<DoneLabel@TodoLabel>:
+    markup: True
+    color: .5, .5, .5, 1
+    text: ('[s]' + root.task['text'] + '[/s]') if root.task else ''   # struck through
+
+# --- a reusable framed panel with a customizable header (slot) ---
+<Panel@BoxLayout>:
+    # declared here (not just on the instance) so kv infers a DictProperty,
+    # which dispatches on in-place key ops; an instance-only `tasks:` would be
+    # a plain ObjectProperty and setitem would not re-render
+    tasks: {}
+    orientation: 'vertical'
+    padding: dp(12)
+    spacing: dp(8)
+    canvas.before:
+        Color:
+            rgba: .12, .12, .14, 1
+        Rectangle:
+            pos: self.pos
+            size: self.size
+    slot header:
+        # slot-scoped local: computed by Panel, readable by any header fill
+        # (and the fallback below) as `slot.summary`
+        summary: f'{len(root.tasks)} task(s)'
+        Label:                                  # fallback, overridden below
+            text: slot.summary
+            size_hint_y: None
+            height: dp(32)
+    slot:                                        # default slot: body lands here
+
+
+# --- the app ---
+Panel:
+    tasks: {uuid.uuid4(): {'text': 'Buy milk', 'done': False}, uuid.uuid4(): {'text': 'Write a kv example', 'done': False}, uuid.uuid4(): {'text': 'Tick me off', 'done': False}}
+    # reactive aggregate; dict.values(self.tasks) keeps `self.tasks` bindable
+    done: len([t for t in dict.values(self.tasks) if t['done']])
+
+    slot header:                                 # fill the panel's header slot
+        Label:
+            # the fill reads the slot-scoped local computed by Panel
+            text: f'My tasks - {slot.summary}, {root.done} done'
+            font_size: '20sp'
+            size_hint_y: None
+            height: dp(32)
+
+    slot:                                        # explicit default fill: ids are
+        BoxLayout:                               # allowed on explicit slot content
+            orientation: 'vertical'
+            spacing: dp(6)
+
+            BoxLayout:                           # input row
+                size_hint_y: None
+                height: dp(40)
+                spacing: dp(8)
+                TextInput:
+                    id: field                    # reactive id on this rule's scope
+                    hint_text: 'Add a task and press Enter'
+                    multiline: False
+                    focus: True
+                    on_text_validate:
+                        if field.text.strip(): root.tasks[uuid.uuid4()] = {'text': field.text, 'done': False}
+                        field.text = ''
+                        field.focus = True
+                Button:
+                    text: 'Add'
+                    size_hint_x: None
+                    width: dp(70)
+                    # `field` is a reactive id (None until the TextInput
+                    # exists), hence the trailing guard. And as everywhere in
+                    # kv, `field.text` must end the dotted chain for kv to
+                    # bind it -- a bare `field.text.strip()` would never
+                    # re-evaluate (see the kv gotchas), so keep the parens.
+                    disabled: not (field.text or '').strip() if field else True
+                    on_release: field.dispatch('on_text_validate')
+
+            if not root.tasks:                   # empty state / hint (if / else)
+                Label:
+                    text: 'No tasks yet. Add one above.'
+                    size_hint_y: None
+                    height: dp(28)
+            else:
+                Label:
+                    text: 'Tick to complete, press x to delete.'
+                    size_hint_y: None
+                    height: dp(28)
+
+            for uid, task in dict.items(root.tasks):     # one row per task
+                key: uid                         # same key => same widgets; a
+                                                 # replaced task re-dispatches
+                                                 # through the kept row's bindings
+                kind: 'DoneLabel' if task['done'] else 'TodoLabel'   # iteration-local
+                BoxLayout:
+                    size_hint_y: None
+                    height: dp(36)
+                    spacing: dp(8)
+                    CheckBox:
+                        size_hint_x: None
+                        width: dp(40)
+                        activated: task['done']          # note: 'activated', not 'active'
+                        on_activated:
+                            # in-place update of one task -- the DictProperty
+                            # dispatches, the row is kept (stable key) and its
+                            # bindings receive the new task value
+                            root.tasks[uid] = dict(task, done=self.activated)
+                    factory kind:                # done vs todo presentation
+                        task: task
+                    Button:
+                        text: 'x'
+                        size_hint_x: None
+                        width: dp(36)
+                        on_release:
+                            del root.tasks[uid]
+
+            Widget:                              # spacer: keep content at the top

--- a/kivy/extras/highlight.py
+++ b/kivy/extras/highlight.py
@@ -3,7 +3,7 @@
 from pygments.lexer import RegexLexer, bygroups, using
 from pygments.lexers.agile import PythonLexer
 from pygments import highlight
-from pygments.token import Comment, Text, Name, Punctuation, Operator
+from pygments.token import Comment, Text, Name, Punctuation, Operator, Keyword
 from pygments.formatters import get_formatter_by_name
 import sys
 
@@ -22,6 +22,19 @@ class KivyLexer(RegexLexer):
                 bygroups(Punctuation, Text, Name.Class, Text, Operator),
                 'classList'),
             (r'[A-Za-z][A-Za-z0-9]*$', Name.Attribute),
+            # control statements: keyword + a Python-highlighted header, e.g.
+            # "if self.x:", "for item in self.items:", "factory expr:".
+            # These must precede the widget-definition rule below, which would
+            # otherwise paint the whole header as a single Name.Class token.
+            (r'(if|elif|for|factory)(\s+)(.+?)(\s*)(:)(\s*)$',
+                bygroups(Keyword, Text, using(PythonLexer), Text,
+                         Punctuation, Text)),
+            (r'(else)(\s*)(:)(\s*)$',
+                bygroups(Keyword, Text, Punctuation, Text)),
+            (r'(slot)(\s+)([A-Za-z_][A-Za-z0-9_]*)(\s*)(:)(\s*)$',
+                bygroups(Keyword, Text, Name, Text, Punctuation, Text)),
+            (r'(slot)(\s*)(:)(\s*)$',
+                bygroups(Keyword, Text, Punctuation, Text)),
             (r'(.*?)(\s*)(:)(\s*)$',
                 bygroups(Name.Class, Text, Punctuation, Text)),
             (r'(.*?)(\s*)(:)(\s*)(.*?)$',

--- a/kivy/lang/__init__.py
+++ b/kivy/lang/__init__.py
@@ -474,6 +474,503 @@ In Python, you can create an instance of the dynamic class as follows:
     properties/methods override those of the child. Be careful if you choose
     to do this.
 
+.. _kv_control_statements:
+
+Control statements
+------------------
+
+.. versionadded:: 3.0.0
+
+Control statements let a rule's widget tree change at runtime: child widgets
+that appear and disappear, and lists that grow and shrink, all described in kv
+and kept in sync automatically.
+
+At any child-widget position a rule may contain an ``if`` / ``elif`` / ``else``,
+``for``, ``slot`` or ``factory`` block. Each block is **reactive**: when a
+property used in its header changes, the block rebuilds the content it manages.
+There is nothing to wire up -- reassign the property and the tree follows.
+
+Conditional content
+~~~~~~~~~~~~~~~~~~~~
+
+Mount widgets only while a condition holds:
+
+.. code-block:: kv
+
+    <LoginPanel@BoxLayout>:
+        logged_in: False
+        Label:
+            text: 'Account'
+        if self.logged_in:
+            Button:
+                text: 'Log out'
+        else:
+            TextInput:
+                hint_text: 'username'
+            Button:
+                text: 'Log in'
+
+Toggling ``logged_in`` swaps a single *Log out* button for a username field
+plus a *Log in* button, keeping their place after the *Account* label. An
+inactive branch's widgets are not in the tree at all: unlike a widget hidden
+with ``opacity`` / ``disabled``, they leave no ghost touch target and no
+leftover layout space.
+
+``elif`` and ``else`` are optional and chain as in Python. A bare ``if`` with no
+matching branch simply builds nothing while its condition is false:
+
+.. code-block:: kv
+
+    if self.error:
+        Label:
+            text: self.message
+
+Setting properties from a branch
+********************************
+
+An ``if`` / ``elif`` / ``else`` branch is a *full rule body* applied to the host
+widget while active. Besides children it may set the host's own properties, so a
+group of properties that all hinge on one condition can state it once instead of
+repeating it on every line:
+
+.. code-block:: kv
+
+    <StatusLabel@Label>:
+        error: False
+        if self.error:
+            color: 1, 0, 0, 1
+            bold: True
+            font_size: '18sp'
+        else:
+            color: 1, 1, 1, 1
+            bold: False
+            font_size: '14sp'
+
+A property that does not exist yet is created on demand, exactly as elsewhere in
+kv.
+
+A branch only *adds* the bindings it declares while active and drops them when
+it leaves; it never reverts a property to a previous value. So the ``else``
+branch is what brings a value back -- without one, the property simply keeps the
+active branch's last value after that branch leaves. (If an unconditional rule
+and a branch, or two branches, drive the same property at once, that is allowed:
+their bindings coexist and the last dependency to change wins, just as with
+overlapping plain kv rules. Prefer a single ``if`` / ``else`` where you can.)
+
+Canvas and event handlers in a branch
+*************************************
+
+A branch may also declare a ``canvas`` and bind event handlers, mounted when the
+branch becomes active and torn down when it leaves:
+
+.. code-block:: kv
+
+    <Badge@Widget>:
+        urgent: False
+        count: 0
+        if self.urgent:
+            on_touch_down: print('badge tapped')
+            canvas:
+                Color:
+                    rgba: 1, 0, 0, 1
+                Ellipse:
+                    pos: self.pos
+                    size: self.size
+            Label:
+                text: f'{root.count}'
+
+The branch's ``canvas`` is added to the host's canvas while active and removed
+when the branch leaves; its instruction expressions update on the next
+:meth:`Builder.sync <BuilderBase.sync>`, like any kv canvas. Handlers are bound
+on activation and unbound on teardown. Host properties, ``canvas`` and handlers
+belong to ``if`` / ``elif`` / ``else`` blocks *outside* any ``for``: an ``if``
+nested inside a ``for`` follows the for-body rules instead (its property lines
+are iteration-locals, and handlers and ``canvas`` stay forbidden -- see
+`Iteration-local values`_).
+
+Repeated content
+~~~~~~~~~~~~~~~~
+
+Build one copy of the body per item, kept in sync as the iterable changes:
+
+.. code-block:: kv
+
+    <TodoList@BoxLayout>:
+        items: []
+        for item in self.items:
+            Label:
+                text: item.title
+
+A single iteration can build several widgets -- everything in the body is
+repeated together, so the loop variables are available to a whole cluster of
+children (and to their event handlers):
+
+.. code-block:: kv
+
+    for item in self.items:
+        Label:
+            text: item.title
+        Button:
+            text: 'delete'
+            on_press: root.items = [x for x in root.items if x is not item]
+
+The header uses Python's *comprehension* grammar -- exactly what is valid
+between the brackets of a list comprehension, which is not quite statement
+grammar -- so tuple (and starred) targets and a trailing ``if`` filter work:
+
+.. code-block:: kv
+
+    for i, item in enumerate(self.items) if item.visible:
+        Label:
+            text: f'{i}: {item.title}'
+
+The iterable is an ordinary kv expression, so the usual binding rules and
+gotchas apply: reassigning the property dispatches (and list/dict properties
+dispatch on in-place changes), but mutating a plain value nested inside one
+does not. Iterating something that is not iterable (``None``, say) fails
+exactly as it does in Python; the error simply carries the kv file and line.
+
+There is no ``for`` / ``else``. The idiomatic empty state is a paired ``if``
+on the same property -- the duplicated condition costs one line and reads
+plainly:
+
+.. code-block:: kv
+
+    if not self.items:
+        Label:
+            text: 'nothing here yet'
+    for item in self.items:
+        Label:
+            text: item.title
+
+``for`` builds a *real* widget per item, so it is not efficient for long lists
+or frequently mutated ones. :class:`~kivy.uix.recycleview.RecycleView` is
+the right tool for large, scrolling, virtualised lists. ``for`` targets the
+everyday handful-of-widgets case where RecycleView would be overkill.
+
+Keyed reconciliation
+********************
+
+By default an iteration's identity is its position in the iterable, so a change
+rebuilds the widgets from the first differing position on. That is fine for
+stateless content, but a widget holding live state -- text being edited, focus,
+selection or scroll position -- would lose it as soon as an item is inserted or
+the list is reordered.
+
+Add a ``key:`` line as the first entry in the body to give each iteration a
+stable identity instead:
+
+.. code-block:: kv
+
+    for item in self.items:
+        key: item.uid
+        TextInput:
+            text: item.title
+
+Now an iteration keeps its widgets for as long as its key is present: **same
+key, same widgets**. When the order changes the widgets are moved, not rebuilt;
+and when the item behind a kept key is *replaced*, the new loop values are
+re-dispatched through the existing bindings instead of rebuilding. So a
+``TextInput`` the user is editing survives another item being inserted above
+it, the whole list being reordered, or its own item being swapped for an
+updated copy: the same widget instance stays, and with it its text, cursor and
+focus. Only new keys build widgets, and only vanished keys destroy them.
+
+Keys behave like dict keys -- hashable, compared by equality -- and must be
+unique. Use *stable* values (an id, a uuid), not something that editing the
+item would change. Re-dispatch follows ordinary property semantics: a
+replacement that compares equal to the previous value does not dispatch.
+
+Iteration-local values
+**********************
+
+A property line in a ``for`` body is not a host property but an
+*iteration-local*: a named, reactive value computed once per iteration and
+shared by everything in that iteration's body (so a ``[]`` is a single list, not
+a fresh one at each use):
+
+.. code-block:: kv
+
+    <Cart@BoxLayout>:
+        items: []
+        for item in self.items:
+            total: item.qty * item.price      # iteration-local
+            Label:
+                text: f'{item.qty}'
+            Label:
+                text: f'= {total}'             # reads the same value
+
+The name is visible only inside the block (it is not a property of the host
+widget), shadows enclosing names, and re-evaluates reactively when its
+dependencies change. A local may reference the loop targets and earlier locals
+of the same block:
+
+.. code-block:: kv
+
+    for x in self.values:
+        squared: x * x
+        scaled: squared * self.factor
+        Label:
+            text: f'{scaled}'
+
+The general rule is that **a property line binds to the nearest enclosing
+scope**: the iteration scope when a ``for`` encloses it, the host widget
+otherwise. So a property line in an ``if`` nested inside a ``for`` is a
+*conditional* iteration-local: it starts as ``None``, is bound while the
+branch is active, and keeps its last value when the branch leaves -- one-way,
+like every kv binding; give the chain an ``else`` to set it back. Handlers
+and ``canvas`` follow the same nesting-context rule and stay forbidden
+anywhere under a ``for``.
+
+A local may not share its name with an ``id`` in the same block. Unlike
+Python shadowing, both writers would stay live (the id is written at mount,
+the local re-evaluates on every dependency change), so the collision is a
+parse-time error.
+
+Slots
+~~~~~
+
+A slot is a named hole a container rule leaves for its callers to fill, with
+fallback content for when they don't -- the same idea as Vue slots or the
+web-components ``<slot>``. It lets you build a reusable shell once and drop
+different content into it at each call site, without subclassing:
+
+.. code-block:: kv
+
+    <Card@BoxLayout>:
+        orientation: 'vertical'
+        slot header:
+            Label:                       # fallback, shown if nobody fills it
+                text: 'Untitled'
+        slot:                            # default slot: plain children land here
+        Label:
+            text: 'footer'
+
+    # usage:
+    Card:
+        slot header:
+            Image:
+                source: root.logo
+        Label:                           # plain child, routed to the default slot
+            text: 'body'
+
+The first rule declaring ``slot name:`` defines the insertion point and its
+fallback. Any later rule declaring the same name provides content instead, and
+the most derived provider wins: a subclass rule overrides the base fallback, and
+the widget instance overrides both. Fill content is evaluated in the context of
+the rule providing it, so ``root.logo`` above refers to the rule instantiating
+the ``Card``, not to the ``Card`` itself. A filled slot never builds its
+fallback.
+
+A slot may be defined inside an ``if`` block (the insertion point then comes and
+goes with the branch), and a fill may itself declare new slots under a fresh
+name, re-exposing customization through a wrapper class. Filling a name that no
+class rule ever declared degrades to defining a new insertion point at the fill's
+own position -- since nothing can ever fill an instance-level definition, this is
+almost always a typo, and a warning is logged.
+
+Slot-scoped locals (slot props)
+*******************************
+
+A property line in a slot *definition* declares a slot-scoped local: a
+reactive value computed in the defining rule's context and handed to whatever
+content ends up in the hole. Fallback and fill content read it through the
+reserved ``slot`` name:
+
+.. code-block:: kv
+
+    <UserCard@BoxLayout>:
+        user: None
+        slot badge:
+            display_name: self.user.name if self.user else ''
+            Label:
+                text: slot.display_name        # the fallback reads it
+
+    # call site -- the fill reads the same value, still computed by UserCard
+    UserCard:
+        user: some_user
+        slot badge:
+            Label:
+                text: '@' + slot.display_name
+                bold: True
+
+This is how a reusable shell passes data to caller-provided content (the same
+idea as Vue's scoped slots). When slots nest, the innermost ``slot`` wins.
+
+An ``id`` is allowed on content declared in an explicit ``slot`` block -- a
+definition's fallback or a fill. It becomes a reactive id on the rule
+*providing* that content (``None`` while the content is not built), reachable
+by that rule's other expressions like an ``if`` id. Implicitly routed plain
+children cannot carry an id: whether they are routed depends on the class
+rules, which the parser cannot see from the call site -- use an explicit
+``slot:`` fill block instead.
+
+Widgets chosen by class
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``factory <expr>`` builds a single child widget whose *class* is chosen by an
+expression -- a class object, or a name resolved through the
+:class:`~kivy.factory.Factory`. The block body is applied to the instance, and
+the widget is rebuilt when the class expression changes:
+
+.. code-block:: kv
+
+    <Form@BoxLayout>:
+        schema: []
+        for field in self.schema:
+            factory field['cls']:        # e.g. 'TextInput', 'CheckBox', ...
+                hint_text: field.get('label', '')
+
+The expression is ordinary Python, so a runtime choice between classes needs no
+extra machinery:
+
+.. code-block:: kv
+
+    for item in self.items:
+        factory 'StrongLabel' if item.highlighted else 'Label':
+            text: item.text
+
+A ``None`` class builds nothing, and a constant class name is built once with no
+binding. When the class does change, the widget is rebuilt and the body
+re-applied; while it stays the same the instance is kept and its body
+expressions stay reactive.
+
+In depth
+~~~~~~~~
+
+Reactive ids
+************
+
+A widget inside a control block may carry an ``id``. Because such a widget comes
+and goes, the id is *reactive* rather than a fixed entry in ``root.ids``.
+
+In an ``if`` / ``elif`` / ``else`` block the id is reachable across the whole
+rule and is ``None`` while its branch is inactive, so other expressions can
+react to the widget mounting and unmounting:
+
+.. code-block:: kv
+
+    <Editor@BoxLayout>:
+        editing: False
+        if self.editing:
+            TextInput:
+                id: field
+        Button:
+            disabled: field is None          # True until the TextInput exists
+
+Because the id really is ``None`` while its branch is inactive, guard
+attribute access accordingly: ``field.text if field else ''``. The usual kv
+binding rules apply through a reactive id exactly as through a static one --
+in particular the property you depend on must end the dotted chain
+(``(field.text or '').strip()`` re-evaluates on typing; a bare
+``field.text.strip()`` never does). Two branches of one chain may declare
+the same id, and so may two complementary chains (``if cond:`` /
+``if not cond:``): the id always points at the widget most recently mounted
+under that name, and a branch tearing down only clears the id if it still
+owns it.
+
+In a ``for`` block the id is iteration-local, like an iteration-local value:
+reachable only by that iteration's own content, never on ``root.ids``:
+
+.. code-block:: kv
+
+    for row in self.rows:
+        CheckBox:
+            id: box
+        Label:
+            text: 'on' if box.activated else 'off'
+
+Such ids never appear in ``root.ids`` -- an entry that blinked in and out would
+silently break anything bound to it.
+
+Control statements inside canvas
+********************************
+
+``if`` and ``for`` also work *inside* a ``canvas`` (or ``canvas.before`` /
+``canvas.after``) block, where they generate graphics instructions instead of
+widgets -- data-driven drawing that reacts to its inputs:
+
+.. code-block:: kv
+
+    <Chart@Widget>:
+        series: []
+        selected: False
+        canvas:
+            Color:
+                rgba: 1, 1, 1, 1
+            for line in self.series:
+                Line:
+                    points: line.points
+            if self.selected:
+                Color:
+                    rgba: 1, 0, 0, 1
+                Rectangle:
+                    pos: self.pos
+                    size: self.size
+
+The instructions a block produces occupy the block's position among the
+surrounding instructions, and are rebuilt when the condition or iterable
+changes; instructions declared after the block stay after it. As with any kv
+canvas, instruction property expressions update on the next
+:meth:`Builder.sync <BuilderBase.sync>`. Blocks nest, so a ``for`` inside an
+``if`` composes as expected.
+
+A canvas ``for`` without a ``key:`` rebuilds its instructions wholesale on
+change -- fine for cheap, stateless drawing. With a ``key:`` it reconciles per
+iteration (keeping, moving or rebuilding instruction groups by key), so
+textured or stateful instructions and large series are not destroyed and
+re-uploaded on every change. Unlike the widget ``for``, a kept canvas
+iteration whose loop values changed is rebuilt rather than re-dispatched --
+instructions hold no user state worth preserving.
+
+Restrictions
+~~~~~~~~~~~~~
+
+- Control statements cannot appear at the top level of a kv file.
+- A property line binds to the nearest enclosing scope: host properties in an
+  ``if`` at rule level, iteration-locals anywhere under a ``for`` (including
+  inside an ``if`` nested in the ``for``), slot-scoped locals in a ``slot``
+  definition. Event handlers and ``canvas`` are accepted only in ``if`` /
+  ``elif`` / ``else`` blocks outside any ``for``; ``for`` bodies and ``slot``
+  blocks take neither.
+- Inside a ``canvas`` block only ``if`` and ``for`` are allowed (not ``slot`` or
+  ``factory``); their bodies hold graphics instructions only, and a control
+  statement may not be nested under an individual instruction.
+- A ``key:`` line is valid only inside a ``for`` and must come before the
+  block's child widgets; ``key`` is a reserved name there (an iteration-local
+  cannot be called ``key``). Keys behave like dict keys and must be unique.
+- ``id`` is allowed on widgets inside ``if`` / ``for`` blocks and inside
+  explicit ``slot`` blocks (reactive); it is rejected directly on a control
+  statement, on plain children implicitly routed into a slot, and inside
+  ``factory`` blocks. A local and an ``id`` cannot share a name.
+- Loop targets form their own scope and may shadow any name, including
+  ``self`` / ``root`` / ``app`` and the metric helpers: within the block the
+  loop variable wins over the global kv context. A child widget's own ``self``
+  (and a handler's ``args``) still take precedence inside that widget, so
+  shadowing ``self`` only affects the block's structure, not the children's
+  expressions. Assignment expressions (``:=``) and ``async for`` are not allowed
+  in headers, and a ``for`` header takes a single ``for ... in ...`` clause.
+- A slot cannot be defined inside a ``for`` block; slot fills must be direct
+  children of the widget instance (put an ``if`` *inside* the fill to make its
+  content conditional), and a default ``slot:`` fill block cannot be mixed with
+  plain children.
+- ``factory`` requires a class expression and cannot be declared inside a
+  ``canvas`` block.
+
+Nothing is reserved beyond this: names like ``while`` or ``match`` in control
+position are syntax errors today, so future statements can be added exactly as
+additively as these were.
+
+.. warning::
+
+    The children built by control statements are managed. Manually *adding*
+    children is safe -- appended widgets always land after the managed
+    content. But manually removing or reordering the children of a widget
+    that uses control statements (``clear_widgets()`` included) declares a
+    second, competing owner of the same list: nothing raises and nothing
+    leaks, but the insertion position of managed content becomes undefined
+    from then on. Drive such changes through the bound properties instead.
+
 .. _redefining-style:
 
 Redefining a widget's style

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -340,6 +340,14 @@ def _collect_item_widgets(items, out):
             out.append(it)
 
 
+class _SlotEntry(object):
+    __slots__ = ('node', 'fill')
+
+    def __init__(self):
+        self.node = None
+        self.fill = None
+
+
 class _ControlNode(EventDispatcher):
     '''Base runtime node for a control statement.'''
 
@@ -876,6 +884,96 @@ class FactoryNode(_ControlNode):
         self.builder._teardown_items(self.host, self.items)
         self.items = []
         super(FactoryNode, self).teardown()
+
+
+class SlotNode(_ControlNode):
+    '''A slot definition site: builds the best fill recorded on the host
+    widget, or its own fallback. Slot-scoped locals are exposed to the
+    content through the reserved ``slot`` name.'''
+
+    def __init__(self, *largs, **kwargs):
+        super(SlotNode, self).__init__(*largs, **kwargs)
+        self.items = []
+        self.scope = None
+        self._content_ids = []
+
+    def iter_items(self):
+        return self.items
+
+    def activate(self, rule_children=None, pos=None):
+        self._active = True
+        self._build(rule_children, pos)
+
+    def _build(self, rule_children, pos):
+        builder = self.builder
+        host = self.host
+        ctl = self.ctl
+        slots = host.__dict__.get('_kv_slots') or {}
+        entry = slots.get(ctl.slot_name)
+        fill = entry.fill if entry is not None else None
+        if fill is not None:
+            crules, source_ids, fill_locals = fill
+        else:
+            crules, source_ids, fill_locals = ctl.children, self.idmap, []
+        local_defs = list(ctl.locals)
+        names = []
+        for name, _ in local_defs + list(fill_locals):
+            if name not in names:
+                names.append(name)
+        scope = _make_scope(names) if names else None
+        self.scope = scope
+        host_proxy = host.proxy_ref
+
+        def bind_locals(pairs, base_ids):
+            idmap = dict(base_ids)
+            idmap['slot'] = scope
+            for name, prop in pairs:
+                co = prop.co_value
+                if type(co) is CodeType:
+                    v, _ = create_handler(
+                        scope, scope, name, co, prop, idmap,
+                        self_ref=host_proxy)
+                else:
+                    v = co
+                setattr(scope, name, v)
+
+        if scope is not None:
+            bind_locals(local_defs, self.idmap)
+            if fill_locals:
+                bind_locals(fill_locals, source_ids)
+        content_ids = dict(source_ids)
+        if scope is not None:
+            content_ids['slot'] = scope
+        if pos is None:
+            pos = self._position()
+        built = rule_children if rule_children is not None else []
+        log = builder._scope_id_log
+        n = len(log)
+        self.items = builder._build_items(
+            host, crules, content_ids, pos, built, None)
+        self._content_ids = log[n:]
+        del log[n:]
+        self._dispatch_kv_post(rule_children, built)
+
+    def teardown(self):
+        for scope, name, widget in self._content_ids:
+            try:
+                if getattr(scope, name) == widget:
+                    setattr(scope, name, None)
+            except ReferenceError:
+                pass
+        self._content_ids = []
+        self.builder._teardown_items(self.host, self.items)
+        self.items = []
+        if self.scope is not None:
+            self.builder.unbind_widget(self.scope.uid)
+            self.scope = None
+        slots = self.host.__dict__.get('_kv_slots')
+        if slots is not None:
+            entry = slots.get(self.ctl.slot_name)
+            if entry is not None and entry.node is self:
+                entry.node = None
+        super(SlotNode, self).teardown()
 
 
 class _CanvasNode(_ControlNode):
@@ -1430,7 +1528,8 @@ class BuilderBase(object):
                          ignored_consts, rule_children):
         if rootrule is rule:
             # re-applying a rule to a widget resets its control nodes
-            if widget.__dict__.get('_kv_control_nodes'):
+            if (widget.__dict__.get('_kv_control_nodes') or
+                    widget.__dict__.get('_kv_slots')):
                 self._reset_control_state(widget, rule)
             # rule-level reactive-id scope (ids in `if`/`slot` blocks)
             if rule.id_scope_key is not None:
@@ -1462,6 +1561,15 @@ class BuilderBase(object):
         # the rule if not, they will be created as ObjectProperty.
         rule.create_missing(widget)
 
+        # register the slot names this rule declares, so fills arriving from
+        # later rules (subclasses, the usage site) find their target
+        slots = widget.__dict__.get('_kv_slots')
+        if rule.slot_defs:
+            if slots is None:
+                slots = widget._kv_slots = {}
+            for name in rule.slot_defs:
+                slots.setdefault(name, _SlotEntry())
+
         # build the widget canvas
         if rule.canvas_before:
             with widget.canvas.before:
@@ -1481,8 +1589,11 @@ class BuilderBase(object):
         # the entry structure nodes use to track their spans; a control-free
         # rule on a plain widget only pays the two boolean tests.
         Factory_get = Factory.get
+        route_default = (
+            slots is not None and '' in slots and
+            not (rule.slot_defs and '' in rule.slot_defs))
         entries = widget.__dict__.get('_kv_entries')
-        tracked = rule.has_controls or entries is not None
+        tracked = rule.has_controls or route_default or entries is not None
         if tracked:
             if entries is None:
                 entries = widget._kv_entries = list(
@@ -1490,9 +1601,22 @@ class BuilderBase(object):
             nodes = widget.__dict__.get('_kv_control_nodes')
             if nodes is None:
                 nodes = widget._kv_control_nodes = []
+        routed = []
+        explicit_default = False
         ids = rctx['ids']
         for crule in rule.children:
             if tracked and isinstance(crule, ParserControlRule):
+                if crule.kind == 'slot':
+                    node, is_default_fill = self._register_slot_block(
+                        widget, rule, rootrule, crule, ids, rule_children)
+                    if node is not None:
+                        entries.append(node)
+                    explicit_default = explicit_default or is_default_fill
+                    if explicit_default and routed:
+                        raise BuilderException(
+                            crule.ctx, crule.line, 'cannot mix an explicit '
+                            '"slot:" fill block with plain children')
+                    continue
                 node = self._make_control_node(widget, crule, ids, None)
                 node.owner_rule = rootrule
                 entries.append(node)
@@ -1506,6 +1630,15 @@ class BuilderBase(object):
                     crule.ctx, crule.line,
                     'Canvas instructions added in kv must '
                     'be declared before child widgets.')
+            if route_default:
+                if explicit_default:
+                    raise BuilderException(
+                        crule.ctx, crule.line, 'cannot mix an explicit '
+                        '"slot:" fill block with plain children')
+                self._check_routed_ids(crule)
+                routed.append(crule)
+                continue
+
             cls = Factory_get(cname)
 
             # we can't construct it without __no_builder=True, because
@@ -1524,6 +1657,8 @@ class BuilderBase(object):
 
             if rule_children is not None:
                 rule_children.append(child)
+        if routed:
+            widget._kv_slots[''].fill = (routed, ids, [])
 
         # append the properties and handlers to our final resolution task
         if rule.properties:
@@ -1605,6 +1740,43 @@ class BuilderBase(object):
     # Control statements runtime support
     #
 
+    def _register_slot_block(self, widget, rule, rootrule, crule, ids,
+                             rule_children):
+        '''Process one ``slot`` block: the first block for a declared name is
+        the definition (a node is created at this position); later same-name
+        blocks are fills. An unknown name degrades to a new definition, with
+        a warning (it can never be filled).'''
+        slots = widget.__dict__.get('_kv_slots')
+        if slots is None:
+            slots = widget._kv_slots = {}
+        name = crule.slot_name
+        entry = slots.get(name)
+        if entry is None:
+            Logger.warning(
+                "Lang: filling unknown slot '%s': no class rule of <%s> "
+                'declares it; treating the block as a new slot definition'
+                % (name, type(widget).__name__))
+            entry = slots[name] = _SlotEntry()
+        elif not (entry.node is None and rule.slot_defs and
+                  name in rule.slot_defs):
+            # a fill: most derived provider wins (later rules overwrite)
+            entry.fill = (list(crule.children), ids, list(crule.locals))
+            return None, name == ''
+        node = SlotNode(self, widget, crule, ids)
+        node.owner_rule = rootrule
+        entry.node = node
+        self._pending.append(partial(node.activate, rule_children))
+        return node, False
+
+    def _check_routed_ids(self, crule):
+        if not isinstance(crule, ParserControlRule) and crule.id:
+            raise BuilderException(
+                crule.ctx, crule.line, '"id" is not allowed on children '
+                'routed into a slot; use an explicit "slot:" fill block '
+                'instead')
+        for child in crule.children:
+            self._check_routed_ids(child)
+
     def _assign_scope_id(self, ids, scope_id, widget):
         scope_key, name = scope_id
         scope = ids.get(scope_key)
@@ -1628,7 +1800,14 @@ class BuilderBase(object):
         cursor = pos
         for crule in crules:
             if isinstance(crule, ParserControlRule):
-                node = self._make_control_node(host, crule, ids, for_scope)
+                if crule.kind == 'slot':
+                    slots = host.__dict__.setdefault('_kv_slots', {})
+                    entry = slots.setdefault(crule.slot_name, _SlotEntry())
+                    node = SlotNode(self, host, crule, ids)
+                    entry.node = node
+                else:
+                    node = self._make_control_node(host, crule, ids,
+                                                   for_scope)
                 items.append(node)
                 node.activate(rule_children, cursor)
                 cursor += node.count()
@@ -1678,9 +1857,13 @@ class BuilderBase(object):
         rule created before, so they are not duplicated.'''
         nodes = widget.__dict__.get('_kv_control_nodes')
         entries = widget.__dict__.get('_kv_entries')
+        slots = widget.__dict__.get('_kv_slots')
         stale = []
         if nodes:
             stale += [n for n in nodes if n.owner_rule is rule]
+        if slots:
+            stale += [e.node for e in slots.values()
+                      if e.node is not None and e.node.owner_rule is rule]
         for node in stale:
             node.teardown()
             if nodes and node in nodes:

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -636,6 +636,175 @@ class IfNode(_ControlNode):
         super(IfNode, self).teardown()
 
 
+class _Iteration(object):
+    __slots__ = ('key', 'values', 'scope', 'items', 'detached')
+
+    def __init__(self, key, values, scope, items):
+        self.key = key
+        self.values = values
+        self.scope = scope
+        self.items = items
+        self.detached = None
+
+
+class ForNode(_ControlNode):
+    '''A ``for`` block: one copy of the body per item, reconciled as the
+    iterable changes. Same key => same widgets: the loop targets live as
+    reactive properties on a per-iteration scope, so a kept key with new
+    values just re-dispatches them through the existing bindings.'''
+
+    def __init__(self, *largs, **kwargs):
+        super(ForNode, self).__init__(*largs, **kwargs)
+        self.iterations = []
+
+    def iter_items(self):
+        for rec in self.iterations:
+            for it in rec.items:
+                yield it
+
+    def activate(self, rule_children=None, pos=None):
+        self._bind_expr(self.ctl.iterator_prop)
+        self._active = True
+        self._reconcile(rule_children, pos)
+
+    def _run_update(self):
+        self._reconcile(None, None)
+
+    def _reconcile(self, rule_children, pos):
+        builder = self.builder
+        host = self.host
+        ctl = self.ctl
+        tuples = list(self.value or ())
+        keys = self._compute_keys(tuples)
+        recs = self.iterations
+        old_by_key = {rec.key: rec for rec in recs}
+        new_keys = set(keys)
+        for rec in recs[:]:
+            if rec.key not in new_keys:
+                self._destroy_iteration(rec)
+                recs.remove(rec)
+        moved = [rec.key for rec in recs] != [
+            k for k in keys if k in old_by_key]
+        if moved:
+            for rec in recs:
+                self._detach(rec)
+        if pos is None:
+            pos = self._position()
+        built = rule_children if rule_children is not None else []
+        cursor = pos
+        new_recs = []
+        targets = ctl.target_names
+        for key, tup in zip(keys, tuples):
+            rec = old_by_key.get(key)
+            if rec is not None:
+                if moved:
+                    cursor += self._reattach(rec, cursor)
+                else:
+                    cursor += _items_count(rec.items)
+                scope = rec.scope
+                for name, v in zip(targets, tup):
+                    setattr(scope, name, v)
+                rec.values = tup
+            else:
+                rec = self._build_iteration(key, tup, cursor, built)
+                cursor += _items_count(rec.items)
+            new_recs.append(rec)
+        self.iterations = new_recs
+        self._dispatch_kv_post(rule_children, built)
+
+    def _compute_keys(self, tuples):
+        ctl = self.ctl
+        prop = ctl.key_prop
+        if prop is None:
+            return list(range(len(tuples)))
+        co = prop.co_value
+        if type(co) is not CodeType:
+            keys = [co] * len(tuples)
+        else:
+            base = copy(self.idmap)
+            base.update(global_idmap)
+            base['self'] = self.host.proxy_ref
+            targets = ctl.target_names
+            keys = []
+            for tup in tuples:
+                idmap = dict(base)
+                idmap.update(zip(targets, tup))
+                try:
+                    keys.append(eval(co, idmap))
+                except Exception as e:
+                    tb = sys.exc_info()[2]
+                    raise BuilderException(
+                        prop.ctx, prop.line,
+                        '{}: {}'.format(e.__class__.__name__, e), cause=tb)
+        seen = set()
+        for key in keys:
+            try:
+                duplicate = key in seen
+                seen.add(key)
+            except TypeError as e:
+                tb = sys.exc_info()[2]
+                raise BuilderException(
+                    ctl.ctx, ctl.line, 'keys of a "for" block must be '
+                    'hashable ({})'.format(e), cause=tb)
+            if duplicate:
+                raise BuilderException(
+                    ctl.ctx, ctl.line,
+                    'duplicate key %r in "for" block' % (key,))
+        return keys
+
+    def _build_iteration(self, key, tup, cursor, built):
+        builder = self.builder
+        host = self.host
+        ctl = self.ctl
+        scope = _make_scope(ctl.scope_names)
+        for name, v in zip(ctl.target_names, tup):
+            setattr(scope, name, v)
+        idmap = dict(self.idmap)
+        idmap[ctl.scope_key] = scope
+        host_proxy = host.proxy_ref
+        for name, prop in ctl.locals:
+            co = prop.co_value
+            if type(co) is CodeType:
+                v, _ = create_handler(
+                    scope, scope, name, co, prop, idmap, self_ref=host_proxy)
+            else:
+                v = co
+            setattr(scope, name, v)
+        log = builder._scope_id_log
+        n = len(log)
+        items = builder._build_items(
+            host, ctl.children, idmap, cursor, built, scope)
+        del log[n:]
+        return _Iteration(key, tup, scope, items)
+
+    def _destroy_iteration(self, rec):
+        self.builder._teardown_items(self.host, rec.items)
+        self.builder.unbind_widget(rec.scope.uid)
+
+    def _detach(self, rec):
+        widgets = []
+        _collect_item_widgets(rec.items, widgets)
+        host = self.host
+        for w in widgets:
+            host.remove_widget(w)
+        rec.detached = widgets
+
+    def _reattach(self, rec, cursor):
+        widgets = rec.detached or []
+        rec.detached = None
+        index = self._insert_index(cursor)
+        host = self.host
+        for w in widgets:
+            host.add_widget(w, index=index)
+        return len(widgets)
+
+    def teardown(self):
+        for rec in self.iterations:
+            self._destroy_iteration(rec)
+        self.iterations = []
+        super(ForNode, self).teardown()
+
+
 class _CanvasNode(_ControlNode):
     '''Base for canvas control nodes: owns one InstructionGroup slotted at
     the block's position in the enclosing canvas (or group).'''
@@ -689,6 +858,117 @@ class CanvasIfNode(_CanvasNode):
         self.builder._build_canvas_content(
             self.group, self.host, branches[index], self.idmap,
             self._captured, self._subnodes)
+
+
+class _CanvasSub(object):
+    __slots__ = ('group', 'values', 'captured', 'subnodes')
+
+    def __init__(self, group):
+        self.group = group
+        self.values = None
+        self.captured = []
+        self.subnodes = []
+
+
+class CanvasForNode(_CanvasNode):
+    '''A canvas ``for``. Without ``key:`` the group is rebuilt wholesale;
+    with it, per-iteration sub-groups are kept, moved or rebuilt by key.'''
+
+    def __init__(self, *largs, **kwargs):
+        super(CanvasForNode, self).__init__(*largs, **kwargs)
+        self.subs = {}
+        self._order = []
+
+    def activate(self, rule_children=None, pos=None):
+        self._bind_expr(self.ctl.iterator_prop)
+        self._active = True
+        self._mount()
+
+    def _run_update(self):
+        self._mount()
+
+    def _content_idmap(self, tup):
+        idmap = dict(self.idmap)
+        idmap.update(zip(self.ctl.target_names, tup))
+        return idmap
+
+    def _mount(self):
+        global InstructionGroup
+        builder = self.builder
+        ctl = self.ctl
+        tuples = list(self.value or ())
+        if ctl.key_prop is None:
+            self._clear_content()
+            for tup in tuples:
+                builder._build_canvas_content(
+                    self.group, self.host, ctl, self._content_idmap(tup),
+                    self._captured, self._subnodes)
+            return
+        # keyed: reconcile per-iteration sub-groups
+        keys = ForNode._compute_keys(self, tuples)
+        if InstructionGroup is None:
+            from kivy.graphics import InstructionGroup
+        old = self.subs
+        new_keys = set(keys)
+        for key in list(old):
+            if key not in new_keys:
+                sub = old.pop(key)
+                self._destroy_sub(sub, remove=True)
+        self._order = [k for k in self._order if k in new_keys]
+        subs = {}
+        for key, tup in zip(keys, tuples):
+            sub = old.get(key)
+            if sub is None:
+                sub = _CanvasSub(InstructionGroup())
+                self.group.add(sub.group)
+                self._fill_sub(sub, tup)
+            elif sub.values != tup:
+                self._destroy_sub(sub, remove=False)
+                self._fill_sub(sub, tup)
+            subs[key] = sub
+        # kept groups sit in old order and new ones were appended in new
+        # order, so nothing moves when the kept order is a prefix of the new
+        if self._order != keys[:len(self._order)]:
+            for sub in subs.values():
+                try:
+                    self.group.remove(sub.group)
+                except Exception:
+                    pass
+            for key in keys:
+                self.group.add(subs[key].group)
+        self.subs = subs
+        self._order = keys
+
+    def _fill_sub(self, sub, tup):
+        sub.values = tup
+        self.builder._build_canvas_content(
+            sub.group, self.host, self.ctl, self._content_idmap(tup),
+            sub.captured, sub.subnodes)
+
+    def _destroy_sub(self, sub, remove):
+        for node in sub.subnodes:
+            node.teardown()
+        sub.subnodes = []
+        for key, captured in sub.captured:
+            _unbind_captured(self.host.uid, key, captured)
+        sub.captured = []
+        sub.group.clear()
+        if remove:
+            try:
+                self.group.remove(sub.group)
+            except Exception:
+                pass
+
+    def _clear_content(self):
+        for sub in self.subs.values():
+            self._destroy_sub(sub, remove=False)
+        self.subs = {}
+        self._order = []
+        super(CanvasForNode, self)._clear_content()
+
+    def teardown(self):
+        self._clear_content()
+        _ControlNode.teardown(self)
 
 
 class BuilderBase(object):
@@ -1261,7 +1541,9 @@ class BuilderBase(object):
 
     def _make_control_node(self, widget, ctl, ids, for_scope):
         kind = ctl.kind
-        return IfNode(self, widget, ctl, ids, for_scope=for_scope)
+        if kind == 'if':
+            return IfNode(self, widget, ctl, ids, for_scope=for_scope)
+        return ForNode(self, widget, ctl, ids)
 
     def _build_items(self, host, crules, ids, pos, rule_children, for_scope):
         '''Build the entries `crules` (widgets and nested control statements)
@@ -1348,7 +1630,9 @@ class BuilderBase(object):
                     from kivy.graphics import InstructionGroup
                 sub = InstructionGroup()
                 group.add(sub)
-                node = CanvasIfNode(self, widget, crule, ids, sub)
+                node_cls = (CanvasIfNode if crule.kind == 'if'
+                            else CanvasForNode)
+                node = node_cls(self, widget, crule, ids, sub)
                 subnodes.append(node)
                 node.activate()
                 continue
@@ -1553,7 +1837,9 @@ class BuilderBase(object):
                 if InstructionGroup is None:
                     from kivy.graphics import InstructionGroup
                 group = InstructionGroup()
-                node = CanvasIfNode(self, widget, crule, idmap, group)
+                node_cls = (CanvasIfNode if crule.kind == 'if'
+                            else CanvasForNode)
+                node = node_cls(self, widget, crule, idmap, group)
                 node.owner_rule = rootrule
                 widget.__dict__.setdefault(
                     '_kv_control_nodes', []).append(node)
@@ -1600,9 +1886,13 @@ if 'KIVY_PROFILE_LANG' in environ:
                 continue
             yield prp
         if isinstance(rule, ParserControlRule):
-            if (rule.selector_prop is not None and
-                    rule.selector_prop.line == index):
-                yield rule.selector_prop
+            for prp in (rule.selector_prop, rule.iterator_prop,
+                        rule.key_prop):
+                if prp is not None and prp.line == index:
+                    yield prp
+            for _, prp in rule.locals:
+                if prp.line == index:
+                    yield prp
             for branch in rule.branches:
                 for r in match_rule(fn, index, branch):
                     yield r

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -805,6 +805,79 @@ class ForNode(_ControlNode):
         super(ForNode, self).teardown()
 
 
+class FactoryNode(_ControlNode):
+    '''A ``factory <expr>`` block: one child whose class comes from an
+    expression, rebuilt when the class changes; the block body is applied to
+    the instance as an ordinary rule.'''
+
+    def __init__(self, *largs, **kwargs):
+        super(FactoryNode, self).__init__(*largs, **kwargs)
+        self.items = []
+
+    def iter_items(self):
+        return self.items
+
+    def activate(self, rule_children=None, pos=None):
+        self._bind_expr(self.ctl.class_prop)
+        self._active = True
+        self._build(rule_children, pos)
+
+    def _run_update(self):
+        # resolve first: two expressions naming the same class (an alias, a
+        # string vs the class object) must not rebuild the widget
+        cls = self._resolve_class()
+        if self.items and type(self.items[0]) is cls:
+            return
+        self.builder._teardown_items(self.host, self.items)
+        self.items = []
+        self._build_resolved(cls, None, None)
+
+    def _resolve_class(self):
+        value = self.value
+        if value is None or not isinstance(value, str):
+            return value
+        try:
+            return Factory.get(value)
+        except Exception as e:
+            tb = sys.exc_info()[2]
+            raise BuilderException(
+                self.ctl.ctx, self.ctl.line,
+                '{}: {}'.format(e.__class__.__name__, e), cause=tb)
+
+    def _build(self, rule_children, pos):
+        self._build_resolved(self._resolve_class(), rule_children, pos)
+
+    def _build_resolved(self, cls, rule_children, pos):
+        if cls is None:
+            return
+        ctl = self.ctl
+        builder = self.builder
+        host = self.host
+        if pos is None:
+            pos = self._position()
+        try:
+            widget = cls(__no_builder=True)
+        except Exception as e:
+            tb = sys.exc_info()[2]
+            raise BuilderException(
+                ctl.ctx, ctl.line,
+                '{}: {}'.format(e.__class__.__name__, e), cause=tb)
+        host.add_widget(widget, index=self._insert_index(pos))
+        built = rule_children if rule_children is not None else []
+        widget.apply_class_lang_rules(
+            root=self.idmap.get('root'), rule_children=built)
+        builder._apply_rule(
+            widget, ctl, ctl, rule_children=built, ids=dict(self.idmap))
+        built.append(widget)
+        self.items = [widget]
+        self._dispatch_kv_post(rule_children, built)
+
+    def teardown(self):
+        self.builder._teardown_items(self.host, self.items)
+        self.items = []
+        super(FactoryNode, self).teardown()
+
+
 class _CanvasNode(_ControlNode):
     '''Base for canvas control nodes: owns one InstructionGroup slotted at
     the block's position in the enclosing canvas (or group).'''
@@ -1543,7 +1616,9 @@ class BuilderBase(object):
         kind = ctl.kind
         if kind == 'if':
             return IfNode(self, widget, ctl, ids, for_scope=for_scope)
-        return ForNode(self, widget, ctl, ids)
+        if kind == 'for':
+            return ForNode(self, widget, ctl, ids)
+        return FactoryNode(self, widget, ctl, ids)
 
     def _build_items(self, host, crules, ids, pos, rule_children, for_scope):
         '''Build the entries `crules` (widgets and nested control statements)
@@ -1887,7 +1962,7 @@ if 'KIVY_PROFILE_LANG' in environ:
             yield prp
         if isinstance(rule, ParserControlRule):
             for prp in (rule.selector_prop, rule.iterator_prop,
-                        rule.key_prop):
+                        rule.key_prop, rule.class_prop):
                 if prp is not None and prp.line == index:
                     yield prp
             for _, prp in rule.locals:

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -9,6 +9,7 @@ from os import environ
 from os.path import join
 from copy import copy
 from types import CodeType
+from functools import partial
 
 from kivy.factory import Factory
 from kivy.lang.parser import (
@@ -17,12 +18,14 @@ from kivy.lang.parser import (
     _handlers,
     global_idmap,
     ParserRuleProperty,
+    ParserControlRule,
 )
 from kivy.logger import Logger
 from kivy import kivy_data_dir
 from kivy.context import register_context
 from kivy.resources import resource_find
 from kivy._event import Observable, EventDispatcher
+from kivy.properties import ObjectProperty
 
 __all__ = ('Observable', 'Builder', 'BuilderBase', 'BuilderException')
 
@@ -56,7 +59,17 @@ def call_fn(args, instance, v):
         trace('Lang: call_fn %s, key=%s, value=%r, %r' % (
             element, key, value, rule.value))
     rule.count += 1
-    e_value = eval(value, idmap)
+    try:
+        e_value = eval(value, idmap)
+    except (BuilderException, ReferenceError):
+        # a ReferenceError means a weak-referenced widget died before this
+        # (delayed) update ran; Builder.sync() relies on catching it as-is
+        raise
+    except Exception as e:
+        tb = sys.exc_info()[2]
+        raise BuilderException(
+            rule.ctx, rule.line,
+            '{}: {}'.format(e.__class__.__name__, e), cause=tb)
     if __debug__:
         trace('Lang: call_fn => value=%r' % (e_value, ))
     setattr(element, key, e_value)
@@ -167,10 +180,11 @@ def update_intermediates(base, keys, bound, s, fn, args, instance, value):
     fn(args, None, None)
 
 
-def create_handler(iself, element, key, value, rule, idmap, delayed=False):
+def create_handler(iself, element, key, value, rule, idmap, delayed=False,
+                   self_ref=None):
     idmap = copy(idmap)
     idmap.update(global_idmap)
-    idmap['self'] = iself.proxy_ref
+    idmap['self'] = self_ref if self_ref is not None else iself.proxy_ref
     bound_list = _handlers[iself.uid][key]
     handler_append = bound_list.append
 
@@ -240,6 +254,443 @@ def create_handler(iself, element, key, value, rule, idmap, delayed=False):
                                cause=tb)
 
 
+# ---------------------------------------------------------------------------
+# Control statements runtime
+#
+# Each control statement compiles to a small node owning a contiguous span of
+# its parent container (widget children or canvas instructions) and rebuilding
+# that span when its bound expression changes. Nodes live on the host widget
+# (never in a module registry), so control-using widgets stay collectable.
+# ---------------------------------------------------------------------------
+
+# late import (kivy.graphics must not load at module import time)
+InstructionGroup = None
+
+# scope classes cache, keyed by the tuple of property names
+_scope_classes = {}
+
+
+def _make_scope(names):
+    '''Build a hidden scope object: an EventDispatcher with one reactive,
+    nullable, rebindable property per name (loop targets, locals, ids).'''
+    key = tuple(names)
+    cls = _scope_classes.get(key)
+    if cls is None:
+        cls = type('KvScope', (EventDispatcher,), {
+            name: ObjectProperty(None, allownone=True, rebind=True)
+            for name in key})
+        _scope_classes[key] = cls
+    return cls()
+
+
+def _unbind_captured(uid, key, captured):
+    '''Unbind exactly the handler entries `captured` (as returned by
+    create_handler into ``_handlers[uid][key]``), leaving every other binding
+    of the property untouched.'''
+    plist = _handlers.get(uid)
+    entries = plist.get(key) if plist is not None else None
+    for bound in captured:
+        for f, k, fn, bound_uid in bound:
+            if fn is None:
+                continue
+            try:
+                f.unbind_uid(k, bound_uid)
+            except ReferenceError:
+                pass
+        if entries is not None and bound in entries:
+            entries.remove(bound)
+    if plist is not None and entries is not None and not entries:
+        del plist[key]
+        if not plist:
+            del _handlers[uid]
+
+
+def _items_count(items):
+    n = 0
+    for it in items:
+        if isinstance(it, _ControlNode):
+            n += it.count()
+        else:
+            n += 1
+    return n
+
+
+def _items_scan(items, target):
+    '''Return (position, found): the document position of `target` within
+    the entry structure `items` (descending into nodes).'''
+    pos = 0
+    for it in items:
+        if it is target:
+            return pos, True
+        if isinstance(it, _ControlNode):
+            sub, found = _items_scan(it.iter_items(), target)
+            pos += sub
+            if found:
+                return pos, True
+        else:
+            pos += 1
+    return pos, False
+
+
+def _collect_item_widgets(items, out):
+    for it in items:
+        if isinstance(it, _ControlNode):
+            _collect_item_widgets(it.iter_items(), out)
+        else:
+            out.append(it)
+
+
+class _ControlNode(EventDispatcher):
+    '''Base runtime node for a control statement.'''
+
+    value = ObjectProperty(None, allownone=True)
+
+    def __init__(self, builder, host, ctl, idmap, for_scope=None, **kwargs):
+        super(_ControlNode, self).__init__(**kwargs)
+        self.builder = builder
+        self.host = host
+        self.ctl = ctl
+        self.idmap = idmap
+        self.for_scope = for_scope
+        self.owner_rule = None
+        self._expr_captured = []
+        self._active = False
+
+    def iter_items(self):
+        return ()
+
+    def count(self):
+        return _items_count(self.iter_items())
+
+    def _position(self):
+        entries = self.host.__dict__.get('_kv_entries') or ()
+        pos, found = _items_scan(entries, self)
+        return pos
+
+    def _insert_index(self, pos):
+        children = self.host.children
+        return max(0, min(len(children), len(children) - pos))
+
+    def _bind_expr(self, prop):
+        co = prop.co_value
+        if type(co) is CodeType:
+            host = self.host
+            blist = _handlers[host.uid]['value']
+            n = len(blist)
+            value, _ = create_handler(
+                host, self, 'value', co, prop, self.idmap)
+            self._expr_captured = blist[n:]
+        else:
+            value = co
+        self.value = value
+        self.fbind('value', self._on_value)
+
+    def _on_value(self, *largs):
+        if not self._active:
+            return
+        builder = self.builder
+        if self in builder._node_queue:
+            return
+        builder._node_queue.append(self)
+        if not (builder._apply_depth or builder._processing):
+            builder._process_queues()
+
+    def _run_update(self):
+        pass
+
+    def teardown(self):
+        self._active = False
+        _unbind_captured(self.host.uid, 'value', self._expr_captured)
+        self._expr_captured = []
+        queue = self.builder._node_queue
+        if self in queue:
+            queue.remove(self)
+
+    def _dispatch_kv_post(self, rule_children, built):
+        # dynamic builds dispatch on_kv_post themselves; initial builds are
+        # dispatched by the outer apply through `rule_children`
+        if rule_children is None:
+            for w in built:
+                w.dispatch('on_kv_post', self.host)
+
+
+_canvas_attrs = ('canvas_before', 'canvas_root', 'canvas_after')
+
+
+class _CanvasMark(object):
+    '''Position bookmark for a conditional canvas group: registered once per
+    branch section in document order, mounted/unmounted with the branch so
+    inactive branches leave nothing in the canvas.'''
+
+    __slots__ = ('group', 'mounted')
+
+    def __init__(self, group):
+        self.group = group
+        self.mounted = False
+
+
+def _mark_register(host, canvas, mark):
+    # registration happens at node activation, i.e. in document order
+    host.__dict__.setdefault('_kv_canvas_marks', {}).setdefault(
+        canvas, []).append(mark)
+
+
+def _mark_mount(host, canvas, mark):
+    if mark.mounted:
+        return
+    marks = host.__dict__['_kv_canvas_marks'][canvas]
+    i = marks.index(mark)
+    for j in range(i - 1, -1, -1):
+        if marks[j].mounted:
+            canvas.insert(canvas.indexof(marks[j].group) + 1, mark.group)
+            break
+    else:
+        for j in range(i + 1, len(marks)):
+            if marks[j].mounted:
+                canvas.insert(canvas.indexof(marks[j].group), mark.group)
+                break
+        else:
+            canvas.add(mark.group)
+    mark.mounted = True
+
+
+def _mark_unmount(canvas, mark):
+    if not mark.mounted:
+        return
+    try:
+        canvas.remove(mark.group)
+    except Exception:
+        pass
+    mark.mounted = False
+
+
+class IfNode(_ControlNode):
+    '''An ``if`` / ``elif`` / ``else`` chain: mounts the active branch's
+    children, host properties, handlers and canvas; tears them down when the
+    branch leaves.'''
+
+    def __init__(self, *largs, **kwargs):
+        super(IfNode, self).__init__(*largs, **kwargs)
+        self.active_index = -1
+        self.items = []
+        self._prop_captured = {}
+        self._handler_uids = []
+        self._canvas_groups = {}
+        self._canvas_captured = []
+        self._canvas_subnodes = []
+        self._branch_ids = []
+
+    def iter_items(self):
+        return self.items
+
+    def activate(self, rule_children=None, pos=None):
+        global InstructionGroup
+        host = self.host
+        for index, branch in enumerate(self.ctl.branches):
+            for attr in _canvas_attrs:
+                if getattr(branch, attr) is None:
+                    continue
+                if InstructionGroup is None:
+                    from kivy.graphics import InstructionGroup
+                mark = _CanvasMark(InstructionGroup())
+                _mark_register(host, self._canvas_for(attr), mark)
+                self._canvas_groups[(index, attr)] = mark
+        self._bind_expr(self.ctl.selector_prop)
+        self._active = True
+        self.active_index = -1
+        self._mount(rule_children, pos)
+
+    def _canvas_for(self, attr):
+        host = self.host
+        return (host.canvas if attr == 'canvas_root' else
+                host.canvas.before if attr == 'canvas_before' else
+                host.canvas.after)
+
+    def _run_update(self):
+        index = self.value
+        index = -1 if index is None else int(index)
+        if index == self.active_index:
+            return
+        self._unmount()
+        self._mount(None, None)
+
+    def _mount(self, rule_children, pos):
+        index = self.value
+        index = -1 if index is None else int(index)
+        self.active_index = index
+        branches = self.ctl.branches
+        if index < 0 or index >= len(branches):
+            return
+        branch = branches[index]
+        builder = self.builder
+        host = self.host
+        if pos is None:
+            pos = self._position()
+        built = rule_children if rule_children is not None else []
+        log = builder._scope_id_log
+        n = len(log)
+        self.items = builder._build_items(
+            host, branch.children, self.idmap, pos, built, self.for_scope)
+        self._branch_ids = log[n:]
+        del log[n:]
+        self._mount_props(branch)
+        self._mount_handlers(branch)
+        self._mount_canvas(index, branch)
+        self._dispatch_kv_post(rule_children, built)
+
+    def _mount_props(self, branch):
+        if not branch.properties:
+            return
+        host = self.host
+        target = self.for_scope if self.for_scope is not None else host
+        if target is host:
+            branch.create_missing(host)
+        self_ref = host.proxy_ref if target is not host else None
+        for name, prop in branch.properties.items():
+            co = prop.co_value
+            if type(co) is CodeType:
+                blist = _handlers[target.uid][name]
+                n = len(blist)
+                value, _ = create_handler(
+                    target, target, name, co, prop, self.idmap,
+                    self_ref=self_ref)
+                self._prop_captured[name] = blist[n:]
+            else:
+                value = co
+            setattr(target, name, value)
+
+    def _mount_handlers(self, branch):
+        host = self.host
+        for crule in branch.handlers:
+            key = crule.name
+            if not host.is_event_type(key):
+                key = key[3:]
+            idmap = copy(global_idmap)
+            idmap.update(self.idmap)
+            idmap['self'] = host.proxy_ref
+            uid = host.fbind(key, custom_callback, crule, idmap)
+            if not uid:
+                raise BuilderException(
+                    crule.ctx, crule.line,
+                    'AttributeError: %s' % crule.name)
+            self._handler_uids.append((key, uid))
+            if crule.name == 'on_parent':
+                Factory.Widget.parent.dispatch(host.__self__)
+
+    def _mount_canvas(self, index, branch):
+        builder = self.builder
+        for attr in _canvas_attrs:
+            crule = getattr(branch, attr)
+            if crule is None:
+                continue
+            mark = self._canvas_groups[(index, attr)]
+            _mark_mount(self.host, self._canvas_for(attr), mark)
+            builder._build_canvas_content(
+                mark.group, self.host, crule, self.idmap,
+                self._canvas_captured, self._canvas_subnodes)
+
+    def _unmount(self):
+        host = self.host
+        builder = self.builder
+        for scope, name, widget in self._branch_ids:
+            try:
+                if getattr(scope, name) == widget:
+                    setattr(scope, name, None)
+            except ReferenceError:
+                pass
+        self._branch_ids = []
+        builder._teardown_items(host, self.items)
+        self.items = []
+        target = self.for_scope if self.for_scope is not None else host
+        for name, captured in self._prop_captured.items():
+            _unbind_captured(target.uid, name, captured)
+        self._prop_captured = {}
+        for key, uid in self._handler_uids:
+            try:
+                host.unbind_uid(key, uid)
+            except ReferenceError:
+                pass
+        self._handler_uids = []
+        for node in self._canvas_subnodes:
+            node.teardown()
+        self._canvas_subnodes = []
+        for key, captured in self._canvas_captured:
+            _unbind_captured(host.uid, key, captured)
+        self._canvas_captured = []
+        index = self.active_index
+        for (branch_index, attr), mark in self._canvas_groups.items():
+            if branch_index == index:
+                mark.group.clear()
+                _mark_unmount(self._canvas_for(attr), mark)
+        self.active_index = -1
+
+    def teardown(self):
+        self._unmount()
+        marks = self.host.__dict__.get('_kv_canvas_marks') or {}
+        for (branch_index, attr), mark in self._canvas_groups.items():
+            _mark_unmount(self._canvas_for(attr), mark)
+            registry = marks.get(self._canvas_for(attr))
+            if registry and mark in registry:
+                registry.remove(mark)
+        self._canvas_groups = {}
+        super(IfNode, self).teardown()
+
+
+class _CanvasNode(_ControlNode):
+    '''Base for canvas control nodes: owns one InstructionGroup slotted at
+    the block's position in the enclosing canvas (or group).'''
+
+    def __init__(self, builder, host, ctl, idmap, group, **kwargs):
+        super(_CanvasNode, self).__init__(builder, host, ctl, idmap, **kwargs)
+        self.group = group
+        self._captured = []
+        self._subnodes = []
+
+    def _clear_content(self):
+        for node in self._subnodes:
+            node.teardown()
+        self._subnodes = []
+        for key, captured in self._captured:
+            _unbind_captured(self.host.uid, key, captured)
+        self._captured = []
+        self.group.clear()
+
+    def teardown(self):
+        self._clear_content()
+        super(_CanvasNode, self).teardown()
+
+
+class CanvasIfNode(_CanvasNode):
+
+    def __init__(self, *largs, **kwargs):
+        super(CanvasIfNode, self).__init__(*largs, **kwargs)
+        self.active_index = -1
+
+    def activate(self, rule_children=None, pos=None):
+        self._bind_expr(self.ctl.selector_prop)
+        self._active = True
+        self._mount()
+
+    def _run_update(self):
+        index = self.value
+        index = -1 if index is None else int(index)
+        if index == self.active_index:
+            return
+        self._clear_content()
+        self._mount()
+
+    def _mount(self):
+        index = self.value
+        index = -1 if index is None else int(index)
+        self.active_index = index
+        branches = self.ctl.branches
+        if index < 0 or index >= len(branches):
+            return
+        self.builder._build_canvas_content(
+            self.group, self.host, branches[index], self.idmap,
+            self._captured, self._subnodes)
+
+
 class BuilderBase(object):
     '''The Builder is responsible for creating a :class:`Parser` for parsing a
     kv file, merging the results into its internal rules, dynamic classes,
@@ -278,6 +729,49 @@ class BuilderBase(object):
         self.dynamic_classes = {}
         self.rules = []
         self.rulectx = {}
+        # control statements runtime state
+        self._apply_depth = 0
+        self._processing = False
+        self._pending = []
+        self._node_queue = []
+        self._scope_id_log = []
+        # rule_children lists awaiting their on_kv_post dispatch: a widget
+        # destroyed while one is pending is scrubbed from it, so the event
+        # never fires on a widget a control statement already tore down
+        self._rc_stack = []
+
+    def _end_apply(self, failed=False):
+        # closes one apply level; at the outermost level, either run the
+        # deferred control-statement work or (on failure) drop it
+        self._apply_depth -= 1
+        if self._apply_depth == 0:
+            if failed:
+                del self._pending[:]
+                del self._node_queue[:]
+            elif not self._processing:
+                self._process_queues()
+
+    def _process_queues(self):
+        '''Run deferred control-statement builds and queued node updates
+        until both queues drain. Content built here may enqueue more work
+        (nested rules, reactive handlers); an update firing while another
+        apply or rebuild is in flight lands in these queues instead of
+        re-entering it.'''
+        if self._processing:
+            return
+        self._processing = True
+        try:
+            while self._pending or self._node_queue:
+                if self._pending:
+                    self._pending.pop(0)()
+                else:
+                    self._node_queue.pop(0)._run_update()
+        except BaseException:
+            del self._pending[:]
+            del self._node_queue[:]
+            raise
+        finally:
+            self._processing = False
 
     @classmethod
     def create_from(cls, builder):
@@ -403,11 +897,22 @@ class BuilderBase(object):
             if parser.root:
                 widget = Factory.get(parser.root.name)(__no_builder=True)
                 rule_children = []
-                widget.apply_class_lang_rules(
-                    root=widget, rule_children=rule_children)
-                self._apply_rule(
-                    widget, parser.root, parser.root,
-                    rule_children=rule_children)
+                # one apply level for the whole root build, so deferred
+                # control-statement work (branches, slots) runs only once
+                # every rule -- class and root -- has been applied
+                self._apply_depth += 1
+                self._rc_stack.append(rule_children)
+                failed = True
+                try:
+                    widget.apply_class_lang_rules(
+                        root=widget, rule_children=rule_children)
+                    self._apply_rule(
+                        widget, parser.root, parser.root,
+                        rule_children=rule_children)
+                    failed = False
+                finally:
+                    self._end_apply(failed=failed)
+                    self._rc_stack.pop()
 
                 for child in rule_children:
                     child.dispatch('on_kv_post', widget)
@@ -459,10 +964,20 @@ class BuilderBase(object):
 
         if dispatch_kv_post:
             rule_children = rule_children if rule_children is not None else []
-        for rule in rules:
-            self._apply_rule(
-                widget, rule, rule, ignored_consts=ignored_consts,
-                rule_children=rule_children)
+        self._apply_depth += 1
+        if rule_children is not None:
+            self._rc_stack.append(rule_children)
+        failed = True
+        try:
+            for rule in rules:
+                self._apply_rule(
+                    widget, rule, rule, ignored_consts=ignored_consts,
+                    rule_children=rule_children)
+            failed = False
+        finally:
+            self._end_apply(failed=failed)
+            if rule_children is not None:
+                self._rc_stack.pop()
         if dispatch_kv_post:
             for w in rule_children:
                 w.dispatch('on_kv_post', widget)
@@ -506,10 +1021,20 @@ class BuilderBase(object):
 
         if dispatch_kv_post:
             rule_children = rule_children if rule_children is not None else []
-        for rule in rules:
-            self._apply_rule(
-                widget, rule, rule, ignored_consts=ignored_consts,
-                rule_children=rule_children)
+        self._apply_depth += 1
+        if rule_children is not None:
+            self._rc_stack.append(rule_children)
+        failed = True
+        try:
+            for rule in rules:
+                self._apply_rule(
+                    widget, rule, rule, ignored_consts=ignored_consts,
+                    rule_children=rule_children)
+            failed = False
+        finally:
+            self._end_apply(failed=failed)
+            if rule_children is not None:
+                self._rc_stack.pop()
         if dispatch_kv_post:
             for w in rule_children:
                 w.dispatch('on_kv_post', widget)
@@ -519,20 +1044,46 @@ class BuilderBase(object):
         self._match_name_cache.clear()
 
     def _apply_rule(self, widget, rule, rootrule,
-                    ignored_consts=set(), rule_children=None):
+                    ignored_consts=set(), rule_children=None, ids=None):
         # widget: the current instantiated widget
         # rule: the current rule
         # rootrule: the current root rule (for children of a rule)
+        # ids: pre-seeded ids context (used when control statements rebuild
+        #      content outside the original rule application)
 
         # will collect reference to all the id in children
         assert rule not in self.rulectx
-        self.rulectx[rule] = rctx = {
-            'ids': {'root': widget.proxy_ref},
+        self.rulectx[rule] = {
+            'ids': ids if ids is not None else {'root': widget.proxy_ref},
             'set': [], 'hdl': []}
 
         # extract the context of the rootrule (not rule!)
         assert rootrule in self.rulectx
         rctx = self.rulectx[rootrule]
+
+        self._apply_depth += 1
+        failed = True
+        try:
+            self._apply_rule_body(
+                widget, rule, rootrule, rctx, ignored_consts, rule_children)
+            failed = False
+        except Exception:
+            self.rulectx.pop(rule, None)
+            raise
+        finally:
+            self._end_apply(failed=failed)
+
+    def _apply_rule_body(self, widget, rule, rootrule, rctx,
+                         ignored_consts, rule_children):
+        if rootrule is rule:
+            # re-applying a rule to a widget resets its control nodes
+            if widget.__dict__.get('_kv_control_nodes'):
+                self._reset_control_state(widget, rule)
+            # rule-level reactive-id scope (ids in `if`/`slot` blocks)
+            if rule.id_scope_key is not None:
+                scope = _make_scope(rule.id_scope_names)
+                rctx['ids'][rule.id_scope_key] = scope
+                widget.__dict__.setdefault('_kv_id_scopes', []).append(scope)
 
         # if we got an id, put it in the root rule for a later global usage
         if rule.id:
@@ -547,6 +1098,9 @@ class BuilderBase(object):
             for _key, _value in _ids.items():
                 if _value == _root:
                     # skip on self
+                    continue
+                if _key.startswith('__kvscope'):
+                    # hidden scope objects are not ids
                     continue
                 _new_ids[_key] = _value
             _root.ids = _new_ids
@@ -569,26 +1123,49 @@ class BuilderBase(object):
                 self._build_canvas(widget.canvas.after, widget,
                                    rule.canvas_after, rootrule)
 
-        # create children tree
+        # create children tree. Rules using control statements (or applied
+        # to a widget with slots or tracked entries) additionally maintain
+        # the entry structure nodes use to track their spans; a control-free
+        # rule on a plain widget only pays the two boolean tests.
         Factory_get = Factory.get
+        entries = widget.__dict__.get('_kv_entries')
+        tracked = rule.has_controls or entries is not None
+        if tracked:
+            if entries is None:
+                entries = widget._kv_entries = list(
+                    reversed(widget.children))
+            nodes = widget.__dict__.get('_kv_control_nodes')
+            if nodes is None:
+                nodes = widget._kv_control_nodes = []
+        ids = rctx['ids']
         for crule in rule.children:
-            cname = crule.name
+            if tracked and isinstance(crule, ParserControlRule):
+                node = self._make_control_node(widget, crule, ids, None)
+                node.owner_rule = rootrule
+                entries.append(node)
+                nodes.append(node)
+                self._pending.append(partial(node.activate, rule_children))
+                continue
 
+            cname = crule.name
             if cname in ('canvas', 'canvas.before', 'canvas.after'):
                 raise ParserException(
                     crule.ctx, crule.line,
                     'Canvas instructions added in kv must '
                     'be declared before child widgets.')
-
             cls = Factory_get(cname)
 
-            # we can't construct it without __no_builder=True, because the
-            # previous implementation was doing the add_widget() before
-            # apply(), and so, we could use "self.parent".
+            # we can't construct it without __no_builder=True, because
+            # the previous implementation was doing the add_widget()
+            # before apply(), and so, we could use "self.parent".
             child = cls(__no_builder=True)
             widget.add_widget(child)
+            if tracked:
+                entries.append(child)
+            if crule.scope_id is not None:
+                self._assign_scope_id(ids, crule.scope_id, child)
             child.apply_class_lang_rules(
-                root=rctx['ids']['root'], rule_children=rule_children)
+                root=ids['root'], rule_children=rule_children)
             self._apply_rule(
                 child, crule, rootrule, rule_children=rule_children)
 
@@ -606,8 +1183,8 @@ class BuilderBase(object):
         if rule.handlers:
             rctx['hdl'].append((widget.proxy_ref, rule.handlers))
 
-        # if we are applying another rule that the root one, then it's done for
-        # us!
+        # if we are applying another rule that the root one, then it's done
+        # for us!
         if rootrule is not rule:
             del self.rulectx[rule]
             return
@@ -670,6 +1247,140 @@ class BuilderBase(object):
 
         # rule finished, forget it
         del self.rulectx[rootrule]
+
+    #
+    # Control statements runtime support
+    #
+
+    def _assign_scope_id(self, ids, scope_id, widget):
+        scope_key, name = scope_id
+        scope = ids.get(scope_key)
+        if scope is not None:
+            setattr(scope, name, widget)
+            self._scope_id_log.append((scope, name, widget))
+
+    def _make_control_node(self, widget, ctl, ids, for_scope):
+        kind = ctl.kind
+        return IfNode(self, widget, ctl, ids, for_scope=for_scope)
+
+    def _build_items(self, host, crules, ids, pos, rule_children, for_scope):
+        '''Build the entries `crules` (widgets and nested control statements)
+        as children of `host`, starting at document position `pos`, with the
+        ids context `ids`. Returns the item list.'''
+        items = []
+        cursor = pos
+        for crule in crules:
+            if isinstance(crule, ParserControlRule):
+                node = self._make_control_node(host, crule, ids, for_scope)
+                items.append(node)
+                node.activate(rule_children, cursor)
+                cursor += node.count()
+            else:
+                child = self._build_child(
+                    host, crule, ids, cursor, rule_children)
+                items.append(child)
+                cursor += 1
+        return items
+
+    def _build_child(self, host, crule, ids, cursor, rule_children):
+        cls = Factory.get(crule.name)
+        child = cls(__no_builder=True)
+        children = host.children
+        index = max(0, min(len(children), len(children) - cursor))
+        host.add_widget(child, index=index)
+        if crule.scope_id is not None:
+            self._assign_scope_id(ids, crule.scope_id, child)
+        child.apply_class_lang_rules(
+            root=ids.get('root'), rule_children=rule_children)
+        self._apply_rule(
+            child, crule, crule, rule_children=rule_children, ids=dict(ids))
+        if rule_children is not None:
+            rule_children.append(child)
+        return child
+
+    def _teardown_items(self, host, items):
+        for it in items:
+            if isinstance(it, _ControlNode):
+                it.teardown()
+            else:
+                self._destroy_widget(host, it)
+
+    def _destroy_widget(self, host, widget):
+        for sub in widget.walk(restrict=True):
+            self.unbind_widget(sub.uid)
+            for sink in self._rc_stack:
+                try:
+                    sink.remove(sub)
+                except ValueError:
+                    pass
+        if widget.parent is host:
+            host.remove_widget(widget)
+
+    def _reset_control_state(self, widget, rule):
+        '''Re-applying a rule to a widget tears down the control nodes that
+        rule created before, so they are not duplicated.'''
+        nodes = widget.__dict__.get('_kv_control_nodes')
+        entries = widget.__dict__.get('_kv_entries')
+        stale = []
+        if nodes:
+            stale += [n for n in nodes if n.owner_rule is rule]
+        for node in stale:
+            node.teardown()
+            if nodes and node in nodes:
+                nodes.remove(node)
+            if entries and node in entries:
+                entries.remove(node)
+        scopes = widget.__dict__.get('_kv_id_scopes')
+        if scopes:
+            del scopes[:]
+
+    def _build_canvas_content(self, group, widget, rule, ids, captured,
+                              subnodes):
+        '''Build the canvas rule `rule`'s children into `group` (explicit
+        adds: no canvas context is active here), recording created bindings
+        in `captured` and nested control nodes in `subnodes`.'''
+        global Instruction, InstructionGroup
+        if Instruction is None:
+            Instruction = Factory.get('Instruction')
+        for crule in rule.children:
+            if isinstance(crule, ParserControlRule):
+                if InstructionGroup is None:
+                    from kivy.graphics import InstructionGroup
+                sub = InstructionGroup()
+                group.add(sub)
+                node = CanvasIfNode(self, widget, crule, ids, sub)
+                subnodes.append(node)
+                node.activate()
+                continue
+            if crule.name == 'Clear':
+                group.clear()
+                continue
+            instr = Factory.get(crule.name)()
+            if not isinstance(instr, Instruction):
+                raise BuilderException(
+                    crule.ctx, crule.line,
+                    'You can add only graphics Instruction in canvas.')
+            group.add(instr)
+            try:
+                for prule in crule.properties.values():
+                    key = prule.name
+                    value = prule.co_value
+                    if type(value) is CodeType:
+                        blist = _handlers[widget.uid][key]
+                        n = len(blist)
+                        value, _ = create_handler(
+                            widget, instr.proxy_ref, key, value, prule,
+                            ids, True)
+                        if len(blist) > n:
+                            captured.append((key, blist[n:]))
+                    setattr(instr, key, value)
+            except BuilderException:
+                raise
+            except Exception as e:
+                tb = sys.exc_info()[2]
+                raise BuilderException(
+                    prule.ctx, prule.line,
+                    '{}: {}'.format(e.__class__.__name__, e), cause=tb)
 
     def match(self, widget):
         '''Return a list of :class:`ParserRule` objects matching the widget.
@@ -830,11 +1541,24 @@ class BuilderBase(object):
             del _handlers[uid]
 
     def _build_canvas(self, canvas, widget, rule, rootrule):
-        global Instruction
+        global Instruction, InstructionGroup
         if Instruction is None:
             Instruction = Factory.get('Instruction')
         idmap = copy(self.rulectx[rootrule]['ids'])
         for crule in rule.children:
+            if isinstance(crule, ParserControlRule):
+                # created inside the canvas `with` block, so the group is
+                # auto-added at the block's document position; the content is
+                # built in the deferred phase, outside the canvas context
+                if InstructionGroup is None:
+                    from kivy.graphics import InstructionGroup
+                group = InstructionGroup()
+                node = CanvasIfNode(self, widget, crule, idmap, group)
+                node.owner_rule = rootrule
+                widget.__dict__.setdefault(
+                    '_kv_control_nodes', []).append(node)
+                self._pending.append(partial(node.activate, None))
+                continue
             name = crule.name
             if name == 'Clear':
                 canvas.clear()
@@ -875,6 +1599,13 @@ if 'KIVY_PROFILE_LANG' in environ:
             if prp.line != index:
                 continue
             yield prp
+        if isinstance(rule, ParserControlRule):
+            if (rule.selector_prop is not None and
+                    rule.selector_prop.line == index):
+                yield rule.selector_prop
+            for branch in rule.branches:
+                for r in match_rule(fn, index, branch):
+                    yield r
         for child in rule.children:
             for r in match_rule(fn, index, child):
                 yield r

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -50,7 +50,7 @@ lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile(r'([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile(r'(_\()')
 lang_cls_split_pat = re.compile(', *')
-lang_control = re.compile(r'(if|elif|else|for)\b')
+lang_control = re.compile(r'(if|elif|else|for|factory)\b')
 
 # all the widget handlers, used to correctly unbind all the callbacks then the
 # widget is deleted
@@ -467,14 +467,14 @@ class ParserControlBranch(ParserRule):
 
 
 class ParserControlRule(ParserRule):
-    '''A control statement (``if`` chain or ``for``)
+    '''A control statement (``if`` chain, ``for`` or ``factory``)
     at child position in a rule. The body is parsed with the ordinary rule
     machinery; :class:`Parser` finalizes it (chain merging, scope resolution,
     reference rewriting) before precompilation.
     '''
 
     __slots__ = ('kind', 'branches', 'selector_prop', 'iterator_prop',
-                 'key_prop', 'target_names',
+                 'key_prop', 'class_prop', 'target_names',
                  'locals', 'scope_key', 'scope_names', 'in_canvas',
                  'header_src')
 
@@ -492,6 +492,8 @@ class ParserControlRule(ParserRule):
         self.iterator_prop = None
         #: for: per-iteration key expression (evaluated during reconcile)
         self.key_prop = None
+        #: factory: the class expression
+        self.class_prop = None
         #: for: loop target names, in order
         self.target_names = []
         #: for: [(name, ParserRuleProperty)] iteration-locals, in order
@@ -508,8 +510,8 @@ class ParserControlRule(ParserRule):
         super(ParserControlRule, self).precompile()
         for branch in self.branches:
             branch.precompile()
-        for prop in (self.selector_prop, self.iterator_prop,
-                     self.key_prop):
+        for prop in (self.selector_prop, self.iterator_prop, self.key_prop,
+                     self.class_prop):
             if prop is not None:
                 prop.precompile()
         for _, prop in self.locals:
@@ -955,8 +957,16 @@ class Parser(object):
             if expr:
                 raise ParserException(self, ln, '"else" takes no expression')
             ctl.header_src = None
-        else:  # for
+        elif kind == 'for':
             self._parse_for_header(ln, ctl, head)
+        else:  # factory
+            if not expr:
+                raise ParserException(
+                    self, ln, '"factory" requires an expression giving the '
+                    'widget class')
+            self._check_header_expr(ln, expr)
+            ctl.class_prop = ParserRuleProperty(
+                self, ln, '__kv_factory_class', expr)
         return ctl
 
     def _split_control_header(self, ln, content):
@@ -1192,6 +1202,9 @@ class Parser(object):
                 if child.kind == 'if':
                     for branch in child.branches:
                         self._collect_scoped_ids(branch, found)
+                elif child.kind == 'factory':
+                    self._forbid_ids(child)
+                # 'for': its ids live on the iteration scope
             else:
                 if child.id:
                     statics.append(self._clean_id(child.id, child))
@@ -1203,10 +1216,20 @@ class Parser(object):
                 if child.kind == 'if':
                     for branch in child.branches:
                         self._collect_scoped_ids(branch, found)
+                elif child.kind == 'factory':
+                    self._forbid_ids(child)
             else:
                 if child.id:
                     found.append((self._clean_id(child.id, child), child))
                 self._collect_scoped_ids(child, found)
+
+    def _forbid_ids(self, rule):
+        for child in rule.children:
+            if not isinstance(child, ParserControlRule) and child.id:
+                raise ParserException(
+                    self, child.line, '"id" is not allowed on widgets inside '
+                    'a "factory" block')
+            self._forbid_ids(child)
 
     #
     # Control statements: validation, scopes and reference rewriting
@@ -1249,6 +1272,14 @@ class Parser(object):
                 self._walk_branch(branch, env, for_ctl)
         elif kind == 'for':
             self._walk_for(ctl, env)
+        else:  # factory
+            self._rewrite_prop(ctl.class_prop, env)
+            if 'key' in ctl.properties:
+                raise ParserException(
+                    self, ctl.properties['key'].line, '"key:" is only '
+                    'allowed inside a "for" block')
+            # the body is an ordinary rule applied to the built instance
+            self._walk_rule(ctl, env, None)
 
     def _walk_branch(self, branch, env, for_ctl):
         if branch.id:
@@ -1351,6 +1382,8 @@ class Parser(object):
                 if child.kind == 'if':
                     for branch in child.branches:
                         self._collect_for_ids(branch.children, out)
+                elif child.kind == 'factory':
+                    self._forbid_ids(child)
                 # nested 'for': its own scope; 'slot': forbidden in for
             else:
                 if child.id:
@@ -1372,6 +1405,9 @@ class Parser(object):
 
     def _walk_canvas_control(self, ctl, env):
         kind = ctl.kind
+        if kind == 'factory':
+            raise ParserException(
+                self, ctl.line, '"factory" cannot be declared inside canvas')
         if kind == 'if':
             self._rewrite_prop(ctl.selector_prop, env)
             for branch in ctl.branches:

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -6,8 +6,10 @@ Class used for the parsing of .kv files into rules.
 '''
 import os
 
+import io
 import re
 import sys
+import tokenize
 import traceback
 import ast
 import importlib
@@ -23,7 +25,8 @@ from kivy.resources import resource_find
 from kivy.utils import rgba
 import kivy.metrics as Metrics
 
-__all__ = ('Parser', 'ParserException')
+__all__ = ('Parser', 'ParserException', 'ParserControlRule',
+           'ParserControlBranch')
 
 
 trace = Logger.trace
@@ -47,6 +50,7 @@ lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile(r'([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile(r'(_\()')
 lang_cls_split_pat = re.compile(', *')
+lang_control = re.compile(r'(if|elif|else)\b')
 
 # all the widget handlers, used to correctly unbind all the callbacks then the
 # widget is deleted
@@ -141,7 +145,8 @@ class ParserRuleProperty(object):
     '''
 
     __slots__ = ('ctx', 'line', 'name', 'value', 'co_value',
-                 'watched_keys', 'mode', 'count', 'ignore_prev')
+                 'watched_keys', 'mode', 'count', 'ignore_prev',
+                 'force_code')
 
     def __init__(self, ctx, line, name, value, ignore_prev=False):
         super(ParserRuleProperty, self).__init__()
@@ -163,6 +168,9 @@ class ParserRuleProperty(object):
         self.count = 0
         #: whether previous rules targeting name should be cleared
         self.ignore_prev = ignore_prev
+        #: always compile to a code object, even for a constant expression
+        #: (an iteration-local like `[]` must evaluate freshly per iteration)
+        self.force_code = False
 
     def precompile(self):
         name = self.name
@@ -175,7 +183,7 @@ class ParserRuleProperty(object):
         mode = self.mode
         if self.mode is None:
             self.mode = mode = 'exec' if name[:3] == 'on_' else 'eval'
-        if mode == 'eval':
+        if mode == 'eval' and not self.force_code:
             # if we don't detect any string/key in it, we can eval and give the
             # result
             if re.search(lang_key, tmp) is None:
@@ -301,7 +309,8 @@ class ParserRule(object):
 
     __slots__ = ('ctx', 'line', 'name', 'children', 'id', 'properties',
                  'canvas_before', 'canvas_root', 'canvas_after',
-                 'handlers', 'level', 'cache_marked', 'avoid_previous_rules')
+                 'handlers', 'level', 'cache_marked', 'avoid_previous_rules',
+                 'has_controls', 'id_scope_key', 'id_scope_names', 'scope_id')
 
     def __init__(self, ctx, line, name, level):
         super(ParserRule, self).__init__()
@@ -331,6 +340,14 @@ class ParserRule(object):
         self.cache_marked = []
         #: Indicate if any previous rules should be avoided.
         self.avoid_previous_rules = False
+        #: True if any direct child is a control statement (fast-path test)
+        self.has_controls = False
+        #: Key and names of the rule-level reactive-id scope (ids declared
+        #: inside `if` branches and `slot` blocks of this rule)
+        self.id_scope_key = None
+        self.id_scope_names = []
+        #: (scope_key, name) when this widget's id lives on a scope object
+        self.scope_id = None
 
         if level == 0:
             self._detect_selectors()
@@ -436,6 +453,112 @@ class ParserRule(object):
         return '<ParserRule name=%r>' % (self.name, )
 
 
+class ParserControlBranch(ParserRule):
+    '''One branch of an ``if`` / ``elif`` / ``else`` chain: a full rule body
+    (children, properties, handlers, canvas) plus the branch condition.
+    '''
+
+    __slots__ = ('cond_src',)
+
+    def __init__(self, ctx, line, level, cond_src):
+        super(ParserControlBranch, self).__init__(ctx, line, 'branch', level)
+        #: Source of the condition; None for ``else``
+        self.cond_src = cond_src
+
+
+class ParserControlRule(ParserRule):
+    '''A control statement (an ``if`` chain)
+    at child position in a rule. The body is parsed with the ordinary rule
+    machinery; :class:`Parser` finalizes it (chain merging, scope resolution,
+    reference rewriting) before precompilation.
+    '''
+
+    __slots__ = ('kind', 'branches', 'selector_prop', 'in_canvas',
+                 'header_src')
+
+    def __init__(self, ctx, line, kind, level):
+        super(ParserControlRule, self).__init__(ctx, line, kind, level)
+        #: 'if', 'for', 'slot' or 'factory' ('elif'/'else' only pre-merge)
+        self.kind = kind
+        #: raw condition source for if/elif headers (None for else)
+        self.header_src = None
+        #: if: list of :class:`ParserControlBranch`
+        self.branches = []
+        #: if: expression giving the index of the active branch (-1: none)
+        self.selector_prop = None
+        #: True when the block generates graphics instructions
+        self.in_canvas = False
+
+    def precompile(self):
+        super(ParserControlRule, self).precompile()
+        for branch in self.branches:
+            branch.precompile()
+        if self.selector_prop is not None:
+            self.selector_prop.precompile()
+
+
+class _ScopeRewriter(ast.NodeTransformer):
+    '''Rewrite ``name`` to ``<scope_key>.name`` for scoped names, respecting
+    lambda and comprehension shadowing.
+    '''
+
+    def __init__(self, env):
+        super(_ScopeRewriter, self).__init__()
+        self.env = env
+        self.shadow = []
+        self.changed = False
+
+    def _shadowed(self, name):
+        return any(name in s for s in self.shadow)
+
+    def visit_Name(self, node):
+        if (isinstance(node.ctx, ast.Load) and node.id in self.env and
+                not self._shadowed(node.id)):
+            self.changed = True
+            return ast.copy_location(ast.Attribute(
+                value=ast.copy_location(
+                    ast.Name(id=self.env[node.id], ctx=ast.Load()), node),
+                attr=node.id, ctx=ast.Load()), node)
+        return node
+
+    def visit_Lambda(self, node):
+        args = node.args
+        # defaults evaluate in the enclosing scope
+        args.defaults = [self.visit(d) for d in args.defaults]
+        args.kw_defaults = [self.visit(d) if d is not None else None
+                            for d in args.kw_defaults]
+        names = {a.arg for a in args.args + args.posonlyargs + args.kwonlyargs}
+        if args.vararg:
+            names.add(args.vararg.arg)
+        if args.kwarg:
+            names.add(args.kwarg.arg)
+        self.shadow.append(names)
+        node.body = self.visit(node.body)
+        self.shadow.pop()
+        return node
+
+    def _visit_comp(self, node):
+        pushed = 0
+        for gen in node.generators:
+            gen.iter = self.visit(gen.iter)
+            self.shadow.append({n.id for n in ast.walk(gen.target)
+                                if isinstance(n, ast.Name)})
+            pushed += 1
+            gen.ifs = [self.visit(i) for i in gen.ifs]
+        if isinstance(node, ast.DictComp):
+            node.key = self.visit(node.key)
+            node.value = self.visit(node.value)
+        else:
+            node.elt = self.visit(node.elt)
+        del self.shadow[-pushed:]
+        return node
+
+    visit_ListComp = _visit_comp
+    visit_SetComp = _visit_comp
+    visit_DictComp = _visit_comp
+    visit_GeneratorExp = _visit_comp
+
+
 class Parser(object):
     '''Create a Parser object to parse a Kivy language file or Kivy content.
     '''
@@ -448,7 +571,7 @@ class Parser(object):
         list(range(ord('0'), ord('9') + 1)) + [ord('_')])
 
     __slots__ = ('rules', 'root', 'sourcecode',
-                 'directives', 'filename', 'dynamic_classes')
+                 'directives', 'filename', 'dynamic_classes', '_scope_count')
 
     def __init__(self, **kwargs):
         super(Parser, self).__init__()
@@ -457,6 +580,7 @@ class Parser(object):
         self.sourcecode = []
         self.directives = []
         self.dynamic_classes = {}
+        self._scope_count = 0
         self.filename = kwargs.get('filename', None)
         content = kwargs.get('content', None)
         if content is None:
@@ -573,7 +697,10 @@ class Parser(object):
         # Get object from the first level
         objects, remaining_lines = self.parse_level(0, lines)
 
-        # Precompile rules tree
+        # Finalize control statements (chain merging, scope resolution,
+        # reference rewriting), then precompile the rules tree
+        for rule in objects:
+            self._finalize_controls(rule)
         for rule in objects:
             rule.precompile()
 
@@ -639,6 +766,17 @@ class Parser(object):
 
             # Current level, create an object
             elif count == indent:
+                if lang_control.match(content):
+                    if count == 0:
+                        raise ParserException(
+                            self, ln, 'Control statements are not allowed at '
+                            'the top level of a kv file')
+                    current_object = self._parse_control_statement(
+                        ln, content, rlevel)
+                    current_property = None
+                    objects.append(current_object)
+                    i += 1
+                    continue
                 x = content.split(':', 1)
                 if not x[0]:
                     raise ParserException(self, ln, 'Identifier missing')
@@ -659,6 +797,17 @@ class Parser(object):
 
             # Next level, is it a property or an object ?
             elif count == indent + spaces:
+                # a control statement is a child: recurse like a class child
+                if lang_control.match(content):
+                    _objects, _lines = self.parse_level(
+                        level + 1, lines[i:], spaces)
+                    if current_object is None:
+                        raise ParserException(self, ln, 'Invalid indentation')
+                    current_object.children = _objects
+                    current_property = None
+                    lines = _lines
+                    i = 1
+                    continue
                 x = content.split(':', 1)
                 if not x[0]:
                     raise ParserException(self, ln, 'Identifier missing')
@@ -756,6 +905,317 @@ class Parser(object):
             i += 1
 
         return objects, []
+
+    #
+    # Control statements: header parsing
+    #
+
+    def _parse_control_statement(self, ln, content, rlevel):
+        kind = lang_control.match(content).group(1)
+        head = self._split_control_header(ln, content)
+        expr = head[len(kind):].strip()
+        ctl = ParserControlRule(self, ln, kind, rlevel)
+
+        if kind in ('if', 'elif'):
+            if not expr:
+                raise ParserException(
+                    self, ln, '"%s" requires a condition expression' % kind)
+            self._check_header_expr(ln, expr)
+            ctl.header_src = expr
+        elif kind == 'else':
+            if expr:
+                raise ParserException(self, ln, '"else" takes no expression')
+            ctl.header_src = None
+        return ctl
+
+    def _split_control_header(self, ln, content):
+        '''Return the header (text before the block colon), rejecting inline
+        bodies. The colon is found at bracket depth 0, so colons inside
+        strings, dicts, slices or parenthesized lambdas are skipped.
+        '''
+        depth = 0
+        colon = None
+        try:
+            tokens = tokenize.generate_tokens(io.StringIO(content).readline)
+            for tok in tokens:
+                if tok.type != tokenize.OP:
+                    continue
+                if tok.string in '([{':
+                    depth += 1
+                elif tok.string in ')]}':
+                    depth -= 1
+                elif tok.string == ':' and depth == 0:
+                    # keep the last depth-0 colon, so a bare lambda in the
+                    # header keeps its own colon
+                    colon = tok.start[1]
+        except tokenize.TokenError:
+            pass
+        if colon is None:
+            raise ParserException(
+                self, ln, "expected ':' at the end of the control statement "
+                'header')
+        tail = content[colon + 1:].strip()
+        if tail and not tail.startswith('#'):
+            raise ParserException(
+                self, ln, "unexpected content after ':' in a control "
+                'statement (the body goes on the following lines)')
+        return content[:colon].rstrip()
+
+    def _check_header_expr(self, ln, expr):
+        try:
+            tree = ast.parse(expr, mode='eval')
+        except SyntaxError as e:
+            raise ParserException(
+                self, ln, 'invalid expression in control statement header '
+                '(%s)' % e)
+        self._forbid_walrus(ln, tree)
+        return tree
+
+    def _forbid_walrus(self, ln, tree):
+        if any(isinstance(n, ast.NamedExpr) for n in ast.walk(tree)):
+            raise ParserException(
+                self, ln, 'assignment expressions (":=") are not allowed in '
+                'control statement headers')
+
+    #
+    # Control statements: finalization (chain merging, scope resolution,
+    # reference rewriting). Runs after parse_level, before precompile.
+    #
+
+    def _new_scope_key(self):
+        key = '__kvscope_%d' % self._scope_count
+        self._scope_count += 1
+        return key
+
+    def _finalize_controls(self, rule):
+        self._merge_control_chains(rule, False)
+        # rule-level reactive-id scope: ids inside `if` branches and `slot`
+        # blocks of this rule (an id under a `for` goes to the iteration
+        # scope instead)
+        found, statics = [], []
+        self._collect_rule_ids(rule, found, statics)
+        env = {}
+        if found:
+            names = [n for n, _ in found]
+            for name in names:
+                if name in statics:
+                    raise ParserException(
+                        self, rule.line, 'reactive id %r clashes with a '
+                        'static id of the same rule' % name)
+            rule.id_scope_key = self._new_scope_key()
+            seen = set()
+            rule.id_scope_names = [
+                n for n in names if not (n in seen or seen.add(n))]
+            for name, crule in found:
+                crule.id = None
+                crule.scope_id = (rule.id_scope_key, name)
+            env = {n: rule.id_scope_key for n in rule.id_scope_names}
+        self._walk_rule(rule, env, None)
+
+    def _merge_control_chains(self, rule, in_canvas):
+        self._merge_list(rule.children, in_canvas)
+        for cv in (rule.canvas_before, rule.canvas_root, rule.canvas_after):
+            if cv is not None:
+                self._merge_list(cv.children, True)
+
+    def _merge_list(self, children, in_canvas):
+        out = []
+        for child in children:
+            if isinstance(child, ParserControlRule):
+                child.in_canvas = in_canvas
+                if child.kind in ('elif', 'else'):
+                    prev = out[-1] if out else None
+                    if (not isinstance(prev, ParserControlRule) or
+                            prev.kind != 'if' or
+                            prev.branches[-1].cond_src is None):
+                        raise ParserException(
+                            self, child.line, '"%s" must immediately follow '
+                            'an "if" or "elif" block' % child.kind)
+                    prev.branches.append(self._as_branch(child))
+                    continue
+                if child.kind == 'if':
+                    child.branches = [self._as_branch(child)]
+                    child.children = []
+                    child.properties = OrderedDict()
+                    child.handlers = []
+                    child.canvas_root = None
+                    child.canvas_before = None
+                    child.canvas_after = None
+                    child.id = None
+            out.append(child)
+        children[:] = out
+        for child in out:
+            if isinstance(child, ParserControlRule):
+                for branch in child.branches:
+                    self._merge_control_chains(branch, in_canvas)
+                self._merge_list(child.children, in_canvas)
+                for cv in (child.canvas_before, child.canvas_root,
+                           child.canvas_after):
+                    if cv is not None:
+                        self._merge_list(cv.children, True)
+                if child.kind == 'if':
+                    child.selector_prop = self._build_selector(child)
+            else:
+                self._merge_control_chains(child, in_canvas)
+
+    def _as_branch(self, ctl):
+        branch = ParserControlBranch(
+            self, ctl.line, ctl.level, ctl.header_src)
+        branch.children = ctl.children
+        branch.properties = ctl.properties
+        branch.handlers = ctl.handlers
+        branch.canvas_root = ctl.canvas_root
+        branch.canvas_before = ctl.canvas_before
+        branch.canvas_after = ctl.canvas_after
+        branch.id = ctl.id
+        return branch
+
+    def _build_selector(self, ctl):
+        conds = []
+        else_index = -1
+        for i, branch in enumerate(ctl.branches):
+            if branch.cond_src is None:
+                else_index = i
+            else:
+                conds.append('%d if (%s)' % (i, branch.cond_src))
+        value = ' else '.join(conds) + ' else %d' % else_index
+        return ParserRuleProperty(self, ctl.line, '__kv_selector', value)
+
+    def _clean_id(self, value, crule):
+        # same normalization as the builder: first word, comments dropped
+        name = value.split('#', 1)[0].strip()
+        if name == 'app':
+            # a scoped id is rewritten wherever it is referenced, so unlike
+            # a static id it would silently hijack the `app` proxy
+            raise ParserException(
+                self, crule.line,
+                'Invalid id, cannot be "self", "root" or "app"')
+        return name
+
+    def _collect_rule_ids(self, rule, found, statics):
+        '''Collect ids belonging to this rule's reactive-id scope: ids on
+        widgets inside `if` branches and `slot` blocks, at any depth, stopping
+        at `for` blocks (iteration scope) and rejecting ids in `factory`
+        bodies. Also collects the rule's static ids for clash detection.
+        '''
+        for child in rule.children:
+            if isinstance(child, ParserControlRule):
+                if child.kind == 'if':
+                    for branch in child.branches:
+                        self._collect_scoped_ids(branch, found)
+            else:
+                if child.id:
+                    statics.append(self._clean_id(child.id, child))
+                self._collect_rule_ids(child, found, statics)
+
+    def _collect_scoped_ids(self, rule, found):
+        for child in rule.children:
+            if isinstance(child, ParserControlRule):
+                if child.kind == 'if':
+                    for branch in child.branches:
+                        self._collect_scoped_ids(branch, found)
+            else:
+                if child.id:
+                    found.append((self._clean_id(child.id, child), child))
+                self._collect_scoped_ids(child, found)
+
+    #
+    # Control statements: validation, scopes and reference rewriting
+    #
+
+    def _walk_rule(self, rule, env, for_ctl):
+        '''Validate and rewrite one rule body (a widget rule, an if branch, a
+        factory body). `env` maps scoped names to their scope key; `for_ctl`
+        is the enclosing `for` when this body is (part of) its direct block.
+        '''
+        for prop in rule.properties.values():
+            self._rewrite_prop(prop, env)
+        for prop in rule.handlers:
+            self._rewrite_prop(prop, env)
+        for cv in (rule.canvas_before, rule.canvas_root, rule.canvas_after):
+            if cv is not None:
+                self._walk_canvas(cv, env)
+        rule.has_controls = any(
+            isinstance(c, ParserControlRule) for c in rule.children)
+        child_env = env
+        if env and ('self' in env or 'args' in env):
+            # a widget's own `self` (and a handler's `args`) win inside it
+            child_env = {k: v for k, v in env.items()
+                         if k not in ('self', 'args')}
+        for child in rule.children:
+            if isinstance(child, ParserControlRule):
+                self._walk_control(child, env, for_ctl)
+            else:
+                self._walk_rule(child, child_env, None)
+
+    def _walk_control(self, ctl, env, for_ctl):
+        kind = ctl.kind
+        if ctl.id:
+            raise ParserException(
+                self, ctl.line, '"id" is not allowed directly on a control '
+                'statement')
+        if kind == 'if':
+            self._rewrite_prop(ctl.selector_prop, env)
+            for branch in ctl.branches:
+                self._walk_branch(branch, env, for_ctl)
+
+    def _walk_branch(self, branch, env, for_ctl):
+        if branch.id:
+            raise ParserException(
+                self, branch.line, '"id" is not allowed directly on a '
+                'control statement')
+        if 'key' in branch.properties:
+            raise ParserException(
+                self, branch.properties['key'].line, '"key:" is only allowed '
+                'inside a "for" block')
+        if not (branch.children or branch.properties or branch.handlers or
+                branch.canvas_root or branch.canvas_before or
+                branch.canvas_after):
+            raise ParserException(
+                self, branch.line, 'an "if" block requires at least one '
+                'child widget, property, handler or canvas')
+        self._walk_rule(branch, env, for_ctl)
+
+    def _walk_canvas(self, canvas_rule, env):
+        for child in canvas_rule.children:
+            if isinstance(child, ParserControlRule):
+                self._walk_canvas_control(child, env)
+            else:
+                for prop in child.properties.values():
+                    self._rewrite_prop(prop, env)
+                if any(isinstance(c, ParserControlRule)
+                       for c in child.children):
+                    raise ParserException(
+                        self, child.line, 'a control statement is not '
+                        'allowed under a graphics instruction')
+
+    def _walk_canvas_control(self, ctl, env):
+        kind = ctl.kind
+        if kind == 'if':
+            self._rewrite_prop(ctl.selector_prop, env)
+            for branch in ctl.branches:
+                if branch.properties or branch.handlers:
+                    prop = (list(branch.properties.values()) +
+                            branch.handlers)[0]
+                    raise ParserException(
+                        self, prop.line, 'only graphics instructions are '
+                        'allowed inside canvas control statements')
+                self._walk_canvas(branch, env)
+
+    def _rewrite_prop(self, prop, env):
+        if not env or prop is None:
+            return
+        mode = 'exec' if prop.name[:3] == 'on_' else 'eval'
+        try:
+            tree = ast.parse(prop.value, mode=mode)
+        except SyntaxError:
+            # let precompile report it with the proper kv context
+            return
+        rewriter = _ScopeRewriter(env)
+        tree = rewriter.visit(tree)
+        if rewriter.changed:
+            ast.fix_missing_locations(tree)
+            prop.value = ast.unparse(tree)
 
 
 class ParserSelector(object):

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -9,6 +9,7 @@ import os
 import io
 import re
 import sys
+import keyword
 import tokenize
 import traceback
 import ast
@@ -50,7 +51,7 @@ lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile(r'([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile(r'(_\()')
 lang_cls_split_pat = re.compile(', *')
-lang_control = re.compile(r'(if|elif|else|for|factory)\b')
+lang_control = re.compile(r'(if|elif|else|for|slot|factory)\b')
 
 # all the widget handlers, used to correctly unbind all the callbacks then the
 # widget is deleted
@@ -310,7 +311,8 @@ class ParserRule(object):
     __slots__ = ('ctx', 'line', 'name', 'children', 'id', 'properties',
                  'canvas_before', 'canvas_root', 'canvas_after',
                  'handlers', 'level', 'cache_marked', 'avoid_previous_rules',
-                 'has_controls', 'id_scope_key', 'id_scope_names', 'scope_id')
+                 'has_controls', 'id_scope_key', 'id_scope_names', 'scope_id',
+                 'slot_defs')
 
     def __init__(self, ctx, line, name, level):
         super(ParserRule, self).__init__()
@@ -348,6 +350,8 @@ class ParserRule(object):
         self.id_scope_names = []
         #: (scope_key, name) when this widget's id lives on a scope object
         self.scope_id = None
+        #: Slot names this rule declares (definitions), in document order
+        self.slot_defs = None
 
         if level == 0:
             self._detect_selectors()
@@ -467,14 +471,14 @@ class ParserControlBranch(ParserRule):
 
 
 class ParserControlRule(ParserRule):
-    '''A control statement (``if`` chain, ``for`` or ``factory``)
+    '''A control statement (``if`` chain, ``for``, ``slot`` or ``factory``)
     at child position in a rule. The body is parsed with the ordinary rule
     machinery; :class:`Parser` finalizes it (chain merging, scope resolution,
     reference rewriting) before precompilation.
     '''
 
     __slots__ = ('kind', 'branches', 'selector_prop', 'iterator_prop',
-                 'key_prop', 'class_prop', 'target_names',
+                 'key_prop', 'class_prop', 'target_names', 'slot_name',
                  'locals', 'scope_key', 'scope_names', 'in_canvas',
                  'header_src')
 
@@ -496,7 +500,9 @@ class ParserControlRule(ParserRule):
         self.class_prop = None
         #: for: loop target names, in order
         self.target_names = []
-        #: for: [(name, ParserRuleProperty)] iteration-locals, in order
+        #: slot: the slot name ('' for the default slot)
+        self.slot_name = ''
+        #: for/slot: [(name, ParserRuleProperty)] scoped locals, in order
         self.locals = []
         #: for: name of the per-iteration scope in expressions
         self.scope_key = None
@@ -959,6 +965,11 @@ class Parser(object):
             ctl.header_src = None
         elif kind == 'for':
             self._parse_for_header(ln, ctl, head)
+        elif kind == 'slot':
+            if expr and (not expr.isidentifier() or keyword.iskeyword(expr)):
+                raise ParserException(
+                    self, ln, 'invalid slot name %r' % expr)
+            ctl.slot_name = expr
         else:  # factory
             if not expr:
                 raise ParserException(
@@ -1103,6 +1114,9 @@ class Parser(object):
                 crule.scope_id = (rule.id_scope_key, name)
             env = {n: rule.id_scope_key for n in rule.id_scope_names}
         self._walk_rule(rule, env, None)
+        defs = []
+        self._collect_slot_defs(rule, defs)
+        rule.slot_defs = defs
 
     def _merge_control_chains(self, rule, in_canvas):
         self._merge_list(rule.children, in_canvas)
@@ -1202,6 +1216,8 @@ class Parser(object):
                 if child.kind == 'if':
                     for branch in child.branches:
                         self._collect_scoped_ids(branch, found)
+                elif child.kind == 'slot':
+                    self._collect_scoped_ids(child, found)
                 elif child.kind == 'factory':
                     self._forbid_ids(child)
                 # 'for': its ids live on the iteration scope
@@ -1216,6 +1232,8 @@ class Parser(object):
                 if child.kind == 'if':
                     for branch in child.branches:
                         self._collect_scoped_ids(branch, found)
+                elif child.kind == 'slot':
+                    self._collect_scoped_ids(child, found)
                 elif child.kind == 'factory':
                     self._forbid_ids(child)
             else:
@@ -1230,6 +1248,19 @@ class Parser(object):
                     self, child.line, '"id" is not allowed on widgets inside '
                     'a "factory" block')
             self._forbid_ids(child)
+
+    def _collect_slot_defs(self, rule, defs):
+        # slot names declared by this rule for its widget: direct blocks,
+        # inside `if` branches and nested in slot bodies (forwarding) -- but
+        # not across a child-widget boundary (those belong to the child)
+        for child in rule.children:
+            if isinstance(child, ParserControlRule):
+                if child.kind == 'slot':
+                    defs.append(child.slot_name)
+                    self._collect_slot_defs(child, defs)
+                elif child.kind == 'if':
+                    for branch in child.branches:
+                        self._collect_slot_defs(branch, defs)
 
     #
     # Control statements: validation, scopes and reference rewriting
@@ -1272,6 +1303,32 @@ class Parser(object):
                 self._walk_branch(branch, env, for_ctl)
         elif kind == 'for':
             self._walk_for(ctl, env)
+        elif kind == 'slot':
+            if for_ctl is not None:
+                raise ParserException(
+                    self, ctl.line, 'a slot cannot be defined inside a '
+                    '"for" block')
+            if ctl.handlers:
+                raise ParserException(
+                    self, ctl.handlers[0].line, 'event handlers are not '
+                    'allowed in a "slot" block')
+            if (ctl.canvas_root or ctl.canvas_before or ctl.canvas_after):
+                raise ParserException(
+                    self, ctl.line, 'canvas is not allowed in a "slot" '
+                    'block')
+            for name, prop in ctl.properties.items():
+                if name == 'key':
+                    raise ParserException(
+                        self, prop.line, '"key:" is only allowed inside a '
+                        '"for" block')
+                self._rewrite_prop(prop, env)
+                ctl.locals.append((name, prop))
+            ctl.properties = OrderedDict()
+            for child in ctl.children:
+                if isinstance(child, ParserControlRule):
+                    self._walk_control(child, env, None)
+                else:
+                    self._walk_rule(child, env, None)
         else:  # factory
             self._rewrite_prop(ctl.class_prop, env)
             if 'key' in ctl.properties:
@@ -1405,9 +1462,10 @@ class Parser(object):
 
     def _walk_canvas_control(self, ctl, env):
         kind = ctl.kind
-        if kind == 'factory':
+        if kind in ('slot', 'factory'):
             raise ParserException(
-                self, ctl.line, '"factory" cannot be declared inside canvas')
+                self, ctl.line, '"%s" cannot be declared inside canvas'
+                % kind)
         if kind == 'if':
             self._rewrite_prop(ctl.selector_prop, env)
             for branch in ctl.branches:

--- a/kivy/lang/parser.py
+++ b/kivy/lang/parser.py
@@ -50,7 +50,7 @@ lang_key = re.compile('([a-zA-Z_]+)')
 lang_keyvalue = re.compile(r'([a-zA-Z_][a-zA-Z0-9_.]*\.[a-zA-Z0-9_.]+)')
 lang_tr = re.compile(r'(_\()')
 lang_cls_split_pat = re.compile(', *')
-lang_control = re.compile(r'(if|elif|else)\b')
+lang_control = re.compile(r'(if|elif|else|for)\b')
 
 # all the widget handlers, used to correctly unbind all the callbacks then the
 # widget is deleted
@@ -467,13 +467,15 @@ class ParserControlBranch(ParserRule):
 
 
 class ParserControlRule(ParserRule):
-    '''A control statement (an ``if`` chain)
+    '''A control statement (``if`` chain or ``for``)
     at child position in a rule. The body is parsed with the ordinary rule
     machinery; :class:`Parser` finalizes it (chain merging, scope resolution,
     reference rewriting) before precompilation.
     '''
 
-    __slots__ = ('kind', 'branches', 'selector_prop', 'in_canvas',
+    __slots__ = ('kind', 'branches', 'selector_prop', 'iterator_prop',
+                 'key_prop', 'target_names',
+                 'locals', 'scope_key', 'scope_names', 'in_canvas',
                  'header_src')
 
     def __init__(self, ctx, line, kind, level):
@@ -486,6 +488,19 @@ class ParserControlRule(ParserRule):
         self.branches = []
         #: if: expression giving the index of the active branch (-1: none)
         self.selector_prop = None
+        #: for: expression giving the list of loop-value tuples
+        self.iterator_prop = None
+        #: for: per-iteration key expression (evaluated during reconcile)
+        self.key_prop = None
+        #: for: loop target names, in order
+        self.target_names = []
+        #: for: [(name, ParserRuleProperty)] iteration-locals, in order
+        self.locals = []
+        #: for: name of the per-iteration scope in expressions
+        self.scope_key = None
+        #: for: every name living on the iteration scope (targets, locals,
+        #: conditional locals, ids)
+        self.scope_names = []
         #: True when the block generates graphics instructions
         self.in_canvas = False
 
@@ -493,8 +508,22 @@ class ParserControlRule(ParserRule):
         super(ParserControlRule, self).precompile()
         for branch in self.branches:
             branch.precompile()
-        if self.selector_prop is not None:
-            self.selector_prop.precompile()
+        for prop in (self.selector_prop, self.iterator_prop,
+                     self.key_prop):
+            if prop is not None:
+                prop.precompile()
+        for _, prop in self.locals:
+            prop.precompile()
+        # keys rooted at a loop target are loop-local, not bindable
+        if self.iterator_prop is not None and self.iterator_prop.watched_keys:
+            targets = set(self.target_names)
+            wk = [k for k in self.iterator_prop.watched_keys
+                  if k[0] not in targets]
+            self.iterator_prop.watched_keys = wk or None
+        if self.key_prop is not None:
+            # the key is evaluated per iteration during reconcile; it never
+            # binds on its own
+            self.key_prop.watched_keys = None
 
 
 class _ScopeRewriter(ast.NodeTransformer):
@@ -926,6 +955,8 @@ class Parser(object):
             if expr:
                 raise ParserException(self, ln, '"else" takes no expression')
             ctl.header_src = None
+        else:  # for
+            self._parse_for_header(ln, ctl, head)
         return ctl
 
     def _split_control_header(self, ln, content):
@@ -977,6 +1008,57 @@ class Parser(object):
                 self, ln, 'assignment expressions (":=") are not allowed in '
                 'control statement headers')
 
+    def _parse_for_header(self, ln, ctl, head):
+        # `head` is the raw header ("for x, y in expr if cond"); parse it
+        # through Python's comprehension grammar
+        src = '[None %s]' % head
+        try:
+            tree = ast.parse(src, mode='eval')
+        except SyntaxError as e:
+            raise ParserException(
+                self, ln, 'invalid "for" header (%s); the header takes a '
+                'single "for ... in ..." clause with comprehension syntax'
+                % e)
+        self._forbid_walrus(ln, tree)
+        generators = tree.body.generators
+        if len(generators) != 1:
+            raise ParserException(
+                self, ln, 'a "for" header takes a '
+                'single "for ... in ..." clause')
+        gen = generators[0]
+        if gen.is_async:
+            raise ParserException(
+                self, ln, '"async for" is not allowed in kv')
+
+        names = []
+
+        def collect(node):
+            if isinstance(node, ast.Name):
+                names.append(node.id)
+            elif isinstance(node, ast.Starred):
+                collect(node.value)
+            elif isinstance(node, (ast.Tuple, ast.List)):
+                for elt in node.elts:
+                    collect(elt)
+            else:
+                raise ParserException(
+                    self, ln, 'invalid loop target in "for" header')
+
+        collect(gen.target)
+        if len(set(names)) != len(names):
+            raise ParserException(
+                self, ln, 'duplicate loop target in "for" header')
+
+        targets_src = ast.get_source_segment(src, gen.target)
+        iter_src = ast.get_source_segment(src, gen.iter)
+        filters = ''.join(
+            ' if (%s)' % ast.get_source_segment(src, f) for f in gen.ifs)
+        value = '[(%s,) for %s in (%s)%s]' % (
+            ', '.join(names), targets_src, iter_src, filters)
+        ctl.target_names = names
+        ctl.iterator_prop = ParserRuleProperty(
+            self, ln, '__kv_iterator', value)
+
     #
     # Control statements: finalization (chain merging, scope resolution,
     # reference rewriting). Runs after parse_level, before precompile.
@@ -1025,6 +1107,13 @@ class Parser(object):
                 child.in_canvas = in_canvas
                 if child.kind in ('elif', 'else'):
                     prev = out[-1] if out else None
+                    if (child.kind == 'else' and
+                            isinstance(prev, ParserControlRule) and
+                            prev.kind == 'for'):
+                        raise ParserException(
+                            self, child.line, '"else" after "for" is not '
+                            'supported; use a paired "if not ..." block for '
+                            'the empty state')
                     if (not isinstance(prev, ParserControlRule) or
                             prev.kind != 'if' or
                             prev.branches[-1].cond_src is None):
@@ -1158,6 +1247,8 @@ class Parser(object):
             self._rewrite_prop(ctl.selector_prop, env)
             for branch in ctl.branches:
                 self._walk_branch(branch, env, for_ctl)
+        elif kind == 'for':
+            self._walk_for(ctl, env)
 
     def _walk_branch(self, branch, env, for_ctl):
         if branch.id:
@@ -1174,7 +1265,97 @@ class Parser(object):
             raise ParserException(
                 self, branch.line, 'an "if" block requires at least one '
                 'child widget, property, handler or canvas')
+        if for_ctl is not None:
+            # nesting context semantics: the branch follows for-body rules
+            if branch.handlers:
+                raise ParserException(
+                    self, branch.handlers[0].line, 'event handlers are not '
+                    'allowed in a "for" block')
+            if (branch.canvas_root or branch.canvas_before or
+                    branch.canvas_after):
+                raise ParserException(
+                    self, branch.line, 'canvas is not allowed in a "for" '
+                    'block')
         self._walk_rule(branch, env, for_ctl)
+
+    def _walk_for(self, ctl, env):
+        if ctl.handlers:
+            raise ParserException(
+                self, ctl.handlers[0].line, 'event handlers are not allowed '
+                'in a "for" block (declare them on a child widget instead)')
+        if ctl.canvas_root or ctl.canvas_before or ctl.canvas_after:
+            raise ParserException(
+                self, ctl.line, 'canvas is not allowed in a "for" block '
+                '(declare it on a child widget instead)')
+        if not ctl.children:
+            raise ParserException(
+                self, ctl.line, 'a "for" block requires at least one child '
+                'widget')
+        self._rewrite_prop(ctl.iterator_prop, env)
+
+        # the iteration scope: loop targets, locals, conditional locals
+        # (from nested ifs) and ids
+        ctl.key_prop = ctl.properties.pop('key', None)
+        ctl.locals = list(ctl.properties.items())
+        ctl.properties = OrderedDict()
+        cond_locals = []
+        self._collect_cond_locals(ctl.children, cond_locals)
+        ids = []
+        self._collect_for_ids(ctl.children, ids)
+        names = list(ctl.target_names)
+        for name, _ in ctl.locals + cond_locals:
+            if name not in names:
+                names.append(name)
+        id_names = []
+        for name, crule in ids:
+            if name in names:
+                raise ParserException(
+                    self, crule.line, 'id %r clashes with a loop target or '
+                    'local of the same "for" block' % name)
+            if name not in id_names:
+                id_names.append(name)
+        ctl.scope_key = key = self._new_scope_key()
+        ctl.scope_names = names + id_names
+        ctl.id_scope_names = id_names
+        for name, crule in ids:
+            crule.id = None
+            crule.scope_id = (key, name)
+
+        inner_env = dict(env)
+        for name in ctl.scope_names:
+            inner_env[name] = key
+        for name, prop in ctl.locals:
+            prop.force_code = True
+            self._rewrite_prop(prop, inner_env)
+        for child in ctl.children:
+            if isinstance(child, ParserControlRule):
+                self._walk_control(child, inner_env, ctl)
+            else:
+                stripped = {k: v for k, v in inner_env.items()
+                            if k not in ('self', 'args')}
+                self._walk_rule(child, stripped, None)
+
+    def _collect_cond_locals(self, children, out):
+        for child in children:
+            if isinstance(child, ParserControlRule) and child.kind == 'if':
+                for branch in child.branches:
+                    for name, prop in branch.properties.items():
+                        if name != 'key':
+                            prop.force_code = True
+                            out.append((name, prop))
+                    self._collect_cond_locals(branch.children, out)
+
+    def _collect_for_ids(self, children, out):
+        for child in children:
+            if isinstance(child, ParserControlRule):
+                if child.kind == 'if':
+                    for branch in child.branches:
+                        self._collect_for_ids(branch.children, out)
+                # nested 'for': its own scope; 'slot': forbidden in for
+            else:
+                if child.id:
+                    out.append((self._clean_id(child.id, child), child))
+                self._collect_for_ids(child.children, out)
 
     def _walk_canvas(self, canvas_rule, env):
         for child in canvas_rule.children:
@@ -1201,6 +1382,23 @@ class Parser(object):
                         self, prop.line, 'only graphics instructions are '
                         'allowed inside canvas control statements')
                 self._walk_canvas(branch, env)
+            return
+        # for
+        ctl.key_prop = ctl.properties.pop('key', None)
+        if ctl.properties or ctl.handlers:
+            prop = (list(ctl.properties.values()) + ctl.handlers)[0]
+            raise ParserException(
+                self, prop.line, 'only graphics instructions are allowed '
+                'inside canvas control statements')
+        if not ctl.children:
+            raise ParserException(
+                self, ctl.line, 'a "for" block requires at least one '
+                'graphics instruction')
+        self._rewrite_prop(ctl.iterator_prop, env)
+        # loop targets are injected as plain names at build time
+        inner_env = {k: v for k, v in env.items()
+                     if k not in ctl.target_names}
+        self._walk_canvas(ctl, inner_env)
 
     def _rewrite_prop(self, prop, env):
         if not env or prop is None:

--- a/kivy/tests/test_lang_control_runtime.py
+++ b/kivy/tests/test_lang_control_runtime.py
@@ -1,0 +1,822 @@
+'''
+Runtime tests for kv control statements (if/elif/else).
+
+These cover the builder stage; pure parsing is tested in
+``test_lang_parser_control.py``.
+'''
+
+import unittest
+
+from kivy.lang import Builder
+from kivy.lang.builder import BuilderException
+from kivy.lang.parser import _handlers
+
+
+def texts(widget):
+    '''Texts of the children in document order.'''
+    return [c.text for c in reversed(widget.children)]
+
+
+def by_text(widget):
+    return {c.text: c for c in reversed(widget.children)}
+
+
+class IfRuntimeTestCase(unittest.TestCase):
+
+    def test_initial_branch_and_switching(self):
+        root = Builder.load_string('''
+BoxLayout:
+    expanded: True
+    Label:
+        text: 'first'
+    if self.expanded:
+        Label:
+            text: 'open'
+        Label:
+            text: 'open2'
+    else:
+        Label:
+            text: 'closed'
+    Label:
+        text: 'last'
+''')
+        self.assertEqual(texts(root), ['first', 'open', 'open2', 'last'])
+        root.expanded = False
+        self.assertEqual(texts(root), ['first', 'closed', 'last'])
+        root.expanded = True
+        self.assertEqual(texts(root), ['first', 'open', 'open2', 'last'])
+
+    def test_if_without_else_builds_nothing_when_false(self):
+        root = Builder.load_string('''
+BoxLayout:
+    show: False
+    if self.show:
+        Label:
+            text: 'maybe'
+''')
+        self.assertEqual(texts(root), [])
+        root.show = True
+        self.assertEqual(texts(root), ['maybe'])
+        root.show = False
+        self.assertEqual(texts(root), [])
+
+    def test_elif_chain(self):
+        root = Builder.load_string('''
+BoxLayout:
+    state: 'a'
+    if self.state == 'a':
+        Label:
+            text: 'A'
+    elif self.state == 'b':
+        Label:
+            text: 'B'
+    else:
+        Label:
+            text: 'other'
+''')
+        self.assertEqual(texts(root), ['A'])
+        root.state = 'b'
+        self.assertEqual(texts(root), ['B'])
+        root.state = 'zzz'
+        self.assertEqual(texts(root), ['other'])
+
+    def test_two_sibling_chains_keep_positions(self):
+        root = Builder.load_string('''
+BoxLayout:
+    a: False
+    b: True
+    if self.a:
+        Label:
+            text: 'A'
+    Label:
+        text: 'mid'
+    if self.b:
+        Label:
+            text: 'B'
+''')
+        self.assertEqual(texts(root), ['mid', 'B'])
+        root.a = True
+        self.assertEqual(texts(root), ['A', 'mid', 'B'])
+        root.b = False
+        self.assertEqual(texts(root), ['A', 'mid'])
+
+    def test_nested_if(self):
+        root = Builder.load_string('''
+BoxLayout:
+    outer: True
+    inner: False
+    if self.outer:
+        Label:
+            text: 'pre'
+        if self.inner:
+            Label:
+                text: 'deep'
+''')
+        self.assertEqual(texts(root), ['pre'])
+        root.inner = True
+        self.assertEqual(texts(root), ['pre', 'deep'])
+        root.outer = False
+        self.assertEqual(texts(root), [])
+        root.outer = True
+        self.assertEqual(texts(root), ['pre', 'deep'])
+
+    def test_branch_content_bindings_work_and_die_with_branch(self):
+        root = Builder.load_string('''
+BoxLayout:
+    show: True
+    n: 0
+    if self.show:
+        Label:
+            text: str(root.n)
+''')
+        label = root.children[0]
+        root.n = 5
+        self.assertEqual(label.text, '5')
+        root.show = False
+        root.n = 9
+        self.assertEqual(label.text, '5')  # unbound on destroy
+        root.show = True
+        self.assertEqual(root.children[0].text, '9')
+
+    def test_no_handler_leak_on_rebuild(self):
+        root = Builder.load_string('''
+BoxLayout:
+    show: True
+    if self.show:
+        Label:
+            text: 'x'
+''')
+        baseline = set(_handlers)
+        for _ in range(30):
+            root.show = False
+            root.show = True
+        # anything new in the registry must belong to the live subtree
+        live = {w.uid for w in root.walk(restrict=True)}
+        leaked = set(_handlers) - baseline - live
+        self.assertEqual(leaked, set())
+
+    def test_condition_can_use_sibling_ids(self):
+        root = Builder.load_string('''
+BoxLayout:
+    Label:
+        id: lbl
+        text: 'off'
+    if lbl.text == 'on':
+        Label:
+            text: 'visible'
+''')
+        self.assertEqual(texts(root), ['off'])
+        lbl = root.ids.lbl
+        lbl.text = 'on'
+        self.assertEqual(texts(root), ['on', 'visible'])
+
+    def test_if_in_class_rule(self):
+        Builder.load_string('''
+<TogglePanel@BoxLayout>:
+    open: True
+    if self.open:
+        Label:
+            text: 'content'
+''')
+        from kivy.factory import Factory
+        panel = Factory.TogglePanel()
+        self.assertEqual(texts(panel), ['content'])
+        panel.open = False
+        self.assertEqual(texts(panel), [])
+
+    def test_no_kv_post_for_widgets_destroyed_during_apply(self):
+        # a widget built by a control statement and torn down again before
+        # the apply finishes (here: its own on_parent flips the condition)
+        # must never receive on_kv_post
+        seen = []
+        from kivy.uix.label import Label
+
+        class GhostLabel(Label):
+            def on_kv_post(self, base_widget):
+                seen.append(self.text)
+
+        root = Builder.load_string('''
+BoxLayout:
+    show: True
+    if self.show:
+        GhostLabel:
+            text: 'ghost'
+            on_parent: root.show = False
+''')
+        self.assertEqual(texts(root), [])
+        self.assertEqual(seen, [])
+
+    def test_on_kv_post_dispatched_for_dynamic_builds(self):
+        seen = []
+        from kivy.uix.label import Label
+
+        class PostLabel(Label):
+            def on_kv_post(self, base_widget):
+                seen.append(self.text)
+
+        root = Builder.load_string('''
+BoxLayout:
+    show: False
+    if self.show:
+        PostLabel:
+            text: 'dyn'
+''')
+        self.assertEqual(seen, [])
+        root.show = True
+        self.assertEqual(seen, ['dyn'])
+
+
+class IfBodyRuntimeTestCase(unittest.TestCase):
+    '''An ``if`` block is a full rule body applied to the host widget:
+    besides children it may carry properties, canvas and handlers.'''
+
+    def test_conditional_property_over_reactive_base(self):
+        # a branch adds an ordinary binding while active; it coexists with
+        # the unconditional one (which stays live) and resolves by reactivity
+        # order. Leaving the branch does not revert the value: the base
+        # re-wins only on its next dependency change (one-way binding).
+        root = Builder.load_string('''
+BoxLayout:
+    cond: False
+    base_src: 10
+    a: self.base_src * 2
+    if self.cond:
+        a: 999
+''')
+        self.assertEqual(root.a, 20)
+        root.cond = True
+        self.assertEqual(root.a, 999)
+        # branch leaves -> no immediate revert, the last value is kept...
+        root.cond = False
+        self.assertEqual(root.a, 999)
+        # ...and the base binding re-wins when its dependency next changes
+        root.base_src = 100
+        self.assertEqual(root.a, 200)
+
+    def test_branch_only_property_keeps_last_value(self):
+        # no unconditional rule for the property -> one-way: leaving the
+        # branch does not revert, the latest set value is kept
+        from kivy.uix.boxlayout import BoxLayout
+        from kivy.properties import NumericProperty, BooleanProperty
+
+        class KeepLast(BoxLayout):
+            b = NumericProperty(0)
+            cond = BooleanProperty(False)
+
+        Builder.load_string('''
+<KeepLast>:
+    if self.cond:
+        b: 777
+''', filename='test_keeplast.kv')
+        try:
+            w = KeepLast()
+            self.assertEqual(w.b, 0)
+            w.cond = True
+            self.assertEqual(w.b, 777)
+            w.cond = False
+            self.assertEqual(w.b, 777)
+        finally:
+            Builder.unload_file('test_keeplast.kv')
+
+    def test_else_branch_property(self):
+        root = Builder.load_string('''
+BoxLayout:
+    cond: False
+    label: ''
+    if self.cond:
+        label: 'on'
+    else:
+        label: 'off'
+''')
+        self.assertEqual(root.label, 'off')
+        root.cond = True
+        self.assertEqual(root.label, 'on')
+        root.cond = False
+        self.assertEqual(root.label, 'off')
+
+    def test_two_parallel_blocks_resolve_by_reactivity(self):
+        # two independent if-blocks driving one property is the power-user
+        # parallel-binding case: the most recently applied write wins, and a
+        # block leaving does not restore another block's value (one-way).
+        root = Builder.load_string('''
+BoxLayout:
+    a: False
+    b: False
+    v: 1
+    if self.a:
+        v: 2
+    if self.b:
+        v: 3
+''')
+        self.assertEqual(root.v, 1)
+        root.a = True
+        self.assertEqual(root.v, 2)
+        root.b = True              # most recent write wins
+        self.assertEqual(root.v, 3)
+        root.b = False             # leaving does not revert to the other
+        self.assertEqual(root.v, 3)
+
+    def test_nested_if_property(self):
+        # nested branches apply their value on activation; leaving a branch
+        # is one-way (no revert), as for any parallel binding
+        root = Builder.load_string('''
+BoxLayout:
+    outer: False
+    inner: False
+    v: 0
+    if self.outer:
+        v: 1
+        if self.inner:
+            v: 2
+''')
+        self.assertEqual(root.v, 0)
+        root.outer = True
+        self.assertEqual(root.v, 1)
+        root.inner = True
+        self.assertEqual(root.v, 2)
+        root.inner = False          # nested block torn down, value kept
+        self.assertEqual(root.v, 2)
+        root.outer = False          # outer block torn down, value kept
+        self.assertEqual(root.v, 2)
+
+    def test_property_with_children_in_same_branch(self):
+        root = Builder.load_string('''
+BoxLayout:
+    cond: False
+    title: 'none'
+    if self.cond:
+        title: 'shown'
+        Label:
+            text: 'child'
+''')
+        self.assertEqual(root.title, 'none')
+        self.assertEqual(texts(root), [])
+        root.cond = True
+        self.assertEqual(root.title, 'shown')
+        self.assertEqual(texts(root), ['child'])
+        root.cond = False
+        self.assertEqual(root.title, 'shown')   # one-way: value kept
+        self.assertEqual(texts(root), [])        # children torn down
+
+    def test_conditional_handler(self):
+        root = Builder.load_string('''
+BoxLayout:
+    cond: False
+    fired: 0
+    if self.cond:
+        on_touch_down: self.fired += 1
+''')
+        root.dispatch('on_touch_down', None)
+        self.assertEqual(root.fired, 0)
+        root.cond = True
+        root.dispatch('on_touch_down', None)
+        self.assertEqual(root.fired, 1)
+        root.cond = False
+        root.dispatch('on_touch_down', None)
+        self.assertEqual(root.fired, 1)
+
+    def test_conditional_canvas_mount_and_binding(self):
+        from kivy.graphics import Color, InstructionGroup
+
+        root = Builder.load_string('''
+BoxLayout:
+    cond: False
+    cval: 0.5
+    if self.cond:
+        canvas:
+            Color:
+                rgba: 1, 0, 0, self.cval
+            Rectangle:
+                size: self.size
+''')
+        groups = [c for c in root.canvas.children
+                  if isinstance(c, InstructionGroup)]
+        self.assertEqual(groups, [])
+        root.cond = True
+        groups = [c for c in root.canvas.children
+                  if isinstance(c, InstructionGroup)]
+        self.assertEqual(len(groups), 1)
+
+        def find_color(group):
+            for instr in group.children:
+                if isinstance(instr, Color):
+                    return instr
+            return None
+        color = find_color(groups[0])
+        self.assertIsNotNone(color)
+        root.cval = 0.9
+        Builder.sync()              # canvas bindings are delayed
+        self.assertAlmostEqual(color.rgba[3], 0.9)
+        root.cond = False
+        groups = [c for c in root.canvas.children
+                  if isinstance(c, InstructionGroup)]
+        self.assertEqual(groups, [])
+
+    def test_branch_creates_missing_property(self):
+        # a property only ever set inside a branch is created on demand
+        root = Builder.load_string('''
+BoxLayout:
+    cond: True
+    if self.cond:
+        brand_new: 42
+''')
+        self.assertEqual(root.brand_new, 42)
+
+    def test_no_handler_leak_on_property_rebuild(self):
+        root = Builder.load_string('''
+BoxLayout:
+    cond: True
+    base_src: 1
+    a: self.base_src * 2
+    if self.cond:
+        a: self.base_src + 5
+''')
+        for _ in range(30):
+            root.cond = False
+            root.cond = True
+        live = len(_handlers.get(root.uid, {}).get('a', ()))
+        # base and active branch coexist (parallel bindings) and do not leak
+        self.assertEqual(live, 2)
+        root.cond = False
+        # the branch binding is removed; the base remains
+        self.assertEqual(len(_handlers.get(root.uid, {}).get('a', ())), 1)
+
+
+class ControlIdRuntimeTestCase(unittest.TestCase):
+    '''Reactive ids inside control blocks: an id in an ``if`` is reachable
+    across the rule and is None while its branch is inactive; an id in a
+    ``for`` is iteration-local, reachable only by that iteration's content.'''
+
+    def test_if_id_nullable_reactive_reachable_outside(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IdEditor@BoxLayout>:
+    editing: False
+    if self.editing:
+        TextInput:
+            id: field
+    Button:
+        disabled: field is None
+''', filename='ideditor.kv')
+        try:
+            w = Factory.IdEditor()
+            btn = [c for c in w.children
+                   if c.__class__.__name__ == 'Button'][0]
+            self.assertTrue(btn.disabled)        # inactive branch -> None
+            w.editing = True
+            self.assertFalse(btn.disabled)       # mounted -> reachable
+            w.editing = False
+            self.assertTrue(btn.disabled)        # unmounted -> None again
+            w.editing = True
+            self.assertFalse(btn.disabled)       # and back
+        finally:
+            Builder.unload_file('ideditor.kv')
+
+    def test_if_id_does_not_leak_into_root_ids(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IdNoLeak@BoxLayout>:
+    flag: True
+    if self.flag:
+        Label:
+            id: hidden
+''', filename='idnoleak.kv')
+        try:
+            w = Factory.IdNoLeak()
+            # the reactive id must not appear in root.ids (it would blink)
+            self.assertNotIn('hidden', w.ids)
+        finally:
+            Builder.unload_file('idnoleak.kv')
+
+    def test_complementary_chains_can_share_an_id(self):
+        # `if cond:` / `if not cond:` may define the same id: the id follows
+        # whichever branch is mounted, and a chain tearing down after the
+        # other one mounted must not clobber the freshly set id (the reset
+        # is compare-and-set: only the widget that owns the value clears it)
+        from kivy.factory import Factory
+        Builder.load_string('''
+<TwoChains@BoxLayout>:
+    cond: True
+    if self.cond:
+        Label:
+            id: face
+            text: 'yes'
+    if not self.cond:
+        Label:
+            id: face
+            text: 'no'
+    Button:
+        text: face.text if face else '?'
+''', filename='twochains.kv')
+        try:
+            w = Factory.TwoChains()
+            btn = [c for c in w.children
+                   if c.__class__.__name__ == 'Button'][0]
+            self.assertEqual(btn.text, 'yes')
+            w.cond = False
+            self.assertEqual(btn.text, 'no')
+            w.cond = True
+            self.assertEqual(btn.text, 'yes')
+        finally:
+            Builder.unload_file('twochains.kv')
+
+    def test_if_id_widget_is_collected(self):
+        import gc
+        import weakref
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IdGc@BoxLayout>:
+    flag: True
+    if self.flag:
+        Label:
+            id: thing
+    Button:
+        disabled: thing is None
+''', filename='idgc.kv')
+        try:
+            w = Factory.IdGc()
+            w.flag = False
+            w.flag = True
+            ref = weakref.ref(w)
+            del w
+            gc.collect()
+            self.assertIsNone(ref())
+        finally:
+            Builder.unload_file('idgc.kv')
+
+
+class ControlStatementGCTestCase(unittest.TestCase):
+    '''A widget that uses control statements must stay garbage-collectable:
+    the control nodes hold the children they build (whose ``.parent`` points
+    back at the host), so they must live on the host, not in a global
+    registry that would pin the whole subtree forever.'''
+
+    def _collected(self, kv):
+        import gc
+        import weakref
+        from kivy.factory import Factory
+        Builder.load_string(kv, filename='gc_probe.kv')
+        try:
+            w = Factory.GcProbe()
+            # exercise any reactive content so a branch/iteration is built
+            w.flag = not w.flag
+            w.flag = not w.flag
+            ref = weakref.ref(w)
+            del w
+            gc.collect()
+            # nodes live on the widget (no uid-keyed registries to leak)
+            return ref() is None, True
+        finally:
+            Builder.unload_file('gc_probe.kv')
+
+    def test_if_widget_is_collected(self):
+        collected, clean = self._collected('''
+<GcProbe@BoxLayout>:
+    flag: True
+    v: 0
+    if self.flag:
+        v: 1
+        Label:
+            text: 'x'
+''')
+        self.assertTrue(collected)
+        self.assertTrue(clean)
+
+    def test_many_rows_collected_after_clear(self):
+        import gc
+        import weakref
+        from kivy.factory import Factory
+        from kivy.uix.boxlayout import BoxLayout
+        Builder.load_string('''
+<GcRow@BoxLayout>:
+    label: '?'
+    if self.label:
+        Label:
+            text: root.label
+''', filename='gc_rows.kv')
+        try:
+            container = BoxLayout()
+            refs = []
+            for i in range(20):
+                row = Factory.GcRow()
+                row.label = 'row %d' % i
+                container.add_widget(row)
+                refs.append(weakref.ref(row))
+            del row
+            container.clear_widgets()
+            gc.collect()
+            alive = sum(1 for r in refs if r() is not None)
+            self.assertEqual(alive, 0)
+        finally:
+            Builder.unload_file('gc_rows.kv')
+
+
+def _canvas_types(canvas):
+    '''Flatten a canvas (descending into instruction groups) to the list of
+    instruction class names, in draw order. ``BindTexture`` is dropped: kv
+    auto-adds it alongside textured instructions (Rectangle/Line) and it is
+    not part of what the rule declares.'''
+    from kivy.graphics import InstructionGroup
+    out = []
+    for instr in canvas.children:
+        if isinstance(instr, InstructionGroup):
+            out += _canvas_types(instr)
+        elif type(instr).__name__ != 'BindTexture':
+            out.append(type(instr).__name__)
+    return out
+
+
+def _canvas_leaves(canvas):
+    '''Flatten a canvas (descending into groups) to the list of leaf
+    instruction *instances* in draw order, dropping kv's auto-added
+    ``BindTexture``. Used to assert instruction identity across reconciles.'''
+    from kivy.graphics import InstructionGroup
+    out = []
+    for instr in canvas.children:
+        if isinstance(instr, InstructionGroup):
+            out += _canvas_leaves(instr)
+        elif type(instr).__name__ != 'BindTexture':
+            out.append(instr)
+    return out
+
+
+class CanvasControlRuntimeTestCase(unittest.TestCase):
+    '''``if`` and ``for`` work inside a canvas block, managing graphics
+    instructions reactively and in document position.'''
+
+    def test_if_in_canvas_switches_instructions(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IfCanvas@Widget>:
+    on: False
+    canvas:
+        Color:
+        if self.on:
+            Rectangle:
+        else:
+            Line:
+''', filename='if_canvas.kv')
+        try:
+            w = Factory.IfCanvas()
+            self.assertEqual(_canvas_types(w.canvas), ['Color', 'Line'])
+            w.on = True
+            self.assertEqual(_canvas_types(w.canvas), ['Color', 'Rectangle'])
+            w.on = False
+            self.assertEqual(_canvas_types(w.canvas), ['Color', 'Line'])
+        finally:
+            Builder.unload_file('if_canvas.kv')
+
+    def test_instruction_property_binding_in_canvas_control(self):
+        from kivy.factory import Factory
+        from kivy.graphics import Color, InstructionGroup
+        Builder.load_string('''
+<BindCanvas@Widget>:
+    on: True
+    alpha: 0.5
+    canvas:
+        if self.on:
+            Color:
+                rgba: 1, 0, 0, self.alpha
+''', filename='bind_canvas.kv')
+        try:
+            w = Factory.BindCanvas()
+
+            def find_color(canvas):
+                for instr in canvas.children:
+                    if isinstance(instr, InstructionGroup):
+                        c = find_color(instr)
+                        if c is not None:
+                            return c
+                    elif isinstance(instr, Color):
+                        return instr
+                return None
+            color = find_color(w.canvas)
+            self.assertIsNotNone(color)
+            w.alpha = 0.9
+            Builder.sync()        # canvas bindings are delayed
+            self.assertAlmostEqual(color.rgba[3], 0.9)
+        finally:
+            Builder.unload_file('bind_canvas.kv')
+
+
+class ControlRegressionTestCase(unittest.TestCase):
+    '''Regression tests pinning behaviors that once broke.'''
+
+    def test_cross_rule_base_coexists_with_branch(self):
+        # base in the class rule, conditional override in the subclass rule:
+        # they coexist like ordinary stacked-rule bindings -- the branch wins
+        # while active, and the base (still live) re-wins on its next change
+        from kivy.factory import Factory
+        Builder.load_string('''
+<CRBase@BoxLayout>:
+    src: 1
+    foo: self.src * 10
+<CRSub@CRBase>:
+    cond: False
+    if self.cond:
+        foo: 999
+''', filename='crbase.kv')
+        try:
+            w = Factory.CRSub()
+            self.assertEqual(w.foo, 10)     # class-rule base
+            w.cond = True
+            self.assertEqual(w.foo, 999)    # subclass-rule branch overrides
+            w.cond = False
+            # one-way: no immediate revert; the class-rule base stays bound
+            self.assertEqual(w.foo, 999)
+            w.src = 5
+            self.assertEqual(w.foo, 50)     # base re-wins on its next change
+        finally:
+            Builder.unload_file('crbase.kv')
+
+    def test_ignored_const_base_not_reasserted(self):
+        from kivy.uix.boxlayout import BoxLayout
+        from kivy.properties import NumericProperty, BooleanProperty
+
+        class IgnConst(BoxLayout):
+            foo = NumericProperty(0)
+            cond = BooleanProperty(False)
+
+        Builder.load_string('''
+<IgnConst>:
+    foo: 7
+    if self.cond:
+        foo: 99
+''', filename='ignconst.kv')
+        try:
+            w = IgnConst(foo=42)            # python value preserved by apply
+            self.assertEqual(w.foo, 42)
+            w.cond = True
+            self.assertEqual(w.foo, 99)
+            w.cond = False
+            # the suppressed constant 7 must NOT be re-asserted; with no live
+            # base the branch's last value is kept (one-way binding)
+            self.assertEqual(w.foo, 99)
+        finally:
+            Builder.unload_file('ignconst.kv')
+
+    def test_reapply_resets_control_nodes(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<ReApply@BoxLayout>:
+    flag: True
+    if self.flag:
+        Label:
+''', filename='reapply.kv')
+        try:
+            w = Factory.ReApply()
+            n1 = len(w._kv_control_nodes)
+            self.assertEqual(n1, 1)
+            Builder.unbind_widget(w.uid)
+            Builder.apply(w)
+            self.assertEqual(len(w._kv_control_nodes), n1)  # not duplicated
+        finally:
+            Builder.unload_file('reapply.kv')
+
+
+class CanvasRegressionTestCase(unittest.TestCase):
+
+    def test_clear_inside_canvas_control_does_not_crash(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<ClearCanvas@Widget>:
+    on: True
+    canvas:
+        if self.on:
+            Color:
+            Clear
+            Color:
+''', filename='clearcanvas.kv')
+        try:
+            w = Factory.ClearCanvas()    # must not raise
+            w.on = False
+            w.on = True
+        finally:
+            Builder.unload_file('clearcanvas.kv')
+
+    def test_branch_canvas_zorder_follows_document_order(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<ZOrder@Widget>:
+    a: False
+    b: False
+    if self.a:
+        canvas:
+            Scale:
+    if self.b:
+        canvas:
+            Rotate:
+''', filename='zorder.kv')
+        try:
+            w = Factory.ZOrder()
+            # activate the later block (b) first, then a: a's group must
+            # still draw before b's, following document order
+            w.b = True
+            w.a = True
+            self.assertEqual(_canvas_types(w.canvas), ['Scale', 'Rotate'])
+        finally:
+            Builder.unload_file('zorder.kv')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kivy/tests/test_lang_control_runtime.py
+++ b/kivy/tests/test_lang_control_runtime.py
@@ -1,5 +1,5 @@
 '''
-Runtime tests for kv control statements (if/elif/else, for, factory).
+Runtime tests for kv control statements (if/elif/else, for, slot, factory).
 
 These cover the builder stage; pure parsing is tested in
 ``test_lang_parser_control.py``.
@@ -1232,6 +1232,300 @@ class ControlIdRuntimeTestCase(unittest.TestCase):
             Builder.unload_file('idgc.kv')
 
 
+class SlotRuntimeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        Builder.load_string('''
+<SlotCard@BoxLayout>:
+    Label:
+        text: 'top'
+    slot header:
+        Label:
+            text: 'fallback-header'
+    slot:
+    Label:
+        text: 'bottom'
+''', filename='test_slot_runtime.kv')
+
+    def tearDown(self):
+        Builder.unload_file('test_slot_runtime.kv')
+
+    def test_fallback_when_instantiated_from_python(self):
+        from kivy.factory import Factory
+        card = Factory.SlotCard()
+        self.assertEqual(texts(card), ['top', 'fallback-header', 'bottom'])
+
+    def test_fallback_not_built_when_filled(self):
+        # the fallback build is deferred until the apply chain ends, so
+        # providing a fill means the fallback widgets are never created
+        # and never receive on_kv_post
+        from kivy.uix.label import Label
+        posts = []
+
+        class PostProbe(Label):
+            def on_kv_post(self, base_widget):
+                posts.append((self.text, self.parent is not None))
+
+        Builder.load_string('''
+<ProbeCard@BoxLayout>:
+    slot header:
+        PostProbe:
+            text: 'fallback'
+''', filename='test_slot_probe.kv')
+        try:
+            root = Builder.load_string('''
+BoxLayout:
+    ProbeCard:
+        slot header:
+            PostProbe:
+                text: 'fill'
+''')
+            self.assertEqual(texts(root.children[0]), ['fill'])
+            self.assertEqual(posts, [('fill', True)])
+        finally:
+            Builder.unload_file('test_slot_probe.kv')
+
+    def test_named_fill_and_routed_plain_children(self):
+        root = Builder.load_string('''
+BoxLayout:
+    title: 'Title'
+    SlotCard:
+        slot header:
+            Label:
+                text: root.title
+        Label:
+            text: 'body1'
+        Label:
+            text: 'body2'
+''')
+        card = root.children[0]
+        self.assertEqual(
+            texts(card), ['top', 'Title', 'body1', 'body2', 'bottom'])
+        root.title = 'New'
+        self.assertEqual(
+            texts(card), ['top', 'New', 'body1', 'body2', 'bottom'])
+
+    def test_explicit_default_fill_block(self):
+        root = Builder.load_string('''
+BoxLayout:
+    SlotCard:
+        slot:
+            Label:
+                text: 'explicit-body'
+''')
+        self.assertEqual(
+            texts(root.children[0]),
+            ['top', 'fallback-header', 'explicit-body', 'bottom'])
+
+    def test_subclass_fill_overrides_base_and_instance_wins(self):
+        Builder.load_string('''
+<FancySlotCard@SlotCard>:
+    slot header:
+        Label:
+            text: 'fancy-header'
+''', filename='test_slot_runtime_sub.kv')
+        try:
+            from kivy.factory import Factory
+            fancy = Factory.FancySlotCard()
+            self.assertEqual(
+                texts(fancy), ['top', 'fancy-header', 'bottom'])
+            root = Builder.load_string('''
+BoxLayout:
+    FancySlotCard:
+        slot header:
+            Label:
+                text: 'instance-header'
+''')
+            self.assertEqual(
+                texts(root.children[0]),
+                ['top', 'instance-header', 'bottom'])
+        finally:
+            Builder.unload_file('test_slot_runtime_sub.kv')
+
+    def test_mixing_default_fill_block_and_plain_children_raises(self):
+        with self.assertRaises(BuilderException) as cm:
+            Builder.load_string('''
+BoxLayout:
+    SlotCard:
+        slot:
+            Label:
+                text: 'in-block'
+        Label:
+            text: 'plain'
+''')
+        self.assertIn('cannot mix', str(cm.exception))
+
+    def test_id_on_routed_children_raises(self):
+        # implicitly routed plain children cannot carry an id (the parser
+        # cannot know they will be routed); an explicit ``slot:`` fill block
+        # is the supported spelling (see test below)
+        with self.assertRaises(BuilderException) as cm:
+            Builder.load_string('''
+BoxLayout:
+    SlotCard:
+        Label:
+            id: nope
+            text: 'body'
+''')
+        self.assertIn('routed into a slot', str(cm.exception))
+
+    def test_id_in_explicit_fill_is_reactive_scoped(self):
+        # an id in an explicit slot fill block is a reactive id on the rule
+        # providing the fill, reachable by that rule's other expressions
+        root = Builder.load_string('''
+BoxLayout:
+    SlotCard:
+        slot header:
+            TextInput:
+                id: head_input
+    Button:
+        disabled: head_input is None
+''')
+        btn = root.children[0]
+        self.assertFalse(btn.disabled)
+        self.assertNotIn('head_input', root.ids)
+
+    def test_slot_inside_if_branch(self):
+        Builder.load_string('''
+<IfSlotPanel@BoxLayout>:
+    show: True
+    if self.show:
+        Label:
+            text: 'pre'
+        slot extra:
+            Label:
+                text: 'extra-fallback'
+''', filename='test_slot_runtime_if.kv')
+        try:
+            root = Builder.load_string('''
+BoxLayout:
+    IfSlotPanel:
+        slot extra:
+            Label:
+                text: 'injected'
+''')
+            panel = root.children[0]
+            self.assertEqual(texts(panel), ['pre', 'injected'])
+            panel.show = False
+            self.assertEqual(texts(panel), [])
+            panel.show = True
+            self.assertEqual(texts(panel), ['pre', 'injected'])
+        finally:
+            Builder.unload_file('test_slot_runtime_if.kv')
+
+    def test_slot_forwarding_through_fill(self):
+        Builder.load_string('''
+<WrapCard@SlotCard>:
+    slot header:
+        Label:
+            text: 'wrap-pre'
+        slot title_extra:
+''', filename='test_slot_runtime_fwd.kv')
+        try:
+            from kivy.factory import Factory
+            wrap = Factory.WrapCard()
+            self.assertEqual(texts(wrap), ['top', 'wrap-pre', 'bottom'])
+            root = Builder.load_string('''
+BoxLayout:
+    WrapCard:
+        slot title_extra:
+            Label:
+                text: 'forwarded'
+''')
+            self.assertEqual(
+                texts(root.children[0]),
+                ['top', 'wrap-pre', 'forwarded', 'bottom'])
+        finally:
+            Builder.unload_file('test_slot_runtime_fwd.kv')
+
+    def test_unknown_slot_name_renders_as_definition_and_warns(self):
+        # filling a name the class never defined degrades to declaring a
+        # new insertion point; instance children are logically appended
+        # after the class rule's children, so it renders at the end. Since
+        # an instance-level definition can never be filled, this is almost
+        # always a typo, so a warning is logged.
+        with self.assertLogs('kivy', level='WARNING') as logs:
+            root = Builder.load_string('''
+BoxLayout:
+    SlotCard:
+        slot typo_name:
+            Label:
+                text: 'oops'
+''')
+        card = root.children[0]
+        self.assertEqual(
+            texts(card), ['top', 'fallback-header', 'bottom', 'oops'])
+        self.assertTrue(any('typo_name' in m for m in logs.output))
+
+    def test_failed_apply_leaves_no_stale_rulectx(self):
+        # a BuilderException escaping mid-apply must not leave entries in
+        # Builder.rulectx; a stale entry breaks BuilderBase.create_from
+        # (used by the kivy_app test fixture) for every later caller
+        with self.assertRaises(BuilderException):
+            Builder.load_string('''
+BoxLayout:
+    SlotCard:
+        Label:
+            id: nope
+''')
+        self.assertEqual(dict(Builder.rulectx), {})
+
+    def test_widgets_without_slots_unaffected(self):
+        root = Builder.load_string('''
+BoxLayout:
+    Label:
+        text: 'plain'
+    BoxLayout:
+        Label:
+            text: 'nested'
+''')
+        self.assertEqual(root.children[1].text, 'plain')
+        self.assertEqual(texts(root.children[0]), ['nested'])
+
+
+class SlotScopeRuntimeTestCase(unittest.TestCase):
+    '''Slot-scoped locals: property lines in a slot definition are evaluated
+    in the defining rule's context and exposed to fallback and fill content
+    through the reserved ``slot`` name, so a shell class can hand values to
+    whatever content ends up in the hole (cascading slot props).'''
+
+    def setUp(self):
+        Builder.load_string('''
+<ScopedCard@BoxLayout>:
+    count: 3
+    slot header:
+        summary: 'items: ' + str(root.count)
+        Label:
+            text: slot.summary
+''', filename='scoped_card.kv')
+
+    def tearDown(self):
+        Builder.unload_file('scoped_card.kv')
+
+    def test_fallback_reads_slot_local(self):
+        from kivy.factory import Factory
+        card = Factory.ScopedCard()
+        self.assertEqual(texts(card), ['items: 3'])
+        card.count = 5
+        self.assertEqual(texts(card), ['items: 5'])
+
+    def test_fill_reads_slot_local_from_defining_context(self):
+        # the local is computed by the defining rule (root == the ScopedCard)
+        # even when the content comes from a fill written elsewhere
+        root = Builder.load_string('''
+BoxLayout:
+    ScopedCard:
+        count: 7
+        slot header:
+            Label:
+                text: '<' + slot.summary + '>'
+''')
+        card = root.children[0]
+        self.assertEqual(texts(card), ['<items: 7>'])
+        card.count = 9
+        self.assertEqual(texts(card), ['<items: 9>'])
+
+
 class ControlStatementGCTestCase(unittest.TestCase):
     '''A widget that uses control statements must stay garbage-collectable:
     the control nodes hold the children they build (whose ``.parent`` points
@@ -1277,6 +1571,16 @@ class ControlStatementGCTestCase(unittest.TestCase):
     for x in self.items:
         Label:
             text: str(x)
+''')
+        self.assertTrue(collected)
+
+    def test_slot_widget_is_collected(self):
+        collected, _ = self._collected('''
+<GcProbe@BoxLayout>:
+    flag: True
+    slot body:
+        Label:
+            text: 'fallback'
 ''')
         self.assertTrue(collected)
 

--- a/kivy/tests/test_lang_control_runtime.py
+++ b/kivy/tests/test_lang_control_runtime.py
@@ -1,5 +1,5 @@
 '''
-Runtime tests for kv control statements (if/elif/else).
+Runtime tests for kv control statements (if/elif/else, for).
 
 These cover the builder stage; pure parsing is tested in
 ``test_lang_parser_control.py``.
@@ -442,6 +442,490 @@ BoxLayout:
         self.assertEqual(len(_handlers.get(root.uid, {}).get('a', ())), 1)
 
 
+class ForRuntimeTestCase(unittest.TestCase):
+
+    def test_initial_build_in_order(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b', 'c']
+    Label:
+        text: 'head'
+    for item in self.items:
+        Label:
+            text: item
+    Label:
+        text: 'tail'
+''')
+        self.assertEqual(texts(root), ['head', 'a', 'b', 'c', 'tail'])
+
+    def test_positional_keys_reuse_unchanged_prefix(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b']
+    for item in self.items:
+        Label:
+            text: item
+''')
+        first = by_text(root)
+        root.items = ['a', 'b', 'c']
+        second = by_text(root)
+        self.assertEqual(texts(root), ['a', 'b', 'c'])
+        self.assertIs(first['a'], second['a'])
+        self.assertIs(first['b'], second['b'])
+
+    def test_keyed_reorder_preserves_identity(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b', 'c']
+    for item in self.items:
+        key: item
+        Label:
+            text: item
+''')
+        before = by_text(root)
+        root.items = ['c', 'a', 'b']
+        after = by_text(root)
+        self.assertEqual(texts(root), ['c', 'a', 'b'])
+        for k in 'abc':
+            self.assertIs(before[k], after[k])
+
+    def test_keyed_remove_and_add(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b', 'c']
+    for item in self.items:
+        key: item
+        Label:
+            text: item
+''')
+        before = by_text(root)
+        root.items = ['c', 'd']
+        after = by_text(root)
+        self.assertEqual(texts(root), ['c', 'd'])
+        self.assertIs(before['c'], after['c'])
+
+    def test_empty_iterable_and_refill(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: []
+    for item in self.items:
+        Label:
+            text: item
+    Label:
+        text: 'end'
+''')
+        self.assertEqual(texts(root), ['end'])
+        root.items = ['x']
+        self.assertEqual(texts(root), ['x', 'end'])
+        root.items = []
+        self.assertEqual(texts(root), ['end'])
+
+    def test_tuple_target_and_filter(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b', 'c']
+    for item, i in zip(self.items, range(99)) if item != 'b':
+        Label:
+            text: '%s%d' % (item, i)
+''')
+        self.assertEqual(texts(root), ['a0', 'c2'])
+
+    def test_loop_variable_in_handler(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b']
+    picked: ''
+    for item in self.items:
+        Button:
+            text: item
+            on_press: root.picked = item
+''')
+        button_a = by_text(root)['a']
+        button_a.dispatch('on_press', None)
+        self.assertEqual(root.picked, 'a')
+
+    def test_loop_target_shadows_metric_helper(self):
+        # 'dp' is a metric helper in the global kv context; as a loop
+        # target it must resolve to the loop value in child property
+        # expressions, not the helper function
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['x', 'y']
+    for dp in self.items:
+        Label:
+            text: dp
+''')
+        self.assertEqual(texts(root), ['x', 'y'])
+
+    def test_loop_target_shadows_global_in_handler(self):
+        # same precedence must hold on the handler eval path
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['x', 'y']
+    picked: ''
+    for dp in self.items:
+        Button:
+            text: dp
+            on_press: root.picked = dp
+''')
+        by_text(root)['y'].dispatch('on_press', None)
+        self.assertEqual(root.picked, 'y')
+
+    def test_loop_target_self_reshadowed_by_child_widget(self):
+        # a loop target named 'self' is shadowed again by each child
+        # widget's own 'self', so 'self.x' refers to the widget
+        root = Builder.load_string('''
+BoxLayout:
+    names: ['a', 'b']
+    for self in self.names:
+        Label:
+            text: self.__class__.__name__
+''')
+        self.assertEqual(texts(root), ['Label', 'Label'])
+
+    def test_nested_for_loop_scopes_compose(self):
+        # inner loop sees its own and the enclosing loop's variables
+        root = Builder.load_string('''
+BoxLayout:
+    rows: [['a', 'b'], ['c']]
+    for row in self.rows:
+        for cell in row:
+            Label:
+                text: '%s:%s' % (len(row), cell)
+''')
+        self.assertEqual(texts(root), ['2:a', '2:b', '1:c'])
+
+    def test_multiple_children_per_iteration(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b']
+    for item in self.items:
+        Label:
+            text: item + '1'
+        Label:
+            text: item + '2'
+''')
+        self.assertEqual(texts(root), ['a1', 'a2', 'b1', 'b2'])
+
+    def test_for_inside_if(self):
+        root = Builder.load_string('''
+BoxLayout:
+    show: True
+    items: ['x', 'y']
+    if self.show:
+        for item in self.items:
+            Label:
+                text: item
+    Label:
+        text: 'end'
+''')
+        self.assertEqual(texts(root), ['x', 'y', 'end'])
+        root.items = ['x', 'y', 'z']
+        self.assertEqual(texts(root), ['x', 'y', 'z', 'end'])
+        root.show = False
+        self.assertEqual(texts(root), ['end'])
+        root.show = True
+        self.assertEqual(texts(root), ['x', 'y', 'z', 'end'])
+
+    def test_if_inside_for_reacts_per_item(self):
+        from kivy.uix.widget import Widget
+        from kivy.properties import StringProperty, BooleanProperty
+
+        class FItem(Widget):
+            name = StringProperty('')
+            special = BooleanProperty(False)
+
+        root = Builder.load_string('''
+BoxLayout:
+    models: []
+    for item in self.models:
+        Label:
+            text: item.name
+        if item.special:
+            Label:
+                text: item.name + '!'
+''')
+        a = FItem(name='a')
+        b = FItem(name='b', special=True)
+        root.models = [a, b]
+        self.assertEqual(texts(root), ['a', 'b', 'b!'])
+        a.special = True
+        self.assertEqual(texts(root), ['a', 'a!', 'b', 'b!'])
+        b.special = False
+        self.assertEqual(texts(root), ['a', 'a!', 'b'])
+
+    def test_nested_for(self):
+        root = Builder.load_string('''
+BoxLayout:
+    rows: [['a', 'b'], ['c']]
+    for row in self.rows:
+        for cell in row:
+            Label:
+                text: cell
+''')
+        self.assertEqual(texts(root), ['a', 'b', 'c'])
+        root.rows = [['x'], ['y', 'z']]
+        self.assertEqual(texts(root), ['x', 'y', 'z'])
+
+    def test_duplicate_key_raises(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b']
+    for item in self.items:
+        key: item
+        Label:
+            text: item
+''')
+        with self.assertRaises(BuilderException) as cm:
+            root.items = ['a', 'a']
+        self.assertIn('duplicate', str(cm.exception))
+
+    def test_unhashable_key_raises(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: []
+    for item in self.items:
+        key: item
+        Label:
+            text: str(item)
+''')
+        with self.assertRaises(BuilderException) as cm:
+            root.items = [['unhashable']]
+        self.assertIn('hashable', str(cm.exception))
+
+    def test_cross_widget_reentrant_rebuild(self):
+        # a handler firing during one widget's build mutates state that
+        # another widget's node (sharing the same class rule) watches;
+        # the second rebuild must be deferred, not re-enter _apply_rule
+        root = Builder.load_string('''
+<ReentryRow@BoxLayout>:
+    items: []
+    poke: False
+    for item in self.items:
+        Label:
+            text: str(item)
+            on_parent:
+                (setattr(root.parent.children[0], 'items', ['p'])
+                if root.poke and root.parent
+                and not root.parent.children[0].items else None)
+BoxLayout:
+    ReentryRow:
+    ReentryRow:
+''')
+        row1, row2 = root.children[1], root.children[0]
+        row1.poke = True
+        row1.items = ['a']
+        self.assertEqual(texts(row1), ['a'])
+        self.assertEqual(texts(row2), ['p'])
+
+    def test_pure_append_does_not_detach_existing(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: ['a', 'b']
+    for item in self.items:
+        key: item
+        Label:
+            text: item
+''')
+        removals = []
+        orig = root.remove_widget
+
+        def tracking_remove(w):
+            removals.append(w)
+            orig(w)
+
+        root.remove_widget = tracking_remove
+        root.items = ['a', 'b', 'c']
+        self.assertEqual(removals, [])
+        self.assertEqual(texts(root), ['a', 'b', 'c'])
+
+    def test_no_handler_leak_on_updates(self):
+        root = Builder.load_string('''
+BoxLayout:
+    items: []
+    for item in self.items:
+        Label:
+            text: item
+''')
+        root.items = ['a', 'b', 'c']
+        baseline = set(_handlers)
+        for i in range(30):
+            root.items = ['a', str(i)]
+            root.items = ['a', 'b', 'c']
+        # anything new in the registry must belong to the live subtree
+        live = {w.uid for w in root.walk(restrict=True)}
+        leaked = set(_handlers) - baseline - live
+        self.assertEqual(leaked, set())
+
+    def test_for_body_local_is_reactive_intermediate(self):
+        # a for body property is an iteration-local reactive value, not a
+        # host property: it is computed per iteration and read by the body
+        from kivy.factory import Factory
+        from kivy.uix.label import Label
+        from kivy.properties import NumericProperty
+
+        class QItem(Label):
+            qty = NumericProperty(0)
+
+        Builder.load_string('''
+<LocReact@BoxLayout>:
+    items: []
+    for it in self.items:
+        doubled: it.qty * 2
+        Label:
+            text: str(doubled)
+''', filename='locreact.kv')
+        try:
+            w = Factory.LocReact()
+            a, b = QItem(qty=1), QItem(qty=5)
+            w.items = [a, b]
+            self.assertEqual(texts(w), ['2', '10'])
+            # changing a dependency recomputes the local, which updates the
+            # widget that reads it
+            a.qty = 9
+            self.assertEqual(texts(w), ['18', '10'])
+            # the local is NOT a host property
+            self.assertFalse(hasattr(w, 'doubled'))
+        finally:
+            Builder.unload_file('locreact.kv')
+
+    def test_for_body_local_value_is_shared_within_iteration(self):
+        # a `[]` local is one object per iteration, shared by every
+        # reference in that iteration; different iterations get their own
+        from kivy.factory import Factory
+        Builder.load_string('''
+<LocShared@BoxLayout>:
+    items: [1, 2]
+    for it in self.items:
+        bucket: []
+        Label:
+            tag: bucket
+        Label:
+            tag: bucket
+''', filename='locshared.kv')
+        try:
+            w = Factory.LocShared()
+            a, b, c, d = list(reversed(w.children))
+            self.assertIs(a.tag, b.tag)        # shared within iteration 0
+            self.assertIs(c.tag, d.tag)        # shared within iteration 1
+            self.assertIsNot(a.tag, c.tag)     # distinct across iterations
+            a.tag.append(99)                   # mutation is visible to both
+            self.assertEqual(b.tag, [99])
+            self.assertEqual(c.tag, [])
+        finally:
+            Builder.unload_file('locshared.kv')
+
+    def test_if_inside_for_reads_loop_local(self):
+        # an if branch inside a for sees the loop's locals
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IfLocal@BoxLayout>:
+    items: []
+    for n in self.items:
+        big: n > 2
+        if big:
+            Label:
+                text: 'big:' + str(n)
+        else:
+            Label:
+                text: 'small:' + str(n)
+''', filename='iflocal.kv')
+        try:
+            w = Factory.IfLocal()
+            w.items = [1, 5]
+            self.assertEqual(texts(w), ['small:1', 'big:5'])
+        finally:
+            Builder.unload_file('iflocal.kv')
+
+    def test_local_references_earlier_local(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<LocChain@BoxLayout>:
+    items: [10, 20]
+    for x in self.items:
+        a: x + 1
+        b: a * 100
+        Label:
+            text: str(b)
+''', filename='locchain.kv')
+        try:
+            w = Factory.LocChain()
+            self.assertEqual(texts(w), ['1100', '2100'])
+        finally:
+            Builder.unload_file('locchain.kv')
+
+    def test_same_key_new_value_keeps_widgets_and_redispatches(self):
+        # reconciliation rule: same key => same widgets; the new loop values
+        # are re-dispatched through the existing bindings, so live widget
+        # state survives an item being replaced under a stable key
+        root = Builder.load_string('''
+BoxLayout:
+    tasks: [{'uid': 1, 'txt': 'a'}, {'uid': 2, 'txt': 'b'}]
+    for task in self.tasks:
+        key: task['uid']
+        Label:
+            text: task['txt']
+''')
+        first = list(reversed(root.children))
+        self.assertEqual(texts(root), ['a', 'b'])
+        root.tasks = [{'uid': 1, 'txt': 'a2'}, {'uid': 2, 'txt': 'b'}]
+        self.assertEqual(texts(root), ['a2', 'b'])
+        self.assertEqual(list(reversed(root.children)), first)
+
+    def test_conditional_local_in_for(self):
+        # nearest-scope rule: a property in an ``if`` inside a ``for`` is an
+        # iteration-local bound while the branch is active; it starts None,
+        # keeps its last value when the branch leaves (one-way), and never
+        # touches the host
+        from kivy.uix.widget import Widget
+        from kivy.properties import NumericProperty
+
+        class CItem(Widget):
+            n = NumericProperty(0)
+
+        root = Builder.load_string('''
+BoxLayout:
+    models: []
+    for it in self.models:
+        if it.n > 2:
+            biglabel: 'big ' + str(it.n)
+        Label:
+            text: biglabel or 'none'
+''')
+        a = CItem(n=1)
+        root.models = [a]
+        self.assertEqual(texts(root), ['none'])
+        a.n = 5
+        self.assertEqual(texts(root), ['big 5'])
+        a.n = 1
+        self.assertEqual(texts(root), ['big 5'])  # one-way: last value kept
+        self.assertFalse(hasattr(root, 'biglabel'))
+
+    def test_non_iterable_raises_with_kv_context(self):
+        # Python semantics: iterating a non-iterable raises; the error must
+        # carry the kv rule location, not surface as a bare TypeError
+        from kivy.uix.boxlayout import BoxLayout
+        from kivy.properties import ObjectProperty
+
+        class AnyItems(BoxLayout):
+            items = ObjectProperty((1,))
+
+        Builder.load_string('''
+<AnyItems>:
+    for x in self.items:
+        Label:
+            text: str(x)
+''', filename='anyitems.kv')
+        try:
+            w = AnyItems()
+            self.assertEqual(texts(w), ['1'])
+            with self.assertRaises(BuilderException) as cm:
+                w.items = 5
+            self.assertIn('not iterable', str(cm.exception))
+        finally:
+            Builder.unload_file('anyitems.kv')
+
+
 class ControlIdRuntimeTestCase(unittest.TestCase):
     '''Reactive ids inside control blocks: an id in an ``if`` is reachable
     across the rule and is None while its branch is inactive; an id in a
@@ -487,6 +971,48 @@ class ControlIdRuntimeTestCase(unittest.TestCase):
             self.assertNotIn('hidden', w.ids)
         finally:
             Builder.unload_file('idnoleak.kv')
+
+    def test_for_id_reachable_by_sibling_in_iteration(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IdRows@BoxLayout>:
+    items: ['a', 'b']
+    for it in self.items:
+        Label:
+            id: lab
+            text: it
+        Button:
+            text: 'echo:' + lab.text
+''', filename='idrows.kv')
+        try:
+            w = Factory.IdRows()
+            self.assertEqual(
+                texts(w), ['a', 'echo:a', 'b', 'echo:b'])
+            # the iteration-local id is not exposed on root.ids
+            self.assertNotIn('lab', w.ids)
+        finally:
+            Builder.unload_file('idrows.kv')
+
+    def test_id_in_if_inside_for_is_iteration_local(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<IdIfFor@BoxLayout>:
+    items: []
+    for n in self.items:
+        if n > 0:
+            Label:
+                id: pos
+                text: 'p' + str(n)
+        Button:
+            text: 'has' if pos is not None else 'none'
+''', filename='idiffor.kv')
+        try:
+            w = Factory.IdIfFor()
+            w.items = [5, -1]
+            # iter 0: pos mounted -> 'has'; iter 1: branch off -> None
+            self.assertEqual(texts(w), ['p5', 'has', 'none'])
+        finally:
+            Builder.unload_file('idiffor.kv')
 
     def test_complementary_chains_can_share_an_id(self):
         # `if cond:` / `if not cond:` may define the same id: the id follows
@@ -582,6 +1108,17 @@ class ControlStatementGCTestCase(unittest.TestCase):
         self.assertTrue(collected)
         self.assertTrue(clean)
 
+    def test_for_widget_is_collected(self):
+        collected, _ = self._collected('''
+<GcProbe@BoxLayout>:
+    flag: True
+    items: [1, 2, 3]
+    for x in self.items:
+        Label:
+            text: str(x)
+''')
+        self.assertTrue(collected)
+
     def test_many_rows_collected_after_clear(self):
         import gc
         import weakref
@@ -644,6 +1181,91 @@ class CanvasControlRuntimeTestCase(unittest.TestCase):
     '''``if`` and ``for`` work inside a canvas block, managing graphics
     instructions reactively and in document position.'''
 
+    def test_for_in_canvas_builds_and_reacts(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<ForCanvas@Widget>:
+    pts: [1, 2, 3]
+    canvas:
+        Color:
+        for p in self.pts:
+            Rectangle:
+''', filename='for_canvas.kv')
+        try:
+            w = Factory.ForCanvas()
+            self.assertEqual(
+                _canvas_types(w.canvas),
+                ['Color', 'Rectangle', 'Rectangle', 'Rectangle'])
+            w.pts = [1, 2]
+            self.assertEqual(
+                _canvas_types(w.canvas), ['Color', 'Rectangle', 'Rectangle'])
+            w.pts = []
+            self.assertEqual(_canvas_types(w.canvas), ['Color'])
+        finally:
+            Builder.unload_file('for_canvas.kv')
+
+    def test_canvas_for_keyed_preserves_instruction_identity(self):
+        # with `key:` a canvas `for` keeps/moves/rebuilds per-iteration
+        # instruction groups instead of rebuilding wholesale
+        from kivy.factory import Factory
+        Builder.load_string('''
+<KeyedForCanvas@Widget>:
+    items: [1, 2, 3]
+    canvas:
+        Color:
+        for it in self.items:
+            key: it
+            Line:
+                points: (it, it)
+''', filename='keyed_for_canvas.kv')
+        try:
+            w = Factory.KeyedForCanvas()
+            leaves = _canvas_leaves(w.canvas)
+            self.assertEqual([type(i).__name__ for i in leaves],
+                             ['Color', 'Line', 'Line', 'Line'])
+            color = leaves[0]
+            lines = leaves[1:]            # for keys 1, 2, 3 in order
+
+            # reorder: same Line objects, new draw order
+            w.items = [3, 1, 2]
+            self.assertEqual(
+                _canvas_leaves(w.canvas),
+                [color, lines[2], lines[0], lines[1]])
+
+            # remove a key: its Line is gone, the others are untouched
+            w.items = [3, 1]
+            self.assertEqual(
+                _canvas_leaves(w.canvas), [color, lines[2], lines[0]])
+
+            # add a key: a fresh Line, the kept ones still identical
+            w.items = [3, 1, 9]
+            after = _canvas_leaves(w.canvas)
+            self.assertEqual(after[:3], [color, lines[2], lines[0]])
+            self.assertEqual(type(after[3]).__name__, 'Line')
+            self.assertNotIn(after[3], lines)
+        finally:
+            Builder.unload_file('keyed_for_canvas.kv')
+
+    def test_canvas_for_keyed_no_op_on_unchanged(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<KeyedForCanvas2@Widget>:
+    items: [1, 2]
+    tick: 0
+    canvas:
+        for it in self.items:
+            key: it
+            Line:
+''', filename='keyed_for_canvas2.kv')
+        try:
+            w = Factory.KeyedForCanvas2()
+            before = _canvas_leaves(w.canvas)
+            # reassigning an equal list must not rebuild the instructions
+            w.items = [1, 2]
+            self.assertEqual(_canvas_leaves(w.canvas), before)
+        finally:
+            Builder.unload_file('keyed_for_canvas2.kv')
+
     def test_if_in_canvas_switches_instructions(self):
         from kivy.factory import Factory
         Builder.load_string('''
@@ -665,6 +1287,55 @@ class CanvasControlRuntimeTestCase(unittest.TestCase):
             self.assertEqual(_canvas_types(w.canvas), ['Color', 'Line'])
         finally:
             Builder.unload_file('if_canvas.kv')
+
+    def test_canvas_control_keeps_document_position(self):
+        # instructions after the control block stay after it
+        from kivy.factory import Factory
+        Builder.load_string('''
+<PosCanvas@Widget>:
+    pts: []
+    canvas:
+        Color:
+        for p in self.pts:
+            Rectangle:
+        Line:
+''', filename='pos_canvas.kv')
+        try:
+            w = Factory.PosCanvas()
+            self.assertEqual(_canvas_types(w.canvas), ['Color', 'Line'])
+            w.pts = [1, 2]
+            self.assertEqual(
+                _canvas_types(w.canvas),
+                ['Color', 'Rectangle', 'Rectangle', 'Line'])
+        finally:
+            Builder.unload_file('pos_canvas.kv')
+
+    def test_nested_for_in_if_in_canvas(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<NestCanvas@Widget>:
+    on: True
+    pts: [1, 2]
+    canvas:
+        if self.on:
+            Color:
+            for p in self.pts:
+                Line:
+''', filename='nest_canvas.kv')
+        try:
+            w = Factory.NestCanvas()
+            self.assertEqual(
+                _canvas_types(w.canvas), ['Color', 'Line', 'Line'])
+            w.pts = [1, 2, 3]
+            self.assertEqual(
+                _canvas_types(w.canvas), ['Color', 'Line', 'Line', 'Line'])
+            w.on = False
+            self.assertEqual(_canvas_types(w.canvas), [])
+            w.on = True
+            self.assertEqual(
+                _canvas_types(w.canvas), ['Color', 'Line', 'Line', 'Line'])
+        finally:
+            Builder.unload_file('nest_canvas.kv')
 
     def test_instruction_property_binding_in_canvas_control(self):
         from kivy.factory import Factory
@@ -697,6 +1368,48 @@ class CanvasControlRuntimeTestCase(unittest.TestCase):
             self.assertAlmostEqual(color.rgba[3], 0.9)
         finally:
             Builder.unload_file('bind_canvas.kv')
+
+    def test_no_handler_leak_on_canvas_rebuild(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<LeakCanvas@Widget>:
+    pts: [1]
+    canvas:
+        for p in self.pts:
+            Color:
+                rgba: 1, 0, 0, p
+''', filename='leak_canvas.kv')
+        try:
+            w = Factory.LeakCanvas()
+            for i in range(30):
+                w.pts = [1, 2, 3]
+                w.pts = [1]
+            n = sum(len(v) for v in _handlers.get(w.uid, {}).values())
+            # one live Color binding per current instruction (here 1)
+            self.assertLessEqual(n, 1)
+        finally:
+            Builder.unload_file('leak_canvas.kv')
+
+    def test_canvas_control_widget_is_collected(self):
+        import gc
+        import weakref
+        from kivy.factory import Factory
+        Builder.load_string('''
+<GcCanvas@Widget>:
+    pts: [1, 2, 3]
+    canvas:
+        for p in self.pts:
+            Rectangle:
+''', filename='gc_canvas.kv')
+        try:
+            w = Factory.GcCanvas()
+            w.pts = [1, 2]
+            ref = weakref.ref(w)
+            del w
+            gc.collect()
+            self.assertIsNone(ref())
+        finally:
+            Builder.unload_file('gc_canvas.kv')
 
 
 class ControlRegressionTestCase(unittest.TestCase):
@@ -773,6 +1486,98 @@ class ControlRegressionTestCase(unittest.TestCase):
         finally:
             Builder.unload_file('reapply.kv')
 
+    def test_constant_key_reports_duplicate_not_typeerror(self):
+        with self.assertRaises(BuilderException) as cm:
+            Builder.load_string('''
+BoxLayout:
+    items: [1, 2]
+    for x in self.items:
+        key: 5
+        Label:
+            text: str(x)
+''')
+        self.assertIn('duplicate', str(cm.exception))
+
+    def test_for_body_local_does_not_touch_host_property(self):
+        # a for-body local is iteration-scoped and never writes the host
+        # property of the same name (which keeps tracking its own binding)
+        root = Builder.load_string('''
+BoxLayout:
+    src: 10
+    n: self.src * 2
+    items: [100, 200]
+    for i in self.items:
+        n: i
+        Label:
+            text: str(n)
+''')
+        self.assertEqual(root.n, 20)        # host n untouched by the local
+        self.assertEqual(texts(root), ['100', '200'])
+        root.src = 5
+        self.assertEqual(root.n, 10)        # host binding still live
+
+    def test_for_local_scopes_unbound_on_iteration_removal(self):
+        # each iteration's scope object owns the local bindings; removing an
+        # iteration tears its scope down (no leftover handler entries)
+        from kivy.lang.parser import _handlers
+        root = Builder.load_string('''
+BoxLayout:
+    offset: 0
+    items: [1, 2, 3]
+    for i in self.items:
+        key: i
+        n: i + root.offset
+        Label:
+            text: str(n)
+''')
+        def n_scopes():
+            return sum(1 for uid in list(_handlers) if 'n' in _handlers[uid])
+
+        before = n_scopes()
+        root.items = [1, 3]                 # remove the middle iteration
+        # exactly one iteration scope (and its 'n' binding) is torn down
+        self.assertEqual(before - n_scopes(), 1)
+
+    def test_for_with_props_widget_is_collected(self):
+        import gc
+        import weakref
+        from kivy.factory import Factory
+        Builder.load_string('''
+<ForPropGc@BoxLayout>:
+    n: 0
+    items: [1, 2]
+    for i in self.items:
+        n: i
+        Label:
+            text: str(i)
+''', filename='forpropgc.kv')
+        try:
+            w = Factory.ForPropGc()
+            ref = weakref.ref(w)
+            del w
+            gc.collect()
+            self.assertIsNone(ref())
+        finally:
+            Builder.unload_file('forpropgc.kv')
+
+    def test_exception_mid_canvas_build_leaves_clean_rulectx(self):
+        from kivy.lang.builder import Builder as B
+        from kivy.factory import Factory
+        Builder.load_string('''
+<BadCanvas@Widget>:
+    zero: 0
+    canvas:
+        for i in [1, 2]:
+            Color:
+                rgba: 1 / self.zero, 0, 0, 1
+''', filename='badcanvas.kv')
+        try:
+            with self.assertRaises(BuilderException):
+                Factory.BadCanvas()      # canvas build divides by zero
+            self.assertEqual(dict(B.rulectx), {})
+        finally:
+            B.unload_file('badcanvas.kv')
+
 
 class CanvasRegressionTestCase(unittest.TestCase):
 
@@ -793,6 +1598,28 @@ class CanvasRegressionTestCase(unittest.TestCase):
             w.on = True
         finally:
             Builder.unload_file('clearcanvas.kv')
+
+    def test_control_in_canvas_before_and_after(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<BACanvas@Widget>:
+    pts: [1, 2]
+    canvas.before:
+        for p in self.pts:
+            Rectangle:
+    canvas.after:
+        if self.pts:
+            Line:
+''', filename='bacanvas.kv')
+        try:
+            w = Factory.BACanvas()
+            self.assertEqual(
+                _canvas_types(w.canvas.before), ['Rectangle', 'Rectangle'])
+            self.assertEqual(_canvas_types(w.canvas.after), ['Line'])
+            w.pts = [1]
+            self.assertEqual(_canvas_types(w.canvas.before), ['Rectangle'])
+        finally:
+            Builder.unload_file('bacanvas.kv')
 
     def test_branch_canvas_zorder_follows_document_order(self):
         from kivy.factory import Factory
@@ -816,6 +1643,23 @@ class CanvasRegressionTestCase(unittest.TestCase):
             self.assertEqual(_canvas_types(w.canvas), ['Scale', 'Rotate'])
         finally:
             Builder.unload_file('zorder.kv')
+
+    def test_canvas_for_skips_rebuild_when_unchanged(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<ForSkip@Widget>:
+    pts: [1, 2]
+    canvas:
+        for p in self.pts:
+            Rectangle:
+''', filename='forskip.kv')
+        try:
+            w = Factory.ForSkip()
+            before = list(w.canvas.children)
+            w.pts = [1, 2]               # equal value -> no rebuild
+            self.assertEqual(list(w.canvas.children), before)  # same objects
+        finally:
+            Builder.unload_file('forskip.kv')
 
 
 if __name__ == '__main__':

--- a/kivy/tests/test_lang_control_runtime.py
+++ b/kivy/tests/test_lang_control_runtime.py
@@ -1,5 +1,5 @@
 '''
-Runtime tests for kv control statements (if/elif/else, for).
+Runtime tests for kv control statements (if/elif/else, for, factory).
 
 These cover the builder stage; pure parsing is tested in
 ``test_lang_parser_control.py``.
@@ -924,6 +924,167 @@ BoxLayout:
             self.assertIn('not iterable', str(cm.exception))
         finally:
             Builder.unload_file('anyitems.kv')
+
+
+class FactoryRuntimeTestCase(unittest.TestCase):
+    '''``factory expr:`` builds a single child widget whose class comes from
+    an expression (a class object or a Factory name), rebuilt reactively when
+    the class changes; the block body is applied to the instance.'''
+
+    def test_build_by_name_and_rebuild_on_change(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<DynByName@BoxLayout>:
+    which: 'Button'
+    caption: 'hi'
+    factory self.which:
+        text: root.caption
+''', filename='dyn_name.kv')
+        try:
+            w = Factory.DynByName()
+            self.assertEqual(type(w.children[0]).__name__, 'Button')
+            self.assertEqual(w.children[0].text, 'hi')
+            # changing the class rebuilds with the new type, body re-applied
+            w.which = 'Label'
+            self.assertEqual(type(w.children[0]).__name__, 'Label')
+            self.assertEqual(w.children[0].text, 'hi')
+        finally:
+            Builder.unload_file('dyn_name.kv')
+
+    def test_class_object_value(self):
+        from kivy.factory import Factory
+        from kivy.uix.label import Label
+        Builder.load_string('''
+<DynByCls@BoxLayout>:
+    klass: None
+    factory self.klass:
+        text: 'z'
+''', filename='dyn_cls.kv')
+        try:
+            w = Factory.DynByCls()
+            self.assertEqual(len(w.children), 0)   # None -> nothing
+            w.klass = Label
+            self.assertEqual(type(w.children[0]).__name__, 'Label')
+            self.assertEqual(w.children[0].text, 'z')
+        finally:
+            Builder.unload_file('dyn_cls.kv')
+
+    def test_body_property_reactive_and_identity_stable(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<DynBody@BoxLayout>:
+    caption: 'a'
+    factory 'Label':
+        text: root.caption
+''', filename='dyn_body.kv')
+        try:
+            w = Factory.DynBody()
+            child = w.children[0]
+            self.assertEqual(child.text, 'a')
+            # body prop is reactive; the widget is NOT rebuilt (class same)
+            w.caption = 'b'
+            self.assertEqual(child.text, 'b')
+            self.assertIs(w.children[0], child)
+        finally:
+            Builder.unload_file('dyn_body.kv')
+
+    def test_factory_inside_for(self):
+        from kivy.factory import Factory
+        from kivy.uix.label import Label
+        from kivy.uix.button import Button
+        Builder.load_string('''
+<DynForm@BoxLayout>:
+    rows: []
+    for row in self.rows:
+        factory row['cls']:
+            text: row['text']
+''', filename='dyn_form.kv')
+        try:
+            w = Factory.DynForm()
+            w.rows = [{'cls': Label, 'text': 'a'},
+                      {'cls': Button, 'text': 'b'}]
+            kids = list(reversed(w.children))
+            self.assertEqual(
+                [(type(k).__name__, k.text) for k in kids],
+                [('Label', 'a'), ('Button', 'b')])
+        finally:
+            Builder.unload_file('dyn_form.kv')
+
+    def test_factory_with_children(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<DynPanel@BoxLayout>:
+    factory 'BoxLayout':
+        orientation: 'vertical'
+        Label:
+            text: 'a'
+        Label:
+            text: 'b'
+''', filename='dyn_panel.kv')
+        try:
+            w = Factory.DynPanel()
+            inner = w.children[0]
+            self.assertEqual(inner.orientation, 'vertical')
+            self.assertEqual(texts(inner), ['a', 'b'])
+        finally:
+            Builder.unload_file('dyn_panel.kv')
+
+    def test_factory_keeps_document_position(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<DynPos@BoxLayout>:
+    which: 'Label'
+    Label:
+        text: 'before'
+    factory self.which:
+        text: 'mid'
+    Label:
+        text: 'after'
+''', filename='dyn_pos.kv')
+        try:
+            w = Factory.DynPos()
+            self.assertEqual(texts(w), ['before', 'mid', 'after'])
+            w.which = 'Button'
+            self.assertEqual(texts(w), ['before', 'mid', 'after'])
+            self.assertEqual(type(by_text(w)['mid']).__name__, 'Button')
+        finally:
+            Builder.unload_file('dyn_pos.kv')
+
+    def test_factory_widget_is_collected(self):
+        import gc
+        import weakref
+        from kivy.factory import Factory
+        Builder.load_string('''
+<DynGc@BoxLayout>:
+    which: 'Label'
+    factory self.which:
+        text: 'x'
+''', filename='dyn_gc.kv')
+        try:
+            w = Factory.DynGc()
+            w.which = 'Button'
+            ref = weakref.ref(w)
+            del w
+            gc.collect()
+            self.assertIsNone(ref())
+        finally:
+            Builder.unload_file('dyn_gc.kv')
+
+    def test_factory_unknown_class_raises_with_context(self):
+        from kivy.factory import Factory
+        Builder.load_string('''
+<DynBad@BoxLayout>:
+    which: 'Label'
+    factory self.which:
+        text: 'x'
+''', filename='dyn_bad.kv')
+        try:
+            w = Factory.DynBad()
+            with self.assertRaises(BuilderException) as cm:
+                w.which = 'NoSuchWidgetClass'
+            self.assertIn('NoSuchWidgetClass', str(cm.exception))
+        finally:
+            Builder.unload_file('dyn_bad.kv')
 
 
 class ControlIdRuntimeTestCase(unittest.TestCase):

--- a/kivy/tests/test_lang_parser_control.py
+++ b/kivy/tests/test_lang_parser_control.py
@@ -1,5 +1,5 @@
 '''
-Tests for parsing kv control statements (if/elif/else, for, factory).
+Tests for parsing kv control statements (if/elif/else, for, slot, factory).
 
 These only cover the parser stage (:class:`kivy.lang.parser.Parser`);
 builder/runtime behavior is tested separately.
@@ -118,6 +118,20 @@ class ControlStatementParseTestCase(unittest.TestCase):
         Label:
 ''').children[0]
         self.assertEqual(ctl.target_names, ['first', 'rest'])
+
+    def test_slot_named_and_default(self):
+        rule = parse_rule('''
+<W@Widget>:
+    slot header:
+        Label:
+    slot:
+''')
+        named, default = rule.children
+        self.assertEqual(named.kind, 'slot')
+        self.assertEqual(named.slot_name, 'header')
+        self.assertEqual(len(named.children), 1)
+        self.assertEqual(default.slot_name, '')
+        self.assertEqual(default.children, [])
 
     def test_nested_controls(self):
         rule = parse_rule('''
@@ -369,6 +383,22 @@ if True:
             id: total
 ''', 'clashes')
 
+    def test_property_inside_slot_is_slot_local(self):
+        # a slot definition property is a slot-scoped local, evaluated in the
+        # defining rule's context and exposed to fallback and fill content as
+        # an attribute of the reserved ``slot`` name
+        rule = parse_rule('''
+<W@Widget>:
+    title: 'x'
+    slot header:
+        summary: self.title.upper()
+        Label:
+            text: slot.summary
+''')
+        ctl = rule.children[0]
+        self.assertEqual([n for n, _ in ctl.locals], ['summary'])
+        self.assertNotIn('summary', ctl.properties)
+
     def test_full_body_inside_if_allowed(self):
         # children + property + canvas + handler all live in one branch
         rule = parse_rule('''
@@ -434,6 +464,24 @@ if True:
         self.assertEqual(ctl.id_scope_names, ['lab'])
         self.assertEqual(ctl.children[0].scope_id, (ctl.scope_key, 'lab'))
         self.assertIn(ctl.scope_key, ctl.children[1].properties['text'].value)
+
+    def test_id_inside_slot_is_rule_scoped(self):
+        # an id on slot content (definition fallback or explicit fill block)
+        # is a reactive id on the rule providing that content
+        rule = parse_rule('''
+<W@Widget>:
+    slot header:
+        Label:
+            id: head
+    Button:
+        disabled: head is None
+''')
+        self.assertEqual(rule.id_scope_names, ['head'])
+        lbl = rule.children[0].children[0]
+        self.assertIsNone(lbl.id)
+        self.assertEqual(lbl.scope_id, (rule.id_scope_key, 'head'))
+        self.assertIn(rule.id_scope_key,
+                      rule.children[1].properties['disabled'].value)
 
     def test_id_inside_factory_body_forbidden(self):
         self.assert_parse_error('''
@@ -603,6 +651,14 @@ if True:
     async for x in self.items:
         Label:
 ''', '')
+
+    def test_invalid_slot_name(self):
+        for name in ('1bad', 'two words', 'if'):
+            self.assert_parse_error('''
+<W@Widget>:
+    slot %s:
+        Label:
+''' % name, 'invalid slot name')
 
     def test_factory_parses_class_expression_and_body(self):
         rule = parse_rule('''

--- a/kivy/tests/test_lang_parser_control.py
+++ b/kivy/tests/test_lang_parser_control.py
@@ -1,0 +1,361 @@
+'''
+Tests for parsing kv control statements (if/elif/else).
+
+These only cover the parser stage (:class:`kivy.lang.parser.Parser`);
+builder/runtime behavior is tested separately.
+'''
+
+import unittest
+
+from kivy.lang.parser import Parser, ParserControlRule, ParserException
+
+
+def parse_rule(kv):
+    '''Parse kv content and return the first rule.'''
+    return Parser(content=kv).rules[0][1]
+
+
+class ControlStatementParseTestCase(unittest.TestCase):
+
+    def assert_parse_error(self, kv, message_part):
+        with self.assertRaises(ParserException) as cm:
+            Parser(content=kv)
+        self.assertIn(message_part, str(cm.exception))
+
+    def test_if_chain_merged_into_branches(self):
+        rule = parse_rule('''
+<W@Widget>:
+    if self.expanded:
+        Label:
+            text: 'open'
+    elif self.collapsed:
+        Label:
+            text: 'mid'
+    else:
+        Label:
+            text: 'closed'
+''')
+        self.assertTrue(rule.has_controls)
+        self.assertEqual(len(rule.children), 1)
+        ctl = rule.children[0]
+        self.assertIsInstance(ctl, ParserControlRule)
+        self.assertEqual(ctl.kind, 'if')
+        self.assertEqual(
+            [b.cond_src for b in ctl.branches],
+            ['self.expanded', 'self.collapsed', None])
+        self.assertEqual([len(b.children) for b in ctl.branches], [1, 1, 1])
+        self.assertEqual(
+            ctl.selector_prop.value,
+            '0 if (self.expanded) else 1 if (self.collapsed) else 2')
+        self.assertIn(['self', 'expanded'], ctl.selector_prop.watched_keys)
+        self.assertIn(['self', 'collapsed'], ctl.selector_prop.watched_keys)
+
+    def test_if_without_else_selects_minus_one(self):
+        ctl = parse_rule('''
+<W@Widget>:
+    if self.x:
+        Label:
+''').children[0]
+        self.assertEqual(ctl.selector_prop.value, '0 if (self.x) else -1')
+
+    def test_two_sibling_if_chains_stay_separate(self):
+        rule = parse_rule('''
+<W@Widget>:
+    if self.a:
+        Label:
+    if self.b:
+        Label:
+    else:
+        Label:
+''')
+        self.assertEqual(len(rule.children), 2)
+        self.assertEqual(len(rule.children[0].branches), 1)
+        self.assertEqual(len(rule.children[1].branches), 2)
+
+    def test_widget_between_if_and_else_is_an_error(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.a:
+        Label:
+    Label:
+    else:
+        Label:
+''', '"else" must immediately follow')
+
+    def test_colon_inside_condition_braces(self):
+        ctl = parse_rule('''
+<W@Widget>:
+    if {1: 2}.get(self.x):
+        Label:
+''').children[0]
+        self.assertEqual(ctl.branches[0].cond_src, '{1: 2}.get(self.x)')
+
+    def test_bare_lambda_colon_in_header(self):
+        # the block colon is the last depth-0 colon, so a bare lambda's own
+        # colon stays inside the header
+        ctl = parse_rule('''
+<W@Widget>:
+    if lambda: 1:
+        Label:
+''').children[0]
+        self.assertEqual(ctl.branches[0].cond_src, 'lambda: 1')
+
+    def test_scoped_id_cannot_be_app(self):
+        # unlike a static id, a scoped id rewrites its references, so `app`
+        # would silently hijack the app proxy
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x:
+        Label:
+            id: app
+''', 'cannot be "self", "root" or "app"')
+
+    def test_trailing_comment_after_colon(self):
+        ctl = parse_rule('''
+<W@Widget>:
+    if self.x:  # visible?
+        Label:
+''').children[0]
+        self.assertEqual(ctl.branches[0].cond_src, 'self.x')
+
+    def test_keyword_prefixed_names_still_parse_as_rules(self):
+        # 'format', 'iffy', 'forward' must not be mistaken for keywords
+        rule = parse_rule('''
+<W@Widget>:
+    format: 'png'
+    iffy: 1
+    forward: True
+''')
+        self.assertFalse(rule.has_controls)
+        self.assertEqual(
+            sorted(rule.properties), ['format', 'forward', 'iffy'])
+
+    def test_orphan_else(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    Label:
+    else:
+        Label:
+''', '"else" must immediately follow')
+
+    def test_orphan_elif(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    elif self.x:
+        Label:
+''', '"elif" must immediately follow')
+
+    def test_else_after_else(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x:
+        Label:
+    else:
+        Label:
+    else:
+        Label:
+''', '"else" must immediately follow')
+
+    def test_non_control_keywords_rejected(self):
+        # while/match/case are not kv control statements; they fall through to
+        # the ordinary class/property path and are rejected as invalid names.
+        # Nothing is reserved: adding such a statement later is additive,
+        # exactly like this feature itself.
+        for kw in ('while', 'match', 'case'):
+            self.assert_parse_error('''
+<W@Widget>:
+    %s self.x:
+        Label:
+''' % kw, 'Invalid property name')
+
+    def test_keyword_named_bare_properties_still_parse(self):
+        # bare names that are Python keywords elsewhere stay plain kv
+        # properties
+        rule = parse_rule('''
+<W@Widget>:
+    match: 1
+    case: 2
+''')
+        self.assertEqual(sorted(rule.properties), ['case', 'match'])
+
+    def test_top_level_control_forbidden(self):
+        self.assert_parse_error('''
+if True:
+    Label:
+''', 'not allowed at the top level')
+
+    def test_walrus_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if (y := self.x):
+        Label:
+''', 'assignment expressions')
+
+    def test_property_inside_if_allowed(self):
+        rule = parse_rule('''
+<W@Widget>:
+    if self.x:
+        text: 'hi'
+''')
+        branch = rule.children[0].branches[0]
+        self.assertIn('text', branch.properties)
+        self.assertEqual(branch.children, [])
+
+    def test_full_body_inside_if_allowed(self):
+        # children + property + canvas + handler all live in one branch
+        rule = parse_rule('''
+<W@Widget>:
+    if self.x:
+        my_prop: self.width
+        on_touch_down: pass
+        canvas:
+            Color:
+        Label:
+    else:
+        my_prop: 0
+''')
+        ctl = rule.children[0]
+        on_branch, off_branch = ctl.branches
+        self.assertIn('my_prop', on_branch.properties)
+        self.assertEqual(len(on_branch.handlers), 1)
+        self.assertIsNotNone(on_branch.canvas_root)
+        self.assertEqual(len(on_branch.children), 1)
+        self.assertIn('my_prop', off_branch.properties)
+
+    def test_id_inside_if_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x:
+        id: nope
+        Label:
+''', '"id" is not allowed')
+
+    def test_id_inside_if_is_reactive_scoped(self):
+        # a widget id inside an if is redirected onto a rule-level scope
+        # object so it can mount/unmount reactively; references to it are
+        # reachable across the whole rule
+        rule = parse_rule('''
+<W@Widget>:
+    if self.x:
+        Label:
+            id: nope
+    Button:
+        disabled: nope is None
+''')
+        self.assertIsNotNone(rule.id_scope_key)
+        self.assertEqual(rule.id_scope_names, ['nope'])
+        lbl = rule.children[0].branches[0].children[0]
+        self.assertIsNone(lbl.id)               # the static id is cleared
+        self.assertEqual(lbl.scope_id, (rule.id_scope_key, 'nope'))
+        # the sibling reference was rewritten onto the scope
+        btn = rule.children[1]
+        self.assertIn(rule.id_scope_key, btn.properties['disabled'].value)
+
+    def test_id_deep_inside_if_is_collected(self):
+        rule = parse_rule('''
+<W@Widget>:
+    if self.x:
+        BoxLayout:
+            BoxLayout:
+                Label:
+                    id: deep
+''')
+        self.assertEqual(rule.id_scope_names, ['deep'])
+
+    def test_id_outside_control_block_still_allowed(self):
+        rule = parse_rule('''
+<W@Widget>:
+    Label:
+        id: fine
+    if self.x:
+        Label:
+''')
+        self.assertEqual(rule.children[0].id, 'fine')
+
+    def test_handler_inside_if_allowed(self):
+        rule = parse_rule('''
+<W@Widget>:
+    if self.x:
+        on_touch_down: pass
+        Label:
+''')
+        branch = rule.children[0].branches[0]
+        self.assertEqual(len(branch.handlers), 1)
+        self.assertEqual(branch.handlers[0].name, 'on_touch_down')
+
+    def test_canvas_inside_if_allowed(self):
+        rule = parse_rule('''
+<W@Widget>:
+    if self.x:
+        canvas:
+            Color:
+        Label:
+''')
+        branch = rule.children[0].branches[0]
+        self.assertIsNotNone(branch.canvas_root)
+
+    def test_property_inside_canvas_control_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    canvas:
+        if self.x:
+            foo: 1
+            Color:
+''', 'only graphics instructions are allowed')
+
+    def test_control_under_canvas_instruction_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    canvas:
+        Rectangle:
+            if self.x:
+                Color:
+''', 'not allowed under a graphics instruction')
+
+    def test_key_outside_for_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x:
+        key: 1
+        Label:
+''', '"key:" is only allowed inside a "for" block')
+
+    def test_empty_if_body(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x:
+    Label:
+''', 'requires at least one child widget')
+
+    def test_missing_colon(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x
+        Label:
+''', "expected ':'")
+
+    def test_inline_body_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x: Label()
+''', "unexpected content after ':'")
+
+    def test_if_without_condition(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if:
+        Label:
+''', 'requires a condition expression')
+
+    def test_else_with_expression(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    if self.x:
+        Label:
+    else self.y:
+        Label:
+''', '"else" takes no expression')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kivy/tests/test_lang_parser_control.py
+++ b/kivy/tests/test_lang_parser_control.py
@@ -1,5 +1,5 @@
 '''
-Tests for parsing kv control statements (if/elif/else, for).
+Tests for parsing kv control statements (if/elif/else, for, factory).
 
 These only cover the parser stage (:class:`kivy.lang.parser.Parser`);
 builder/runtime behavior is tested separately.
@@ -435,6 +435,14 @@ if True:
         self.assertEqual(ctl.children[0].scope_id, (ctl.scope_key, 'lab'))
         self.assertIn(ctl.scope_key, ctl.children[1].properties['text'].value)
 
+    def test_id_inside_factory_body_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    factory 'Label':
+        Label:
+            id: nope
+''', '"id" is not allowed')
+
     def test_id_deep_inside_if_is_collected(self):
         rule = parse_rule('''
 <W@Widget>:
@@ -595,6 +603,47 @@ if True:
     async for x in self.items:
         Label:
 ''', '')
+
+    def test_factory_parses_class_expression_and_body(self):
+        rule = parse_rule('''
+<W@Widget>:
+    which: 'Button'
+    factory self.which:
+        text: root.caption
+        Label:
+            text: 'inner'
+''')
+        self.assertTrue(rule.has_controls)
+        ctl = rule.children[-1]
+        self.assertIsInstance(ctl, ParserControlRule)
+        self.assertEqual(ctl.kind, 'factory')
+        self.assertEqual(ctl.class_prop.value, 'self.which')
+        self.assertIn(['self', 'which'], ctl.class_prop.watched_keys)
+        # the body is a full widget rule applied to the instance
+        self.assertIn('text', ctl.properties)
+        self.assertEqual(len(ctl.children), 1)
+
+    def test_factory_requires_expression(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    factory:
+        Label:
+''', '"factory" requires an expression')
+
+    def test_factory_in_canvas_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    canvas:
+        factory self.which:
+            Color:
+''', 'cannot be declared inside canvas')
+
+    def test_factory_walrus_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    factory (x := self.which):
+        Label:
+''', 'assignment expressions')
 
 
 if __name__ == '__main__':

--- a/kivy/tests/test_lang_parser_control.py
+++ b/kivy/tests/test_lang_parser_control.py
@@ -1,5 +1,5 @@
 '''
-Tests for parsing kv control statements (if/elif/else).
+Tests for parsing kv control statements (if/elif/else, for).
 
 These only cover the parser stage (:class:`kivy.lang.parser.Parser`);
 builder/runtime behavior is tested separately.
@@ -82,6 +82,57 @@ class ControlStatementParseTestCase(unittest.TestCase):
         Label:
 ''', '"else" must immediately follow')
 
+    def test_for_with_tuple_target_filter_and_key(self):
+        ctl = parse_rule('''
+<W@Widget>:
+    for item, index in enumerate(self.items) if item.visible:
+        key: item.uid
+        Label:
+            text: str(item)
+''').children[0]
+        self.assertEqual(ctl.kind, 'for')
+        self.assertEqual(ctl.target_names, ['item', 'index'])
+        self.assertEqual(
+            ctl.iterator_prop.value,
+            '[(item, index,) for item, index in (enumerate(self.items))'
+            ' if (item.visible)]')
+        self.assertEqual(ctl.key_prop.value, 'item.uid')
+        self.assertEqual(len(ctl.children), 1)
+
+    def test_for_watched_keys_exclude_loop_targets(self):
+        ctl = parse_rule('''
+<W@Widget>:
+    for item in self.items if item.visible and root.active:
+        key: item.uid
+        Label:
+''').children[0]
+        self.assertEqual(
+            sorted(map(tuple, ctl.iterator_prop.watched_keys)),
+            [('root', 'active'), ('self', 'items')])
+        self.assertIsNone(ctl.key_prop.watched_keys)
+
+    def test_for_star_target(self):
+        ctl = parse_rule('''
+<W@Widget>:
+    for first, *rest in self.rows:
+        Label:
+''').children[0]
+        self.assertEqual(ctl.target_names, ['first', 'rest'])
+
+    def test_nested_controls(self):
+        rule = parse_rule('''
+<W@Widget>:
+    for row in self.rows:
+        BoxLayout:
+            if row.title:
+                Label:
+                    text: row.title
+''')
+        outer = rule.children[0]
+        box = outer.children[0]
+        self.assertTrue(box.has_controls)
+        self.assertEqual(box.children[0].kind, 'if')
+
     def test_colon_inside_condition_braces(self):
         ctl = parse_rule('''
 <W@Widget>:
@@ -156,6 +207,15 @@ class ControlStatementParseTestCase(unittest.TestCase):
         Label:
 ''', '"else" must immediately follow')
 
+    def test_else_after_for(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for x in self.items:
+        Label:
+    else:
+        Label:
+''', '"else" after "for" is not supported')
+
     def test_non_control_keywords_rejected(self):
         # while/match/case are not kv control statements; they fall through to
         # the ordinary class/property path and are rejected as invalid names.
@@ -191,6 +251,28 @@ if True:
         Label:
 ''', 'assignment expressions')
 
+    def test_loop_target_may_shadow_reserved_names(self):
+        # loop targets form their own scope and may shadow any name,
+        # including self/root/app and the metric helpers (resolved at
+        # runtime; here we only assert the parser accepts them)
+        for name in ('self', 'root', 'app', 'dp', 'cm', 'rgba'):
+            ctl = parse_rule('''
+<W@Widget>:
+    for %s in self.items:
+        Label:
+''' % name).children[0]
+            self.assertEqual(ctl.target_names, [name])
+
+    def test_key_must_precede_widgets(self):
+        # "key:" is a property; like all kv properties it must come before
+        # the block's child widgets (kv rejects any property after a child)
+        self.assert_parse_error('''
+<W@Widget>:
+    for item in self.items:
+        Label:
+        key: item.uid
+''', 'Invalid data after declaration')
+
     def test_property_inside_if_allowed(self):
         rule = parse_rule('''
 <W@Widget>:
@@ -200,6 +282,92 @@ if True:
         branch = rule.children[0].branches[0]
         self.assertIn('text', branch.properties)
         self.assertEqual(branch.children, [])
+
+    def test_property_inside_for_is_a_local(self):
+        # a for body property is an iteration-local: extracted out of
+        # ``properties`` into ``locals`` with a scope key, and references to
+        # it rewritten to attribute access on that scope
+        rule = parse_rule('''
+<W@Widget>:
+    for i in self.items:
+        doubled: i * 2
+        Label:
+            text: str(doubled)
+''')
+        ctl = rule.children[0]
+        self.assertNotIn('doubled', ctl.properties)
+        self.assertEqual([n for n, _ in ctl.locals], ['doubled'])
+        self.assertIsNotNone(ctl.scope_key)
+        # the child reference is rewritten to <scope>.doubled
+        child = ctl.children[0]
+        self.assertIn(ctl.scope_key, child.properties['text'].value)
+
+    def test_for_with_only_a_local_and_no_child_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        n: i
+''', 'requires at least one child widget')
+
+    def test_for_handler_and_canvas_still_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        on_x: print(i)
+        Label:
+''', 'event handlers are not allowed')
+
+    def test_property_in_if_inside_for_is_conditional_local(self):
+        # nearest-scope rule: a property line binds to the nearest enclosing
+        # scope, so in an ``if`` nested in a ``for`` it is an iteration-local
+        # (bound while the branch is active), not a host property
+        rule = parse_rule('''
+<W@Widget>:
+    for n in self.items:
+        if n > 2:
+            label: 'big ' + str(n)
+        Label:
+            text: label or ''
+''')
+        ctl = rule.children[0]
+        self.assertIn('label', ctl.scope_names)
+        self.assertNotIn('label', [x for x, _ in ctl.locals])
+        child = ctl.children[-1]
+        self.assertIn(ctl.scope_key, child.properties['text'].value)
+
+    def test_handler_in_if_inside_for_forbidden(self):
+        # nesting context semantics: an ``if`` under a ``for`` follows the
+        # for-body content rules, so host handlers stay forbidden
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        if i:
+            on_touch_down: pass
+            Label:
+        Label:
+''', 'event handlers are not allowed')
+
+    def test_canvas_in_if_inside_for_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        if i:
+            canvas:
+                Color:
+            Label:
+        Label:
+''', 'canvas is not allowed')
+
+    def test_local_and_id_name_clash_is_error(self):
+        # one name cannot be driven by both a local binding and an id: both
+        # writers would stay live (this is not Python shadowing)
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        total: i * 2
+        Label:
+            id: total
+''', 'clashes')
 
     def test_full_body_inside_if_allowed(self):
         # children + property + canvas + handler all live in one branch
@@ -251,6 +419,22 @@ if True:
         btn = rule.children[1]
         self.assertIn(rule.id_scope_key, btn.properties['disabled'].value)
 
+    def test_id_inside_for_is_iteration_scoped(self):
+        # a widget id inside a for is redirected onto the per-iteration scope
+        rule = parse_rule('''
+<W@Widget>:
+    for it in self.items:
+        Label:
+            id: lab
+        Button:
+            text: lab.text
+''')
+        ctl = rule.children[0]
+        self.assertIsNotNone(ctl.scope_key)
+        self.assertEqual(ctl.id_scope_names, ['lab'])
+        self.assertEqual(ctl.children[0].scope_id, (ctl.scope_key, 'lab'))
+        self.assertIn(ctl.scope_key, ctl.children[1].properties['text'].value)
+
     def test_id_deep_inside_if_is_collected(self):
         rule = parse_rule('''
 <W@Widget>:
@@ -283,6 +467,14 @@ if True:
         self.assertEqual(len(branch.handlers), 1)
         self.assertEqual(branch.handlers[0].name, 'on_touch_down')
 
+    def test_handler_inside_for_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        on_touch_down: pass
+        Label:
+''', 'event handlers are not allowed')
+
     def test_canvas_inside_if_allowed(self):
         rule = parse_rule('''
 <W@Widget>:
@@ -293,6 +485,33 @@ if True:
 ''')
         branch = rule.children[0].branches[0]
         self.assertIsNotNone(branch.canvas_root)
+
+    def test_canvas_inside_for_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for i in self.items:
+        canvas:
+            Color:
+        Label:
+''', 'canvas is not allowed')
+
+    def test_control_inside_canvas_allowed(self):
+        rule = parse_rule('''
+<W@Widget>:
+    canvas:
+        Color:
+        for p in self.points:
+            Line:
+                points: p
+        if self.selected:
+            Rectangle:
+''')
+        children = rule.canvas_root.children
+        self.assertEqual(children[0].name, 'Color')
+        self.assertEqual(children[1].kind, 'for')
+        self.assertTrue(children[1].in_canvas)
+        self.assertEqual(children[2].kind, 'if')
+        self.assertTrue(children[2].in_canvas)
 
     def test_property_inside_canvas_control_forbidden(self):
         self.assert_parse_error('''
@@ -327,6 +546,13 @@ if True:
     Label:
 ''', 'requires at least one child widget')
 
+    def test_empty_for_body(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for x in self.items:
+    Label:
+''', 'requires at least one child widget')
+
     def test_missing_colon(self):
         self.assert_parse_error('''
 <W@Widget>:
@@ -355,6 +581,20 @@ if True:
     else self.y:
         Label:
 ''', '"else" takes no expression')
+
+    def test_multiple_for_clauses_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    for x in self.a for y in self.b:
+        Label:
+''', 'single "for ... in ..." clause')
+
+    def test_async_for_forbidden(self):
+        self.assert_parse_error('''
+<W@Widget>:
+    async for x in self.items:
+        Label:
+''', '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Control statements for kv-lang

> Targets Kivy **3.0.0**.

I'm quite happy to share this feature which I hope will be welcomed in the Kivy project.
I've been working on it for a long time, and I admit that a few sessions using Claude Fable 5 helped me finalize it.

This PR message goes into details, to share the whys and hows of decisions I believe are right and that weren't obvious at first.

## Why

kv-lang is great at describing a *fixed* tree of widgets, but most UIs aren't fixed: things appear and disappear, and lists grow and shrink. kv has no real answer for either, so everyone improvises - and tends to improvise differently each time.

Take hiding a widget. There's no "hide" in kv, so in practice you reach for several properties at once and hope the combination is good enough:

```yaml
Label:
    opacity: 0 if hide else 1         # make it invisible...
    disabled: hide                    # ...and stop it handling touches...
    height: 0 if hide else dp(40)     # ...and try to reclaim its space
    size_hint_y: None
```

None of those removes the widget; each has its own side effects; and the recipe varies from project to project (if not from file to file).

Rendering a list has the same problem from the other direction - you leave kv and do it in Python, or use a RecycleView for half a dozen widgets, and every contributor picks a different pattern.

The two things people actually want here are just `if` and `for`. This PR brings these Pythonic control structures into kv, declaratively and reactively, so the common case has one boring, obvious shape:

```yaml

if visible:
    Label:
        text: 'now you see me'

for item in self.items:
    Label:
        text: item.title
```

This is not a RecycleView replacement: `for` builds a real widget per item, so RecycleView is still the right tool for large, scrolling, virtualised lists. The target is the everyday handful-of-widgets case where RecycleView is overkill.

## A todo list, in kv and nothing else

Add, list, empty state, delete - the whole thing, with no Python beyond loading the string:

```yaml
BoxLayout:
    orientation: 'vertical'
    padding: dp(8)
    spacing: dp(8)
    todos: []

    BoxLayout:                              # input row
        size_hint_y: None
        height: dp(40)
        spacing: dp(8)
        TextInput:
            id: field
            hint_text: 'What needs doing?'
            multiline: False
            on_text_validate:
                root.todos = root.todos + [self.text]
                self.text = ''
        Button:
            text: 'Add'
            size_hint_x: None
            width: dp(80)
            on_release: field.dispatch('on_text_validate')

    if not root.todos:
        Label:
            text: 'Nothing to do...'

    for i, todo in enumerate(root.todos):   # one row per todo
        BoxLayout:
            size_hint_y: None
            height: dp(36)
            Label:
                text: todo
            Button:
                text: 'x'
                size_hint_x: None
                width: dp(40)
                on_release: root.todos = root.todos[:i] + root.todos[i + 1:]
```

Reassigning `todos` is all it takes - the `if` and `for` blocks re-render themselves.

A fully working demo is included in `examples/kv/app_todo.kv`.

## What it adds

Four reactive control statements at child-widget position, with the same binding semantics as ordinary kv property expressions:

- **`if` / `elif` / `else`** - mount a block while its condition holds. A block is *whatever fits in an ordinary rule*: besides children it may set properties, declare a `canvas`, and bind handlers, all applied to the host widget while the branch is active and removed when it leaves.
- **`for ... in ...`** - one copy of the body per item, reconciled as the iterable changes. It uses native Python comprehension syntax, so tuple targets and trailing `if` filters work (`for i, x in enumerate(items) if x.visible:`). 
- **`slot`** - a named insertion point in a class rule that the usage site can fill, with a fallback.
- **`factory <expr>`** - build one child widget whose class is chosen by an expression (a class object, or a name resolved through the `Factory`).

**Opt-in and non-breaking.** This is purely additive. Existing kv keeps parsing and behaving exactly as before - control statements are new keywords in positions that used to be syntax errors, so nothing that parses today changes meaning. A rule with no control statements takes an unchanged fast path, so code that doesn't use the feature pays nothing for it, in behaviour or performance.


### Setting properties conditionally, without repeating yourself

An `if`/`else` block can set the host widget's own properties, so a group of properties that all hinge on one condition can state it once instead of on every line:

```yaml
# today - the condition is repeated on every property:
<StatusLabel@Label>:
    error: False
    color: (1, 0, 0, 1) if self.error else (1, 1, 1, 1)
    bold: self.error
    font_size: '18sp' if self.error else '14sp'
```

```yaml
# with if / else - say it once:
<StatusLabel@Label>:
    error: False
    if self.error:
        color: 1, 0, 0, 1
        bold: True
        font_size: '18sp'
    else:
        color: 1, 1, 1, 1
        bold: False
        font_size: '14sp'
```

### Slots

A slot is a named hole a container class leaves for its callers to fill, with fallback content for when they don't. It lets you build a reusable layout shell once and drop different content into it at each call site, without subclassing:

```yaml
# a reusable frame with a header slot and a default (body) slot
<Card@BoxLayout>:
    orientation: 'vertical'
    slot header:
        Label:
            text: 'Untitled'         # shown when the caller fills nothing
    slot:                            # default slot: plain children land here

# call site - fill the header, drop the body content straight in
Card:
    slot header:
        Label:
            text: 'Inbox'
            bold: True
    Label:
        text: 'You have 3 new messages'
```

A definition can also hand values to whatever fills it: a property line in a `slot` definition is a *slot-scoped local*, computed in the defining rule's context and read by fallback and fill content through the reserved `slot` name:

```yaml
<Card@BoxLayout>:
    unread: 0
    slot header:
        badge: f'({root.unread})' if root.unread else ''
        Label:
            text: 'Untitled ' + slot.badge     # fallback reads it

Card:
    slot header:
        Label:
            text: 'Inbox ' + slot.badge        # so does the fill
```

### A widget chosen at runtime (`factory`)

`factory <expr>` builds one child whose class comes from an expression - a class object, or a name resolved through the `Factory`. The body is applied to the instance, and the widget is rebuilt when the class expression changes. Combined with `for`, this is a whole form rendered from data:

```yaml
<Form@BoxLayout>:
    schema: []
    for field in self.schema:
        factory field['cls']:        # e.g. 'TextInput', 'CheckBox', ...
            hint_text: field.get('label', '')
```

### Iteration-local values and reactive ids

A property line inside a `for` is a *local*: one reactive value per iteration, shared by everything in that iteration's body (so the `[]` below is one list, not three). A widget inside the block may carry an `id`, which the iteration's own content can reach:

```yaml
<Cart@BoxLayout>:
    items: []
    for item in self.items:
        line_total: item.qty * item.price     # iteration-local, reactive
        CheckBox:
            id: pick                          # iteration-local id
        Label:
            text: '%s = %s' % (item.name, line_total)
        Label:
            text: 'picked' if pick.activated else ''
```

In an `if`, an id is reachable across the whole rule and is `None` while the branch is inactive - so a sibling can react to the widget coming and going:

```yaml
<Editor@BoxLayout>:
    editing: False
    if self.editing:
        TextInput:
            id: field
    Button:
        disabled: field is None      # True until the TextInput exists
```

### Graphics control flow (inside canvas)

`if` and `for` also work *inside* a `canvas` block, where they generate graphics instructions instead of widgets - data-driven drawing that reacts to its inputs, the same way it reacts for widgets:

```yaml
<Chart@Widget>:
    series: []
    canvas:
        Color:
            rgba: 1, 1, 1, 1
        for line in self.series:      # one Line per series, reactive
            key: line.uid             # keyed: reconcile instead of rebuild
            Line:
                points: line.points
        if self.selected:             # extra graphics only when selected
            Color:
                rgba: 1, 0, 0, 1
            Rectangle:
                pos: self.pos
                size: self.size
```

The block's instructions sit at its position among the surrounding ones and are rebuilt when the condition or iterable changes. A canvas `for` without a `key:` rebuilds its instructions wholesale; with a `key:` it reconciles per iteration (keeping, moving or rebuilding instruction groups by key), so textured/stateful instructions (`Rectangle(source=...)`, `Mesh`, `Fbo`) and large series are not re-uploaded on every change.

## Design

The guiding choice is that control statements are not a second engine bolted onto kv - they reuse the language's existing reactivity. An `if` chain compiles to a single *selector* expression (the index of the active branch) and a `for` to a single *iterator* expression (the list of loop-value tuples), both ordinary `ParserRuleProperty` objects. Binding, rebinding and teardown ride the standard watched-keys path, so the same things that make `text: self.value` reactive make the conditions reactive.

At runtime each control statement is a small node that owns a contiguous span of its parent's children and rebuilds that span when its expression changes. Nodes activate in a deferred phase of `_apply_rule`, after properties and handlers are resolved, so ids and values are already in place; they build their subtrees by re-entering `_apply_rule`, so canvas, handlers and nested control statements come for free. Rebuilds are synchronous (after `self.open = True` the children exist immediately), and an update that fires while another apply or rebuild is in flight is queued and run right after it, so a rebuild can never re-enter an in-flight rule or observe a half-reconciled children list. Widgets without control statements take a fast path - one boolean test per child.


### Reactive properties

**Golden rule: scoped values.** A property line binds to the *nearest enclosing scope*: the host widget in a rule-level `if`, the iteration in a `for` (including in an `if` nested inside the `for`, where it becomes a *conditional* local), the slot in a `slot` definition. An iteration-local is a named, reactive intermediate computed once per iteration and *shared* by everything in that iteration's body. The name is visible only inside the block.

Properties in an active `if` / `elif` / `else` branch **add ordinary kv bindings while active and drop them when inactive**, and they compose exactly like bindings from stacked rules: coexisting drivers settle by reactivity order (the last dependency to change wins), and kv never auto-reverts a property.

So the idiomatic way to drive a property by a condition is `if` / `elif` / `else`, which keeps exactly one binding live and always leaves the property with a defined value:

```yaml
<StatusLabel@Label>:
    error: False
    if self.error:
        color: 1, 0, 0, 1
        bold: True
    else:
        color: 1, 1, 1, 1
        bold: False
```

The `else` branch is how a value comes back - there is no implicit reversion to an earlier state. A property set in a branch with nothing to fall back to (no `else`, no unconditional binding) keeps the branch's last value after it leaves: kv's one-way binding, applied to structure.

Mixing an unconditional binding with a conditional override of the *same* property - or two independent conditional blocks that drive the same property at once - is allowed, but is a power-user move with the usual parallel-binding caveat: while more than one is active their bindings are all live and resolve by reactivity order, just like several rules setting one property:

```yaml
color: self.theme_color     # always bound
if self.urgent:
    color: self.urgent_color     # bound while urgent
# when both are bound, the last reactive update wins
```

Two properties of the model matter:

- **Inactive branches hold no bindings at all.** A branch's expressions are bound and evaluated only when it activates - synchronously, so the value is correct on the first frame - which keeps the property *hot path* untouched: a widget with no active branch performs exactly as before.
- **Teardown is surgical.** Binding a branch records exactly the handler entries it created (`_bind_prop` / `_unbind_captured`), so deactivating it unbinds only its own callbacks and never disturbs another binding's, whether base or sibling.

Handlers and canvas in a branch follow the same mount/teardown discipline: a branch's handlers are `fbind`'d on activation and `unbind_uid`'d on teardown, and its `canvas` is built into one `InstructionGroup` added to the host canvas and removed atomically when the branch leaves.

### Iteration scopes: locals and loop targets

Canvas and handlers are accepted only in `if`/`elif`/`else` blocks outside any `for` - an `if` nested in a `for` follows the for-body rules (nesting context semantics). A property line in a `for` body is not a host property but an **iteration-local** (see below); canvas and handlers, whose per-iteration meaning would be ambiguous, are rejected. A property line in a `slot` definition is a **slot-scoped local** (see below).

A property declared in a `for` body is a value local to each iteration, not a property of the host widget. Each iteration owns a hidden scope object (an `EventDispatcher`); the local is a real reactive property on it, evaluated once per iteration, so a `[]` is a single shared list (every reference in the iteration sees the same object), and it re-evaluates when its dependencies change. References to the name are rewritten at parse time to attribute access on the scope object (`__kvscope_N.name`), so reactivity rides the same watched-keys path as everything else - no new binding engine, and the name is naturally scoped to the block. Locals may reference the loop targets and earlier locals.

The **loop targets live on the same scope object**, as reactive properties. Every reference to a loop variable - in children, locals, handlers, nested headers - is rewritten to scope attribute access, which is what makes keyed reconciliation cheap: when a kept key comes back with a *replaced* item, the runtime just assigns the new values to the scope properties and the existing bindings re-fire. No rebuild, no re-apply pass - the same dispatch that drives `text: self.value` drives "this row now shows another task".

By the nearest-scope rule, a property line in an `if` nested inside a `for` is a *conditional* iteration-local: declared on the scope up front (`None` until first activation), bound while the branch is active, keeping its last value when the branch leaves - the same add/drop-bindings model as conditional host properties, applied to the scope. A local and an `id` cannot share a name: unlike Python shadowing, both writers would stay live (the id writes at mount, the local re-evaluates on every dependency change), so the clash is a parse-time error.

### Slot-scoped locals

A property line in a `slot` definition declares a local on a per-slot scope object, evaluated in the *defining* rule's context. Content reads it through the reserved `slot` name (`slot.badge`), which is injected into the content's evaluation context - deliberately *not* parse-time rewriting: a fill is written in another rule (often another file), whose parser cannot know the slot's local names. Dotted access through an injected dispatcher gives fills reactivity through the ordinary watched-keys path with zero cross-rule knowledge. In nested slots the innermost `slot` wins.

This is deliberately **not** textual inlining: inlining `bucket: []` would substitute a fresh `[]` at each reference, giving three different lists instead of one shared value. Backing the local with a property is what makes the value single and shared.

### Reactive ids

`id` is allowed on a widget inside an `if`, a `for`, or an explicit `slot` block. Because that widget comes and goes, the id can't be a static entry in `root.ids` (it would blink in and out and silently break anything bound to it). Instead it is held as a reactive property on a scope object:

- In an **`if`** the id lives on a rule-level scope, reachable across the whole rule, and is `None` while its branch is inactive - so an expression like `disabled: field is None` reacts to the widget mounting and unmounting. The runtime resets it to `None` when the branch leaves - with a compare-and-set (only the widget that owns the value clears it), so two branches of one chain, or two complementary chains (`if cond:` / `if not cond:`), may share an id: it always points at the widget most recently mounted under that name.
- In a **`for`** the id lives on the iteration scope, reachable only by that iteration's own content, and dies with the iteration.
- In a **`slot` block** (a definition's fallback or a fill) the id lives on the rule-level scope of the rule *providing* that content.

The id'd widget is parse-time marked with its `(scope_key, name)`; at build time the runtime sets `scope.name = widget` instead of touching `root.ids`, and references are rewritten to scope attribute access (so they bind reactively). Scope properties are created `allownone=True, rebind=True`. `id` is still rejected directly on a control statement, inside `factory` blocks, and on plain children implicitly routed into a slot - whether those are routed depends on class rules the parser cannot see from the call site; an explicit `slot:` fill block is the supported spelling.

### Building a widget by class (`factory`)

`factory <expr>` is the single-widget analogue of the span nodes: a `FactoryNode` (an `ExpressionNode`) owns a one-widget span and rebuilds it when the class expression changes. The expression yields a class object or a string resolved through `Factory.get`; the block body is applied to the instance as an ordinary rule (so its properties, children, canvas and handlers all work, and unknown properties auto-create as elsewhere in kv). A constant class name is built once with no binding. `factory` is rejected inside `canvas`.

### Control flow inside canvas

A canvas is an ordered container just like `widget.children`, so the same "reactive span of a container" idea applies - the only differences are the four container ops (build / mount / unmount / teardown). The expression machinery is factored into a mixin (`_ExpressionDriven`) shared by the widget nodes and the canvas nodes, so both react through the identical bound-expression path.

Each canvas `if`/`for` owns one `InstructionGroup` slotted into the enclosing canvas at the block's position; rebuilding clears and refills that group, so instruction positions never need recomputing and content after the block stays put. Nesting composes (a nested block adds its own group to its parent's group). A canvas `for` without a `key:` rebuilds the group wholesale - fine for cheap, stateless drawing; with a `key:` it reconciles per iteration (each iteration owns a sub-group kept, moved or rebuilt by key), so textured/stateful instructions (`Rectangle(source=...)`, `Mesh`, `Fbo`) and large series are not destroyed and re-uploaded on every change - mirroring the widget `for`. Like the widget nodes, the canvas nodes live with their host widget (no module registry), so they are collected with it.

### Other decisions

- **Keyed `for` reconciliation: same key, same widgets.** A kept key keeps (and if needed moves) its widgets; a kept key whose item was replaced gets the new loop values re-dispatched through its scope properties, so live widget state (text mid-edit, focus, selection) survives item updates. Only new keys build and only vanished keys destroy. Keys behave like dict keys (hashable, compared by equality) and must be unique and *stable*. Without `key:` the position in the iterable is the key. In canvas, a kept iteration with changed values is rebuilt instead - instructions hold no user state worth preserving.
- **Slot precedence: most derived wins.** The first rule declaring a slot defines the insertion point and fallback; later same-name blocks are fills (base fallback < subclass fill < instance fill), evaluated in the providing rule's context. Fills may re-expose a slot under a fresh name (forwarding through wrappers), and a slot may live inside an `if`. A filled slot never builds its fallback. Filling a name no class rule ever declared degrades to defining a new insertion point in place - and logs a warning, since an instance-level definition can never be filled (it is almost always a typo).


## Rejected ideas

- **A layered "single live driver" property stack.** An earlier version kept, per `(widget, property)`, a stack of candidate bindings - an unconditional *base* plus one *layer* per active branch - bound only the top layer, gave layers document-order priority (a later block beat an earlier one), and on deactivation *re-asserted* the base, rebinding it live; a companion path recorded a base set in one rule so an `if` in another rule could restore it. Dropped: it is a second precedence model bolted alongside kv's existing "stacked bindings, last-writer-per-dependency wins", and the re-assert step is an implicit revert no other kv binding performs (kv is strictly one-way). The chosen model - a branch adds and removes ordinary bindings - needs none of that machinery, keeps one precedence rule (reactivity order, as everywhere else), and makes reversion explicit via `else`.

- **One global precedence stack across all rules.** A further step would fold cross-rule precedence and branch precedence into a single priority-ordered stack per property, with `-prop:` meaning "clear lower layers". Rejected: applied universally it changes the meaning of existing control-free multi-rule kv (whose bindings coexist today); applied only to control-using widgets it reintroduces the inconsistency it was meant to remove. Cross-rule precedence is therefore left exactly as kv has it today.

- **Reverting a branch-only property to its default.** Considered snapping a property that is set only inside a branch back to its property default when the branch leaves. Rejected as un-kv: one-way bindings never revert. The value is kept; use `else` to set it back deliberately.

- **`for` / `else` for empty states.** Jinja renders the `else` block when the iterable is empty; Python's `for ... else` means something else entirely (run after normal completion), so overloading the keyword would confuse more than it helps. The golden path is a paired `if not x:` block next to the loop - one duplicated condition on the same bound property.

- **`let` for locals.** Considered a dedicated keyword for scoped locals instead of bare property lines. Rejected for now: the nearest-scope rule ("a property line binds to the nearest enclosing scope") is one sentence and covers host properties, iteration-locals and slot-locals uniformly. `let name:` is a syntax error today, so it can still be added later if rule-level locals prove needed.

- **Last-wins for local/id name clashes.** Considered Python-style shadowing. Rejected: unlike Python, neither writer stops - the id writes at mount, the local re-evaluates on each dependency change, so "last" would mean reactivity order and the name would flap between a widget and a value. Every program the clash rejects is broken, so it is a parse-time error.

## Follow-up ideas (out of scope here)

Things this implementation surfaced that stand on their own:

- **AST-based watched keys.** kv's dependency extraction is a regex (`lang_keyvalue`), which is why `field.text.strip()` binds nothing (the dependency must *end* the dotted chain) and why iterating a dict needs the `dict.items(x)` spelling. The parser now runs `ast.parse` over every expression anyway (for scope rewriting); deriving watched keys from the AST would fix both gotchas for *all* of kv, not just control headers. The highest-value follow-up.
- **Mount/unmount transitions.** Nodes have clean mount/unmount seams; `enter:` / `leave:` animation blocks would be a localized extension of `IfNode` / `ForNode`.
- **Scoped slots inside `for`.** Chaining an iteration scope into a slot scope would lift the no-slot-in-for restriction and give the caller-provided-row-template pattern (`List` shells with `slot row:`).
- **Inspector integration.** Nodes are introspectable on their host (`_kv_control_nodes`, spans, active branch, iteration keys); the inspector module could visualize live control flow with little work.


## Restrictions (enforced with targeted error messages)

- No control statements at the top level of a kv file.
- A property line binds to the nearest enclosing scope (host in a rule-level `if`, iteration anywhere under a `for`, slot in a `slot` definition). Handlers and `canvas` are accepted only in `if`/`elif`/`else` outside any `for`; `for` bodies and `slot` blocks take neither. A one-off conditional value can still use an expression (`text: 'a' if cond else 'b'`).
- Inside a `canvas` block only `if`/`for` are allowed (not `slot`/`factory`); their bodies are graphics instructions, and a control statement may not be nested under an individual instruction.
- `id` is allowed on widgets inside `if`/`for` and explicit `slot` blocks (reactive); it is rejected directly on a control statement, on plain children implicitly routed into a slot, and inside `factory` blocks. A local and an `id` cannot share a name.
- `key` is a reserved name inside `for` bodies (an iteration-local cannot be called `key`); keys behave like dict keys and must be unique.
- Loop targets form their own scope and may shadow any name (including `self`/`root`/`app` and the metric helpers); a child widget's own `self`/`args` still win inside that widget. No walrus in headers, no `async for`, single `for` clause.
- No slot definition inside `for`; fills must be direct children of the instance; a `slot:` fill block can't be mixed with plain children. `factory` requires a class expression and is not allowed inside `canvas`.

## Caveats

- The children a control statement builds are managed. Manually *adding* children is safe (appends land after the managed content); manually removing or reordering them (`clear_widgets()` included) declares a second, competing owner of the same list - nothing raises and nothing leaks, but the insertion position of managed content becomes undefined from then on. Kivy-style soft behavior, documented in the language guide.

## Testing

- **60 parser tests** (`test_lang_parser_control.py`): syntax, compiled output, full-body `if` parsing, `factory` parsing, iteration-local and slot-local extraction, conditional locals (if-in-for), reference rewriting, reactive-id scoping (if / for / slot), the local/id name-clash error, and every error path.
- **101 runtime tests** (`test_lang_control_runtime.py`): branch switching; keyed reconciliation - identity across reorders/removals/appends *and* same-key value re-dispatch through kept widgets; nesting both ways; per-item reactivity; slot fallback / fill / inheritance / forwarding / scoped locals / fill ids / unknown-name warning; handler- and `rulectx`-leak regressions; re-entrant rebuild convergence; the full-body `if` - conditional properties as add/remove bindings (one-way, no revert; `else` for graceful reversion; parallel blocks resolve by reactivity order; base coexists across rules), conditional canvas mount/unmount and binding, conditional handlers; iteration-locals (shared identity, reactivity, local-to-local, conditional locals' lifecycle); `factory` (by name and by class, reactive rebuild, inside `for`, document position, unknown-class error context, GC); reactive ids (`if` nullable/reachable-outside, `for` iteration-local, complementary chains sharing an id via compare-and-set reset, no `root.ids` leak, GC); `if`/`for` inside canvas - reactive instruction build/teardown, document position, z-order across branches, nesting, delayed bindings, keyed reconciliation, no instruction-handler leaks; kv-located header errors (non-iterable); and that a widget using control statements is garbage-collected once dropped.
- Full suite green apart from environment-specific collection errors for optional native modules (system tray SDL3, thorvg) present before this change.

Maintainer merge checklist
* [X] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [X] **Unittests** are included in PR.
* [X] Properly documented, including `versionadded`, `versionchanged` as needed.
