### PR TITLE
Update dessant/support-requests action to v5

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -11,7 +11,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/support-requests@v4
+      - uses: dessant/support-requests@v5
         with:
           github-token: ${{ github.token }}
           support-label: 'support'


### PR DESCRIPTION
## Summary
- Bump `dessant/support-requests` from `v4` to `v5` in `.github/workflows/support.yml`.

## Why
The `Support Requests` workflow was failing with:
```
Error: ValidationError: "github-token" length must be less than or equal to 100 characters long
```
in addition to a Node 20 deprecation warning.

- **Node 20 deprecation**: v5.0.0 of the action requires Node.js 24, removing the deprecation warning.
- **`github-token` validation error**: GitHub rolled out a new, longer stateless token format (~520 chars) for `GITHUB_TOKEN`, which exceeded the action's old hardcoded `Joi` validation of `max(100)` characters. This was fixed upstream in `v5.0.1` ("update github-token validation schema"), which raises the limit to `max(1000)`.

Since the workflow already pins the moving major tag `@v5`, this update resolves both issues without any further config changes.

## Test plan
- [ ] Confirm the `Support Requests` workflow runs successfully on the next labeled/unlabeled/reopened issue event without the Node 20 warning or the `github-token` validation error.
- Note: this can't be verified live from the PR itself. The `issues` event trigger only uses the workflow file from the repository's default branch (`master`), not from the PR's branch, so this change will only take effect—and can only be tested—once merged.