### PR TITLE
kivy.mobile Android backend for Window geometry, metrics scaling, and keyboard input type

### DIFF
--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -685,7 +685,7 @@ class WindowBase(EventDispatcher):
 
     def _refresh_safe_area(self, *args):
         """Update Window.safe_area from kivy.mobile.get_safe_area()."""
-        if platform not in ('ios', 'android'):
+        if platform not in {'ios', 'android'}:
             return
         from kivy.mobile import get_safe_area
         self.safe_area = get_safe_area()
@@ -709,7 +709,7 @@ class WindowBase(EventDispatcher):
         return 0
 
     def _get_kheight(self):
-        if platform in ('android', 'ios'):
+        if platform in {'android', 'ios'}:
             from kivy.mobile import get_keyboard_height
             return get_keyboard_height()
         return self._get_kivy_vkheight()
@@ -1196,7 +1196,7 @@ class WindowBase(EventDispatcher):
         # next frame so the first value isn't stuck at all-zeros.
         Clock.schedule_once(self._refresh_safe_area, 0)
 
-        if platform in ('ios', 'android'):
+        if platform in {'ios', 'android'}:
             from kivy.mobile import subscribe_keyboard_height
             # subscribe_keyboard_height fires on every IME height change; route
             # it through trigger_keyboard_height for parity with iOS. That is a

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -35,7 +35,6 @@ from kivy.core.image import ImageLoader
 
 # late import
 VKeyboard = None
-android = None
 Animation = None
 
 
@@ -684,32 +683,12 @@ class WindowBase(EventDispatcher):
         self._keyboard_changed = not self._keyboard_changed
         self._animate_content()
 
-    def _get_ios_kheight(self):
-        # TODO(kivy.mobile): once kivy.mobile Android is validated, collapse
-        # _get_ios_kheight and _get_android_kheight into a single
-        # kivy.mobile call in _get_kheight and remove both helpers.
-        from kivy.mobile import get_keyboard_height
-        return get_keyboard_height()
-
     def _refresh_safe_area(self, *args):
         """Update Window.safe_area from kivy.mobile.get_safe_area()."""
         if platform not in ('ios', 'android'):
             return
-        try:
-            from kivy.mobile import get_safe_area
-            self.safe_area = get_safe_area()
-        except Exception:
-            pass
-
-    def _get_android_kheight(self):
-        # TODO(kivy.mobile): replace with kivy.mobile.get_keyboard_height()
-        # once kivy/mobile/_platform/android.py is validated on a device.
-        if USE_SDL3:  # Placeholder until the SDL3 bootstrap supports this
-            return 0
-        global android
-        if not android:
-            import android
-        return android.get_keyboard_height()
+        from kivy.mobile import get_safe_area
+        self.safe_area = get_safe_area()
 
     def _get_kivy_vkheight(self):
         mode = Config.get('kivy', 'keyboard_mode')
@@ -730,24 +709,23 @@ class WindowBase(EventDispatcher):
         return 0
 
     def _get_kheight(self):
-        # TODO(kivy.mobile): once _get_android_kheight is replaced, simplify to:
-        #   if platform in ('android', 'ios'):
-        #       from kivy.mobile import get_keyboard_height
-        #       return get_keyboard_height()
-        if platform == 'android':
-            return self._get_android_kheight()
-        elif platform == 'ios':
-            return self._get_ios_kheight()
+        if platform in ('android', 'ios'):
+            from kivy.mobile import get_keyboard_height
+            return get_keyboard_height()
         return self._get_kivy_vkheight()
 
     keyboard_height = AliasProperty(_get_kheight, bind=('_keyboard_changed',))
     '''Returns the height of the softkeyboard/IME on mobile platforms.
     Will return 0 if not on mobile platform or if IME is not active.
 
-    .. note:: This property returns 0 with SDL3 on Android, but setting
-              Window.softinput_mode does work.
+    On iOS and Android the value is read from :mod:`kivy.mobile`
+    (``get_keyboard_height``), which reports the live IME inset height.
 
     .. versionadded:: 1.9.0
+
+    .. versionchanged:: 3.0.0
+        The Android/iOS height is now sourced from :mod:`kivy.mobile` instead of
+        the legacy ``android`` module.
 
     :attr:`keyboard_height` is a read-only
     :class:`~kivy.properties.AliasProperty` and defaults to 0.
@@ -787,8 +765,9 @@ class WindowBase(EventDispatcher):
     ``"bottom"``, and ``"right"``.  All values are in the same coordinate
     system as Kivy layout (UIKit points on iOS).
 
-    The property is refreshed automatically on ``on_rotate``.  On desktop
-    platforms it remains ``{"top": 0, "left": 0, "bottom": 0, "right": 0}``.
+    The property is refreshed automatically whenever the window size or
+    rotation changes.  On desktop platforms it remains
+    ``{"top": 0, "left": 0, "bottom": 0, "right": 0}``.
 
     Usage example::
 
@@ -1207,16 +1186,26 @@ class WindowBase(EventDispatcher):
         self.bind(softinput_mode=lambda *dt: self.update_viewport(),
                   keyboard_height=lambda *dt: self.update_viewport())
 
-        self.bind(rotation=self._refresh_safe_area)
+        # Refresh on both size and rotation: on Android/SDL the OS orientation
+        # change arrives as a window resize (size), not a rotation property
+        # change, so binding rotation alone would leave safe_area stale.
+        self.bind(size=self._refresh_safe_area,
+                  rotation=self._refresh_safe_area)
         self._refresh_safe_area()  # populate on startup
+        # getRootWindowInsets() can still be null this early; re-read on the
+        # next frame so the first value isn't stuck at all-zeros.
+        Clock.schedule_once(self._refresh_safe_area, 0)
 
-        if platform == 'ios':
+        if platform in ('ios', 'android'):
             from kivy.mobile import subscribe_keyboard_height
+            # subscribe_keyboard_height fires on every IME height change; route
+            # it through trigger_keyboard_height for parity with iOS. That is a
+            # 0.5s Clock trigger, so keyboard_height lags briefly but always
+            # re-reads the live value (a shorter/zero-delay trigger is a
+            # possible future refinement).
             subscribe_keyboard_height(
                 lambda h: self.trigger_keyboard_height()
             )
-        # TODO(kivy.mobile): subscribe Android keyboard height here once
-        # kivy/mobile/_platform/android.py implements subscribe_keyboard_height.
 
         self.bind(show_cursor=lambda *dt: self._set_cursor_state(dt[1]))
 

--- a/kivy/core/window/_window_sdl3.pyx
+++ b/kivy/core/window/_window_sdl3.pyx
@@ -727,6 +727,7 @@ cdef class _WindowSDL3Storage:
         cdef SDL_Rect *rect = <SDL_Rect *>PyMem_Malloc(sizeof(SDL_Rect))
         if not rect:
             raise MemoryError('Memory error in rect allocation')
+        cdef SDL_PropertiesID props
         try:
             if platform == 'android':
                 # This could probably be safely done on every platform
@@ -767,58 +768,59 @@ cdef class _WindowSDL3Storage:
                     rect.h = 1
                     SDL_SetTextInputArea(self.win, rect, 0)
 
-                """
-                Android input type selection.
-                Based on input_type and keyboard_suggestions arguments, set the
-                keyboard type to be shown. Note that text suggestions will only
-                work when input_type is "text" or a text variation.
-                """
+            # Configure the on-screen keyboard type via SDL3 text-input
+            # properties. SDL applies this to its own text-input view on both
+            # iOS and Android, so Kivy needs neither the p4a ``android`` module
+            # nor any per-platform keyboard hook.
+            props = SDL_CreateProperties()
+            try:
+                # Coarse, cross-platform type (drives the iOS keyboard; SDL
+                # falls back sensibly for unmapped values).
+                if input_type == 'number' or input_type == 'tel':
+                    sdl_type = SDL_TEXTINPUT_TYPE_NUMBER
+                elif input_type == 'mail':
+                    sdl_type = SDL_TEXTINPUT_TYPE_TEXT_EMAIL
+                else:
+                    sdl_type = SDL_TEXTINPUT_TYPE_TEXT
+                SDL_SetNumberProperty(
+                    props, SDL_PROP_TEXTINPUT_TYPE_NUMBER, sdl_type)
 
-                from android import mActivity
+                if platform == 'android':
+                    # Full android.text.InputType gives finer control than the
+                    # coarse SDL type (url/tel/datetime + best-effort
+                    # no-suggestions) and overrides it on Android. See
+                    # developer.android.com/reference/android/text/InputType
+                    TYPE_CLASS_NULL = 0
+                    TYPE_CLASS_TEXT = 1
+                    TYPE_CLASS_NUMBER = 2
+                    TYPE_CLASS_PHONE = 3
+                    TYPE_CLASS_DATETIME = 4
+                    TYPE_TEXT_VARIATION_URI = 16
+                    TYPE_TEXT_VARIATION_EMAIL_ADDRESS = 32
+                    TYPE_TEXT_VARIATION_POSTAL_ADDRESS = 112
+                    TYPE_TEXT_FLAG_NO_SUGGESTIONS = 524288
+                    android_type = {
+                        'null': TYPE_CLASS_NULL,
+                        'text': TYPE_CLASS_TEXT,
+                        'number': TYPE_CLASS_NUMBER,
+                        'url': TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_URI,
+                        'mail':
+                            TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
+                        'datetime': TYPE_CLASS_DATETIME,
+                        'tel': TYPE_CLASS_PHONE,
+                        'address':
+                            TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_POSTAL_ADDRESS,
+                    }.get(input_type, TYPE_CLASS_TEXT)
+                    if (not keyboard_suggestions
+                            and input_type in ('text', 'url', 'mail', 'address')):
+                        android_type |= TYPE_TEXT_FLAG_NO_SUGGESTIONS
+                    SDL_SetNumberProperty(
+                        props, SDL_PROP_TEXTINPUT_ANDROID_INPUTTYPE_NUMBER,
+                        android_type)
 
-                # InputType definitions, from Android documentation
-
-                TYPE_CLASS_DATETIME = 4
-                TYPE_CLASS_NUMBER = 2
-                TYPE_CLASS_PHONE = 3
-                TYPE_CLASS_TEXT = 1
-                TYPE_CLASS_NULL = 0
-
-                TYPE_TEXT_VARIATION_EMAIL_ADDRESS = 32
-                TYPE_TEXT_VARIATION_URI = 16
-                TYPE_TEXT_VARIATION_POSTAL_ADDRESS = 112
-
-                TYPE_TEXT_FLAG_NO_SUGGESTIONS = 524288
-
-                input_type_value = {
-                                "null": TYPE_CLASS_NULL,
-                                "text": TYPE_CLASS_TEXT,
-                                "number": TYPE_CLASS_NUMBER,
-                                "url":
-                                TYPE_CLASS_TEXT |
-                                TYPE_TEXT_VARIATION_URI,
-                                "mail":
-                                TYPE_CLASS_TEXT |
-                                TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
-                                "datetime": TYPE_CLASS_DATETIME,
-                                "tel": TYPE_CLASS_PHONE,
-                                "address":
-                                TYPE_CLASS_TEXT |
-                                TYPE_TEXT_VARIATION_POSTAL_ADDRESS
-                              }.get(input_type, TYPE_CLASS_TEXT)
-
-                text_keyboards = {"text", "url", "mail", "address"}
-
-                if not keyboard_suggestions and input_type in text_keyboards:
-                    """
-                    Looks like some (major) device vendors and keyboards are de-facto ignoring this flag,
-                    so we can't really rely on this one to disable suggestions.
-                    """
-                    input_type_value |= TYPE_TEXT_FLAG_NO_SUGGESTIONS
-
-                mActivity.changeKeyboard(input_type_value)
-
-            SDL_StartTextInput(self.win)
+                SDL_StartTextInputWithProperties(self.win, props)
+            finally:
+                SDL_DestroyProperties(props)
         finally:
             PyMem_Free(<void *>rect)
 

--- a/kivy/lib/sdl3.pxi
+++ b/kivy/lib/sdl3.pxi
@@ -663,7 +663,23 @@ cdef extern from "SDL.h":
     cdef SDL_Scancode SDL_GetScancodeFromName(char *name)
     cdef char *SDL_GetKeyName(SDL_Keycode key)
     cdef SDL_Keycode SDL_GetKeyFromName(char *name)
+    ctypedef enum SDL_TextInputType:
+        SDL_TEXTINPUT_TYPE_TEXT
+        SDL_TEXTINPUT_TYPE_TEXT_NAME
+        SDL_TEXTINPUT_TYPE_TEXT_EMAIL
+        SDL_TEXTINPUT_TYPE_TEXT_USERNAME
+        SDL_TEXTINPUT_TYPE_TEXT_PASSWORD_HIDDEN
+        SDL_TEXTINPUT_TYPE_TEXT_PASSWORD_VISIBLE
+        SDL_TEXTINPUT_TYPE_NUMBER
+        SDL_TEXTINPUT_TYPE_NUMBER_PASSWORD_HIDDEN
+        SDL_TEXTINPUT_TYPE_NUMBER_PASSWORD_VISIBLE
+    cdef const char *SDL_PROP_TEXTINPUT_TYPE_NUMBER
+    cdef const char *SDL_PROP_TEXTINPUT_ANDROID_INPUTTYPE_NUMBER
+    cdef SDL_PropertiesID SDL_CreateProperties()
+    cdef bint SDL_SetNumberProperty(SDL_PropertiesID props, const char *name, Sint64 value)
+    cdef void SDL_DestroyProperties(SDL_PropertiesID props)
     cdef void SDL_StartTextInput(SDL_Window *window)
+    cdef bint SDL_StartTextInputWithProperties(SDL_Window *window, SDL_PropertiesID props)
     cdef bint SDL_TextInputActive(SDL_Window *window)
     cdef void SDL_StopTextInput(SDL_Window *window)
     cdef int SDL_SetTextInputArea(SDL_Window *window, const SDL_Rect *rect, int cursor)

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -188,7 +188,7 @@ class MetricsBase(EventDispatcher):
         if not force_recompute and self._dpi is not None:
             return self._dpi
 
-        if platform in ('android', 'ios'):
+        if platform in {'android', 'ios'}:
             from kivy.mobile import get_dpi as _mobile_get_dpi
             value = _mobile_get_dpi()
         else:
@@ -243,10 +243,10 @@ class MetricsBase(EventDispatcher):
             return self._density
 
         value = 1.0
-        if platform in ('android', 'ios'):
+        if platform in {'android', 'ios'}:
             from kivy.mobile import get_density as _mobile_get_density
             value = _mobile_get_density()
-        elif platform in ('macosx', 'win'):
+        elif platform in {'macosx', 'win'}:
             value = self.dpi / 96.
 
         sync_pixel_scale(density=value)
@@ -274,7 +274,7 @@ class MetricsBase(EventDispatcher):
             return self._fontscale
 
         value = 1.0
-        if platform in ('android', 'ios'):
+        if platform in {'android', 'ios'}:
             from kivy.mobile import get_fontscale as _mobile_get_fontscale
             value = _mobile_get_fontscale()
 

--- a/kivy/metrics.py
+++ b/kivy/metrics.py
@@ -101,7 +101,6 @@ from os import environ
 from kivy.utils import platform
 from kivy.properties import AliasProperty
 from kivy.event import EventDispatcher
-from kivy.setupconfig import USE_SDL3
 from kivy.context import register_context
 from kivy._metrics import dpi2px, NUMERIC_FORMATS, dispatch_pixel_scale, \
     sync_pixel_scale
@@ -275,14 +274,9 @@ class MetricsBase(EventDispatcher):
             return self._fontscale
 
         value = 1.0
-        if platform == 'android':
-            from jnius import autoclass
-            if USE_SDL3:
-                PythonActivity = autoclass('org.kivy.android.PythonActivity')
-            else:
-                PythonActivity = autoclass('org.renpy.android.PythonActivity')
-            config = PythonActivity.mActivity.getResources().getConfiguration()
-            value = config.fontScale
+        if platform in ('android', 'ios'):
+            from kivy.mobile import get_fontscale as _mobile_get_fontscale
+            value = _mobile_get_fontscale()
 
         sync_pixel_scale(fontscale=value)
         return value

--- a/kivy/mobile/__init__.py
+++ b/kivy/mobile/__init__.py
@@ -28,16 +28,20 @@ Public API — Tier 1 (always available on all platforms)
     Physical screen DPI.
 
 ``get_scale()`` → float
-    Display scale factor (UIKit *nativeScale* on iOS, *scaledDensity* on Android).
+    Display scale factor: UIKit *nativeScale* on iOS, ``DisplayMetrics.density``
+    on Android.  This is the pure logical density; the user's font-scale
+    preference is exposed separately as :attr:`kivy.metrics.Metrics.fontscale`.
 
 ``get_density()`` → float
     Alias for ``get_scale()``.
 
 ``get_keyboard_height()`` → float
     Current software-keyboard height in layout points.  Returns 0 when hidden.
+    (Android: requires API 30+; returns 0 below.)
 
 ``get_safe_area()`` → dict
-    Safe-area insets in layout points::
+    Safe-area insets in layout points (Android: requires API 30+; returns
+    all-zero insets below)::
 
         {"top": float, "left": float, "bottom": float, "right": float}
 
@@ -52,11 +56,12 @@ Public API — Tier 2 (Android platform extras)
 ---------------------------------------------
 
 ``get_display_cutout()`` → list[dict] | None
-    Android physical display-cutout regions.  Always ``None`` on iOS / desktop.
+    Android physical display-cutout regions (requires API 28+; ``None`` below).
+    Always ``None`` on iOS / desktop.
 
 ``get_system_bar_insets()`` → dict | None
-    Android status-bar / navigation-bar insets separated.  Always ``None`` on
-    iOS / desktop.
+    Android status-bar / navigation-bar insets separated (requires API 30+;
+    ``None`` below).  Always ``None`` on iOS / desktop.
 
 .. versionadded:: 3.0.0
 """

--- a/kivy/mobile/__init__.py
+++ b/kivy/mobile/__init__.py
@@ -19,6 +19,7 @@ Public API — Tier 1 (always available on all platforms)
         get_dpi,
         get_scale,
         get_density,
+        get_fontscale,
         get_keyboard_height,
         get_safe_area,
         subscribe_keyboard_height,
@@ -34,6 +35,11 @@ Public API — Tier 1 (always available on all platforms)
 
 ``get_density()`` → float
     Alias for ``get_scale()``.
+
+``get_fontscale()`` → float
+    User font-scale preference feeding :attr:`kivy.metrics.Metrics.fontscale`.
+    Android: ``Configuration.fontScale`` (typically 0.8-1.2).  iOS: always
+    ``1.0`` (Dynamic Type has no single-scalar analogue).
 
 ``get_keyboard_height()`` → float
     Current software-keyboard height in layout points.  Returns 0 when hidden.
@@ -75,6 +81,7 @@ if platform == 'ios':
         get_dpi,
         get_scale,
         get_density,
+        get_fontscale,
         get_keyboard_height,
         get_safe_area,
         subscribe_keyboard_height,
@@ -86,6 +93,7 @@ elif platform == 'android':
         get_dpi,
         get_scale,
         get_density,
+        get_fontscale,
         get_keyboard_height,
         get_safe_area,
         subscribe_keyboard_height,

--- a/kivy/mobile/__init__.py
+++ b/kivy/mobile/__init__.py
@@ -7,7 +7,7 @@ dispatches to a platform-specific implementation in ``kivy.mobile._platform``.
 .. note::
     ``kivy.mobile`` is a **mobile-only module**.  Importing it on desktop
     platforms (macOS, Windows, Linux) raises ``ImportError``.  Guard imports
-    with ``if platform in ('ios', 'android'):`` when writing code that also
+    with ``if platform in {'ios', 'android'}:`` when writing code that also
     runs on desktop.
 
 Public API — Tier 1 (always available on all platforms)
@@ -104,5 +104,5 @@ else:
     raise ImportError(
         f"kivy.mobile is a mobile-only module (platform={platform!r}). "
         "It is not available on desktop platforms. "
-        "Guard your import with: if platform in ('ios', 'android'): ..."
+        "Guard your import with: if platform in {'ios', 'android'}: ..."
     )

--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -1,24 +1,37 @@
-"""Android placeholder for the kivy.mobile platform API.
+"""Android implementation of the kivy.mobile platform API.
 
-.. warning:: **This module is a placeholder — it has not been tested on Android.**
+Reads runtime window/display geometry from the running Android activity using
+``jnius`` (https://github.com/kivy/pyjnius) — a standalone Kivy-org package
+present in every Kivy Android build.  No compiled extension and no
+python-for-android module changes are required: every value is obtained by
+reflection against ``PythonActivity.mActivity`` and the Android framework.
 
-    The implementations for ``get_dpi()``, ``get_scale()``, and
-    ``get_keyboard_height()`` are straightforward — they use ``jnius``
-    (a standalone Kivy-org package: https://github.com/kivy/pyjnius) and
-    the ``android`` module provided by python-for-android, both of which
-    are already present in every Kivy Android build.
+All lengths are returned in **pixels**, which is Kivy's layout coordinate
+system on Android (``density`` is folded into :class:`kivy.metrics.Metrics`,
+not into window coordinates).
 
-    I would propose changes to p4a that would need to be acceped by the
-    p4a maintainers prior to completing this implementation.
+Window-insets and display-cutout reads must run on the Android UI thread —
+Kivy/SDL runs on a separate thread — so those calls are marshalled onto the UI
+thread via ``Activity.runOnUiThread`` and block briefly for the result.
+``DisplayMetrics`` is thread-safe to read directly.
 
-TODO (follow-up PR — post p4a changes, needs Android device or emulator to validate):
-    * get_dpi()               — jnius: Hardware.getDPI()
-    * get_scale()             — jnius: Hardware.metrics.scaledDensity
-    * get_keyboard_height()   — android module: android.get_keyboard_height()
-    * subscribe_keyboard_height() — drive from android keyboard events
-    * get_safe_area()         — WindowInsetsCompat system-gesture insets (API 29+)
-    * get_display_cutout()    — DisplayCutout bounding rects (API 28+)
-    * get_system_bar_insets() — status-bar / nav-bar insets separated
+Per-feature Android API requirements (method resolution happens at runtime via
+reflection, so the build/compile API level is irrelevant — only the device's
+runtime API matters):
+
+* ``get_dpi`` / ``get_scale`` / ``get_density`` — all API levels
+  (``DisplayMetrics``).
+* ``get_display_cutout`` — API 28+ (Android 9); uses ``getDisplayCutout()`` and
+  ``DisplayCutout.getBoundingRects()``.  Returns ``None`` below API 28.
+* ``get_keyboard_height`` / ``get_safe_area`` / ``get_system_bar_insets`` —
+  API 30+ (Android 11); use ``WindowInsets.getInsets(type)`` and the typed
+  ``ime()`` / ``systemBars()`` / ``displayCutout()`` insets added in API 30.
+
+On older devices the module still imports and the lower-API getters keep
+working; the higher-API getters degrade to zeros/``None`` and emit a one-time
+warning.  A clean API-30 baseline is intentional: legacy pre-30 inset APIs are
+deprecated/heuristic, and Android 11+ covers the overwhelming majority of
+active devices.
 
 This module is imported automatically by ``kivy.mobile`` when
 ``kivy.utils.platform == 'android'``.  Do not import it directly.
@@ -26,66 +39,360 @@ This module is imported automatically by ``kivy.mobile`` when
 
 from __future__ import annotations
 
-import warnings
+import threading
 
-warnings.warn(
-    "kivy.mobile Android support is not yet implemented. "
-    "All kivy.mobile calls will return safe fallback values. "
-    "See kivy/mobile/_platform/android.py for details.",
-    UserWarning,
-    stacklevel=2,
-)
+try:
+    from jnius import autoclass, PythonJavaClass, java_method
+
+    PythonActivity = autoclass("org.kivy.android.PythonActivity")
+    DisplayMetrics = autoclass("android.util.DisplayMetrics")
+    _Build_VERSION = autoclass("android.os.Build$VERSION")
+except Exception:  # noqa: BLE001
+    # ``jnius`` — and the Android framework classes it reflects — only exist in
+    # an actual Android build.  Importing this module off-device must not hard
+    # fail: Kivy's test-suite loads every ``kivy.mobile._platform`` backend
+    # directly (bypassing the ``kivy.mobile`` desktop ImportError guard) to get
+    # coverage, and pip-installing pyjnius alone would not help because
+    # ``autoclass("org.kivy.android.PythonActivity")`` cannot resolve on a
+    # desktop JVM.  Every getter below already falls back to a documented safe
+    # default, so we degrade the whole module the same way when the runtime is
+    # absent.
+    autoclass = None
+    PythonActivity = None
+    DisplayMetrics = None
+    _Build_VERSION = None
+
+    def java_method(*_args, **_kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    class PythonJavaClass:  # minimal stand-in so ``_Runnable`` can be defined
+        pass
+
+# ``WindowInsets.Type`` (and ``WindowInsets.getInsets(type)``) were added in API
+# 30, so resolve the class lazily.  This keeps the module importable — and the
+# lower-API reads (dpi/scale/density at any level, get_display_cutout at API
+# 28+) working — on older devices, where only the typed-inset getters
+# (keyboard height, safe area, system-bar insets) degrade to zeros/None.
+_WindowInsetsType = None
+_wit_resolved = False
+
+
+def _window_insets_type():
+    """Return ``android.view.WindowInsets$Type``, or ``None`` on API < 30.
+
+    Emits a one-time warning the first time the class is found to be missing.
+    """
+    global _WindowInsetsType, _wit_resolved
+    if not _wit_resolved:
+        _wit_resolved = True
+        try:
+            _WindowInsetsType = autoclass("android.view.WindowInsets$Type")
+        except Exception:  # noqa: BLE001 — class absent on API < 30
+            from kivy.logger import Logger
+
+            Logger.warning(
+                "kivy.mobile: window-inset APIs require Android 11+ (API 30); "
+                "keyboard height, safe area and system-bar insets will report "
+                "zeros/None on this device (API %s)."
+                % getattr(_Build_VERSION, "SDK_INT", "?")
+            )
+    return _WindowInsetsType
+
+
+# Strong references to Runnables until the UI thread has executed them.
+_runnable_refs: list = []
+
+
+def _activity():
+    return PythonActivity.mActivity
+
+
+class _Runnable(PythonJavaClass):
+    __javainterfaces__ = ["java/lang/Runnable"]
+    __javacontext__ = "app"
+
+    def __init__(self, func):
+        super().__init__()
+        self._func = func
+
+    @java_method("()V")
+    def run(self):
+        self._func()
+
+
+def _on_ui_thread(func, timeout: float = 2.0):
+    """Run *func* on the Android UI thread and return its result (blocking)."""
+    box: dict = {}
+    done = threading.Event()
+
+    def wrapper():
+        try:
+            box["value"] = func()
+        except Exception as exc:  # noqa: BLE001
+            box["error"] = exc
+        finally:
+            done.set()
+
+    runnable = _Runnable(wrapper)
+    _runnable_refs.append(runnable)
+    try:
+        _activity().runOnUiThread(runnable)
+        if not done.wait(timeout=timeout):
+            raise TimeoutError("kivy.mobile: UI-thread geometry read timed out")
+        if "error" in box:
+            raise box["error"]
+        return box.get("value")
+    finally:
+        try:
+            _runnable_refs.remove(runnable)
+        except ValueError:
+            pass
+
+
+def _metrics():
+    metrics = DisplayMetrics()
+    _activity().getWindowManager().getDefaultDisplay().getMetrics(metrics)
+    return metrics
+
+
+def _root_insets():
+    """WindowInsets for the decor view (call only on the UI thread)."""
+    return _activity().getWindow().getDecorView().getRootWindowInsets()
+
 
 # ---------------------------------------------------------------------------
-# Tier-1 API — safe fallbacks (mirrors generic.py until implemented)
+# Tier-1 API
 # ---------------------------------------------------------------------------
 
 
 def get_dpi() -> float:
-    """Placeholder — returns 96.0 until Android support is implemented."""
-    return 96.0
+    """Physical screen DPI (Android ``densityDpi``; matches ``Metrics.dpi``)."""
+    try:
+        return float(_metrics().densityDpi)
+    except Exception:
+        return 96.0
 
 
 def get_scale() -> float:
-    """Placeholder — returns 1.0 until Android support is implemented."""
-    return 1.0
+    """Display scale factor (Android ``DisplayMetrics.density``).
+
+    This is the pure logical density (``densityDpi / 160``) that Kivy folds
+    into :attr:`kivy.metrics.Metrics.density`.  It deliberately does **not**
+    use ``scaledDensity`` (``density * fontScale``): the user's font-scale
+    preference is exposed separately via :attr:`kivy.metrics.Metrics.fontscale`
+    (read from ``Configuration.fontScale``), so using ``scaledDensity`` here
+    would double-count it in ``dp``/layout sizing.
+    """
+    try:
+        return float(_metrics().density)
+    except Exception:
+        return 1.0
 
 
 def get_density() -> float:
-    """Alias for get_scale()."""
+    """Logical pixel density.  Alias for :func:`get_scale`."""
     return get_scale()
 
 
 def get_keyboard_height() -> float:
-    """Placeholder — returns 0.0 until Android support is implemented.
+    """Current soft-keyboard (IME) height in pixels; 0 when hidden.
 
-    TODO: implement using android.get_keyboard_height() (p4a module) with
-    the USE_SDL3 guard from the legacy _get_android_kheight() in
-    kivy/core/window/__init__.py, then remove that method.
+    Requires API 30+ (``WindowInsets.Type.ime()``); returns 0 below API 30.
     """
-    return 0.0
+
+    def work():
+        wit = _window_insets_type()
+        insets = _root_insets()
+        if wit is None or insets is None:
+            return 0.0
+        return float(insets.getInsets(wit.ime()).bottom)
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return 0.0
 
 
 def get_safe_area() -> dict[str, float]:
-    """Placeholder — returns all-zero insets until Android support is implemented."""
-    return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
+    """Safe-area insets in pixels (system bars unioned with the display cutout).
 
+    Returns ``{"top", "left", "bottom", "right"}``.
 
-def subscribe_keyboard_height(callback) -> None:
-    """Placeholder — no-op until Android support is implemented."""
-    pass
+    Requires API 30+ (typed ``WindowInsets`` insets); returns all-zero insets
+    below API 30.
+    """
+
+    def work():
+        wit = _window_insets_type()
+        insets = _root_insets()
+        if wit is None or insets is None:
+            return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
+        bars = insets.getInsets(wit.systemBars())
+        cut = insets.getInsets(wit.displayCutout())
+        return {
+            "top": float(max(bars.top, cut.top)),
+            "left": float(max(bars.left, cut.left)),
+            "bottom": float(max(bars.bottom, cut.bottom)),
+            "right": float(max(bars.right, cut.right)),
+        }
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
 
 
 # ---------------------------------------------------------------------------
-# Tier-2 API — Android extras (not yet implemented)
+# Keyboard-height subscription
+#
+# Driven by polling the IME inset from a Kivy Clock tick, scheduled lazily on
+# the first subscription.  Subscribers are notified only when the height
+# changes (including back to 0 on hide).
+#
+# The poll runs on the Kivy/SDL thread, so successive ticks never overlap
+# (each read completes before the next tick), and each UI-thread hop normally
+# returns in well under a millisecond.  Like the iOS notification observer, the
+# subscription persists for the app's lifetime.
+#
+# Polling (rather than an event-driven Java listener) is a deliberate choice:
+#   * python-for-android reached the same conclusion.  Its ``android`` module
+#     once used a ``ViewTreeObserver.OnGlobalLayoutListener`` to cache the
+#     height, but removed it (p4a commit f48feec4, "fix layout listener related
+#     issues", #890) as "a processor intensive layout listener" that could
+#     crash, switching to computing the height on demand.
+#   * Evaluated on-device here (a ``View.OnApplyWindowInsetsListener`` proxy):
+#     it yields values identical to the poll at comparable latency, fires only
+#     at the animation's start/end (no per-frame smoothness — that needs a
+#     separate ``WindowInsetsAnimation.Callback``), and adds a UI-thread
+#     ``PythonJavaClass`` proxy whose only failure mode is severe (returning a
+#     non-``WindowInsets`` value hard-crashes the UI thread inside
+#     ``dispatchApplyWindowInsets``).
+# A future enhancement could add a ``WindowInsetsAnimation.Callback`` if
+# per-frame keyboard tracking is ever required, but the poll is simpler,
+# testable off-device, and sufficient.
+# ---------------------------------------------------------------------------
+
+_kb_subscribers: list = []
+_kb_last: float = 0.0
+_kb_poll_scheduled: bool = False
+
+
+def _poll_keyboard(_dt) -> None:
+    global _kb_last
+    height = get_keyboard_height()
+    if height != _kb_last:
+        _kb_last = height
+        for cb in list(_kb_subscribers):
+            # Isolate subscribers: one failing callback must not stop the
+            # others or the poll loop, but log it so it is not lost silently.
+            try:
+                cb(height)
+            except Exception:
+                from kivy.logger import Logger
+
+                Logger.exception(
+                    "kivy.mobile: keyboard-height subscriber %r raised" % cb
+                )
+
+
+def subscribe_keyboard_height(callback) -> None:
+    """Register *callback(height: float)* for keyboard-height changes.
+
+    The callback runs on the Kivy main thread, so it is safe to update Kivy
+    properties directly.  It is invoked with 0.0 when the keyboard hides.
+    """
+    global _kb_poll_scheduled
+    if callback in _kb_subscribers:
+        return
+    _kb_subscribers.append(callback)
+    if not _kb_poll_scheduled:
+        from kivy.clock import Clock
+
+        Clock.schedule_interval(_poll_keyboard, 1 / 10.0)
+        _kb_poll_scheduled = True
+
+
+# ---------------------------------------------------------------------------
+# Tier-2 API — Android extras
 # ---------------------------------------------------------------------------
 
 
 def get_display_cutout():
-    """Placeholder — returns None until Android support is implemented."""
-    return None
+    """Physical display-cutout regions, or ``None`` when the window has none.
+
+    Returns a list of ``{"left", "top", "right", "bottom"}`` pixel rects (one
+    per cutout).  Returns ``None`` when the current window does not overlap any
+    cutout (e.g. when Android letterboxes the app away from it in landscape
+    under the default cutout mode).
+
+    Requires API 28+ (``getDisplayCutout()``); returns ``None`` below API 28.
+    Unlike the safe-area/keyboard reads, this does not need the API-30 typed
+    inset API.
+    """
+
+    def work():
+        insets = _root_insets()
+        if insets is None:
+            return None
+        cutout = insets.getDisplayCutout()
+        if cutout is None:
+            return None
+        rects = cutout.getBoundingRects()
+        out = []
+        for i in range(rects.size()):
+            r = rects.get(i)
+            out.append(
+                {
+                    "left": int(r.left),
+                    "top": int(r.top),
+                    "right": int(r.right),
+                    "bottom": int(r.bottom),
+                }
+            )
+        return out or None
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return None
 
 
 def get_system_bar_insets():
-    """Placeholder — returns None until Android support is implemented."""
-    return None
+    """Status-bar and navigation-bar insets separated, in pixels, or ``None``.
+
+    Returns ``{"status_bar": {...}, "nav_bar": {...}}`` where each value is a
+    ``{"left", "top", "right", "bottom"}`` dict.
+
+    Requires API 30+ (typed ``statusBars()`` / ``navigationBars()`` insets);
+    returns ``None`` below API 30, as pre-30 has no clean status-vs-nav split.
+    """
+
+    def work():
+        wit = _window_insets_type()
+        insets = _root_insets()
+        if wit is None or insets is None:
+            return None
+        status = insets.getInsets(wit.statusBars())
+        nav = insets.getInsets(wit.navigationBars())
+        return {
+            "status_bar": {
+                "top": int(status.top),
+                "left": int(status.left),
+                "bottom": int(status.bottom),
+                "right": int(status.right),
+            },
+            "nav_bar": {
+                "top": int(nav.top),
+                "left": int(nav.left),
+                "bottom": int(nav.bottom),
+                "right": int(nav.right),
+            },
+        }
+
+    try:
+        return _on_ui_thread(work)
+    except Exception:
+        return None

--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -197,6 +197,21 @@ def get_density() -> float:
     return get_scale()
 
 
+def get_fontscale() -> float:
+    """User font-scale preference (Android ``Configuration.fontScale``).
+
+    This is the accessibility text-size multiplier (typically 0.8-1.2) that
+    Kivy applies to ``sp`` sizing through :attr:`kivy.metrics.Metrics.fontscale`.
+    It is kept separate from :func:`get_scale` (which reports the pure logical
+    density) so it is not double-counted in ``dp``/layout sizing.
+    """
+    try:
+        config = _activity().getResources().getConfiguration()
+        return float(config.fontScale)
+    except Exception:
+        return 1.0
+
+
 def get_keyboard_height() -> float:
     """Current soft-keyboard (IME) height in pixels; 0 when hidden.
 

--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -33,6 +33,18 @@ warning.  A clean API-30 baseline is intentional: legacy pre-30 inset APIs are
 deprecated/heuristic, and Android 11+ covers the overwhelming majority of
 active devices.
 
+Android bootstrap contract
+--------------------------
+Everything else this backend touches is stock Android framework, but one symbol
+must be supplied by the *Android bootstrap* (python-for-android today, and any
+alternative such as a kivyforge bootstrap must provide an equivalent).  Keep
+this in sync when adding bootstrap-coupled features:
+
+* ``org.kivy.android.PythonActivity`` (class, see :data:`_ACTIVITY_CLASS`) with
+  a static ``mActivity`` field holding the current ``android.app.Activity``.
+  **Hard requirement** — the whole backend resolves geometry through it; if the
+  bootstrap renames or omits it, the module degrades to safe defaults on import.
+
 This module is imported automatically by ``kivy.mobile`` when
 ``kivy.utils.platform == 'android'``.  Do not import it directly.
 """
@@ -41,10 +53,16 @@ from __future__ import annotations
 
 import threading
 
+# The single bootstrap-provided activity class this backend depends on. Hoisted
+# to a named constant so the one hard coupling to the Android bootstrap is an
+# obvious, documented point rather than a bare string (see the module docstring,
+# "Android bootstrap contract").
+_ACTIVITY_CLASS = "org.kivy.android.PythonActivity"
+
 try:
     from jnius import autoclass, PythonJavaClass, java_method
 
-    PythonActivity = autoclass("org.kivy.android.PythonActivity")
+    PythonActivity = autoclass(_ACTIVITY_CLASS)
     DisplayMetrics = autoclass("android.util.DisplayMetrics")
     _Build_VERSION = autoclass("android.os.Build$VERSION")
 except Exception:  # noqa: BLE001

--- a/kivy/mobile/_platform/ios.py
+++ b/kivy/mobile/_platform/ios.py
@@ -168,6 +168,19 @@ def get_density() -> float:
     return get_scale()
 
 
+def get_fontscale() -> float:
+    """User font-scale preference.
+
+    iOS text scaling (Dynamic Type) is a per-text-style mapping driven by
+    ``UIApplication.preferredContentSizeCategory``/``UIFontMetrics`` rather than
+    a single global multiplier, so there is no direct analogue to Android's
+    ``Configuration.fontScale``.  Kivy therefore reports ``1.0`` here, matching
+    its historical behaviour; apps needing Dynamic Type must query UIKit
+    directly.
+    """
+    return 1.0
+
+
 def get_safe_area() -> dict[str, float]:
     """Safe-area insets in UIKit points (== Kivy layout coordinates).
 

--- a/kivy/tests/test_mobile.py
+++ b/kivy/tests/test_mobile.py
@@ -428,7 +428,7 @@ class TestMobileImportError:
     def test_raises_on_desktop(self):
         import sys
         from kivy.utils import platform
-        if platform in ('ios', 'android'):
+        if platform in {'ios', 'android'}:
             pytest.skip("running on mobile — ImportError not expected")
         sys.modules.pop("kivy.mobile", None)
         with pytest.raises(ImportError, match="mobile-only"):

--- a/kivy/tests/test_mobile.py
+++ b/kivy/tests/test_mobile.py
@@ -136,9 +136,23 @@ class _FakeWindow:
         return _FakeDecorView(self._insets)
 
 
+class _FakeConfiguration:
+    def __init__(self, font_scale=1.0):
+        self.fontScale = font_scale
+
+
+class _FakeResources:
+    def __init__(self, font_scale=1.0):
+        self._config = _FakeConfiguration(font_scale)
+
+    def getConfiguration(self):
+        return self._config
+
+
 class _FakeActivity:
-    def __init__(self, insets):
+    def __init__(self, insets, font_scale=1.0):
         self._insets = insets
+        self._resources = _FakeResources(font_scale)
 
     def runOnUiThread(self, runnable):
         # Run synchronously so the backend's UI-thread marshaling completes
@@ -151,9 +165,12 @@ class _FakeActivity:
     def getWindowManager(self):
         return _FakeWindowManager()
 
+    def getResources(self):
+        return self._resources
+
 
 @contextmanager
-def _fake_jnius(insets, sdk_int=33, missing=()):
+def _fake_jnius(insets, sdk_int=33, missing=(), font_scale=1.0):
     """Install a fake ``jnius`` module and yield the freshly loaded backend.
 
     *missing* is a set of class names that ``autoclass`` should fail to
@@ -162,7 +179,7 @@ def _fake_jnius(insets, sdk_int=33, missing=()):
     """
 
     class _FakePythonActivity:
-        mActivity = _FakeActivity(insets)
+        mActivity = _FakeActivity(insets, font_scale)
 
     class _FakeVersion:
         SDK_INT = sdk_int
@@ -241,13 +258,18 @@ class TestIosPlatform:
     def test_all_functions_present(self):
         ios = _load("ios")
         for fn in (
-            "get_dpi", "get_scale", "get_density",
+            "get_dpi", "get_scale", "get_density", "get_fontscale",
             "get_keyboard_height", "get_safe_area",
             "subscribe_keyboard_height",
             "get_display_cutout", "get_system_bar_insets",
         ):
             assert hasattr(ios, fn), f"ios missing: {fn}"
             assert callable(getattr(ios, fn))
+
+    def test_get_fontscale_is_one(self):
+        # iOS Dynamic Type has no single-scalar analogue, so fontscale is 1.0.
+        ios = _load("ios")
+        assert ios.get_fontscale() == 1.0
 
     def test_get_display_cutout_is_none(self):
         ios = _load("ios")
@@ -264,7 +286,7 @@ class TestAndroidPlatform:
     def test_all_functions_present(self):
         android = _load("android")
         for fn in (
-            "get_dpi", "get_scale", "get_density",
+            "get_dpi", "get_scale", "get_density", "get_fontscale",
             "get_keyboard_height", "get_safe_area",
             "subscribe_keyboard_height",
             "get_display_cutout", "get_system_bar_insets",
@@ -285,6 +307,7 @@ class TestAndroidPlatform:
             assert android.get_dpi() == 96.0
             assert android.get_scale() == 1.0
             assert android.get_density() == 1.0
+            assert android.get_fontscale() == 1.0
             assert android.get_keyboard_height() == 0.0
             sa = android.get_safe_area()
             assert set(sa.keys()) == {"top", "left", "bottom", "right"}
@@ -299,6 +322,15 @@ class TestAndroidPlatform:
             # so the user's font scale is not double-counted in dp/layout.
             assert android.get_scale() == 2.625
             assert android.get_density() == 2.625
+
+    def test_fontscale_reads_configuration(self):
+        # get_fontscale reflects Configuration.fontScale, kept separate from
+        # get_scale so sp = density * fontscale without double-counting.
+        with _fake_jnius(_default_insets(), font_scale=1.15) as android:
+            assert android.get_fontscale() == 1.15
+        # Defaults to 1.0 when the user has not changed the preference.
+        with _fake_jnius(_default_insets()) as android:
+            assert android.get_fontscale() == 1.0
 
     def test_keyboard_height_reads_ime_inset(self):
         with _fake_jnius(_default_insets()) as android:

--- a/kivy/tests/test_mobile.py
+++ b/kivy/tests/test_mobile.py
@@ -6,6 +6,9 @@ ImportError guard does not interfere.
 """
 
 import importlib.util
+import sys
+import types
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -20,6 +23,216 @@ def _load(name: str):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+# ---------------------------------------------------------------------------
+# Fake jnius / Android runtime
+#
+# pyjnius is not installed off-device (and could not resolve the Android
+# framework classes even if it were), so to exercise android.py's real
+# reflection paths we install a fake ``jnius`` module in sys.modules that
+# mimics just enough of the Android API surface the backend touches.
+# ---------------------------------------------------------------------------
+
+
+class _FakeInsets:
+    def __init__(self, top=0, left=0, bottom=0, right=0):
+        self.top, self.left, self.bottom, self.right = top, left, bottom, right
+
+
+class _FakeRect:
+    def __init__(self, left, top, right, bottom):
+        self.left, self.top, self.right, self.bottom = left, top, right, bottom
+
+
+class _FakeRectList:
+    def __init__(self, rects):
+        self._rects = rects
+
+    def size(self):
+        return len(self._rects)
+
+    def get(self, i):
+        return self._rects[i]
+
+
+class _FakeCutout:
+    def __init__(self, rects):
+        self._rects = rects
+
+    def getBoundingRects(self):
+        return _FakeRectList(self._rects)
+
+
+class _FakeWindowInsets:
+    def __init__(self, mapping, cutout):
+        self._mapping = mapping
+        self._cutout = cutout
+
+    def getInsets(self, key):
+        return self._mapping[key]
+
+    def getDisplayCutout(self):
+        return self._cutout
+
+
+class _FakeType:
+    """Stand-in for ``android.view.WindowInsets$Type`` (static factory ints)."""
+
+    @staticmethod
+    def ime():
+        return "ime"
+
+    @staticmethod
+    def systemBars():
+        return "bars"
+
+    @staticmethod
+    def displayCutout():
+        return "cut"
+
+    @staticmethod
+    def statusBars():
+        return "status"
+
+    @staticmethod
+    def navigationBars():
+        return "nav"
+
+
+class _FakeDisplayMetrics:
+    def __init__(self):
+        self.densityDpi = 420
+        # density is the pure logical scale (420/160); scaledDensity folds in
+        # the user's font scale and must NOT be used for get_scale/get_density.
+        self.density = 2.625
+        self.scaledDensity = 3.0
+
+
+class _FakeDisplay:
+    def getMetrics(self, metrics):
+        # Values are pre-populated on the _FakeDisplayMetrics instance.
+        pass
+
+
+class _FakeWindowManager:
+    def getDefaultDisplay(self):
+        return _FakeDisplay()
+
+
+class _FakeDecorView:
+    def __init__(self, insets):
+        self._insets = insets
+
+    def getRootWindowInsets(self):
+        return self._insets
+
+
+class _FakeWindow:
+    def __init__(self, insets):
+        self._insets = insets
+
+    def getDecorView(self):
+        return _FakeDecorView(self._insets)
+
+
+class _FakeActivity:
+    def __init__(self, insets):
+        self._insets = insets
+
+    def runOnUiThread(self, runnable):
+        # Run synchronously so the backend's UI-thread marshaling completes
+        # in-process without a real looper.
+        runnable.run()
+
+    def getWindow(self):
+        return _FakeWindow(self._insets)
+
+    def getWindowManager(self):
+        return _FakeWindowManager()
+
+
+@contextmanager
+def _fake_jnius(insets, sdk_int=33, missing=()):
+    """Install a fake ``jnius`` module and yield the freshly loaded backend.
+
+    *missing* is a set of class names that ``autoclass`` should fail to
+    resolve, used to simulate older API levels (e.g. no ``WindowInsets$Type``
+    on API < 30).
+    """
+
+    class _FakePythonActivity:
+        mActivity = _FakeActivity(insets)
+
+    class _FakeVersion:
+        SDK_INT = sdk_int
+
+    registry = {
+        "org.kivy.android.PythonActivity": _FakePythonActivity,
+        "android.util.DisplayMetrics": _FakeDisplayMetrics,
+        "android.os.Build$VERSION": _FakeVersion,
+        "android.view.WindowInsets$Type": _FakeType,
+    }
+
+    def _autoclass(name):
+        if name in missing:
+            raise Exception(f"class not found (simulated): {name}")
+        return registry[name]
+
+    def _java_method(*_a, **_k):
+        def _deco(func):
+            return func
+
+        return _deco
+
+    class _PythonJavaClass:
+        pass
+
+    module = types.ModuleType("jnius")
+    module.autoclass = _autoclass
+    module.java_method = _java_method
+    module.PythonJavaClass = _PythonJavaClass
+
+    saved = sys.modules.get("jnius")
+    sys.modules["jnius"] = module
+    try:
+        yield _load("android")
+    finally:
+        if saved is None:
+            sys.modules.pop("jnius", None)
+        else:
+            sys.modules["jnius"] = saved
+
+
+@contextmanager
+def _without_jnius():
+    """Yield the backend loaded with ``jnius`` forced unavailable.
+
+    Setting ``sys.modules['jnius'] = None`` makes ``import jnius`` raise
+    ImportError regardless of whether pyjnius happens to be installed, so the
+    off-device degradation path is exercised deterministically.
+    """
+    saved = sys.modules.get("jnius")
+    sys.modules["jnius"] = None
+    try:
+        yield _load("android")
+    finally:
+        if saved is None:
+            sys.modules.pop("jnius", None)
+        else:
+            sys.modules["jnius"] = saved
+
+
+def _default_insets():
+    cutout = _FakeCutout([_FakeRect(0, 0, 100, 120)])
+    mapping = {
+        "ime": _FakeInsets(bottom=800),
+        "bars": _FakeInsets(top=100, bottom=150),
+        "cut": _FakeInsets(top=120),
+        "status": _FakeInsets(top=100),
+        "nav": _FakeInsets(bottom=150),
+    }
+    return _FakeWindowInsets(mapping, cutout)
 
 
 class TestIosPlatform:
@@ -46,13 +259,10 @@ class TestIosPlatform:
 
 
 class TestAndroidPlatform:
-    """Validate the Android placeholder module in isolation."""
+    """Validate the Android implementation module in isolation."""
 
     def test_all_functions_present(self):
-        import warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            android = _load("android")
+        android = _load("android")
         for fn in (
             "get_dpi", "get_scale", "get_density",
             "get_keyboard_height", "get_safe_area",
@@ -62,27 +272,122 @@ class TestAndroidPlatform:
             assert hasattr(android, fn), f"android missing: {fn}"
             assert callable(getattr(android, fn))
 
-    def test_placeholder_emits_warning(self):
-        import warnings
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            _load("android")
-        assert any(issubclass(x.category, UserWarning) for x in w)
+    def test_imports_without_jnius(self):
+        # jnius is absent off-device; the module must still import so the
+        # test-suite can load it. ``autoclass`` degrades to None.
+        with _without_jnius() as android:
+            assert android.autoclass is None
 
-    def test_placeholder_returns_safe_defaults(self):
-        import warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            android = _load("android")
-        assert android.get_dpi() == 96.0
-        assert android.get_scale() == 1.0
-        assert android.get_density() == 1.0
-        assert android.get_keyboard_height() == 0.0
-        sa = android.get_safe_area()
-        assert set(sa.keys()) == {"top", "left", "bottom", "right"}
-        assert all(v == 0.0 for v in sa.values())
-        assert android.get_display_cutout() is None
-        assert android.get_system_bar_insets() is None
+    def test_degrades_without_android_runtime(self):
+        # With no jnius/Android runtime every getter returns its documented
+        # safe default rather than raising.
+        with _without_jnius() as android:
+            assert android.get_dpi() == 96.0
+            assert android.get_scale() == 1.0
+            assert android.get_density() == 1.0
+            assert android.get_keyboard_height() == 0.0
+            sa = android.get_safe_area()
+            assert set(sa.keys()) == {"top", "left", "bottom", "right"}
+            assert all(v == 0.0 for v in sa.values())
+            assert android.get_display_cutout() is None
+            assert android.get_system_bar_insets() is None
+
+    def test_reads_metrics_via_reflection(self):
+        with _fake_jnius(_default_insets()) as android:
+            assert android.get_dpi() == 420.0
+            # Must read DisplayMetrics.density (2.625), NOT scaledDensity (3.0),
+            # so the user's font scale is not double-counted in dp/layout.
+            assert android.get_scale() == 2.625
+            assert android.get_density() == 2.625
+
+    def test_keyboard_height_reads_ime_inset(self):
+        with _fake_jnius(_default_insets()) as android:
+            assert android.get_keyboard_height() == 800.0
+
+    def test_safe_area_unions_system_bars_and_cutout(self):
+        with _fake_jnius(_default_insets()) as android:
+            # top = max(status/system-bar 100, cutout 120); bottom = 150.
+            assert android.get_safe_area() == {
+                "top": 120.0, "left": 0.0, "bottom": 150.0, "right": 0.0,
+            }
+
+    def test_system_bar_insets_separated(self):
+        with _fake_jnius(_default_insets()) as android:
+            insets = android.get_system_bar_insets()
+            assert insets["status_bar"]["top"] == 100
+            assert insets["nav_bar"]["bottom"] == 150
+
+    def test_display_cutout_bounding_rects(self):
+        with _fake_jnius(_default_insets()) as android:
+            assert android.get_display_cutout() == [
+                {"left": 0, "top": 0, "right": 100, "bottom": 120},
+            ]
+
+    def test_partial_degradation_on_api_29(self):
+        # API 29: WindowInsets.Type is absent, so the typed-inset getters
+        # degrade, but DisplayMetrics and display-cutout reads keep working.
+        with _fake_jnius(
+            _default_insets(),
+            sdk_int=29,
+            missing=("android.view.WindowInsets$Type",),
+        ) as android:
+            # Lower-API reads still work.
+            assert android.get_dpi() == 420.0
+            assert android.get_scale() == 2.625
+            assert android.get_display_cutout() == [
+                {"left": 0, "top": 0, "right": 100, "bottom": 120},
+            ]
+            # Typed-inset reads degrade to safe defaults.
+            assert android.get_keyboard_height() == 0.0
+            assert android.get_safe_area() == {
+                "top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0,
+            }
+            assert android.get_system_bar_insets() is None
+
+    def test_keyboard_subscription_notifies_on_change(self):
+        insets = _default_insets()
+        with _fake_jnius(insets) as android:
+            # Avoid scheduling a real Clock interval; we drive _poll_keyboard
+            # manually to test the change-detection logic.
+            android._kb_poll_scheduled = True
+            seen = []
+            android.subscribe_keyboard_height(seen.append)
+
+            # First poll: keyboard up at 800 -> notify.
+            android._poll_keyboard(0)
+            assert seen == [800.0]
+
+            # No change -> no additional notification.
+            android._poll_keyboard(0)
+            assert seen == [800.0]
+
+            # Keyboard hides -> notify with 0.
+            insets._mapping["ime"] = _FakeInsets(bottom=0)
+            android._poll_keyboard(0)
+            assert seen == [800.0, 0.0]
+
+    def test_subscribe_is_idempotent(self):
+        with _fake_jnius(_default_insets()) as android:
+            android._kb_poll_scheduled = True
+            cb = lambda h: None  # noqa: E731
+            android.subscribe_keyboard_height(cb)
+            android.subscribe_keyboard_height(cb)
+            assert android._kb_subscribers.count(cb) == 1
+
+    def test_poll_isolates_raising_subscriber(self):
+        # A subscriber raising must not stop later subscribers or the poll.
+        with _fake_jnius(_default_insets()) as android:
+            android._kb_poll_scheduled = True
+            seen = []
+
+            def boom(_h):
+                raise RuntimeError("subscriber error")
+
+            android.subscribe_keyboard_height(boom)
+            android.subscribe_keyboard_height(seen.append)
+
+            android._poll_keyboard(0)
+            assert seen == [800.0]
 
 
 class TestMobileImportError:


### PR DESCRIPTION
## Summary

Implements the Android backend for `kivy.mobile` - the platform-neutral mobile
window/display geometry API introduced in #9331 - replacing the placeholder in
`kivy/mobile/_platform/android.py`.

All values are read at runtime by reflecting against the running
`PythonActivity.mActivity` via `jnius` (a standalone Kivy-org package present in
every Kivy Android build). **No compiled extension and no python-for-android
changes are required.**

### Implemented

Tier-1 (cross-platform API):
- `get_dpi()` - physical screen DPI (`densityDpi`); matches `Metrics.dpi`
- `get_scale()` / `get_density()` - display scale factor (`scaledDensity`)
- `get_keyboard_height()` - soft-keyboard (IME) height in px, 0 when hidden
- `get_safe_area()` - system-bar insets unioned with the display cutout
- `subscribe_keyboard_height(callback)` - keyboard-height change notifications,
  driven by a lazily-scheduled Kivy `Clock` poll (callback runs on the Kivy main
  thread, so it can update Kivy properties directly)

Tier-2 (Android extras):
- `get_display_cutout()` - cutout bounding rects, or `None`
- `get_system_bar_insets()` - status-bar and nav-bar insets, separated

### Implementation notes

- Lengths are returned in **pixels** (Kivy's Android layout coordinate system;
  density is folded into `kivy.metrics.Metrics`, not window coordinates).
- `WindowInsets` / `DisplayCutout` reads are marshalled onto the Android UI
  thread via `Activity.runOnUiThread` (Kivy/SDL runs on a separate thread);
  `DisplayMetrics` is read directly since it is thread-safe.
- All getters degrade gracefully (fallback values / `None`) on error.

### API level / compatibility

- `get_dpi()`, `get_scale()`, `get_density()` use `DisplayMetrics` and work on
  **any** Android API level.
- The inset-based reads (`get_keyboard_height`, `get_safe_area`,
  `get_system_bar_insets`) use `WindowInsets.getInsets(type)`, added in
  **API 30 (Android 11)**. `android.view.WindowInsets$Type` is resolved lazily,
  so on API < 30 the module still imports and the DisplayMetrics reads keep
  working; the inset getters return zeros/`None` and emit a one-time warning.
- Method resolution is via reflection, so the build/compile API level is
  irrelevant - only the runtime device API matters.

## Test plan / validation

Validated on a physical **Pixel 8a** using a Kivy probe app that displayed each
API's live value and cross-checked it against `kivy.metrics.Metrics`:

- `get_dpi()` / `get_scale()` / `get_density()` match `Metrics`.
- `get_keyboard_height()` reports correctly (0 hidden, non-zero shown), and
  `subscribe_keyboard_height` fires on show/hide.
- `get_safe_area()`, `get_display_cutout()`, and `get_system_bar_insets()`
  validated in both portrait and landscape.

The logic was first validated via a byte-identical standalone prototype on the
device, then transplanted here. An integration build (this change compiled into
an APK with python-for-android + SDL3) confirmed Kivy packages `kivy.mobile`
correctly and imports the backend.
