### PR TITLE
style: use set literals for list-based membership tests

### DIFF
--- a/examples/keyboard/main.py
+++ b/examples/keyboard/main.py
@@ -124,7 +124,7 @@ class ModeScreen(Screen):
         self.mode_spinner.text = "'{0}'".format(self.keyboard_mode)
 
         p1 = "Current keyboard mode: '{0}'\n\n".format(self.keyboard_mode)
-        if self.keyboard_mode in ['dock', 'system', 'systemanddock']:
+        if self.keyboard_mode in {'dock', 'system', 'systemanddock'}:
             p2 = "You have the right setting to use this demo.\n\n"
         else:
             p2 = "You need the keyboard mode to 'dock', 'system' or '"\

--- a/kivy/clock.py
+++ b/kivy/clock.py
@@ -503,7 +503,7 @@ try:
                 obj, ctypes.byref(delay), 0,
                 ctypes.c_void_p(), ctypes.c_void_p(), False)
             _kernel32.WaitForSingleObject(obj, 0xffffffff)
-    elif platform in ['android', 'ios']:
+    elif platform in {'android', 'ios'}:
         # on mobile platforms, just use time.sleep
         def _usleep(microseconds, obj=None):
             time.sleep(microseconds / 1000000.)

--- a/kivy/core/camera/__init__.py
+++ b/kivy/core/camera/__init__.py
@@ -138,7 +138,7 @@ class CameraBase(EventDispatcher):
 all_providers = get_provider_modules('camera')
 providers = []
 
-if platform in ['macosx', 'ios']:
+if platform in {'macosx', 'ios'}:
     providers.append(make_provider_tuple(
         'avfoundation', all_providers, 'CameraAVFoundation'
     ))

--- a/kivy/core/window/__init__.py
+++ b/kivy/core/window/__init__.py
@@ -714,7 +714,7 @@ class WindowBase(EventDispatcher):
     def _get_kivy_vkheight(self):
         mode = Config.get('kivy', 'keyboard_mode')
         if (
-            mode in ['dock', 'systemanddock']
+            mode in {'dock', 'systemanddock'}
             and self._vkeyboard_cls is not None
         ):
             for w in self.children:
@@ -2102,7 +2102,7 @@ class WindowBase(EventDispatcher):
             mActivity.moveTaskToBack(True)
             return True
         elif WindowBase.on_keyboard.exit_on_escape:
-            if key == 27 or all([is_osx, key in [113, 119], modifier == 1024]):
+            if key == 27 or all([is_osx, key in {113, 119}, modifier == 1024]):
                 if not self.dispatch('on_request_close', source='keyboard'):
                     stopTouchApp()
                     self.close()

--- a/kivy/input/providers/tuio.py
+++ b/kivy/input/providers/tuio.py
@@ -167,7 +167,7 @@ class TuioMotionEventProvider(MotionEventProvider):
         oscpath, command, args = value
 
         # verify commands
-        if command not in [b'alive', b'set']:
+        if command not in {b'alive', b'set'}:
             return
 
         # move or create a new touch

--- a/kivy/loader.py
+++ b/kivy/loader.py
@@ -333,7 +333,7 @@ class LoaderBase(object):
                 # A custom context is only needed on Android and iOS
                 # as we need to use the certs provided via certifi.
                 ssl_ctx = None
-                if platform in ['android', 'ios']:
+                if platform in {'android', 'ios'}:
                     import certifi
                     import ssl
                     ssl_ctx = ssl.create_default_context(cafile=certifi.where())

--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -225,7 +225,7 @@ class UrlRequestBase(Thread):
         self._requested_url = url
         self._auth = auth
 
-        if platform in ['android', 'ios']:
+        if platform in {'android', 'ios'}:
             import certifi
             self.ca_file = ca_file or certifi.where()
         else:

--- a/kivy/tests/test_uix_bubble.py
+++ b/kivy/tests/test_uix_bubble.py
@@ -411,13 +411,13 @@ class BubbleTest(GraphicUnitTest):
                 self.render(bubble)
 
                 haw = bubble.arrow_width / 2  # half arrow_width
-                if arrow_side in ["l", "r"]:
+                if arrow_side in {"l", "r"}:
                     self.assertSequenceAlmostEqual(
                         bubble.arrow_center_pos_within_arrow_layout,
                         (haw, flex_arrow_pos[1]),
                         delta=haw,
                     )
-                elif arrow_side in ["b", "t"]:
+                elif arrow_side in {"b", "t"}:
                     self.assertSequenceAlmostEqual(
                         bubble.arrow_center_pos_within_arrow_layout,
                         (flex_arrow_pos[0], haw),

--- a/kivy/tools/gallery.py
+++ b/kivy/tools/gallery.py
@@ -246,7 +246,7 @@ def make_detail_page(info):
         if '\\' in full_name:
             full_name = full_name.replace(sep, sep * 2)
 
-        if ext in ['.png', '.jpg', '.jpeg']:
+        if ext in {'.png', '.jpg', '.jpeg'}:
             title = 'Image **' + full_name + '**'
             a('\n' + title)
             a('~' * len(title))

--- a/kivy/uix/textinput.py
+++ b/kivy/uix/textinput.py
@@ -1359,7 +1359,7 @@ class TextInput(FocusBehavior, Widget):
                 else:
                     col, row = col + 1, row
 
-        dont_move_cursor = control and action in ['cursor_up', 'cursor_down']
+        dont_move_cursor = control and action in {'cursor_up', 'cursor_down'}
         if dont_move_cursor:
             self._trigger_update_graphics()
         else:

--- a/setup.py
+++ b/setup.py
@@ -319,9 +319,9 @@ c_options['use_x11'] = False
 c_options['use_wayland'] = None
 c_options['use_gstreamer'] = None
 c_options['use_thorvg'] = None
-c_options['use_avfoundation'] = platform in ['darwin', 'ios']
+c_options['use_avfoundation'] = platform in {'darwin', 'ios'}
 c_options['use_osx_frameworks'] = platform == 'darwin'
-c_options['use_angle_gl_backend'] = platform in ['darwin', 'ios']
+c_options['use_angle_gl_backend'] = platform in {'darwin', 'ios'}
 c_options['debug_gl'] = False
 
 # now check if environ is changing the default values
@@ -624,7 +624,7 @@ if c_options['use_sdl3'] or can_autodetect_sdl3:
             sdl3_source = 'macos-frameworks'
             print('Activate SDL3 compilation')
 
-    if not sdl3_valid and platform not in ["android", "ios"]:
+    if not sdl3_valid and platform not in {"android", "ios"}:
         # use pkg-config approach instead
         sdl3_flags = pkgconfig('sdl3', 'sdl3-ttf', 'sdl3-image', 'sdl3-mixer')
         if 'libraries' in sdl3_flags:
@@ -1119,7 +1119,7 @@ def determine_gl_flags():
                 'for rpi platform, falling back to EGL and GLESv2.')
             gl_libs = ['EGL', 'GLESv2']
         flags['libraries'] = ['bcm_host'] + gl_libs
-    elif platform in ['mali', 'vc']:
+    elif platform in {'mali', 'vc'}:
         flags['include_dirs'] = ['/usr/include/']
         flags['library_dirs'] = ['/usr/lib/arm-linux-gnueabihf']
         flags['libraries'] = ['GLESv2']


### PR DESCRIPTION
## Summary

Membership tests written against a **list literal** (`x in [...]`) build a
throwaway list and scan it linearly. A **set literal** (`x in {...}`) is hashed
for O(1) membership and more clearly signals intent — order and duplicates are
irrelevant for a membership check.

This PR converts the list-literal membership tests flagged by ruff's
[`PLR6201` (`literal-membership`)](https://docs.astral.sh/ruff/rules/literal-membership/)
rule to set literals. All converted literals contain only hashable, static
values (strings, ints, bytes), so the change is behavior-preserving.

## Changes

16 call sites across 11 files:

- `examples/keyboard/main.py`
- `kivy/clock.py`
- `kivy/core/camera/__init__.py`
- `kivy/core/window/__init__.py` (2)
- `kivy/input/providers/tuio.py`
- `kivy/loader.py`
- `kivy/network/urlrequest.py`
- `kivy/tests/test_uix_bubble.py` (2)
- `kivy/tools/gallery.py`
- `kivy/uix/textinput.py`
- `setup.py` (4)

## Notes

- The vendored pycodestyle copy in `kivy/tools/pep8checker/pep8.py` has one
  matching test but is intentionally **left untouched** to avoid diverging from
  upstream third-party code.
- Scope is limited to **list**-literal membership tests. Tuple-literal tests
  are out of scope for this PR.

## Test plan

- [ ] `ruff check` passes on the changed files
- [ ] CI green
