### PR TITLE
Accept pathlib.Path in path-accepting APIs

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -475,7 +475,7 @@ from kivy.logger import Logger
 from kivy.event import EventDispatcher
 from kivy.lang import Builder
 from kivy.resources import resource_find
-from kivy.utils import platform, normalize_path_id
+from kivy.utils import platform, normalize_path_id, path_to_str
 from kivy.uix.widget import Widget
 from kivy.properties import ObjectProperty, StringProperty
 from kivy.setupconfig import USE_SDL3
@@ -730,8 +730,13 @@ class App(EventDispatcher):
             :meth:`run` is called (e.g. in `__init__`), won't have its styling
             applied. Note that :meth:`build` is called after :attr:`load_kv`
             has been called.
+
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str``.
         '''
         # Detect filename automatically if it was not specified.
+        filename = path_to_str(filename)
         if filename:
             filename = resource_find(filename)
         else:
@@ -818,8 +823,12 @@ class App(EventDispatcher):
             Changed the Android version to make use of the
             :attr:`~App.user_data_dir` and added a missing dot to the iOS
             config file name.
-        '''
 
+        .. versionchanged:: 3.0.0
+            `defaultpath` may be a :class:`os.PathLike` (e.g.
+            :class:`pathlib.Path`) in addition to a ``str``.
+        '''
+        defaultpath = path_to_str(defaultpath)
         if platform == 'android':
             return join(self.user_data_dir, '.{0}.ini'.format(self.name))
         elif platform == 'ios':

--- a/kivy/atlas.py
+++ b/kivy/atlas.py
@@ -145,6 +145,7 @@ from os.path import basename, dirname, join, splitext
 from kivy.event import EventDispatcher
 from kivy.logger import Logger
 from kivy.properties import AliasProperty, DictProperty, ListProperty
+from kivy.utils import path_to_str
 import os
 
 
@@ -183,7 +184,7 @@ class Atlas(EventDispatcher):
     '''
 
     def __init__(self, filename):
-        self._filename = filename
+        self._filename = path_to_str(filename)
         super(Atlas, self).__init__()
         self._load()
 

--- a/kivy/config.py
+++ b/kivy/config.py
@@ -446,7 +446,7 @@ from weakref import ref
 
 from kivy import kivy_config_fn
 from kivy.logger import Logger, logger_config_update
-from kivy.utils import pi_version, platform
+from kivy.utils import pi_version, platform, path_to_str
 
 _is_rpi = exists('/opt/vc/include/bcm_host.h')
 
@@ -533,7 +533,15 @@ class ConfigParser(PythonConfigParser, object):
         .. versionchanged:: 1.9.0
             :meth:`read` now calls the callbacks if read changed any values.
 
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str``. Passing multiple filenames (a list) is
+            still rejected.
+
         '''
+        # Coerce os.PathLike -> str; still reject anything else (e.g. a list of
+        # filenames) to preserve the "one filename only" contract.
+        filename = path_to_str(filename)
         if not isinstance(filename, str):
             raise Exception('Only one filename is accepted (str)')
         self.filename = filename

--- a/kivy/core/audio_output/__init__.py
+++ b/kivy/core/audio_output/__init__.py
@@ -103,7 +103,7 @@ from kivy.core import core_register_libs, load_with_provider_selection, \
 from kivy.resources import resource_find
 from kivy.properties import StringProperty, NumericProperty, OptionProperty, \
     AliasProperty, BooleanProperty, BoundedNumericProperty
-from kivy.utils import platform
+from kivy.utils import platform, path_to_str
 from kivy.setupconfig import USE_SDL3
 
 from sys import float_info
@@ -157,7 +157,14 @@ class SoundLoader:
         :returns: A Sound instance, or None if no loader could handle the file.
         :raises ValueError: If ``audio_output_provider`` is specified but not
             found or doesn't support the file format (when KIVY_PROVIDER_STRICT=1).
+
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str``.
         '''
+        # Coerce os.PathLike -> str so extension parsing below is safe even
+        # when resource_find does not resolve the file.
+        filename = path_to_str(filename)
         rfn = resource_find(filename)
         if rfn is not None:
             filename = rfn

--- a/kivy/core/image/__init__.py
+++ b/kivy/core/image/__init__.py
@@ -316,7 +316,7 @@ from kivy.cache import Cache
 from kivy.clock import Clock
 from kivy.atlas import Atlas
 from kivy.resources import resource_find
-from kivy.utils import platform
+from kivy.utils import platform, path_to_str
 from kivy.setupconfig import USE_SDL3
 import zipfile
 from io import BytesIO
@@ -760,6 +760,8 @@ class ImageLoader(object):
 
     @staticmethod
     def load(filename, **kwargs):
+        # Coerce os.PathLike -> str before any URI/extension string parsing.
+        filename = path_to_str(filename)
         # Handle atlas:// URIs
         result = ImageLoader._load_atlas(filename)
         if result is not None:
@@ -874,6 +876,11 @@ class Image(EventDispatcher):
         # indicator of images having been loded in cache
         self._iteration_done = False
         self._image_provider = kwargs.get('image_provider', None)
+
+        # Accept os.PathLike (e.g. pathlib.Path) as a filename argument by
+        # coercing to str; non-path args (Image, Texture, BytesIO, ...) are
+        # left untouched.
+        arg = path_to_str(arg)
 
         if isinstance(arg, Image):
             for attr in Image.copy_attributes:
@@ -1041,10 +1048,14 @@ class Image(EventDispatcher):
         '''Load an image
 
         :Parameters:
-            `filename`: str
+            `filename`: str or os.PathLike
                 Filename of the image.
             `keep_data`: bool, defaults to False
                 Keep the image data when the texture is created.
+
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str``.
         '''
         kwargs.setdefault('keep_data', False)
         return Image(filename, **kwargs)
@@ -1084,6 +1095,7 @@ class Image(EventDispatcher):
         return self._filename
 
     def _set_filename(self, value):
+        value = path_to_str(value)
         if value is None or value == self._filename:
             return
         self._filename = value
@@ -1224,7 +1236,13 @@ class Image(EventDispatcher):
             Parameter `fmt` added to force the output format of the file
             Filename can now be a BytesIO object.
 
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str`` or a BytesIO-like object.
+
         '''
+        # Coerce os.PathLike -> str (BytesIO-like objects pass through).
+        filename = path_to_str(filename)
         is_bytesio_like = False
         if callable(getattr(filename, 'read', None)):
             # BytesIO like(RawIO, RawIOBase, BytesIO..)

--- a/kivy/core/lottie/__init__.py
+++ b/kivy/core/lottie/__init__.py
@@ -66,6 +66,7 @@ import json
 from kivy.clock import Clock
 from kivy.core import core_select_lib, get_provider_modules, make_provider_tuple
 from kivy.event import EventDispatcher
+from kivy.utils import path_to_str
 
 
 class LottieBase(EventDispatcher):
@@ -161,6 +162,7 @@ class LottieBase(EventDispatcher):
         return self._filename
 
     def _set_filename(self, filename):
+        filename = path_to_str(filename)
         if filename == self._filename:
             return
         self.unload()

--- a/kivy/core/svg/__init__.py
+++ b/kivy/core/svg/__init__.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 
 from kivy.logger import Logger
 from kivy.core import core_register_libs, get_provider_modules, make_provider_tuple
+from kivy.utils import path_to_str
 
 
 class SvgProviderBase(ABC):
@@ -152,10 +153,15 @@ class SvgLoader:
         '''Try each registered provider in order and return the first that
         successfully loads *source*.
 
-        :param str source: File path to the SVG document.
+        :param source: File path (``str`` or :class:`os.PathLike`) to the SVG
+            document.
         :returns: A loaded :class:`SvgProviderBase` instance, or ``None`` if
             no provider could load the document.
+
+        .. versionchanged:: 3.0.0
+            `source` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`).
         '''
+        source = path_to_str(source)
         for provider_class in cls.providers:
             try:
                 provider = provider_class()

--- a/kivy/core/text/__init__.py
+++ b/kivy/core/text/__init__.py
@@ -133,7 +133,7 @@ from functools import partial
 from copy import copy
 from kivy import kivy_data_dir
 from kivy.config import Config
-from kivy.utils import platform
+from kivy.utils import platform, path_to_str
 from kivy.graphics.texture import Texture
 from kivy.core import core_register_libs, get_provider_modules, make_provider_tuple
 from kivy.core.text.text_layout import layout_text, LayoutWord
@@ -432,6 +432,10 @@ class LabelBase(object):
         All the fn_regular/fn_italic/fn_bold parameters are resolved with
         :func:`kivy.resources.resource_find`. If fn_italic/fn_bold are None,
         fn_regular will be used instead.
+
+        .. versionchanged:: 3.0.0
+            The ``fn_*`` font paths may be :class:`os.PathLike` (e.g.
+            :class:`pathlib.Path`) in addition to ``str``.
         '''
 
         if fn_regular is None:
@@ -440,6 +444,7 @@ class LabelBase(object):
         fonts = []
 
         for font_type in fn_regular, fn_italic, fn_bold, fn_bolditalic:
+            font_type = path_to_str(font_type)
             if font_type is not None:
                 font = resource_find(font_type)
 
@@ -529,7 +534,10 @@ class LabelBase(object):
 
     def resolve_font_name(self):
         options = self.options
-        fontname = options['font_name']
+        # Coerce os.PathLike -> str and write back so downstream string ops
+        # (endswith/format) and the _fonts / _fonts_cache dict keys are
+        # consistent regardless of whether a Path or str was supplied.
+        fontname = options['font_name'] = path_to_str(options['font_name'])
         fonts = self._fonts
         fontscache = self._fonts_cache
 

--- a/kivy/core/video/__init__.py
+++ b/kivy/core/video/__init__.py
@@ -38,6 +38,7 @@ from kivy.clock import Clock
 from kivy.core import core_select_lib, get_provider_modules, make_provider_tuple
 from kivy.event import EventDispatcher
 from kivy.logger import Logger
+from kivy.utils import path_to_str
 
 
 class VideoBase(EventDispatcher):
@@ -147,6 +148,7 @@ class VideoBase(EventDispatcher):
         return self._filename
 
     def _set_filename(self, filename):
+        filename = path_to_str(filename)
         if filename == self._filename:
             return
         self.unload()
@@ -250,7 +252,11 @@ class VideoBase(EventDispatcher):
         an informational message and returns ``None``.
 
         .. versionadded:: 3.0.0
+
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`).
         '''
+        filename = path_to_str(filename)
         Logger.info(
             'VideoBase: generate_thumbnail is not supported by '
             'provider {!r}'.format(cls.__name__))

--- a/kivy/lang/builder.py
+++ b/kivy/lang/builder.py
@@ -22,6 +22,7 @@ from kivy.logger import Logger
 from kivy import kivy_data_dir
 from kivy.context import register_context
 from kivy.resources import resource_find
+from kivy.utils import path_to_str
 from kivy._event import Observable, EventDispatcher
 
 __all__ = ('Observable', 'Builder', 'BuilderBase', 'BuilderException')
@@ -308,8 +309,13 @@ class BuilderBase(object):
                 widget inside the definition.
 
             `encoding`: File character encoding. Defaults to utf-8,
+
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str``.
         '''
 
+        filename = path_to_str(filename)
         filename = resource_find(filename) or filename
         if __debug__:
             trace('Lang: load file %s, using %s encoding', filename, encoding)
@@ -328,8 +334,13 @@ class BuilderBase(object):
 
             This will not remove rules already applied/used on current
             widgets. It will only effect the next widgets creation.
+
+        .. versionchanged:: 3.0.0
+            `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+            in addition to a ``str``.
         '''
         # remove rules associated with this file
+        filename = path_to_str(filename)
         filename = resource_find(filename) or filename
         self.rules = [x for x in self.rules if x[1].ctx.filename != filename]
         self._clear_matchcache()
@@ -368,7 +379,7 @@ class BuilderBase(object):
         '''
 
         kwargs.setdefault('rulesonly', False)
-        self._current_filename = fn = kwargs.get('filename', None)
+        self._current_filename = fn = path_to_str(kwargs.get('filename', None))
 
         # put a warning if a file is loaded multiple times
         if fn in self.files:

--- a/kivy/properties.pyx
+++ b/kivy/properties.pyx
@@ -274,6 +274,7 @@ include "include/config.pxi"
 
 
 from weakref import ref
+from os import fspath, PathLike
 from kivy.config import ConfigParser
 from functools import partial
 from kivy.clock import Clock
@@ -785,10 +786,21 @@ cdef class StringProperty(Property):
         `defaultvalue`: string, defaults to ''
             Specifies the default value of the property.
 
+    .. versionchanged:: 3.0.0
+        :class:`os.PathLike` values (such as :class:`pathlib.Path`) are now
+        accepted and coerced to their string representation via
+        :func:`os.fspath`. Any other value type is left unchanged, so a
+        non-string, non-path value still raises ``ValueError``.
+
     '''
 
     def __init__(self, defaultvalue='', **kw):
         super(StringProperty, self).__init__(defaultvalue, **kw)
+
+    cdef convert(self, EventDispatcher obj, x, PropertyStorage property_storage):
+        if isinstance(x, PathLike):
+            return fspath(x)
+        return x
 
     cdef check(self, EventDispatcher obj, value, PropertyStorage property_storage):
         if Property.check(self, obj, value, property_storage):

--- a/kivy/resources.py
+++ b/kivy/resources.py
@@ -34,7 +34,7 @@ import re
 from os.path import join, dirname, exists, abspath
 from kivy import kivy_data_dir
 from kivy.cache import Cache
-from kivy.utils import platform
+from kivy.utils import platform, path_to_str
 from kivy.logger import Logger
 import sys
 import os
@@ -77,7 +77,15 @@ def resource_find(filename, use_cache=("KIVY_DOC_INCLUDE" not in os.environ)):
 
     .. versionchanged:: 3.0.0
         Added support for @image_provider:providername(path) URI scheme.
+
+    .. versionchanged:: 3.0.0
+        `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+        in addition to a ``str``. It is coerced to ``str`` before resolution
+        so cache keys stay consistent.
     '''
+    # Coerce os.PathLike -> str up front so all downstream string parsing and
+    # the resource cache keys operate on a single, consistent type.
+    filename = path_to_str(filename)
     if not filename:
         return
     found_filename = None
@@ -110,7 +118,12 @@ def resource_find(filename, use_cache=("KIVY_DOC_INCLUDE" not in os.environ)):
 
 def resource_add_path(path):
     '''Add a custom path to search in.
+
+    .. versionchanged:: 3.0.0
+        `path` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`) in
+        addition to a ``str``.
     '''
+    path = path_to_str(path)
     if path in resource_paths:
         return
     Logger.debug('Resource: add <%s> in path list' % path)
@@ -121,7 +134,12 @@ def resource_remove_path(path):
     '''Remove a search path.
 
     .. versionadded:: 1.0.8
+
+    .. versionchanged:: 3.0.0
+        `path` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`) in
+        addition to a ``str``.
     '''
+    path = path_to_str(path)
     if path not in resource_paths:
         return
     Logger.debug('Resource: remove <%s> from path list' % path)

--- a/kivy/storage/dictstore.py
+++ b/kivy/storage/dictstore.py
@@ -15,11 +15,16 @@ except ImportError:
 import errno
 from os.path import exists, abspath, dirname
 from kivy.storage import AbstractStore
+from kivy.utils import path_to_str
 
 
 class DictStore(AbstractStore):
     '''Store implementation using a pickled `dict`.
     See the :mod:`kivy.storage` module documentation for more information.
+
+    .. versionchanged:: 3.0.0
+        `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+        in addition to a ``str`` (or the legacy ``dict`` first argument).
     '''
     def __init__(self, filename, data=None, **kwargs):
         if isinstance(filename, dict):
@@ -27,7 +32,7 @@ class DictStore(AbstractStore):
             self.filename = None
             self._data = filename
         else:
-            self.filename = filename
+            self.filename = path_to_str(filename)
             self._data = data or {}
         self._is_changed = True
         super(DictStore, self).__init__(**kwargs)

--- a/kivy/storage/jsonstore.py
+++ b/kivy/storage/jsonstore.py
@@ -12,15 +12,20 @@ __all__ = ('JsonStore', )
 import errno
 from os.path import exists, abspath, dirname
 from kivy.storage import AbstractStore
+from kivy.utils import path_to_str
 from json import loads, dump
 
 
 class JsonStore(AbstractStore):
     '''Store implementation using a json file for storing the key-value pairs.
     See the :mod:`kivy.storage` module documentation for more information.
+
+    .. versionchanged:: 3.0.0
+        `filename` may be a :class:`os.PathLike` (e.g. :class:`pathlib.Path`)
+        in addition to a ``str``.
     '''
     def __init__(self, filename, indent=None, sort_keys=False, **kwargs):
-        self.filename = filename
+        self.filename = path_to_str(filename)
         self.indent = indent
         self.sort_keys = sort_keys
         self._data = {}

--- a/kivy/tests/test_pathlib_support.py
+++ b/kivy/tests/test_pathlib_support.py
@@ -1,0 +1,282 @@
+"""
+pathlib.Path support tests
+===========================
+
+Verify that Kivy's path-accepting APIs accept :class:`pathlib.Path` (any
+:class:`os.PathLike`) in addition to ``str``. Each relevant case is
+parametrized over ``str`` and ``Path`` to prove equivalence and guard against
+regressions.
+
+The low-level string coercion is centralized in
+:func:`kivy.utils.path_to_str` and, for widget properties, in
+:class:`kivy.properties.StringProperty`.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from kivy.utils import path_to_str
+
+
+# ---------------------------------------------------------------------------
+# path_to_str helper
+# ---------------------------------------------------------------------------
+
+def test_path_to_str_coerces_pathlike():
+    p = Path('a/b/c.png')
+    result = path_to_str(p)
+    assert isinstance(result, str)
+    assert result == os.fspath(p)
+
+
+@pytest.mark.parametrize('value', [
+    'plain-string',
+    'atlas://tex/id',
+    'http://example.com/x.png',
+    'data:image/png;base64,AAAA',
+    b'raw-bytes',
+    None,
+    123,
+])
+def test_path_to_str_passthrough(value):
+    # Non-PathLike values must be returned unchanged (identity).
+    assert path_to_str(value) is value
+
+
+def test_path_to_str_bytesio_passthrough():
+    import io
+    bio = io.BytesIO()
+    assert path_to_str(bio) is bio
+
+
+# ---------------------------------------------------------------------------
+# StringProperty coercion (requires the compiled properties extension)
+# ---------------------------------------------------------------------------
+
+def test_stringproperty_accepts_path():
+    from kivy.event import EventDispatcher
+    from kivy.properties import StringProperty
+
+    class Probe(EventDispatcher):
+        src = StringProperty('')
+        opt = StringProperty(None, allownone=True)
+
+    p = Probe()
+    fired = []
+    p.bind(src=lambda *a: fired.append(a))
+
+    p.src = Path('a/b/c.png')
+    assert isinstance(p.src, str)
+    assert p.src == os.fspath(Path('a/b/c.png'))
+    assert len(fired) == 1
+
+    # Assigning the equal string value must not re-dispatch.
+    fired.clear()
+    p.src = os.fspath(Path('a/b/c.png'))
+    assert len(fired) == 0
+
+    # Plain strings (including URIs) untouched.
+    p.src = 'atlas://tex/id'
+    assert p.src == 'atlas://tex/id'
+
+    # allownone still works and coerces Path.
+    p.opt = None
+    assert p.opt is None
+    p.opt = Path('x/y')
+    assert p.opt == os.fspath(Path('x/y'))
+
+
+def test_stringproperty_rejects_non_path_non_str():
+    from kivy.event import EventDispatcher
+    from kivy.properties import StringProperty
+
+    class Probe(EventDispatcher):
+        src = StringProperty('')
+
+    p = Probe()
+    with pytest.raises(ValueError):
+        p.src = 12345
+
+
+# ---------------------------------------------------------------------------
+# resource_find
+# ---------------------------------------------------------------------------
+
+RESOURCE_CACHE = 'kv.resourcefind'
+_RESOURCE = 'uix/textinput.py'
+
+
+def test_resource_find_path_equals_str():
+    from kivy.cache import Cache
+    from kivy.resources import resource_find
+
+    Cache.remove(RESOURCE_CACHE)
+    from_str = resource_find(_RESOURCE)
+    from_path = resource_find(Path(_RESOURCE))
+    assert from_str is not None
+    assert from_path is not None
+    assert from_str == from_path
+
+
+def test_resource_find_path_cache_consistency():
+    from kivy.cache import Cache
+    from kivy.resources import resource_find
+
+    Cache.remove(RESOURCE_CACHE)
+    p = Path(_RESOURCE)
+    first = resource_find(p)
+    assert first is not None
+    # The cache key is the coerced (str) form, so a second call with the same
+    # Path argument must hit the cache.
+    cached = Cache.get(RESOURCE_CACHE, path_to_str(p))
+    assert cached == first
+    assert resource_find(p) == first
+
+
+@pytest.mark.parametrize('uri', ['atlas://data/x/id', 'data:image/png;base64,AAAA'])
+def test_resource_find_uri_str_untouched(uri):
+    from kivy.resources import resource_find
+    # URIs are plain str and must never be coerced/mangled.
+    assert resource_find(uri) == uri
+
+
+def test_resource_add_remove_path_accepts_path(tmp_path):
+    from kivy.resources import (
+        resource_add_path, resource_remove_path, resource_paths)
+
+    resource_add_path(tmp_path)
+    assert os.fspath(tmp_path) in resource_paths
+    # Idempotent add with the same Path.
+    resource_add_path(tmp_path)
+    assert resource_paths.count(os.fspath(tmp_path)) == 1
+    resource_remove_path(tmp_path)
+    assert os.fspath(tmp_path) not in resource_paths
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def test_config_read_write_accepts_path(tmp_path):
+    from kivy.config import ConfigParser
+
+    cfg_file = tmp_path / 'my.ini'
+    cfg_file.write_text('[section]\nkey = value\n', encoding='utf-8')
+
+    cfg = ConfigParser()
+    cfg.read(cfg_file)  # Path
+    assert cfg.get('section', 'key') == 'value'
+    assert cfg.filename == os.fspath(cfg_file)
+    # write() round-trips to the same file.
+    cfg.set('section', 'key', 'value2')
+    cfg.write()
+    assert 'value2' in cfg_file.read_text(encoding='utf-8')
+
+
+def test_config_read_rejects_multiple_filenames():
+    from kivy.config import ConfigParser
+    cfg = ConfigParser()
+    with pytest.raises(Exception):
+        cfg.read(['a.ini', 'b.ini'])
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+def test_jsonstore_accepts_path(tmp_path):
+    from kivy.storage.jsonstore import JsonStore
+
+    store = JsonStore(tmp_path / 'store.json')
+    store.put('tshirt', size='M', color='blue')
+    assert store.exists('tshirt')
+    assert store.get('tshirt')['size'] == 'M'
+    # Reopen with a Path to confirm it persisted.
+    store2 = JsonStore(tmp_path / 'store.json')
+    assert store2.get('tshirt')['color'] == 'blue'
+
+
+def test_dictstore_accepts_path(tmp_path):
+    from kivy.storage.dictstore import DictStore
+
+    store = DictStore(tmp_path / 'store.dict')
+    store.put('k', v=1)
+    assert store.get('k')['v'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Builder (kv loading) -- no GL context required for rule registration
+# ---------------------------------------------------------------------------
+
+def test_builder_load_unload_file_accepts_path(tmp_path):
+    from kivy.lang import Builder
+    from kivy.factory import Factory
+
+    kv = tmp_path / 'pathlib_rule.kv'
+    kv.write_text(
+        '<PathlibTestWidget@Widget>:\n'
+        '    size_hint: 0.25, 0.25\n',
+        encoding='utf-8',
+    )
+
+    Builder.load_file(kv)  # Path
+    assert 'PathlibTestWidget' in Factory.classes
+
+    # Unloading with a Path must match the entry registered via load_file.
+    Builder.unload_file(kv)
+    # Factory entry registered from a kv file is removed on unload.
+    assert Factory.classes.get('PathlibTestWidget', {}).get('cls') is None
+
+
+# ---------------------------------------------------------------------------
+# Provider-dependent cases (skipped when the provider is unavailable, e.g.
+# a headless checkout without SDL3 runtime libraries; validated in CI).
+# ---------------------------------------------------------------------------
+
+def _image_asset():
+    from kivy.resources import resource_find
+    return resource_find('data/logo/kivy-icon-64.png')
+
+
+def test_coreimage_loads_from_path():
+    from kivy.core.image import Image as CoreImage, ImageLoader
+    if not ImageLoader.loaders:
+        pytest.skip('no image provider available')
+    asset = _image_asset()
+    if not asset:
+        pytest.skip('image asset not found')
+    img = CoreImage(Path(asset))
+    assert img.texture is not None
+    assert img.filename == os.fspath(Path(asset))
+
+
+def test_corelabel_font_name_accepts_path():
+    try:
+        from kivy.core.text import Label as CoreLabel
+    except Exception:
+        pytest.skip('no text provider available')
+    from kivy.resources import resource_find
+    font = resource_find('data/fonts/DejaVuSans.ttf')
+    if not font:
+        pytest.skip('font asset not found')
+    lbl = CoreLabel(text='hi', font_name=Path(font))
+    try:
+        lbl.refresh()
+    except Exception:
+        pytest.skip('text provider cannot render in this environment')
+    assert lbl.texture is not None
+
+
+def test_soundloader_accepts_path():
+    from kivy.core.audio_output import SoundLoader
+    if not SoundLoader._classes:
+        pytest.skip('no audio provider available')
+    from kivy.resources import resource_find
+    snd_file = resource_find('data/logo/kivy-icon-64.png')  # any bundled file
+    # We only assert coercion/no-crash on the load path; a non-audio file may
+    # legitimately return None.
+    sound = SoundLoader.load(Path(snd_file) if snd_file else Path('missing.wav'))
+    if sound is not None:
+        assert isinstance(sound.source, str)

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -19,9 +19,9 @@ __all__ = ('intersection', 'difference', 'strtotuple',
            'deprecated', 'SafeList',
            'interpolate', 'QueryDict',
            'platform', 'escape_markup', 'reify', 'rgba', 'pi_version',
-           'format_bytes_to_human', 'normalize_path_id')
+           'format_bytes_to_human', 'normalize_path_id', 'path_to_str')
 
-from os import environ, path
+from os import environ, path, fspath, PathLike
 from sys import platform as _sys_platform
 from re import match, split, search, sub, MULTILINE, IGNORECASE
 from unicodedata import normalize, category
@@ -40,6 +40,22 @@ def intersection(set1, set2):
 def difference(set1, set2):
     '''Return the difference between 2 lists.'''
     return [s for s in set1 if s not in set2]
+
+
+def path_to_str(value):
+    '''Coerce an :class:`os.PathLike` object (such as :class:`pathlib.Path`)
+    to its string representation via :func:`os.fspath`.
+
+    Any value that is not path-like (``str``, ``bytes``, ``None``,
+    file-like objects, URIs, ...) is returned unchanged, so this is safe to
+    apply at the boundary of APIs that historically accepted only ``str``
+    paths.
+
+    .. versionadded:: 3.0.0
+    '''
+    if isinstance(value, PathLike):
+        return fspath(value)
+    return value
 
 
 def normalize_path_id(path_id):


### PR DESCRIPTION
## Summary

Kivy's path-accepting APIs historically required a `str`. This PR lets them also accept any `os.PathLike` (e.g. `pathlib.Path`), by coercing `Path -> str` via `os.fspath()` at a small set of central choke points. All internals (string parsing, cache keys, Cython `.encode()`) stay string-based, so provider `.pyx` code is untouched.

Coercion only fires for `isinstance(x, os.PathLike)`. A `str` is never `os.PathLike` (even a path-shaped one), so plain strings — including URIs like `atlas://`, `http://`, `data:` — and `BytesIO` inputs pass through unchanged.

## Changes

- **`kivy/utils.py`**: new `path_to_str()` helper (coerces `os.PathLike` -> `str`; leaves `str`/`bytes`/`None`/file-like/URIs unchanged).
- **`kivy/properties.pyx`**: `StringProperty.convert()` now coerces `os.PathLike` -> `str`. This one change makes every path-bearing `StringProperty` accept `Path` (`Image.source`, `font_name`, `App.kv_file`, the `background_*`/atlas image sources, `Window.icon`, ...). A non-path, non-`str` value still raises `ValueError`.
- **`kivy/resources.py`**: coerce in `resource_find`, `resource_add_path`, `resource_remove_path` (cache keys / path-list membership stay consistent).
- **core loaders**: `Image`/`ImageLoader` (`load`/`save`/`filename`), `SoundLoader.load`, `VideoBase.filename`/`generate_thumbnail`, `LabelBase.resolve_font_name`/`register`, `SvgLoader.load`, Lottie filename.
- **lang / atlas / storage**: `Builder.load_file`/`unload_file`/`load_string`, `Atlas`, `JsonStore`, `DictStore`.
- **app / config**: `App.load_kv`/`get_application_config`; `Config.read` now accepts `os.PathLike` while still rejecting multiple filenames.
- Docstrings updated with `.. versionchanged:: 3.0.0` notes.
- New tests: `kivy/tests/test_pathlib_support.py`, parametrized over `str` vs `Path`.

## Note for reviewers: global `StringProperty` coercion

The coercion lives in `StringProperty.convert()`, so it applies to **every** `StringProperty`, not only path-bearing ones. This is intentional (one change unlocks ~50 `source`/`font_name`/image-source properties) and benign — passing a `Path` to a non-path text field was already a bug, and the coercion just yields its string form. Happy to scope it more narrowly (e.g. a dedicated `PathProperty`) if preferred.

## Known nuance: Windows separators / cache dedup

`os.fspath(Path('a/b'))` returns the OS-native form (`'a\\b'` on Windows), so a `Path` and an equivalent forward-slash `str` do not share the same raw cache key. This is a dedup nicety, **not** a correctness issue — `resource_find` -> `abspath` resolves every spelling to the same file, and the `Builder.files`/`Factory` registry already keys on the resolved abspath. Coercion is consistent per argument.

This raw-key duality is pre-existing (it already applies to `'a/b'` vs `'a\\b'` string spellings today). A separate follow-up PR will normalize the `kv.resourcefind` / `kv.loader` cache keys to the resolved path to close it for all spellings, including `Path`.

## Test plan

- [ ] CI green across the matrix (Windows/macOS/Linux, py3.11-3.14). The `StringProperty` coercion requires the Cython rebuild that CI performs.
- [x] `ruff check` passes on the changed files (project config).
- [x] Locally (`py -3.12`): the pure-Python coercion tests pass (`resource_find`, cache consistency, URI passthrough, `resource_add/remove_path`, `Config` read/write, `JsonStore`/`DictStore`, `Builder` load/unload) and de-risking spikes for the `StringProperty`, cache-ordering, passthrough, and Windows-separator behaviors all pass.
