### PR TITLE
kivy.mobile: pull the Android Activity from the bootstrap instead of a hardcoded PythonActivity

### DIFF
--- a/kivy/app.py
+++ b/kivy/app.py
@@ -927,11 +927,8 @@ class App(EventDispatcher):
         if platform == 'ios':
             data_dir = join('~/Documents', self.name)
         elif platform == 'android':
-            from jnius import autoclass, cast
-            PythonActivity = autoclass('org.kivy.android.PythonActivity')
-            context = cast('android.content.Context', PythonActivity.mActivity)
-            file_p = cast('java.io.File', context.getFilesDir())
-            data_dir = file_p.getAbsolutePath()
+            from kivy.mobile._platform.android import get_files_dir
+            data_dir = get_files_dir()
         elif platform == 'win':
             data_dir = join(os.environ['APPDATA'], app_id)
         elif platform == 'macosx':
@@ -956,11 +953,8 @@ class App(EventDispatcher):
         if platform == 'ios':
             cache_dir = join('~/Library/Caches', self.name)
         elif platform == 'android':
-            from jnius import autoclass, cast
-            PythonActivity = autoclass('org.kivy.android.PythonActivity')
-            context = cast('android.content.Context', PythonActivity.mActivity)
-            file_p = cast('java.io.File', context.getCacheDir())
-            cache_dir = file_p.getAbsolutePath()
+            from kivy.mobile._platform.android import get_cache_dir
+            cache_dir = get_cache_dir()
         elif platform == 'win':
             cache_dir = join(os.environ['LOCALAPPDATA'], app_id, 'Cache')
         elif platform == 'macosx':

--- a/kivy/base.py
+++ b/kivy/base.py
@@ -236,7 +236,14 @@ class EventLoopBase(EventDispatcher):
             self.postproc_modules.remove(mod)
 
     def remove_android_splash(self, *args):
-        '''Remove android presplash in SDL3 bootstrap.'''
+        '''Let the Android bootstrap dismiss its boot splash, now that the
+        first frame has been drawn.
+
+        A bootstrap with no splash to dismiss is not an error and warns nothing;
+        the backend treats the absence as the no-op it is.  The ImportError here
+        covers only the case this method should never have reached — no Android
+        platform backend at all.
+        '''
         try:
             from kivy.mobile._platform.android import remove_presplash
             remove_presplash()

--- a/kivy/core/clipboard/clipboard_android.py
+++ b/kivy/core/clipboard/clipboard_android.py
@@ -7,61 +7,31 @@ Android implementation of Clipboard provider, using Pyjnius.
 
 __all__ = ('ClipboardAndroid', )
 
+import time
+
 from kivy import Logger
 from kivy.core.clipboard import ClipboardBase
-from jnius import autoclass, cast, PythonJavaClass, java_method
+from kivy.mobile._platform.android import get_app_context, run_on_ui_thread
+from jnius import autoclass
 
 AndroidString = autoclass('java.lang.String')
-PythonActivity = autoclass('org.kivy.android.PythonActivity')
 Context = autoclass('android.content.Context')
 VER = autoclass('android.os.Build$VERSION')
 sdk = VER.SDK_INT
 
-
-class _Runnable(PythonJavaClass):
-    '''Schedule a Python call onto the Android UI thread (fire-and-forget).
-
-    A tiny local replacement for python-for-android's ``android.runnable`` so
-    this provider depends only on pyjnius, not the p4a ``android`` module.
-    '''
-
-    __javainterfaces__ = ['java/lang/Runnable']
-    __javacontext__ = 'app'
-    # Keep strong references until the JVM has run each proxy, otherwise the
-    # pyjnius object may be collected before ``run()`` fires.
-    _refs = []
-
-    def __init__(self, func, args, kwargs):
-        super().__init__()
-        self._func = func
-        self._args = args
-        self._kwargs = kwargs
-        _Runnable._refs.append(self)
-
-    @java_method('()V')
-    def run(self):
-        try:
-            self._func(*self._args, **self._kwargs)
-        finally:
-            _Runnable._refs.remove(self)
-
-
-def run_on_ui_thread(f):
-    '''Decorator running *f* on the UI thread via ``Activity.runOnUiThread``.'''
-    def wrapper(*args, **kwargs):
-        PythonActivity.mActivity.runOnUiThread(_Runnable(f, args, kwargs))
-    return wrapper
+# The ClipboardManager, fetched once on the UI thread.  Process-wide rather than
+# per-instance because it comes from the Application context, which outlives any
+# one Activity.
+_clipboard = None
 
 
 class ClipboardAndroid(ClipboardBase):
 
     def __init__(self):
         super(ClipboardAndroid, self).__init__()
-        self._clipboard = None
         self._data = dict()
         self._data['text/plain'] = None
         self._data['application/data'] = None
-        PythonActivity._clipboard = None
 
     def get(self, mimetype='text/plain'):
         return self._get(mimetype).encode('utf-8')
@@ -72,46 +42,57 @@ class ClipboardAndroid(ClipboardBase):
     def get_types(self):
         return list(self._data.keys())
 
-    @run_on_ui_thread
     def _initialize_clipboard(self):
-        PythonActivity._clipboard = cast(
-            'android.app.Activity',
-            PythonActivity.mActivity).getSystemService(
-                                        Context.CLIPBOARD_SERVICE)
+        '''Fetch the ClipboardManager, waiting for the UI thread to deliver it.
+
+        The lookup has to happen on the UI thread, so the failure has to be
+        carried back rather than raised in place: without that, a Context we
+        cannot reach would leave the wait below spinning forever instead of
+        reporting itself.
+        '''
+        failure = []
+
+        def work():
+            global _clipboard
+            try:
+                _clipboard = get_app_context().getSystemService(
+                    Context.CLIPBOARD_SERVICE)
+            except Exception as exc:
+                failure.append(exc)
+
+        run_on_ui_thread(work)
+        while not _clipboard:
+            if failure:
+                raise failure[0]
+            time.sleep(.01)
 
     def _get_clipboard(f):
         def called(*args, **kargs):
-            self = args[0]
-            if not PythonActivity._clipboard:
-                self._initialize_clipboard()
-                import time
-                while not PythonActivity._clipboard:
-                    time.sleep(.01)
+            if not _clipboard:
+                args[0]._initialize_clipboard()
             return f(*args, **kargs)
         return called
 
     @_get_clipboard
     def _get(self, mimetype='text/plain'):
-        clippy = PythonActivity._clipboard
+        clippy = _clipboard
         data = ''
         if sdk < 11:
             data = clippy.getText()
         else:
-            ClipDescription = autoclass('android.content.ClipDescription')
             primary_clip = clippy.getPrimaryClip()
             if primary_clip:
                 try:
                     data = primary_clip.getItemAt(0)
                     if data:
-                        data = data.coerceToText(
-                            PythonActivity.mActivity.getApplicationContext())
+                        data = data.coerceToText(get_app_context())
                 except Exception:
                     Logger.exception('Clipboard: failed to paste')
         return data
 
     @_get_clipboard
     def _set(self, data, mimetype):
-        clippy = PythonActivity._clipboard
+        clippy = _clipboard
 
         if sdk < 11:
             # versions previous to honeycomb

--- a/kivy/core/clipboard/clipboard_android.py
+++ b/kivy/core/clipboard/clipboard_android.py
@@ -83,9 +83,7 @@ class ClipboardAndroid(ClipboardBase):
             primary_clip = clippy.getPrimaryClip()
             if primary_clip:
                 try:
-                    data = primary_clip.getItemAt(0)
-                    if data:
-                        data = data.coerceToText(get_app_context())
+                    data = primary_clip.getItemAt(0).coerceToText(get_app_context())
                 except Exception:
                     Logger.exception('Clipboard: failed to paste')
         return data

--- a/kivy/mobile/__init__.py
+++ b/kivy/mobile/__init__.py
@@ -69,6 +69,33 @@ Public API — Tier 2 (Android platform extras)
     Android status-bar / navigation-bar insets separated (requires API 30+;
     ``None`` below).  Always ``None`` on iOS / desktop.
 
+Public API — Tier 3 (Android bootstrap contract)
+------------------------------------------------
+
+Android-only, and unlike Tiers 1 it has no iOS counterpart: iOS has no
+bootstrap in this sense.  See ``kivy.mobile._platform.android``
+for the full contract.
+
+Kivy holds no Android bootstrap class name.  Instead the bootstrap — whoever
+*builds* the APK, be that python-for-android, kivyforge or a custom one — ships
+a top-level ``_kivy_bootstrap`` module, which Kivy imports on first use:
+
+``_kivy_bootstrap.get_activity()`` → Activity | None
+    **Required.**  The current ``android.app.Activity``, or ``None`` where none
+    exists (a background service).  Kivy calls it live on every access, so the
+    bootstrap need do nothing when Android recreates the Activity.
+
+``_kivy_bootstrap.get_context()`` → Context | None
+    **Optional.**  For a context that never has an Activity.  When absent, the
+    Application context is derived from the current Activity.
+
+Applications read these through:
+
+``get_activity()`` / ``get_app_context()``
+    The current Activity / a usable Context.  Both raise
+    ``ActivityProviderMissing`` when the bootstrap supplied no activity source,
+    rather than silently returning defaults.
+
 .. versionadded:: 3.0.0
 """
 
@@ -99,6 +126,11 @@ elif platform == 'android':
         subscribe_keyboard_height,
         get_display_cutout,
         get_system_bar_insets,
+        # Tier 3 — bootstrap contract. Android-only by nature, so these are
+        # deliberately absent from the iOS branch above.
+        ActivityProviderMissing,
+        get_activity,
+        get_app_context,
     )
 else:
     raise ImportError(

--- a/kivy/mobile/_platform/android.py
+++ b/kivy/mobile/_platform/android.py
@@ -2,9 +2,10 @@
 
 Reads runtime window/display geometry from the running Android activity using
 ``jnius`` (https://github.com/kivy/pyjnius) — a standalone Kivy-org package
-present in every Kivy Android build.  No compiled extension and no
-python-for-android module changes are required: every value is obtained by
-reflection against ``PythonActivity.mActivity`` and the Android framework.
+present in every Kivy Android build.  No compiled extension is required: every
+value is obtained by reflection against the Android framework, starting from an
+Activity the *bootstrap* supplies (see "Android bootstrap contract" below).
+Kivy names no bootstrap class itself.
 
 All lengths are returned in **pixels**, which is Kivy's layout coordinate
 system on Android (``density`` is folded into :class:`kivy.metrics.Metrics`,
@@ -27,9 +28,9 @@ runtime API matters):
   API 30+ (Android 11); use ``WindowInsets.getInsets(type)`` and the typed
   ``ime()`` / ``systemBars()`` / ``displayCutout()`` insets added in API 30.
 * ``move_task_to_back`` / ``finish_and_remove_task`` — all supported API levels
-  (stock ``android.app.Activity`` methods).  ``remove_presplash`` similarly
-  needs no minimum API but depends on the bootstrap ``removeLoadingScreen``
-  method (see the bootstrap contract below).  These are app/task lifecycle
+  (stock ``android.app.Activity`` methods).  ``remove_presplash`` needs no
+  minimum API either, but is only as available as the bootstrap's own splash
+  handling (see the bootstrap contract below).  These are app/task lifecycle
   actions rather than geometry reads; they are Android-only (no cross-platform
   analogue) so they are not surfaced through the neutral ``kivy.mobile`` API.
 
@@ -41,20 +42,45 @@ active devices.
 
 Android bootstrap contract
 --------------------------
-Everything else this backend touches is stock Android framework, but one symbol
-must be supplied by the *Android bootstrap* (python-for-android today, and any
-alternative such as a kivyforge bootstrap must provide an equivalent).  Keep
-this in sync when adding bootstrap-coupled features:
+Everything else this backend touches is stock Android framework, but the
+Activity itself must come from the *Android bootstrap* — the component that
+builds the APK and owns the Java activity class (python-for-android today, and
+any alternative such as a kivyforge bootstrap).  Kivy defines the handshake and
+holds no bootstrap class name; the bootstrap keeps that knowledge, which is
+where it belongs, since it is the party that decides the class.  Keep this in
+sync when adding bootstrap-coupled features:
 
-* ``org.kivy.android.PythonActivity`` (class, see :data:`_ACTIVITY_CLASS`) with
-  a static ``mActivity`` field holding the current ``android.app.Activity``.
-  **Hard requirement** — the whole backend resolves geometry through it; if the
-  bootstrap renames or omits it, the module degrades to safe defaults on import.
-* ``mActivity.removeLoadingScreen()`` — **soft requirement**, used only by
-  :func:`remove_presplash` to dismiss the boot splash.  This is a
-  bootstrap-provided method (not stock Android framework); a bootstrap that
-  omits it simply cannot remove the splash this way, and the caller in
-  ``kivy.base`` already tolerates that.
+* ``get_activity()`` on a top-level ``_kivy_bootstrap`` module (see
+  :data:`_BOOTSTRAP_MODULE`), returning the current ``android.app.Activity``.
+  **Hard requirement** — the whole backend resolves geometry through it.  This
+  backend imports the module on first use; a build whose bootstrap ships no
+  such module raises :class:`ActivityProviderMissing` rather than silently
+  reporting default geometry.
+
+  Kivy pulls rather than asking the bootstrap to register at startup, because
+  registering would mean importing Kivy *before* the application runs, which
+  fixes Kivy's ``KIVY_*`` environment and config before the app can set them.
+  Pulling also means there is no ordering requirement to get wrong: the
+  bootstrap only has to make the module importable.
+* ``get_context()`` on the same module — **optional**, for a context that never
+  has an Activity, such as a background service.  When absent,
+  :func:`get_app_context` derives the Application context from the current
+  Activity.
+* ``remove_presplash()`` on the same module — **optional**, called once the
+  first frame has been drawn so the bootstrap can dismiss its boot splash.
+  Only Kivy knows when that moment is, which is why the call exists at all;
+  *how* a splash is dismissed is the bootstrap's business and differs
+  fundamentally between them (python-for-android removes a View it inserted;
+  a bootstrap using the Android 12 system splash releases a keep-on-screen
+  condition instead, which is not a method on the Activity).  A bootstrap with
+  no splash to dismiss simply omits it and :func:`remove_presplash` does
+  nothing.
+
+Note that the Activity is *pulled* on every access, never cached: Android
+recreates it on configuration changes and after process death, so a stored
+instance both goes stale and pins a JNI reference to a dead Activity.  Because
+nothing is registered or cached, this backend holds no mutable cross-thread
+state beyond the one-time module import.
 
 This module is imported automatically by ``kivy.mobile`` when
 ``kivy.utils.platform == 'android'``.  Do not import it directly.
@@ -63,17 +89,17 @@ This module is imported automatically by ``kivy.mobile`` when
 from __future__ import annotations
 
 import threading
+from importlib import import_module
 
-# The single bootstrap-provided activity class this backend depends on. Hoisted
-# to a named constant so the one hard coupling to the Android bootstrap is an
-# obvious, documented point rather than a bare string (see the module docstring,
-# "Android bootstrap contract").
-_ACTIVITY_CLASS = "org.kivy.android.PythonActivity"
+# The module an Android bootstrap ships to satisfy Kivy's contract (see the
+# module docstring, "Android bootstrap contract").  The name is Kivy-owned, so
+# depending on it couples Kivy to no particular bootstrap; any bootstrap —
+# python-for-android, kivyforge, or a custom one — may implement it.
+_BOOTSTRAP_MODULE = "_kivy_bootstrap"
 
 try:
-    from jnius import autoclass, PythonJavaClass, java_method
+    from jnius import autoclass, cast, PythonJavaClass, java_method
 
-    PythonActivity = autoclass(_ACTIVITY_CLASS)
     DisplayMetrics = autoclass("android.util.DisplayMetrics")
     _Build_VERSION = autoclass("android.os.Build$VERSION")
 except Exception:  # noqa: BLE001
@@ -81,13 +107,11 @@ except Exception:  # noqa: BLE001
     # an actual Android build.  Importing this module off-device must not hard
     # fail: Kivy's test-suite loads every ``kivy.mobile._platform`` backend
     # directly (bypassing the ``kivy.mobile`` desktop ImportError guard) to get
-    # coverage, and pip-installing pyjnius alone would not help because
-    # ``autoclass("org.kivy.android.PythonActivity")`` cannot resolve on a
-    # desktop JVM.  Every getter below already falls back to a documented safe
+    # coverage.  Every geometry getter below falls back to a documented safe
     # default, so we degrade the whole module the same way when the runtime is
     # absent.
     autoclass = None
-    PythonActivity = None
+    cast = None
     DisplayMetrics = None
     _Build_VERSION = None
 
@@ -135,8 +159,102 @@ def _window_insets_type():
 _runnable_refs: list = []
 
 
+class ActivityProviderMissing(RuntimeError):
+    """The Android bootstrap did not supply a way to reach the current Activity.
+
+    Raised only when there *is* an Android runtime, so it always means a real
+    build misconfiguration: the bootstrap that produced this APK does not
+    satisfy Kivy's contract.  Deliberately not caught by the geometry getters,
+    which would otherwise mask it as a plausible-looking default.
+    """
+
+
+class _AndroidRuntimeUnavailable(RuntimeError):
+    """There is no Android runtime at all, so nothing can be resolved.
+
+    Distinct from :class:`ActivityProviderMissing` because it is not an error
+    to report to anyone: it is what happens when this backend is imported off
+    device, which Kivy's own test-suite does deliberately.  The getters treat it
+    like any other resolution failure and fall back to their documented
+    defaults.
+    """
+
+
+_bootstrap = None
+_bootstrap_resolved = False
+
+
+def _bootstrap_module():
+    """Import the bootstrap's contract module, once.
+
+    Both outcomes are cached, including failure: a build whose bootstrap ships
+    no such module must not pay for a failed import on every geometry read.
+
+    Only ``ImportError`` is treated as "no bootstrap".  Anything else raised
+    while importing is a fault in the bootstrap's own module and propagates, so
+    it is not mistaken for an absent bootstrap.
+    """
+    global _bootstrap, _bootstrap_resolved
+    if not _bootstrap_resolved:
+        _bootstrap_resolved = True
+        try:
+            _bootstrap = import_module(_BOOTSTRAP_MODULE)
+        except ImportError:
+            _bootstrap = None
+    return _bootstrap
+
+
+def get_activity():
+    """The current ``android.app.Activity``, pulled live from the bootstrap.
+
+    Called afresh every time rather than cached: Android destroys and recreates
+    the Activity on configuration changes (rotation, dark mode, locale,
+    multi-window) and after process death, so a stored instance goes stale and
+    holding one alive in a Python global pins a JNI reference to a dead
+    Activity.  Pulling live self-heals for free.
+
+    May legitimately return ``None`` where no Activity exists, such as in a
+    background service.  Raises :class:`ActivityProviderMissing` when there is
+    an Android runtime but the bootstrap supplied nothing — a build
+    misconfiguration, so it is reported rather than papered over with a default.
+    """
+    module = _bootstrap_module()
+    provider = getattr(module, "get_activity", None)
+    if not callable(provider):
+        if autoclass is None:
+            raise _AndroidRuntimeUnavailable(
+                "no Android runtime: jnius is unavailable, so there is no "
+                "Activity to resolve"
+            )
+        raise ActivityProviderMissing(
+            "No Android activity source available: this build's bootstrap "
+            f"ships no {_BOOTSTRAP_MODULE!r} module exposing get_activity(). "
+            "Kivy 3 requires the bootstrap to supply the current Activity. "
+            "If you are using python-for-android, update it to a version that "
+            "supports Kivy 3."
+        )
+    return provider()
+
+
+def get_app_context():
+    """A usable ``android.content.Context``, or ``None`` without an Activity.
+
+    A bootstrap may optionally expose ``get_context()`` for contexts that never
+    have an Activity — a background service, say.  Otherwise the Application
+    context is derived from the current Activity, which is equivalent for
+    everything Kivy uses a Context for.
+    """
+    provider = getattr(_bootstrap_module(), "get_context", None)
+    if callable(provider):
+        context = provider()
+        if context is not None:
+            return context
+    activity = get_activity()
+    return activity.getApplicationContext() if activity is not None else None
+
+
 def _activity():
-    return PythonActivity.mActivity
+    return get_activity()
 
 
 class _Runnable(PythonJavaClass):
@@ -181,6 +299,30 @@ def _on_ui_thread(func, timeout: float = 2.0):
             pass
 
 
+def run_on_ui_thread(func, *args, **kwargs):
+    """Post *func* to the Android UI thread and return without waiting.
+
+    The counterpart to :func:`_on_ui_thread`, which blocks for a result: use
+    this where the caller only needs the call to land on the main thread, as
+    Android requires for most framework calls.  Provided here so that callers
+    elsewhere in Kivy need neither ``jnius`` boilerplate nor an Activity of
+    their own — the Activity comes from the bootstrap contract above.
+    """
+
+    def wrapper():
+        try:
+            func(*args, **kwargs)
+        finally:
+            try:
+                _runnable_refs.remove(runnable)
+            except ValueError:
+                pass
+
+    runnable = _Runnable(wrapper)
+    _runnable_refs.append(runnable)
+    _activity().runOnUiThread(runnable)
+
+
 def _metrics():
     metrics = DisplayMetrics()
     _activity().getWindowManager().getDefaultDisplay().getMetrics(metrics)
@@ -201,6 +343,8 @@ def get_dpi() -> float:
     """Physical screen DPI (Android ``densityDpi``; matches ``Metrics.dpi``)."""
     try:
         return float(_metrics().densityDpi)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return 96.0
 
@@ -217,6 +361,8 @@ def get_scale() -> float:
     """
     try:
         return float(_metrics().density)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return 1.0
 
@@ -237,6 +383,8 @@ def get_fontscale() -> float:
     try:
         config = _activity().getResources().getConfiguration()
         return float(config.fontScale)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return 1.0
 
@@ -256,6 +404,8 @@ def get_keyboard_height() -> float:
 
     try:
         return _on_ui_thread(work)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return 0.0
 
@@ -285,6 +435,8 @@ def get_safe_area() -> dict[str, float]:
 
     try:
         return _on_ui_thread(work)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return {"top": 0.0, "left": 0.0, "bottom": 0.0, "right": 0.0}
 
@@ -400,6 +552,8 @@ def get_display_cutout():
 
     try:
         return _on_ui_thread(work)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return None
 
@@ -438,6 +592,8 @@ def get_system_bar_insets():
 
     try:
         return _on_ui_thread(work)
+    except ActivityProviderMissing:
+        raise
     except Exception:
         return None
 
@@ -476,11 +632,57 @@ def finish_and_remove_task() -> None:
 
 
 def remove_presplash() -> None:
-    """Dismiss the Android boot splash / loading screen.
+    """Ask the bootstrap to dismiss its boot splash; a no-op if it has none.
 
-    Wraps the bootstrap-provided ``mActivity.removeLoadingScreen()`` (see the
-    "Android bootstrap contract" above), mirroring python-for-android's
-    ``android.remove_presplash`` for the sdl2/sdl3 bootstraps so ``kivy.base``
-    can drop the splash without importing the p4a ``android`` module.
+    Kivy calls this once the first frame is drawn — the one thing about a boot
+    splash that only Kivy knows.  The mechanism belongs to the bootstrap, so
+    this delegates to an optional ``remove_presplash()`` on the contract module
+    (see "Android bootstrap contract" above) rather than naming any bootstrap's
+    method.
+
+    Doing nothing is a correct outcome, not a swallowed error: a bootstrap may
+    have no splash, or one the system dismisses by itself.  Bootstraps that do
+    are expected to be idempotent — Kivy makes no promise about being called
+    exactly once.
     """
-    _activity().removeLoadingScreen()
+    hook = getattr(_bootstrap_module(), "remove_presplash", None)
+    if callable(hook):
+        hook()
+
+
+# ---------------------------------------------------------------------------
+# App-private storage paths
+#
+# Android hands these out through the Context rather than as fixed paths, so
+# they are resolved by reflection like everything else here.  Both are
+# app-scoped, so the Application context and an Activity context give the same
+# answer.  Unlike the geometry getters these have no safe default: a wrong path
+# would silently write the user's data somewhere it will not be found again, so
+# failures propagate.
+# ---------------------------------------------------------------------------
+
+
+def _context_path(getter: str):
+    context = get_app_context()
+    if context is None:
+        return None
+    return cast("java.io.File", getattr(context, getter)()).getAbsolutePath()
+
+
+def get_files_dir():
+    """Absolute path of the app's private files dir (``getFilesDir()``).
+
+    ``None`` where there is no Context to ask.  Backs
+    :attr:`kivy.app.App.user_data_dir` on Android.
+    """
+    return _context_path("getFilesDir")
+
+
+def get_cache_dir():
+    """Absolute path of the app's private cache dir (``getCacheDir()``).
+
+    ``None`` where there is no Context to ask.  Backs
+    :attr:`kivy.app.App.user_cache_dir` on Android.  Android may delete this
+    directory's contents under storage pressure.
+    """
+    return _context_path("getCacheDir")

--- a/kivy/tests/test_mobile.py
+++ b/kivy/tests/test_mobile.py
@@ -149,13 +149,35 @@ class _FakeResources:
         return self._config
 
 
+class _FakeFile:
+    def __init__(self, path):
+        self._path = path
+
+    def getAbsolutePath(self):
+        return self._path
+
+
+class _FakeContext:
+    """Stands in for the process-stable Application ``Context``."""
+
+    def getFilesDir(self):
+        return _FakeFile("/data/user/0/org.test.app/files")
+
+    def getCacheDir(self):
+        return _FakeFile("/data/user/0/org.test.app/cache")
+
+
 class _FakeActivity:
     def __init__(self, insets, font_scale=1.0):
         self._insets = insets
         self._resources = _FakeResources(font_scale)
+        self._app_context = _FakeContext()
         self.moved_to_back = None
         self.finished = False
         self.presplash_removed = False
+
+    def getApplicationContext(self):
+        return self._app_context
 
     def runOnUiThread(self, runnable):
         # Run synchronously so the backend's UI-thread marshaling completes
@@ -182,22 +204,52 @@ class _FakeActivity:
 
 
 @contextmanager
-def _fake_jnius(insets, sdk_int=33, missing=(), font_scale=1.0):
-    """Install a fake ``jnius`` module and yield the freshly loaded backend.
+def _fake_bootstrap(get_activity=None, get_context=None, remove_presplash=None):
+    """Publish a fake ``_kivy_bootstrap`` module, as a real bootstrap would.
+
+    Kivy resolves the Activity by importing this Kivy-named module from the
+    bootstrap (see the backend's "Android bootstrap contract"), so faking the
+    contract means publishing a module — there is nothing to register.  Passing
+    neither function simulates a bootstrap that does not satisfy the contract.
+    """
+    module = types.ModuleType("_kivy_bootstrap")
+    if get_activity is not None:
+        module.get_activity = get_activity
+    if get_context is not None:
+        module.get_context = get_context
+    if remove_presplash is not None:
+        module.remove_presplash = remove_presplash
+
+    saved = sys.modules.get("_kivy_bootstrap")
+    sys.modules["_kivy_bootstrap"] = module
+    try:
+        yield module
+    finally:
+        if saved is None:
+            sys.modules.pop("_kivy_bootstrap", None)
+        else:
+            sys.modules["_kivy_bootstrap"] = saved
+
+
+@contextmanager
+def _fake_jnius(insets, sdk_int=33, missing=(), font_scale=1.0, bootstrap=True):
+    """Install fake ``jnius`` + bootstrap modules, yield the loaded backend.
 
     *missing* is a set of class names that ``autoclass`` should fail to
     resolve, used to simulate older API levels (e.g. no ``WindowInsets$Type``
-    on API < 30).
-    """
+    on API < 30).  Pass ``bootstrap=False`` to simulate an Android runtime whose
+    bootstrap does not satisfy Kivy's contract; because discovery is lazy, a
+    test may then supply its own via :func:`_fake_bootstrap`.
 
-    class _FakePythonActivity:
-        mActivity = _FakeActivity(insets, font_scale)
+    Note there is no fake ``org.kivy.android.PythonActivity``: Kivy no longer
+    knows any bootstrap class name, so the Activity arrives via the bootstrap
+    module instead.  Tests reach it back through ``android.get_activity()``.
+    """
 
     class _FakeVersion:
         SDK_INT = sdk_int
 
     registry = {
-        "org.kivy.android.PythonActivity": _FakePythonActivity,
         "android.util.DisplayMetrics": _FakeDisplayMetrics,
         "android.os.Build$VERSION": _FakeVersion,
         "android.view.WindowInsets$Type": _FakeType,
@@ -221,11 +273,25 @@ def _fake_jnius(insets, sdk_int=33, missing=(), font_scale=1.0):
     module.autoclass = _autoclass
     module.java_method = _java_method
     module.PythonJavaClass = _PythonJavaClass
+    # Real jnius re-types a Java object; the fakes are already Python objects,
+    # so the signature is irrelevant here.
+    module.cast = lambda _signature, obj: obj
+
+    activity = _FakeActivity(insets, font_scale)
 
     saved = sys.modules.get("jnius")
     sys.modules["jnius"] = module
     try:
-        yield _load("android")
+        if bootstrap:
+            # Implements the splash hook the way python-for-android does, by
+            # removing a view of its own; a bootstrap need not offer it at all.
+            with _fake_bootstrap(
+                get_activity=lambda: activity,
+                remove_presplash=activity.removeLoadingScreen,
+            ):
+                yield _load("android")
+        else:
+            yield _load("android")
     finally:
         if saved is None:
             sys.modules.pop("jnius", None)
@@ -353,19 +419,36 @@ class TestAndroidPlatform:
         # Backgrounds the task via Activity.moveTaskToBack(true).
         with _fake_jnius(_default_insets()) as android:
             android.move_task_to_back()
-            assert android.PythonActivity.mActivity.moved_to_back is True
+            assert android.get_activity().moved_to_back is True
 
     def test_finish_and_remove_task_calls_activity(self):
         # Tears the task down via Activity.finishAndRemoveTask().
         with _fake_jnius(_default_insets()) as android:
             android.finish_and_remove_task()
-            assert android.PythonActivity.mActivity.finished is True
+            assert android.get_activity().finished is True
 
-    def test_remove_presplash_calls_activity(self):
-        # Dismisses the boot splash via the bootstrap removeLoadingScreen().
+    def test_remove_presplash_delegates_to_the_bootstrap(self):
+        # Kivy supplies the timing (first frame drawn); the bootstrap supplies
+        # the mechanism, here p4a-style view removal.
         with _fake_jnius(_default_insets()) as android:
             android.remove_presplash()
-            assert android.PythonActivity.mActivity.presplash_removed is True
+            assert android.get_activity().presplash_removed is True
+
+    def test_storage_paths_come_from_the_context(self):
+        # Backs App.user_data_dir / user_cache_dir, which used to reflect the
+        # bootstrap's activity class directly from kivy/app.py.
+        with _fake_jnius(_default_insets()) as android:
+            assert android.get_files_dir() == "/data/user/0/org.test.app/files"
+            assert android.get_cache_dir() == "/data/user/0/org.test.app/cache"
+
+    def test_run_on_ui_thread_posts_to_activity(self):
+        # Fire-and-forget marshaling, used by the clipboard provider.
+        with _fake_jnius(_default_insets()) as android:
+            seen = []
+            android.run_on_ui_thread(seen.append, "posted")
+            assert seen == ["posted"]
+            # The Runnable must not be retained once it has run.
+            assert android._runnable_refs == []
 
     def test_safe_area_unions_system_bars_and_cutout(self):
         with _fake_jnius(_default_insets()) as android:
@@ -451,6 +534,100 @@ class TestAndroidPlatform:
 
             android._poll_keyboard(0)
             assert seen == [800.0]
+
+
+class TestAndroidBootstrapContract:
+    """The handshake by which a bootstrap supplies the Activity.
+
+    Kivy names no bootstrap class: it imports a Kivy-named ``_kivy_bootstrap``
+    module and pulls from it, so python-for-android, kivyforge and custom
+    bootstraps are all interchangeable here.
+    """
+
+    def test_kivy_holds_no_bootstrap_class_name(self):
+        # A regression guard on the point of the whole contract: the backend
+        # must not name any bootstrap's activity class.  Read the source rather
+        # than importing it, for the same reason as the rest of this module.
+        source = (_PLATFORM_DIR / "android.py").read_text(encoding="utf-8")
+        assert "org.kivy.android" not in source
+        # Nor any bootstrap-invented method name: removeLoadingScreen is
+        # python-for-android's, and reaching for it here is what broke on
+        # bootstraps that dismiss their splash some other way.
+        assert "removeLoadingScreen" not in source
+
+    def test_missing_bootstrap_raises(self):
+        # A runtime is present but no bootstrap satisfies the contract: that is
+        # a build misconfiguration, so it must be reported.
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with pytest.raises(android.ActivityProviderMissing,
+                               match="_kivy_bootstrap"):
+                android.get_activity()
+
+    def test_bootstrap_without_get_activity_raises(self):
+        # A module that exists but does not implement the contract is not
+        # mistaken for a conforming one.
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with _fake_bootstrap():
+                with pytest.raises(android.ActivityProviderMissing):
+                    android.get_activity()
+
+    def test_missing_bootstrap_is_not_masked_by_getter_defaults(self):
+        # The geometry getters swallow reflection failures to return safe
+        # defaults; that must not hide an unsatisfied contract, or the app runs
+        # silently mis-scaled.
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with pytest.raises(android.ActivityProviderMissing):
+                android.get_fontscale()
+
+    def test_activity_is_pulled_live(self):
+        # Android recreates the Activity on rotation and after process death,
+        # so Kivy must re-ask every time rather than cache.
+        current = {"activity": _FakeActivity(_default_insets())}
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with _fake_bootstrap(get_activity=lambda: current["activity"]):
+                first = android.get_activity()
+                current["activity"] = _FakeActivity(_default_insets())
+                assert android.get_activity() is not first
+                assert android.get_activity() is current["activity"]
+
+    def test_service_may_have_no_activity(self):
+        # A background service legitimately has no Activity; that is not an
+        # error, and no Context can be derived from it.
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with _fake_bootstrap(get_activity=lambda: None):
+                assert android.get_activity() is None
+                assert android.get_app_context() is None
+
+    def test_presplash_hook_is_optional(self):
+        # A bootstrap whose splash the system dismisses by itself (or which has
+        # none) implements nothing, and that must be silent rather than an
+        # AttributeError one frame into the app.
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with _fake_bootstrap(get_activity=lambda: object()):
+                android.remove_presplash()  # must not raise
+
+    def test_presplash_hook_needs_no_activity(self):
+        # The bootstrap owns the mechanism, so Kivy must not require an Activity
+        # to exist just to ask: a system splash is not attached to one.
+        called = []
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with _fake_bootstrap(get_activity=lambda: None,
+                                 remove_presplash=lambda: called.append(True)):
+                android.remove_presplash()
+        assert called == [True]
+
+    def test_optional_get_context_is_preferred(self):
+        # Contexts with no Activity (a service) supply one directly.
+        with _fake_jnius(_default_insets(), bootstrap=False) as android:
+            with _fake_bootstrap(get_activity=lambda: None,
+                                 get_context=lambda: "SERVICE_CONTEXT"):
+                assert android.get_app_context() == "SERVICE_CONTEXT"
+
+    def test_context_derived_from_activity_when_not_supplied(self):
+        # The common case: a UI bootstrap implements only get_activity().
+        with _fake_jnius(_default_insets()) as android:
+            activity = android.get_activity()
+            assert android.get_app_context() is activity.getApplicationContext()
 
 
 class TestMobileImportError:


### PR DESCRIPTION
Kivy's Android backend reflects a class name it hardcodes,
`org.kivy.android.PythonActivity`. That makes Kivy depend on a
python-for-android implementation detail, and it silently breaks any build whose
activity is named something else — including p4a's own `--activity-class-name`.

This inverts it. Kivy names no activity class: it imports a top-level
`_kivy_bootstrap` module, supplied by whoever built the APK, and pulls the
current Activity from it.

## The contract

| member | required | meaning |
| --- | --- | --- |
| `get_activity()` | yes | the current `android.app.Activity`, or `None` where none exists |
| `get_context()` | no | a `Context` for processes that never have an Activity |
| `remove_presplash()` | no | dismiss the boot splash; Kivy calls it after the first frame |

The module is imported on first use and `get_activity()` is called live on every
access, so nothing goes stale when Android recreates the Activity on rotation,
configuration change or process death — the reason this is a call into the
bootstrap rather than a value registered once.

`None` is a legitimate answer, since a background service has no Activity. A
*missing module* while an Android runtime is present raises
`ActivityProviderMissing` rather than degrading to plausible-looking defaults,
because it can only mean the APK was built by something that does not support
Kivy 3; the geometry getters deliberately re-raise it instead of swallowing it
with their fallbacks. Off-device, where jnius is absent, those getters keep
returning their documented defaults, so desktop imports and the test suite are
unaffected.

Kivy pulls rather than the bootstrap pushing a provider at startup. p4a runs the
app's `main.py` as the process entry point, so it has no Python of its own to
register from without a new C-level seam in every bootstrap; and registering
would mean importing Kivy before the app could set its `KIVY_*` environment and
config.

## What changed

| file | change |
| --- | --- |
| `kivy/mobile/_platform/android.py` | the contract: discovery, `get_activity`, `get_app_context`, `remove_presplash`, plus `run_on_ui_thread`, `get_files_dir`, `get_cache_dir` |
| `kivy/mobile/__init__.py` | Tier 3 public API (`ActivityProviderMissing`, `get_activity`, `get_app_context`) and its documentation |
| `kivy/app.py` | `user_data_dir` / `user_cache_dir` from the Context instead of `PythonActivity.mActivity` |
| `kivy/core/clipboard/clipboard_android.py` | dropped its private `_Runnable`, its own `run_on_ui_thread`, and stashing the clipboard on `PythonActivity` |
| `kivy/base.py` | `remove_android_splash` goes through the bootstrap hook |
| `kivy/tests/test_mobile.py` | fake-bootstrap harness and contract tests |

`remove_presplash()` is optional because dismissing a splash belongs to the
bootstrap: p4a overlays a `View` and removes it, while a bootstrap using the
Android 12 system splash has no equivalent method to offer. Making it a
module-level hook restores the capability negotiation Kivy 2.x got from
`try: import android`, without Kivy naming a bootstrap or a Java method. An
absent hook is a no-op, not a warning.

After this, `grep -rn "PythonActivity\|mActivity" kivy/` matches nothing outside
the test harness.

## Tests

`kivy/tests/test_mobile.py` gains a fake `_kivy_bootstrap` harness in place of
the fake `autoclass`, and contract tests covering: that Kivy holds no bootstrap
class name; that a missing module, or one without `get_activity`, raises; that
the failure is not masked by the getters' defaults; that the Activity is pulled
live rather than cached; that `None` is accepted for a process without one; that
an optional `get_context()` is preferred when present; that storage paths come
from the Context; that `run_on_ui_thread` posts to the Activity; and that the
presplash hook is optional. A regression guard asserts that no bootstrap method
name reappears in the backend source.

## Verified on device

An x86_64 emulator running an APK built by python-for-android's `sdl3` bootstrap
from this branch (NDK r28c, SDL3 3.4.2, CPython 3.14.2). Each check prints one
marker:

```
CONTRACT: ACTIVITY_OK package=org.kivy.contract3
CONTRACT: PULLED_FROM_BOOTSTRAP_OK kivy.get_activity() is the bootstrap's Activity
CONTRACT: NO_CLASS_NAME_IN_KIVY_OK kivy asked _kivy_bootstrap; build chose org.kivy.android.PythonActivity
CONTRACT: APP_CONTEXT_OK package=org.kivy.contract3
CONTRACT: GEOMETRY_OK dpi=160.0 scale=1.00 density=1.00 fontscale=1.00 keyboard=0 ...
CONTRACT: STORAGE_OK user_data_dir=/data/user/0/org.kivy.contract3/files
CONTRACT: CLIPBOARD_OK provider=ClipboardAndroid round-trip exact
CONTRACT: PRESPLASH_OK bootstrap implements remove_presplash
CONTRACT: ALL_OK 8/8
```

`PULLED_FROM_BOOTSTRAP` asserts that `kivy.mobile.get_activity()` and
`_kivy_bootstrap.get_activity()` return the same Java object.
`NO_CLASS_NAME_IN_KIVY` asserts that the live Activity's Java class equals the
build's `android.config.ACTIVITY_CLASS_NAME` — the build's choice, not Kivy's.
`CLIPBOARD` exercises the coupling that started this.

## Bootstrap side

This needs a bootstrap that ships `_kivy_bootstrap`. The python-for-android
implementation is kivy/python-for-android#3356 — one new 64-line module in the
`android` recipe plus documentation for bootstrap authors, with no changes to
`start.c`, to any bootstrap, or to the build. Until it merges, testing on p4a
needs that branch. A second, Gradle- and wheel-based Android builder implements
the same contract against an unmodified Kivy, differing only in the ways the
contract allows: its own activity constant, and no `remove_presplash()` because
it uses the androidx core-splashscreen system splash.

Kivy 2.3.1 is unaffected — it does not import `kivy.mobile`, and p4a keeps its
existing `android` module for it.

---

Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.