### PR TITLE
clipboard_android: replace busy-wait with a threading.Event (5s timeout)

### DIFF
--- a/kivy/core/clipboard/clipboard_android.py
+++ b/kivy/core/clipboard/clipboard_android.py
@@ -24,6 +24,11 @@ sdk = VER.SDK_INT
 # one Activity.
 _clipboard = None
 
+# How long to wait for the UI thread to deliver the ClipboardManager before
+# giving up. A module-level constant (rather than inline in the method) so
+# tests can shrink it instead of sleeping for the real duration.
+_INIT_TIMEOUT = 5.0
+
 
 class ClipboardAndroid(ClipboardBase):
 
@@ -64,7 +69,7 @@ class ClipboardAndroid(ClipboardBase):
                 done.set()
 
         run_on_ui_thread(work)
-        if not done.wait(timeout=5.0):
+        if not done.wait(timeout=_INIT_TIMEOUT):
             raise TimeoutError(
                 'Clipboard: timed out waiting for the UI thread to '
                 'initialize the ClipboardManager')

--- a/kivy/core/clipboard/clipboard_android.py
+++ b/kivy/core/clipboard/clipboard_android.py
@@ -7,7 +7,7 @@ Android implementation of Clipboard provider, using Pyjnius.
 
 __all__ = ('ClipboardAndroid', )
 
-import time
+import threading
 
 from kivy import Logger
 from kivy.core.clipboard import ClipboardBase
@@ -47,10 +47,11 @@ class ClipboardAndroid(ClipboardBase):
 
         The lookup has to happen on the UI thread, so the failure has to be
         carried back rather than raised in place: without that, a Context we
-        cannot reach would leave the wait below spinning forever instead of
+        cannot reach would leave the wait below hanging forever instead of
         reporting itself.
         '''
         failure = []
+        done = threading.Event()
 
         def work():
             global _clipboard
@@ -59,12 +60,16 @@ class ClipboardAndroid(ClipboardBase):
                     Context.CLIPBOARD_SERVICE)
             except Exception as exc:
                 failure.append(exc)
+            finally:
+                done.set()
 
         run_on_ui_thread(work)
-        while not _clipboard:
-            if failure:
-                raise failure[0]
-            time.sleep(.01)
+        if not done.wait(timeout=5.0):
+            raise TimeoutError(
+                'Clipboard: timed out waiting for the UI thread to '
+                'initialize the ClipboardManager')
+        if failure:
+            raise failure[0]
 
     def _get_clipboard(f):
         def called(*args, **kargs):

--- a/kivy/tests/test_clipboard_android.py
+++ b/kivy/tests/test_clipboard_android.py
@@ -1,0 +1,154 @@
+"""Tests for kivy.core.clipboard.clipboard_android.
+
+``clipboard_android`` unconditionally does ``from jnius import autoclass`` and
+``from kivy.mobile._platform.android import get_app_context,
+run_on_ui_thread`` at module scope, so it cannot be imported off-device by
+normal means: ``jnius`` is not installed, and importing ``kivy.mobile`` on a
+non-mobile platform raises ``ImportError`` (see ``kivy/mobile/__init__.py``).
+
+To exercise the module's own logic anyway, this installs fake ``jnius`` and
+``kivy.mobile._platform.android`` modules in ``sys.modules`` and then loads
+``clipboard_android.py`` directly by file path (the same technique used by
+``kivy/tests/test_mobile.py`` for the platform backends).  The fakes here are
+deliberately minimal: they only stand in for what ``_initialize_clipboard``
+touches (``run_on_ui_thread`` and ``get_app_context``), not a full Android
+runtime.
+"""
+
+import importlib.util
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).parent.parent / "core" / "clipboard" / "clipboard_android.py"
+)
+
+
+class _FakeVersion:
+    SDK_INT = 33
+
+
+class _FakeContext:
+    CLIPBOARD_SERVICE = "clipboard"
+
+
+def _autoclass(name):
+    registry = {
+        "java.lang.String": str,
+        "android.content.Context": _FakeContext,
+        "android.os.Build$VERSION": _FakeVersion,
+    }
+    return registry[name]
+
+
+@contextmanager
+def _fake_environment(run_on_ui_thread, get_app_context=None):
+    """Install fake ``jnius``/backend modules, then load a fresh module.
+
+    *run_on_ui_thread* controls whether/when the UI-thread callback actually
+    runs, which is exactly what each test below needs to vary. *get_app_context*
+    defaults to a stand-in that is never expected to be called (the timeout
+    case never reaches it).
+    """
+    jnius_module = types.ModuleType("jnius")
+    jnius_module.autoclass = _autoclass
+
+    android_module = types.ModuleType("kivy.mobile._platform.android")
+    android_module.run_on_ui_thread = run_on_ui_thread
+    android_module.get_app_context = get_app_context or (
+        lambda: pytest.fail("get_app_context() should not have been called")
+    )
+
+    affected = (
+        "jnius",
+        "kivy.mobile",
+        "kivy.mobile._platform",
+        "kivy.mobile._platform.android",
+    )
+    saved = {name: sys.modules.get(name) for name in affected}
+
+    sys.modules["jnius"] = jnius_module
+    sys.modules["kivy.mobile"] = types.ModuleType("kivy.mobile")
+    sys.modules["kivy.mobile._platform"] = types.ModuleType("kivy.mobile._platform")
+    sys.modules["kivy.mobile._platform.android"] = android_module
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "clipboard_android", _MODULE_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
+
+class _FakeClipboardManager:
+    """Stands in for whatever ``getSystemService(CLIPBOARD_SERVICE)`` returns."""
+
+
+class _FakeAppContext:
+    def getSystemService(self, service):
+        assert service == _FakeContext.CLIPBOARD_SERVICE
+        return _FakeClipboardManager()
+
+
+def _run_immediately(func, *args, **kwargs):
+    """Fake ``run_on_ui_thread`` that runs *func* synchronously in-thread.
+
+    Adequate for the success/failure cases: ``_initialize_clipboard`` only
+    needs the callback to have run (and signalled ``done``) by the time it
+    calls ``done.wait()``, which is just as true whether that happens on this
+    thread or another.
+    """
+    func(*args, **kwargs)
+
+
+def _never_run(func, *args, **kwargs):
+    """Fake ``run_on_ui_thread`` that simulates a UI thread that never responds."""
+
+
+class TestClipboardAndroidInitialize:
+    def test_success_sets_clipboard_and_returns(self):
+        with _fake_environment(
+            run_on_ui_thread=_run_immediately,
+            get_app_context=lambda: _FakeAppContext(),
+        ) as module:
+            clippy = module.ClipboardAndroid()
+            clippy._initialize_clipboard()
+            assert isinstance(module._clipboard, _FakeClipboardManager)
+
+    def test_ui_thread_exception_is_reraised_on_the_caller(self):
+        class Boom(Exception):
+            pass
+
+        def failing_get_app_context():
+            raise Boom("no context available")
+
+        with _fake_environment(
+            run_on_ui_thread=_run_immediately,
+            get_app_context=failing_get_app_context,
+        ) as module:
+            clippy = module.ClipboardAndroid()
+            with pytest.raises(Boom, match="no context available"):
+                clippy._initialize_clipboard()
+            # The failed lookup must not leave a truthy-but-wrong clipboard.
+            assert module._clipboard is None
+
+    def test_times_out_when_ui_thread_never_responds(self):
+        with _fake_environment(run_on_ui_thread=_never_run) as module:
+            # Real UI-thread turnaround is milliseconds; shrink the timeout so
+            # this test doesn't have to sleep for the production value.
+            module._INIT_TIMEOUT = 0.05
+            clippy = module.ClipboardAndroid()
+            with pytest.raises(TimeoutError, match="timed out"):
+                clippy._initialize_clipboard()
+            assert module._clipboard is None


### PR DESCRIPTION
## Summary
- `_initialize_clipboard` waited for the UI-thread lookup of the `ClipboardManager` by polling `_clipboard`'s truthiness in a `time.sleep(.01)` loop, with no bound: if the UI thread never delivered a value (and never raised), the wait would hang forever.
- Replaces the busy-wait with a `threading.Event`, set from a `finally` in the UI-thread callback so it fires on both success and failure, and waited on with a 5s timeout.
- On timeout, raises a clear `TimeoutError` instead of hanging indefinitely.

## Test plan
- [ ] CI (this backend only runs `jnius` reflection on-device; off-device import/behavioral coverage is via `kivy/tests/test_mobile.py` and the existing clipboard tests)
- [ ] Manual on-device check that clipboard get/set still works normally on Android
