### PR TITLE
Build ThorVG for Android without a python-for-android recipe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,16 @@ if platform == 'android':
             'SDL3_ttf': {
                 'path': join(lib_path, 'libSDL3_ttf.so'),
                 'headers': join(root, 'dist', 'include', 'SDL3_ttf'),
-            }
+            },
+            # Built by tools/build_thorvg.sh (THORVG_ANDROID=<abi>), not a
+            # python-for-android recipe - a static archive, unlike the .so
+            # siblings above, since Kivy's Android wheel pipeline has no
+            # wheel-repair step to bundle a separate libthorvg.so (see
+            # [tool.cibuildwheel.android] in pyproject.toml).
+            'ThorVG': {
+                'path': join(lib_path, 'libthorvg.a'),
+                'headers': join(root, 'dist', 'include', 'thorvg-1'),
+            },
         }
 
     android_data['abis'] = android_abis
@@ -903,8 +912,15 @@ def determine_thorvg_flags():
       ``tools/build_thorvg.sh``. Kivy's Windows wheel pipeline does not
       run a wheel-repair step, so dynamic linking would force a separate
       ``kivy_deps.thorvg`` package - out of scope for this PR.
-    * **iOS / Android** - handled by mobile recipes / cibuildwheel (not
-      this function's concern beyond ``KIVY_THORVG_*`` env var support).
+    * **Android** - static: ``libthorvg.a`` produced by
+      ``tools/build_thorvg.sh`` (``THORVG_ANDROID=<abi>``) directly - not
+      a python-for-android recipe. Same no-wheel-repair-step rationale as
+      Windows (see ``[tool.cibuildwheel.android]`` in ``pyproject.toml``);
+      resolved via ``plat_options['android']['libraries'][abi]['ThorVG']``,
+      matching the existing SDL3 ``dist/libs/<abi>/`` convention.
+    * **iOS** - handled by the xcframework built by
+      ``tools/build_thorvg.sh`` (see the framework branch above), not this
+      function's fallback path.
     """
     # macOS (desktop): look for ``KivyThorVG.framework`` first. This is
     # the path produced by ``tools/build_macos_dependencies.sh`` and
@@ -971,6 +987,38 @@ def determine_thorvg_flags():
                 'define_macros': [],
             }
 
+    if platform == 'android':
+        # Built by tools/build_thorvg.sh (THORVG_ANDROID=<abi>) into
+        # dist/libs/<abi>/libthorvg.a - a static archive, not a
+        # python-for-android recipe (mirrors the iOS xcframework approach:
+        # ThorVG is part of Kivy's own wheel build, not a separate mobile
+        # dependency). See the ``ThorVG`` entry added to
+        # ``plat_options['android']['libraries']`` above.
+        android_libs = plat_options['android']['libraries']
+        android_abis = plat_options['android']['abis']
+
+        host_triplet = environ.get('CIBW_HOST_TRIPLET', '')
+        if 'aarch64' in host_triplet:
+            current_abi = 'arm64-v8a'
+        elif 'x86_64' in host_triplet:
+            current_abi = 'x86_64'
+        else:
+            current_abi = android_abis[0]
+
+        thorvg = android_libs[current_abi]['ThorVG']
+        return {
+            'include_dirs': [thorvg['headers']],
+            'library_dirs': [dirname(thorvg['path'])],
+            'libraries': ['thorvg'],
+            'extra_compile_args': [],
+            'extra_link_args': [],
+            # Static archive linked directly into _thorvg.so - see the
+            # TVG_STATIC rationale below (Android now genuinely matches
+            # the "links statically" case, unlike before this archive
+            # existed).
+            'define_macros': [('TVG_STATIC', '1')],
+        }
+
     # ThorVG's Meson build declares the library as ``thorvg-<MAJOR>``,
     # which produces ``libthorvg-1.so.*`` (Linux), ``libthorvg-1.a``
     # (static), and ``libthorvg-1.dylib`` (macOS). On Windows the static
@@ -996,13 +1044,15 @@ def determine_thorvg_flags():
     # library it must be omitted so the visibility attributes stay active
     # and dynamic symbol resolution works.
     #
-    # Windows stays static (Kivy has no wheel-repair step there).
+    # Windows stays static (Kivy has no wheel-repair step there). Android
+    # is also static, but returns early above with its own TVG_STATIC
+    # (same rationale, different lib layout) so it never reaches here.
     # macOS desktop is shared via the framework branch above - the
     # fallback dylib path reaches this branch only when the framework
     # is absent, in which case we treat it as shared too (no TVG_STATIC).
     # iOS returns early above via the framework path (shared dylib —
-    # no TVG_STATIC).  Windows and Android still link statically.
-    if platform in ('win32', 'android'):
+    # no TVG_STATIC).
+    if platform == 'win32':
         flags['define_macros'].append(('TVG_STATIC', '1'))
 
     explicit_include = environ.get('KIVY_THORVG_INCLUDE_DIR')
@@ -1031,12 +1081,13 @@ def determine_thorvg_flags():
     # still gets a working link. auditwheel / manylinux treats
     # ``libstdc++.so.6`` as a system-provided library (not vendored), so
     # the extra ``DT_NEEDED`` entry is free. Windows (MSVC) pulls the
-    # runtime in automatically. Mobile toolchains (Android NDK, iOS) use
-    # libc++ and arrange the runtime themselves in the recipe /
-    # cibuildwheel config, not here.
+    # runtime in automatically. Android returns early above (its own NDK
+    # clang++ link driver pulls in libc++ automatically via the
+    # ``language='cpp'`` Extension, same as this ``-lstdc++`` flag does on
+    # Linux). iOS also returns early above via the framework path.
     if platform == 'darwin':
         flags['extra_link_args'].append('-lc++')
-    elif platform not in ('win32', 'android', 'ios'):
+    elif platform not in ('win32', 'ios'):
         flags['extra_link_args'].append('-lstdc++')
 
     return flags

--- a/tools/build_thorvg.sh
+++ b/tools/build_thorvg.sh
@@ -67,12 +67,47 @@
 #                               THORVG_MACOS_UNIVERSAL is forced to 0 when
 #                               this is set. Default: "" (disabled; builds
 #                               for the host platform).
+#   THORVG_ANDROID              When set to "arm64-v8a" or "x86_64" (the
+#                               two ABIs Kivy's Android wheel already
+#                               targets - see the ``dist/libs/<abi>``
+#                               convention in ``setup.py``), cross-compile
+#                               ThorVG for that Android ABI using the NDK's
+#                               LLVM toolchain instead of building for the
+#                               host platform. Requires ``ANDROID_NDK_HOME``
+#                               (or ``ANDROID_NDK_ROOT``) to point at an
+#                               installed NDK (r23+, for the unified LLVM
+#                               binutils).
+#
+#                               Android builds always force THORVG_SHARED=0
+#                               (static): Kivy's Android wheel build has no
+#                               wheel-repair step (see
+#                               ``[tool.cibuildwheel.android]`` in
+#                               ``pyproject.toml``, same rationale as the
+#                               Windows static path above), so the archive
+#                               is linked directly into
+#                               ``kivy.lib.thorvg._thorvg.so`` with no
+#                               separate ``libthorvg.so`` to bundle.
+#
+#                               API level: 21, matching
+#                               ``ANDROID_API_LEVEL`` in ``pyproject.toml``.
+#
+#                               Installs the archive under
+#                               ``<prefix>/libs/<abi>/libthorvg.a`` (headers
+#                               under the ABI-independent
+#                               ``<prefix>/include/thorvg-1/``) rather than
+#                               the flat ``<prefix>/lib/`` used by every
+#                               other platform, so it drops straight into
+#                               the same ``dist/libs/<abi>/`` tree the
+#                               Android SDL3 libraries already use. Default:
+#                               "" (disabled; builds for the host platform).
 #
 # Requires ``meson``, ``ninja``, ``curl``, ``tar``, and a working C++14
 # toolchain on PATH. On Windows, the caller must have already sourced the
 # MSVC environment (e.g. via ``ilammy/msvc-dev-cmd``).
 # On iOS (THORVG_IOS set), full Xcode is also required (xcrun must resolve
 # the named SDK).
+# On Android (THORVG_ANDROID set), an installed NDK is also required
+# (ANDROID_NDK_HOME / ANDROID_NDK_ROOT).
 
 set -e -x
 
@@ -85,6 +120,7 @@ THORVG_BUILD_ROOT="${THORVG_BUILD_ROOT:-$(pwd)/kivy-dependencies/build/thorvg}"
 THORVG_INSTALL_PREFIX="${THORVG_INSTALL_PREFIX:-$(pwd)/kivy-dependencies/dist}"
 THORVG_SHARED="${THORVG_SHARED:-0}"
 THORVG_IOS="${THORVG_IOS:-}"
+THORVG_ANDROID="${THORVG_ANDROID:-}"
 
 # Detect Windows (git-bash / msys / cygwin) so we can keep the rest of the
 # script POSIX-style while still emitting .lib / handling link.exe.
@@ -130,6 +166,9 @@ fi
 if [ -n "$THORVG_IOS" ]; then
   THORVG_MACOS_UNIVERSAL=0
   THORVG_SHARED=1
+elif [ -n "$THORVG_ANDROID" ]; then
+  THORVG_MACOS_UNIVERSAL=0
+  THORVG_SHARED=0
 elif [ "$IS_MACOS" = "1" ]; then
   THORVG_MACOS_UNIVERSAL="${THORVG_MACOS_UNIVERSAL:-1}"
 else
@@ -239,6 +278,17 @@ _thorvg_configure_and_install() {
   local prefix="$2"
   shift 2
 
+  # ``libdir`` is relative to ``prefix`` (matches Meson's own semantics).
+  # Callers set _THORVG_LIBDIR before invoking this function to override
+  # the default "lib"; THORVG_ANDROID uses "libs/<abi>" instead so the
+  # archive lands directly under dist/libs/<abi>/, matching the flat
+  # layout setup.py's Android SDL3 wiring already expects (see this
+  # script's THORVG_ANDROID docs above). Headers always install to the
+  # ABI-independent <prefix>/include/thorvg-1/, regardless of libdir.
+  # (A plain positional arg would be ambiguous with the pass-through
+  # meson args below, e.g. THORVG_IOS's leading "--cross-file".)
+  local libdir="${_THORVG_LIBDIR:-lib}"
+
   pushd "$_THORVG_SRC_DIR"
 
   # Clean stale build dir from previous invocations (idempotent CI reruns).
@@ -248,7 +298,7 @@ _thorvg_configure_and_install() {
     --buildtype=release \
     --default-library="$_THORVG_DEFAULT_LIBRARY" \
     --prefix="$prefix" \
-    --libdir=lib \
+    --libdir="$libdir" \
     -Dlog=false \
     -Dstatic=true \
     -Dthreads=false \
@@ -325,6 +375,79 @@ if [ -n "$THORVG_IOS" ]; then
     otool -D "$_ios_dylib" || true
   fi
 
+elif [ -n "$THORVG_ANDROID" ]; then
+  # ---------------------------------------------------------------------------
+  # Android cross-compile path (THORVG_ANDROID=arm64-v8a | x86_64), matching
+  # the two ABIs Kivy's Android wheel build already targets.
+  #
+  # Uses the NDK's unified (r23+) LLVM toolchain directly rather than a
+  # separate python-for-android recipe: the plain "clang"/"clang++" driver
+  # is put on PATH from the NDK's host-tag toolchain bin dir, and the
+  # target triple + API level + sysroot are supplied via -Dc_args /
+  # -Dcpp_args / -D*_link_args, mirroring how the iOS branch above keeps
+  # the SDK sysroot out of the cross-file itself.
+  #
+  # Always static (THORVG_SHARED forced to 0 above): Kivy's Android wheel
+  # pipeline has no wheel-repair step (see pyproject.toml
+  # [tool.cibuildwheel.android]), so there is nowhere to bundle a separate
+  # libthorvg.so - the archive links directly into
+  # kivy.lib.thorvg._thorvg.so instead, same rationale as the Windows
+  # static path.
+  # ---------------------------------------------------------------------------
+  _ANDROID_NDK_ROOT="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}"
+  if [ -z "$_ANDROID_NDK_ROOT" ]; then
+    echo "FATAL: THORVG_ANDROID requires ANDROID_NDK_HOME (or ANDROID_NDK_ROOT) to point at an installed NDK" >&2
+    exit 1
+  fi
+
+  case "$(uname -s 2>/dev/null || echo)" in
+    Linux)  _ANDROID_NDK_HOST_TAG="linux-x86_64" ;;
+    Darwin) _ANDROID_NDK_HOST_TAG="darwin-x86_64" ;;
+    *)
+      echo "FATAL: THORVG_ANDROID is only supported when building on Linux or macOS hosts" >&2
+      exit 1
+      ;;
+  esac
+
+  # Matches ANDROID_API_LEVEL in pyproject.toml's [tool.cibuildwheel.android].
+  _ANDROID_API_LEVEL="${THORVG_ANDROID_API_LEVEL:-21}"
+  _ANDROID_TOOLCHAIN_BIN="$_ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$_ANDROID_NDK_HOST_TAG/bin"
+  _ANDROID_SYSROOT="$_ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$_ANDROID_NDK_HOST_TAG/sysroot"
+  if [ ! -d "$_ANDROID_TOOLCHAIN_BIN" ]; then
+    echo "FATAL: NDK LLVM toolchain not found at $_ANDROID_TOOLCHAIN_BIN (need NDK r23+)" >&2
+    exit 1
+  fi
+  # Prepend so the NDK's plain "clang"/"clang++"/"llvm-ar"/"llvm-strip"
+  # (referenced by tools/meson-cross-android-*.ini) resolve before any
+  # host toolchain of the same name.
+  export PATH="$_ANDROID_TOOLCHAIN_BIN:$PATH"
+
+  case "$THORVG_ANDROID" in
+    arm64-v8a) _ANDROID_TARGET="aarch64-linux-android${_ANDROID_API_LEVEL}" ;;
+    x86_64)    _ANDROID_TARGET="x86_64-linux-android${_ANDROID_API_LEVEL}" ;;
+    *)
+      echo "FATAL: THORVG_ANDROID must be 'arm64-v8a' or 'x86_64', got: '$THORVG_ANDROID'" >&2
+      exit 1
+      ;;
+  esac
+  _ANDROID_CROSS_FILE="$_SCRIPT_DIR/meson-cross-android-$THORVG_ANDROID.ini"
+
+  echo "-- Build ThorVG (Android $THORVG_ANDROID, API $_ANDROID_API_LEVEL)"
+  echo "   NDK        : $_ANDROID_NDK_ROOT"
+  echo "   Target     : $_ANDROID_TARGET"
+  echo "   Cross-file : $_ANDROID_CROSS_FILE"
+
+  # libdir="libs/<abi>" (relative to prefix) so the archive lands at
+  # <prefix>/libs/<abi>/libthorvg.a - see _thorvg_configure_and_install's
+  # _THORVG_LIBDIR docs above.
+  _THORVG_LIBDIR="libs/$THORVG_ANDROID" \
+  _thorvg_configure_and_install "build-android-$THORVG_ANDROID" "$THORVG_INSTALL_PREFIX" \
+    --cross-file "$_ANDROID_CROSS_FILE" \
+    -Dc_args="--target=$_ANDROID_TARGET --sysroot=$_ANDROID_SYSROOT" \
+    -Dcpp_args="--target=$_ANDROID_TARGET --sysroot=$_ANDROID_SYSROOT" \
+    -Dc_link_args="--target=$_ANDROID_TARGET --sysroot=$_ANDROID_SYSROOT" \
+    -Dcpp_link_args="--target=$_ANDROID_TARGET --sysroot=$_ANDROID_SYSROOT"
+
 elif [ "$THORVG_MACOS_UNIVERSAL" = "1" ]; then
   # Single-invocation universal2 build (matches libpng's CMake
   # ``-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"`` path in
@@ -385,8 +508,16 @@ fi
 #   on macOS). ``auditwheel repair`` / ``delocate-wheel`` / the framework
 #   wrapper in ``build_macos_dependencies.sh`` take it from there. We still
 #   fail fast here if Meson silently produced only a static archive.
+#
+# Android builds installed under ``<prefix>/libs/<abi>/`` instead of the
+# flat ``<prefix>/lib/`` (see the THORVG_ANDROID branch above), so resolve
+# the libdir accordingly here too.
 # ---------------------------------------------------------------------------
-_libdir="$THORVG_INSTALL_PREFIX/lib"
+if [ -n "$THORVG_ANDROID" ]; then
+  _libdir="$THORVG_INSTALL_PREFIX/libs/$THORVG_ANDROID"
+else
+  _libdir="$THORVG_INSTALL_PREFIX/lib"
+fi
 echo "--- Contents of $_libdir ---"
 ls -lR "$_libdir" || true
 

--- a/tools/meson-cross-android-arm64-v8a.ini
+++ b/tools/meson-cross-android-arm64-v8a.ini
@@ -1,0 +1,40 @@
+# Meson cross-file for Android arm64-v8a (aarch64)
+#
+# API level:    matches ANDROID_API_LEVEL in pyproject.toml's
+#               [tool.cibuildwheel.android] section (currently 21).
+# Architecture: arm64-v8a (aarch64)
+#
+# ``c``/``cpp`` are left as the NDK's plain, unversioned ``clang``/``clang++``
+# driver (found via ``$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/<host-tag>/bin``
+# on PATH). The target triple + API level (``--target=aarch64-linux-android21``)
+# and sysroot are injected at build time by tools/build_thorvg.sh
+# (THORVG_ANDROID=arm64-v8a branch) via -Dc_args / -Dcpp_args /
+# -Dc_link_args / -Dcpp_link_args, mirroring how the iOS cross-files keep
+# the SDK sysroot / deployment target out of this file. Cross-files are
+# re-read on reconfigure, so keeping runtime-variable values (in
+# particular the API level, which callers may want to bump later) out of
+# this file avoids stale-cache surprises.
+#
+# ``ar``/``strip`` use the NDK's unified (non-arch-prefixed) LLVM binutils,
+# available since NDK r23.
+
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+# Disable pkg-config so Meson cannot accidentally resolve host libraries
+# while cross-compiling for Android.
+pkgconfig = 'false'
+
+[properties]
+# Android executables cannot run on the build machine.
+needs_exe_wrapper = true
+
+[host_machine]
+system     = 'android'
+subsystem  = 'android'
+kernel     = 'linux'
+cpu_family = 'aarch64'
+cpu        = 'aarch64'
+endian     = 'little'

--- a/tools/meson-cross-android-x86_64.ini
+++ b/tools/meson-cross-android-x86_64.ini
@@ -1,0 +1,26 @@
+# Meson cross-file for Android x86_64
+#
+# API level:    matches ANDROID_API_LEVEL in pyproject.toml's
+#               [tool.cibuildwheel.android] section (currently 21).
+# Architecture: x86_64
+#
+# See tools/meson-cross-android-arm64-v8a.ini for the full rationale; this
+# file mirrors it for the x86_64 ABI (used by Android emulator images).
+
+[binaries]
+c         = 'clang'
+cpp       = 'clang++'
+ar        = 'llvm-ar'
+strip     = 'llvm-strip'
+pkgconfig = 'false'
+
+[properties]
+needs_exe_wrapper = true
+
+[host_machine]
+system     = 'android'
+subsystem  = 'android'
+kernel     = 'linux'
+cpu_family = 'x86_64'
+cpu        = 'x86_64'
+endian     = 'little'


### PR DESCRIPTION
## Summary

ThorVG's Android integration currently depends on an out-of-tree python-for-android recipe: it isn't built by CI, is versioned separately from the pin in `tools/build_thorvg.sh`, and is an undocumented unconditional runtime dependency. This PR replaces that with the same approach Kivy already uses for iOS: ThorVG becomes part of Kivy's own build (via `tools/build_thorvg.sh` + `setup.py`), not a separate mobile dependency.

- `tools/build_thorvg.sh`: new `THORVG_ANDROID=<abi>` mode that cross-compiles ThorVG with the NDK's unified LLVM toolchain, targeting API 21 (matching `ANDROID_API_LEVEL` in `pyproject.toml`). Always static — Kivy's Android wheel build has no wheel-repair step, so the archive links directly into `kivy.lib.thorvg._thorvg.so` (same rationale as the existing Windows static path). Installs to `<prefix>/libs/<abi>/libthorvg.a`, dropping into the same `dist/libs/<abi>/` tree the Android SDL3 libraries already use.
- `tools/meson-cross-android-{arm64-v8a,x86_64}.ini`: new Meson cross files for the two ABIs Kivy's Android wheel targets.
- `setup.py`: adds a `ThorVG` entry to `plat_options['android']['libraries'][abi]` alongside the existing SDL3 entries, and a dedicated `platform == 'android'` branch in `determine_thorvg_flags()` (`TVG_STATIC=1`, matching Windows).

Only `arm64-v8a` and `x86_64` are wired up (the ABIs Kivy's Android wheel already targets). 

## Test plan

- [x] Cross-compiled `libthorvg.a` for both `arm64-v8a` and `x86_64` via `tools/build_thorvg.sh` and verified the object code architecture (`ELF64 AArch64` / `x86_64`).
- [x] Built a full Kivy Android wheel (`arm64-v8a`) via `cibuildwheel` linking against the new static archive; confirmed `use_thorvg = 1` and a clean link with `-Wl,--no-undefined` (no missing symbols).
- [x] Deployed to a physical Pixel 8a (Android 16) via `kivyforge`. Used `svg-explorer` example and visually confirmed `img_thorvg_svg` renders correctly on-device — flat shapes (star, heart) and a gradient fill (hexagon) all render as expected.
- [x] CI (wheel builds / lint) on this PR.
