### PR TITLE
Stop configuring the Android input provider removed in 787336a2

### DIFF
--- a/kivy/__init__.py
+++ b/kivy/__init__.py
@@ -515,15 +515,14 @@ if not environ.get('KIVY_DOC_INCLUDE'):
     from kivy.modules import Modules
     Modules.configure()
 
-    # android hooks: force fullscreen and add android touch input provider
-    if platform in ('android', 'ios'):
+    # mobile hooks: force fullscreen, and clear the input section. The
+    # providers configured there are desktop ones; on mobile SDL adds its own
+    # provider from the window instead (kivy/core/window/window_sdl3.py).
+    if platform in {'android', 'ios'}:
         from kivy.config import Config
         Config.set('graphics', 'fullscreen', 'auto')
         Config.remove_section('input')
         Config.add_section('input')
-
-    if platform == 'android':
-        Config.set('input', 'androidtouch', 'android')
 
 for msg in _logging_msgs:
     Logger.info(msg)


### PR DESCRIPTION
Kivy's `__init__.py` still set [input] androidtouch = android on Android, but commit 787336a2 in #9347 had already deleted the provider that registered under that id — so every launch logged `Unknown <android> provider`. The fix deletes that config line and the stale comment above it.

It's cosmetic only: Android's [input] section is already emptied a few lines earlier, and under SDL the window installs SDL3MotionEventProvider directly, so touch never came through that config path.

## Why

"Remove dead pygame-era Android code"  #9347 deleted
`kivy/input/providers/androidjoystick.py` and its registration branch, but left
the line in `kivy/__init__.py` that configures it:

```python
Config.set('input', 'androidtouch', 'android')
```

Nothing registers the provider id `android` any more, so `base.py`'s input loop
looks it up, gets `None`, and warns:

```python
provider = MotionEventFactory.get(provider_id)
if provider is None:
    Logger.warning('Base: Unknown <%s> provider' % str(provider_id))
    continue
```

`androidtouch` appears nowhere else in the tree, and that lookup is its only
consumer.

## Why removing it is a no-op for input

The `remove_section('input')` / `add_section('input')` pair immediately above
already leaves Android with an empty `[input]` section. Under SDL the window
installs its own provider directly rather than going through the config
section — `window_sdl3.py`:

```python
Logger.info('Window: auto add sdl3 input provider')
SDL3MotionEventProvider.win = self
EventLoop.add_input_provider(SDL3MotionEventProvider('sdl', ''))
```

That is the familiar `Window: auto add sdl3 input provider` line in any Android
logcat. Touch has not travelled through the config section in an SDL build.

## Also

- The comment above the block promised to "add android touch input provider",
  which has not been true since 787336a2.
- The membership test on that line is now a set literal rather than a tuple.

## Testing

Found while running a Kivy 3.0 / SDL3 app on an Android emulator (API 36,
arm64): the warning appears at every launch and the app is otherwise fine —
touch, rendering and rotation all work, which is consistent with the config
entry being inert.
