### PR TITLE
Fix garbled AttributeError message in QueryDict.__getattr__

### DIFF
--- a/kivy/tests/test_utils.py
+++ b/kivy/tests/test_utils.py
@@ -127,8 +127,11 @@ class UtilsTest(unittest.TestCase):
         # __getattr__
         toto = qd.toto
         self.assertEqual(toto, 1)
-        with self.assertRaises(AttributeError):
-            foo = qd.not_an_attribute
+        with self.assertRaises(AttributeError) as cm:
+            qd.not_an_attribute
+        # the error message should name the missing attribute and the class
+        self.assertIn('not_an_attribute', str(cm.exception))
+        self.assertIn('QueryDict', str(cm.exception))
 
     def test_intersection(self):
         abcd = ['a', 'b', 'c', 'd']

--- a/kivy/utils.py
+++ b/kivy/utils.py
@@ -497,7 +497,7 @@ class QueryDict(dict):
             return self.__getitem__(attr)
         except KeyError:
             raise AttributeError("%r object has no attribute %r" % (
-                self.__class__.__name__self, attr))
+                self.__class__.__name__, attr))
 
     def __setattr__(self, attr, value):
         self.__setitem__(attr, value)


### PR DESCRIPTION
### Summary

`QueryDict.__getattr__` builds its error message with a typo — a stray `self` fused onto `__name__`:

```python
def __getattr__(self, attr):
    try:
        return self.__getitem__(attr)
    except KeyError:
        raise AttributeError("%r object has no attribute %r" % (
            self.__class__.__name__self, attr))   # <-- __name__self
```

Python parses `self.__class__.__name__self` as `getattr(self.__class__, "__name__self")`. After name mangling that becomes `_QueryDict__name__self`, which doesn't exist — so **constructing the error message itself raises a second, misleading `AttributeError`** that neither names the class correctly nor mentions the attribute the caller asked for.

### Reproduce

```python
from kivy.utils import QueryDict
QueryDict().missing
```

- Current: `AttributeError: type object 'QueryDict' has no attribute '_QueryDict__name__self'`
- Expected: `AttributeError: 'QueryDict' object has no attribute 'missing'`

### Fix

Drop the trailing `self` so the format string's first `%r` gets the class name as intended:

```python
self.__class__.__name__
```

Now `QueryDict().missing` raises `'QueryDict' object has no attribute 'missing'`.

### Tests

`test_QueryDict` only asserted that *some* `AttributeError` is raised, which passed even with the garbled message. Tightened it to assert the message names the missing attribute and the class — it fails on the current code and passes with the fix. (Also dropped an unused local in that block.)